### PR TITLE
fix(archive): open main chat from living archive

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2950,6 +2950,23 @@ describe("App boot flow", () => {
     expect(screen.getByRole("button", { name: "Move chat back to the right" })).toBeTruthy();
   });
 
+  it("opens the main chat rail from Living Archive instead of toggling hidden archive chat layout", async () => {
+    const { container } = render(<App />);
+
+    expect((await screen.findAllByText("Launch your AI tools from one workbench.")).length).toBeGreaterThan(0);
+    fireEvent.click(screen.getAllByRole("button", { name: /Archive/i })[0]);
+    expect(await screen.findByText("Current memory configuration")).toBeTruthy();
+    expect(container.querySelector(".shell.chat-closed")).toBeTruthy();
+    expect(container.querySelector(".shell.center-chat-owner")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Chat" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open main chat" }));
+
+    await waitFor(() => expect(screen.getByText("Launch your AI tools from one workbench.")).toBeTruthy());
+    expect(container.querySelector(".shell.chat-open")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Move chat beside the launcher" })).toBeTruthy();
+  });
+
   it("detaches chat by opening the floating window and hiding the dashboard rail/history", async () => {
     const { container } = render(<App />);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -726,6 +726,11 @@ export function App() {
 
   const toggleWorkspaceLayout = () => {
     updateRuntimeState((draft) => {
+      if (currentSection === "archive" && !isFloatingChatSurface) {
+        draft.uiPreferences.activeSection = "overview";
+        draft.uiPreferences.chatSidebarOpen = true;
+        return draft;
+      }
       draft.uiPreferences.workspaceLayout = draft.uiPreferences.workspaceLayout === "chat-main" ? "main-chat" : "chat-main";
       draft.uiPreferences.chatSidebarOpen = true;
       return draft;
@@ -2062,7 +2067,7 @@ export function App() {
     <div className="app-zoom-viewport" style={zoomStyle}>
       <div className="app-zoom-stage">
         <div
-          className={`shell ${effectiveChatOpen ? "chat-open" : "chat-closed"} ${chatInterfaceAvailable ? "" : "chat-unavailable"} ${isFloatingChatSurface ? "floating-chat-surface" : ""} ${homeChatSurface ? "home-chat-surface" : ""} layout-${state.uiPreferences.workspaceLayout}`}
+          className={`shell ${effectiveChatOpen ? "chat-open" : "chat-closed"} ${chatInterfaceAvailable ? "" : "chat-unavailable"} ${isFloatingChatSurface ? "floating-chat-surface" : ""} ${homeChatSurface ? "home-chat-surface" : ""} ${centerWorkspaceOwnsAgentChat ? "center-chat-owner" : ""} layout-${state.uiPreferences.workspaceLayout}`}
           style={shellStyle}
         >
       <header className="system-topbar" aria-label="ResonantOS system bar">
@@ -2079,12 +2084,16 @@ export function App() {
             type="button"
             className="system-icon-button"
             title={
-              state.uiPreferences.workspaceLayout === "chat-main"
+              centerWorkspaceOwnsAgentChat
+                ? "Open main chat"
+                : state.uiPreferences.workspaceLayout === "chat-main"
                 ? "Move chat back to the right"
                 : "Move chat beside the launcher"
             }
             aria-label={
-              state.uiPreferences.workspaceLayout === "chat-main"
+              centerWorkspaceOwnsAgentChat
+                ? "Open main chat"
+                : state.uiPreferences.workspaceLayout === "chat-main"
                 ? "Move chat back to the right"
                 : "Move chat beside the launcher"
             }
@@ -2093,7 +2102,9 @@ export function App() {
           >
             <VendorIcon
               icon={
-                state.uiPreferences.workspaceLayout === "chat-main"
+                centerWorkspaceOwnsAgentChat
+                  ? "layout-sidebar-left-expand"
+                  : state.uiPreferences.workspaceLayout === "chat-main"
                   ? "layout-sidebar-right-collapse"
                   : "layout-sidebar-left-expand"
               }
@@ -2703,6 +2714,7 @@ export function App() {
       {chatInterfaceAvailable && (
       <StrategistChatRail
         isOpen={effectiveChatOpen}
+        showCollapsedToggle={!centerWorkspaceOwnsAgentChat}
         mode={recoveryModeActive ? "emergency" : "strategist"}
         title={activeChatAgentName}
         eyebrow={

--- a/src/modules/chat/StrategistChatRail.tsx
+++ b/src/modules/chat/StrategistChatRail.tsx
@@ -51,6 +51,7 @@ const supportsThinkingDepth = (model: string): boolean => model.startsWith("gpt-
 
 type StrategistChatRailProps = {
   isOpen: boolean;
+  showCollapsedToggle?: boolean;
   mode: "strategist" | "emergency";
   title: string;
   eyebrow: string;
@@ -502,6 +503,9 @@ export function StrategistChatRail(props: StrategistChatRailProps) {
   };
 
   if (!props.isOpen) {
+    if (props.showCollapsedToggle === false) {
+      return null;
+    }
     return (
       <aside className={`chat-sidebar closed ${props.mode === "emergency" ? "emergency" : ""}`}>
         <button type="button" className="chat-collapsed-toggle" onClick={props.onToggleSidebar}>

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -24,12 +24,20 @@
     grid-template-columns: 76px minmax(0, 1fr) 56px;
   }
 
+  .shell.center-chat-owner {
+    grid-template-columns: 76px minmax(0, 1fr);
+  }
+
   .shell.layout-chat-main {
     grid-template-columns: 76px minmax(320px, min(var(--chat-rail-width, 520px), 42vw)) minmax(0, 1fr);
   }
 
   .shell.layout-chat-main.chat-closed {
     grid-template-columns: 76px 56px minmax(0, 1fr);
+  }
+
+  .shell.layout-chat-main.center-chat-owner {
+    grid-template-columns: 76px minmax(0, 1fr);
   }
 
   .nav-item small {
@@ -85,6 +93,13 @@
     grid-template-areas:
       "topbar topbar topbar"
       "dock main chat";
+  }
+
+  .shell.center-chat-owner {
+    grid-template-columns: 76px minmax(0, 1fr);
+    grid-template-areas:
+      "topbar topbar"
+      "dock main";
   }
 
   .shell.home-chat-surface {

--- a/src/styles/shell.css
+++ b/src/styles/shell.css
@@ -33,6 +33,13 @@
   grid-template-columns: 76px minmax(0, 1fr) 60px;
 }
 
+.shell.center-chat-owner {
+  grid-template-columns: 76px minmax(0, 1fr);
+  grid-template-areas:
+    "topbar topbar"
+    "dock main";
+}
+
 .shell.chat-unavailable {
   grid-template-columns: 76px minmax(0, 1fr);
   grid-template-areas:
@@ -49,6 +56,13 @@
 
 .shell.layout-chat-main.chat-closed {
   grid-template-columns: 76px 60px minmax(0, 1fr);
+}
+
+.shell.layout-chat-main.center-chat-owner {
+  grid-template-columns: 76px minmax(0, 1fr);
+  grid-template-areas:
+    "topbar topbar"
+    "dock main";
 }
 
 .shell.layout-chat-main.chat-unavailable {


### PR DESCRIPTION
Makes Living Archive open the real main chat rail, suppresses the hidden collapsed chat handle/gutter when Archive owns the center chat surface, and adds focused App coverage. Verified manually and as part of the all-five local integration branch.