### PR TITLE
feat(provider): add local smoke workflow scripts

### DIFF
--- a/docs/LOCAL_PROVIDER_SMOKE.md
+++ b/docs/LOCAL_PROVIDER_SMOKE.md
@@ -1,0 +1,45 @@
+# Local Provider Smoke Workflow
+
+This workflow configures a private OpenAI-compatible local runtime as the active Augmentor route, then verifies that ResonantOS can call it.
+
+## Requirements
+
+- A private endpoint that exposes OpenAI-compatible `GET /v1/models` and `POST /v1/chat/completions`.
+- The endpoint must be on `localhost`, `127.0.0.0/8`, `10.0.0.0/8`, `172.16.0.0/12`, or `192.168.0.0/16`.
+- A model id returned by `/v1/models`.
+
+The configure script refuses non-private endpoints. Do not commit runtime-state files or provider secrets.
+
+## Commands
+
+Use an isolated state root while testing:
+
+```bash
+export RESONANTOS_APP_STATE_ROOT=/tmp/resonantos-local-provider-state
+export PRIMARY_LOCAL_ENDPOINT=http://192.168.1.13:8081/v1
+export PRIMARY_MODEL_NAME='Qwen/Qwen2.5-Coder-7B-Instruct-GGUF:Q4_K_M'
+
+npm run configure:local-provider
+npm run smoke:local-provider
+```
+
+`configure:local-provider` discovers models from `/v1/models`, writes the provider/runtime node into `runtime-state.json`, and routes `strategy-augmentor-primary` to the selected model.
+
+`smoke:local-provider` reads that runtime state and sends a minimal chat completion request to the configured local route.
+
+## Environment
+
+- `RESONANTOS_APP_STATE_ROOT`: alternate Electron/Tauri app state root for isolated tests.
+- `PRIMARY_LOCAL_ENDPOINT`: preferred local OpenAI-compatible base URL, such as `http://192.168.1.13:8081/v1`.
+- `PRIMARY_MODEL_NAME`: expected local model id.
+- `RESONANTOS_LOCAL_PROVIDER_ENDPOINT`: fallback endpoint variable used by the configure script.
+- `RESONANTOS_LOCAL_PROVIDER_MODEL`: fallback model variable used by the configure script.
+- `RESONANTOS_LOCAL_PROVIDER_ID`: optional provider id; defaults to `local-llamacpp-primary`.
+- `RESONANTOS_LOCAL_PROVIDER_NODE_ID`: optional runtime node id; defaults to `node-local-llamacpp-primary`.
+- `RESONANTOS_PROVIDER_SMOKE_*`: Electron product-smoke inputs, including `RESONANTOS_PROVIDER_SMOKE=1`, `RESONANTOS_PROVIDER_SMOKE_PROVIDER_ID`, `RESONANTOS_PROVIDER_SMOKE_PROVIDER_TYPE`, `RESONANTOS_PROVIDER_SMOKE_MODEL`, `RESONANTOS_PROVIDER_SMOKE_BASE_URL`, `RESONANTOS_PROVIDER_SMOKE_RUNTIME_NODE_ID`, `RESONANTOS_PROVIDER_SMOKE_RUNTIME_NODE_KIND`, `RESONANTOS_PROVIDER_SMOKE_RUNTIME_NODE_ENDPOINT`, `RESONANTOS_PROVIDER_SMOKE_AUTH_TIER`, and `RESONANTOS_PROVIDER_SMOKE_PROMPT`.
+
+## Electron Settings
+
+In Electron, Settings provider **Test** and **Smoke Test** reuse the existing `provider_service_chat_completion` IPC path, so a configured OpenAI-compatible local-runtime provider should show the existing smoke result and notice.
+
+Settings **Setup** probing is not implemented for Electron yet. It returns an explicit `adapter-pending` / unsupported result instead of silently failing; use **Check Health** or **Test** to verify the local route in Electron.

--- a/electron-host/product-main.mjs
+++ b/electron-host/product-main.mjs
@@ -367,6 +367,26 @@ function sanitizeAssistantContent(providerType, content) {
   return providerType === "minimax" ? stripThinkBlocks(content) : String(content ?? "").trim();
 }
 
+function providerSmokeInputFromEnv() {
+  const providerId = process.env.RESONANTOS_PROVIDER_SMOKE_PROVIDER_ID || "shared-minimax";
+  const providerType = process.env.RESONANTOS_PROVIDER_SMOKE_PROVIDER_TYPE || "minimax";
+  const model = process.env.RESONANTOS_PROVIDER_SMOKE_MODEL || "MiniMax-M3";
+  return {
+    requestId: "electron-provider-smoke",
+    providerId,
+    providerType,
+    apiBaseUrl: process.env.RESONANTOS_PROVIDER_SMOKE_BASE_URL || undefined,
+    runtimeNodeId: process.env.RESONANTOS_PROVIDER_SMOKE_RUNTIME_NODE_ID || undefined,
+    runtimeNodeKind: process.env.RESONANTOS_PROVIDER_SMOKE_RUNTIME_NODE_KIND || "cloud",
+    runtimeNodeEndpoint: process.env.RESONANTOS_PROVIDER_SMOKE_RUNTIME_NODE_ENDPOINT || undefined,
+    authTier: process.env.RESONANTOS_PROVIDER_SMOKE_AUTH_TIER || undefined,
+    model,
+    reasoningEffort: "minimal",
+    systemPrompt: "Reply briefly to confirm the ResonantOS provider smoke test reached you.",
+    messages: [{ role: "user", content: process.env.RESONANTOS_PROVIDER_SMOKE_PROMPT || "hello" }],
+  };
+}
+
 async function providerDiagnostics(providerId = null) {
   const state = await readRuntimeState();
   const providers = Array.isArray(state?.providers) ? state.providers : [];
@@ -376,8 +396,9 @@ async function providerDiagnostics(providerId = null) {
   for (const provider of providers) {
     if (providerId && provider.id !== providerId) continue;
     if (provider.id === "shared-local") continue;
-    const credentialConfigured = Boolean(await resolveProviderSecret(provider.id));
+    const credentialConfigured = provider.authMethod === "local-runtime" || Boolean(await resolveProviderSecret(provider.id));
     const node = runtimeNodes.find((candidate) => candidate.providerProfileId === provider.id);
+    const providerReady = credentialConfigured || node?.kind === "desktop-local" || node?.kind === "remote-user-owned";
     reports.push({
       providerId: provider.id,
       providerLabel: provider.label ?? provider.id,
@@ -386,8 +407,8 @@ async function providerDiagnostics(providerId = null) {
       authTier: provider.authTier ?? "supported",
       executionAdapter: node?.kind === "remote-user-owned" ? "local-ollama" : provider.providerType === "minimax" ? "cloud-minimax-compatible" : "cloud-openai-compatible",
       credentialConfigured,
-      status: credentialConfigured || node?.kind === "desktop-local" || node?.kind === "remote-user-owned" ? "ready" : "blocked",
-      summary: credentialConfigured ? "Credential configured in portable provider vault." : "Credentials are not configured for this provider.",
+      status: providerReady ? "healthy" : "offline",
+      summary: credentialConfigured ? "Credential configured or not required for this provider." : "Credentials are not configured for this provider.",
       checkedAt,
       primaryModel: provider.primaryModel,
       fallbackModel: provider.fallbackModel ?? null,
@@ -1004,16 +1025,7 @@ async function runProductSmoke() {
     }
     const providerSmoke =
       process.env.RESONANTOS_PROVIDER_SMOKE === "1"
-        ? await handleInvoke({ sender: mainWindow.webContents }, "provider_service_chat_completion", {
-            requestId: "electron-provider-smoke",
-            providerId: "shared-minimax",
-            providerType: "minimax",
-            runtimeNodeKind: "cloud",
-            model: "MiniMax-M3",
-            reasoningEffort: "minimal",
-            systemPrompt: "Reply with exactly: ResonantOS provider smoke OK",
-            messages: [{ role: "user", content: "Run the smoke test." }],
-          })
+        ? await handleInvoke({ sender: mainWindow.webContents }, "provider_service_chat_completion", providerSmokeInputFromEnv())
         : null;
     process.stdout.write(
       `${JSON.stringify({

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "test:electron-host": "node --test electron-host/test/*.test.mjs",
     "electron-host:smoke": "node electron-host/run-smoke.mjs",
     "electron-host:rust-ipc": "node electron-host/rust-core-ipc-smoke.mjs",
+    "configure:local-provider": "node scripts/configure-local-test-provider.mjs",
+    "smoke:local-provider": "node scripts/smoke-local-provider.mjs",
     "electron:dev": "npm run build && node electron-host/run-product.mjs",
     "electron:smoke": "npm run build && node electron-host/run-product-smoke.mjs",
     "test:browser-native": "node --test addons/resonant-browser-native/test/*.test.mjs",

--- a/scripts/configure-local-test-provider.mjs
+++ b/scripts/configure-local-test-provider.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+const DEFAULT_PROVIDER_ID = "local-llamacpp-primary";
+const DEFAULT_NODE_ID = "node-local-llamacpp-primary";
+
+function homeDir() {
+  return process.env.HOME || process.env.USERPROFILE || os.homedir();
+}
+
+function tauriAppStateRoot() {
+  if (process.env.RESONANTOS_APP_STATE_ROOT) {
+    return path.resolve(process.env.RESONANTOS_APP_STATE_ROOT);
+  }
+  if (process.platform === "darwin") {
+    return path.join(homeDir(), "Library", "Application Support", "com.resonantos.vnext");
+  }
+  if (process.platform === "win32") {
+    return path.join(process.env.APPDATA || path.join(homeDir(), "AppData", "Roaming"), "com.resonantos.vnext");
+  }
+  return path.join(process.env.XDG_CONFIG_HOME || path.join(homeDir(), ".config"), "com.resonantos.vnext");
+}
+
+function runtimeStatePath() {
+  return path.join(tauriAppStateRoot(), "runtime-state.json");
+}
+
+function assertPrivateHttpEndpoint(endpoint) {
+  const parsed = new URL(endpoint);
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("PRIMARY_LOCAL_ENDPOINT must be http or https.");
+  }
+  const host = parsed.hostname.toLowerCase();
+  const privateHost =
+    host === "localhost" ||
+    host === "127.0.0.1" ||
+    host.startsWith("127.") ||
+    host.startsWith("10.") ||
+    host.startsWith("192.168.") ||
+    /^172\.(1[6-9]|2\d|3[0-1])\./.test(host);
+  if (!privateHost) {
+    throw new Error(`Refusing non-private local provider endpoint: ${endpoint}`);
+  }
+  return parsed.toString().replace(/\/$/, "");
+}
+
+async function discoverModel(endpoint, requestedModel) {
+  const response = await fetch(`${endpoint}/models`);
+  if (!response.ok) {
+    throw new Error(`Model discovery failed with HTTP ${response.status} at ${endpoint}/models`);
+  }
+  const payload = await response.json();
+  const models = [
+    ...(Array.isArray(payload.data) ? payload.data.map((item) => item.id || item.model || item.name) : []),
+    ...(Array.isArray(payload.models) ? payload.models.map((item) => item.id || item.model || item.name) : []),
+  ].filter(Boolean);
+  const uniqueModels = [...new Set(models.map(String))];
+  if (!uniqueModels.length) {
+    throw new Error(`No model ids found in ${endpoint}/models response.`);
+  }
+  return {
+    models: uniqueModels,
+    selectedModel: uniqueModels.includes(requestedModel) ? requestedModel : uniqueModels[0],
+  };
+}
+
+async function readJson(filePath, fallback) {
+  if (!existsSync(filePath)) {
+    return fallback;
+  }
+  const raw = await readFile(filePath, "utf8");
+  return raw.trim() ? JSON.parse(raw) : fallback;
+}
+
+function upsertById(items = [], item) {
+  const next = items.filter((current) => current?.id !== item.id);
+  next.push(item);
+  return next;
+}
+
+function localProvider({ providerId, endpoint, model }) {
+  return {
+    id: providerId,
+    label: "Local llama.cpp Test",
+    providerType: "openai-compatible",
+    authSource: "manual",
+    authMethod: "local-runtime",
+    authTier: "supported",
+    apiBaseUrl: endpoint,
+    allowedModels: [model],
+    primaryModel: model,
+    fallbackModel: undefined,
+    modelContext: [
+      {
+        model,
+        maxContextTokens: 8192,
+        tokenEstimateMethod: "provider-metadata",
+        source: "runtime-node",
+      },
+    ],
+    consumerScopes: ["strategist", "setup", "archive-ingest", "recovery"],
+    shared: true,
+    status: "ready",
+    credentialStatus: "configured",
+  };
+}
+
+function localRuntimeNode({ providerId, nodeId, endpoint, model }) {
+  return {
+    id: nodeId,
+    label: "Local llama.cpp Test Runtime",
+    providerProfileId: providerId,
+    kind: "remote-user-owned",
+    locality: "lan-remote",
+    endpoint,
+    supportedModels: [model],
+    authTier: "supported",
+    healthState: "ready",
+    deployableOnDemand: false,
+    notes: ["Configured from local host-owned test provider setup. No cloud API key required."],
+  };
+}
+
+function configureState(state, { providerId, nodeId, endpoint, model }) {
+  const provider = localProvider({ providerId, endpoint, model });
+  const node = localRuntimeNode({ providerId, nodeId, endpoint, model });
+  const route = {
+    providerProfileId: providerId,
+    runtimeNodeId: nodeId,
+    model,
+    costPosture: "free-local",
+    note: "Default local llama.cpp test route.",
+  };
+  const chain = {
+    id: "chain-local-llamacpp-test",
+    label: "Local llama.cpp Test Chain",
+    rule: "Use the configured local OpenAI-compatible llama.cpp endpoint before any cloud route.",
+    orderedRoutes: [route],
+    lastResortRoute: undefined,
+  };
+
+  const workloadStrategies = upsertById(state.modelStrategy?.workloadStrategies, {
+    id: "strategy-augmentor-primary",
+    label: "Augmentor Primary Chat",
+    workloadClass: "primary-chat",
+    ownerType: "agent",
+    ownerId: "strategist.core",
+    primaryRoute: route,
+    fallbackChainId: chain.id,
+    hardStopWhenNoFallback: false,
+    notes: ["Configured for local test chat through an OpenAI-compatible llama.cpp endpoint."],
+  });
+
+  return {
+    ...state,
+    providers: upsertById(state.providers, provider),
+    runtimeNodes: upsertById(state.runtimeNodes, node),
+    agents: upsertById(state.agents, {
+      id: "strategist.core",
+      providerProfileId: providerId,
+      fallbackProviderProfileId: undefined,
+    }),
+    modelStrategy: {
+      ...(state.modelStrategy ?? {}),
+      fallbackChains: upsertById(state.modelStrategy?.fallbackChains, chain),
+      workloadStrategies,
+    },
+    uiPreferences: {
+      ...(state.uiPreferences ?? {}),
+      activeSection: "strategist",
+      activeChatThreadId: state.uiPreferences?.activeChatThreadId ?? "thread-main-desktop",
+      workspaceLayout: "main-chat",
+      chatSidebarOpen: true,
+    },
+  };
+}
+
+async function main() {
+  const endpoint = assertPrivateHttpEndpoint(
+    process.env.PRIMARY_LOCAL_ENDPOINT || process.env.RESONANTOS_LOCAL_PROVIDER_ENDPOINT || "",
+  );
+  const requestedModel = process.env.PRIMARY_MODEL_NAME || process.env.RESONANTOS_LOCAL_PROVIDER_MODEL || "";
+  if (!requestedModel) {
+    throw new Error("Set PRIMARY_MODEL_NAME to the expected local model id.");
+  }
+  const { models, selectedModel } = await discoverModel(endpoint, requestedModel);
+  const providerId = process.env.RESONANTOS_LOCAL_PROVIDER_ID || DEFAULT_PROVIDER_ID;
+  const nodeId = process.env.RESONANTOS_LOCAL_PROVIDER_NODE_ID || DEFAULT_NODE_ID;
+  const filePath = runtimeStatePath();
+  const current = await readJson(filePath, {});
+  const next = configureState(current, {
+    providerId,
+    nodeId,
+    endpoint,
+    model: selectedModel,
+  });
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        ok: true,
+        runtimeStatePath: filePath,
+        providerId,
+        runtimeNodeId: nodeId,
+        endpoint,
+        requestedModel,
+        selectedModel,
+        discoveredModels: models,
+        modelChanged: requestedModel !== selectedModel,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/smoke-local-provider.mjs
+++ b/scripts/smoke-local-provider.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+function homeDir() {
+  return process.env.HOME || process.env.USERPROFILE || os.homedir();
+}
+
+function tauriAppStateRoot() {
+  if (process.env.RESONANTOS_APP_STATE_ROOT) {
+    return path.resolve(process.env.RESONANTOS_APP_STATE_ROOT);
+  }
+  if (process.platform === "darwin") {
+    return path.join(homeDir(), "Library", "Application Support", "com.resonantos.vnext");
+  }
+  if (process.platform === "win32") {
+    return path.join(process.env.APPDATA || path.join(homeDir(), "AppData", "Roaming"), "com.resonantos.vnext");
+  }
+  return path.join(process.env.XDG_CONFIG_HOME || path.join(homeDir(), ".config"), "com.resonantos.vnext");
+}
+
+async function readRuntimeState() {
+  const filePath = path.join(tauriAppStateRoot(), "runtime-state.json");
+  if (!existsSync(filePath)) {
+    throw new Error(`Runtime state does not exist: ${filePath}`);
+  }
+  return { filePath, state: JSON.parse(await readFile(filePath, "utf8")) };
+}
+
+function primaryChatRoute(state) {
+  const strategy = state.modelStrategy?.workloadStrategies?.find((item) => item.id === "strategy-augmentor-primary");
+  const route = strategy?.primaryRoute;
+  if (!route) {
+    throw new Error("No strategy-augmentor-primary route is configured.");
+  }
+  const provider = state.providers?.find((item) => item.id === route.providerProfileId);
+  const runtimeNode = state.runtimeNodes?.find((item) => item.id === route.runtimeNodeId);
+  if (!provider || !runtimeNode) {
+    throw new Error("Configured primary chat route is missing its provider or runtime node.");
+  }
+  if (provider.providerType !== "openai-compatible" || provider.authMethod !== "local-runtime") {
+    throw new Error(`Refusing to smoke-test non-local provider route: ${provider.id}`);
+  }
+  return {
+    provider,
+    runtimeNode,
+    model: route.model || provider.primaryModel,
+    endpoint: runtimeNode.endpoint || provider.apiBaseUrl,
+  };
+}
+
+async function main() {
+  const { filePath, state } = await readRuntimeState();
+  const route = primaryChatRoute(state);
+  const response = await fetch(`${String(route.endpoint).replace(/\/$/, "")}/chat/completions`, {
+    method: "POST",
+    headers: {
+      "Authorization": "Bearer not-needed",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: route.model,
+      messages: [
+        { role: "system", content: "You are a concise ResonantOS local provider smoke-test assistant." },
+        { role: "user", content: "hello" },
+      ],
+    }),
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(payload?.error?.message || `Provider smoke failed with HTTP ${response.status}.`);
+  }
+  const reply = payload?.choices?.[0]?.message?.content;
+  if (!String(reply ?? "").trim()) {
+    throw new Error("Provider smoke did not return assistant content.");
+  }
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        ok: true,
+        runtimeStatePath: filePath,
+        providerId: route.provider.id,
+        runtimeNodeId: route.runtimeNode.id,
+        endpoint: route.endpoint,
+        model: route.model,
+        prompt: "hello",
+        reply: String(reply).trim(),
+        usage: payload.usage ?? null,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/src/core/runtime.test.ts
+++ b/src/core/runtime.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AddOnManifest, ResonantShellState } from "./contracts";
 import { buildDefaultState } from "./defaults";
-import { applyProviderCredentialStatuses, normalizeState, rebaseStateOnManifests } from "./runtime";
+import { applyProviderCredentialStatuses, normalizeState, rebaseStateOnManifests, requestProviderSmokeTest } from "./runtime";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("runtime state migration", () => {
   it("migrates legacy recovery state onto the Resonant Engineer Agent and Gemma local runtime", () => {
@@ -200,6 +204,40 @@ describe("runtime state migration", () => {
     const updated = applyProviderCredentialStatuses(state, {});
 
     expect(updated.providers.find((item) => item.id === provider.id)?.credentialStatus).toBe("configured");
+  });
+
+  it("routes Electron provider smoke tests through provider chat completion", async () => {
+    const invoke = vi.fn(async () => "Coder7 smoke response.");
+    vi.stubGlobal("window", { resonantosElectron: { invoke } });
+
+    const result = await requestProviderSmokeTest({
+      providerId: "provider-coder7",
+      providerType: "openai-compatible",
+      apiBaseUrl: "http://192.168.1.13:8081/v1",
+      runtimeNodeId: "node-coder7",
+      runtimeNodeKind: "remote-user-owned",
+      runtimeNodeEndpoint: "http://192.168.1.13:8081/v1",
+      authTier: "supported",
+      model: "Qwen/Qwen2.5-Coder-7B-Instruct-GGUF:Q4_K_M",
+    });
+
+    expect(invoke).toHaveBeenCalledWith(
+      "provider_service_chat_completion",
+      expect.objectContaining({
+        providerId: "provider-coder7",
+        providerType: "openai-compatible",
+        runtimeNodeKind: "remote-user-owned",
+        model: "Qwen/Qwen2.5-Coder-7B-Instruct-GGUF:Q4_K_M",
+        reasoningEffort: "minimal",
+      }),
+    );
+    expect(result).toMatchObject({
+      providerId: "provider-coder7",
+      model: "Qwen/Qwen2.5-Coder-7B-Instruct-GGUF:Q4_K_M",
+      ok: true,
+      replyPreview: "Coder7 smoke response.",
+    });
+    expect(result.summary).toContain("Provider smoke test succeeded");
   });
 
   it("rebases stale placeholder GX10 runtime state onto the verified default runtime", () => {

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -1621,6 +1621,44 @@ export const requestProviderSmokeTest = async (input: {
   authTier?: string;
   model: string;
 }): Promise<ProviderSmokeTestResult> => {
+  if (hasElectronHost()) {
+    const checkedAt = new Date().toISOString();
+    const reply = await requestProviderServiceChatCompletion({
+      requestId: `provider-smoke:${input.providerId}:${Date.now()}`,
+      threadId: "settings-provider-smoke",
+      agentId: "settings.provider-smoke",
+      channelId: "settings",
+      providerId: input.providerId,
+      providerType: input.providerType,
+      apiBaseUrl: input.apiBaseUrl,
+      runtimeNodeId: input.runtimeNodeId,
+      runtimeNodeKind: input.runtimeNodeKind,
+      runtimeNodeEndpoint: input.runtimeNodeEndpoint,
+      authTier: input.authTier,
+      model: input.model,
+      reasoningEffort: "minimal",
+      systemPrompt: "You are a provider smoke test. Reply briefly and do not ask follow-up questions.",
+      messages: [
+        {
+          id: `provider-smoke:${input.providerId}:user`,
+          threadId: "settings-provider-smoke",
+          channelId: "settings",
+          role: "user",
+          author: "Settings",
+          content: "Reply with one short sentence confirming this provider can answer.",
+          createdAt: checkedAt,
+        },
+      ],
+    });
+    return {
+      providerId: input.providerId,
+      model: input.model,
+      ok: true,
+      replyPreview: reply.slice(0, 500),
+      checkedAt,
+      summary: `Provider smoke test succeeded for ${input.model}.`,
+    };
+  }
   if (hasTauri()) {
     return (await invoke("provider_smoke_test", input)) as ProviderSmokeTestResult;
   }
@@ -1635,6 +1673,20 @@ export const requestProviderSetupProbe = async (input: {
   runtimeNodeEndpoint?: string;
   authTier?: string;
 }): Promise<ProviderSetupProbeResult> => {
+  if (hasElectronHost()) {
+    const endpoint = input.runtimeNodeEndpoint ?? input.apiBaseUrl ?? "";
+    return {
+      providerId: input.providerId,
+      ok: false,
+      setupState: "adapter-pending",
+      discoveredModels: [],
+      endpoint,
+      checkedAt: new Date().toISOString(),
+      summary: "Electron setup probing is not implemented yet. Use Check Health or Test to verify this provider.",
+      detail: "Provider setup probing currently requires the Tauri host adapter; Electron can still run diagnostics and smoke tests.",
+      source: "unsupported-adapter",
+    };
+  }
   if (hasTauri()) {
     return (await invoke("provider_setup_probe", input)) as ProviderSetupProbeResult;
   }


### PR DESCRIPTION
Adds local OpenAI-compatible provider configuration and smoke-test scripts, package entries, env-driven Electron provider smoke input, Electron Settings smoke-test routing, and docs/LOCAL_PROVIDER_SMOKE.md. Setup probing now reports explicit adapter-pending status in Electron instead of appearing inert. Verified as part of the all-five local integration branch.