### PR TITLE
fix(chat): clear run state on failures

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -3952,7 +3952,10 @@ describe("App boot flow", () => {
   });
 
   it("shows string backend errors instead of collapsing them into a generic message", async () => {
-    requestProviderServiceChatCompletionMock.mockRejectedValue("You exceeded your current quota.");
+    requestProviderServiceChatCompletionMock
+      .mockRejectedValueOnce("You exceeded your current quota.")
+      .mockRejectedValueOnce("You exceeded your current quota.")
+      .mockResolvedValueOnce("Recovered after provider failure.");
 
     render(<App />);
 
@@ -3964,6 +3967,14 @@ describe("App boot flow", () => {
     fireEvent.click(screen.getAllByRole("button", { name: "Send message" })[0]);
 
     expect((await screen.findAllByText("You exceeded your current quota.")).length).toBeGreaterThan(0);
+
+    fireEvent.change(screen.getAllByPlaceholderText("Message Augmentor")[0], {
+      target: { value: "try again" },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: "Send message" })[0]);
+
+    expect(await screen.findByText("Recovered after provider failure.")).toBeTruthy();
+    expect(requestProviderServiceChatCompletionMock).toHaveBeenCalledTimes(3);
   });
 
   it("injects Living Archive context into Strategist chat turns", async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1280,30 +1280,33 @@ export function App() {
       setChatNotice("Stop the current response before sending a follow-up correction.");
       return;
     }
-    await executeChatTurn({
-      snapshot: { state, bundled, sideloaded },
-      activeThread,
-      composer,
-      attachments,
-      activeChatModel,
-      thinkingDepth,
-      overrideMessage,
-      commitReadyState,
-      setComposer,
-      setAttachments,
-      setChatNotice,
-      setChatBusy,
-      setChatRunPhase,
-      setChatRunEvents,
-      setAgentActivityLabel,
-      setProviderDiagnostics,
-      setRecoveryRuntimeStatus,
-      runToken,
-      isRunCurrent: (token) => activeChatRunTokenRef.current === token,
-      errorMessageOf,
-    });
-    if (releaseChatRun(activeChatRunTokenRef, runToken)) {
-      setChatRunPhase("idle");
+    try {
+      await executeChatTurn({
+        snapshot: { state, bundled, sideloaded },
+        activeThread,
+        composer,
+        attachments,
+        activeChatModel,
+        thinkingDepth,
+        overrideMessage,
+        commitReadyState,
+        setComposer,
+        setAttachments,
+        setChatNotice,
+        setChatBusy,
+        setChatRunPhase,
+        setChatRunEvents,
+        setAgentActivityLabel,
+        setProviderDiagnostics,
+        setRecoveryRuntimeStatus,
+        runToken,
+        isRunCurrent: (token) => activeChatRunTokenRef.current === token,
+        errorMessageOf,
+      });
+    } finally {
+      if (releaseChatRun(activeChatRunTokenRef, runToken)) {
+        setChatRunPhase("idle");
+      }
     }
   };
 
@@ -1366,31 +1369,34 @@ export function App() {
       return;
     }
 
-    await executeChatTurn({
-      snapshot: { state: stateWithThread, bundled, sideloaded },
-      activeThread: thread,
-      composer: "",
-      attachments: [],
-      activeChatModel,
-      thinkingDepth,
-      overrideMessage: message,
-      overrideContextPrompt: contextPrompt,
-      commitReadyState,
-      setComposer,
-      setAttachments,
-      setChatNotice,
-      setChatBusy,
-      setChatRunPhase,
-      setChatRunEvents,
-      setAgentActivityLabel,
-      setProviderDiagnostics,
-      setRecoveryRuntimeStatus,
-      runToken,
-      isRunCurrent: (token) => activeChatRunTokenRef.current === token,
-      errorMessageOf,
-    });
-    if (releaseChatRun(activeChatRunTokenRef, runToken)) {
-      setChatRunPhase("idle");
+    try {
+      await executeChatTurn({
+        snapshot: { state: stateWithThread, bundled, sideloaded },
+        activeThread: thread,
+        composer: "",
+        attachments: [],
+        activeChatModel,
+        thinkingDepth,
+        overrideMessage: message,
+        overrideContextPrompt: contextPrompt,
+        commitReadyState,
+        setComposer,
+        setAttachments,
+        setChatNotice,
+        setChatBusy,
+        setChatRunPhase,
+        setChatRunEvents,
+        setAgentActivityLabel,
+        setProviderDiagnostics,
+        setRecoveryRuntimeStatus,
+        runToken,
+        isRunCurrent: (token) => activeChatRunTokenRef.current === token,
+        errorMessageOf,
+      });
+    } finally {
+      if (releaseChatRun(activeChatRunTokenRef, runToken)) {
+        setChatRunPhase("idle");
+      }
     }
   };
 
@@ -1452,30 +1458,33 @@ export function App() {
       setChatNotice("Hermes is already working on a response. Please wait.");
       return;
     }
-    await executeChatTurn({
-      snapshot: { state: nextState, bundled, sideloaded },
-      activeThread: thread,
-      composer: "",
-      attachments: [],
-      activeChatModel,
-      thinkingDepth,
-      overrideMessage: buildArchivePreflightAugmentorPrompt(report),
-      commitReadyState,
-      setComposer,
-      setAttachments,
-      setChatNotice,
-      setChatBusy,
-      setChatRunPhase,
-      setChatRunEvents,
-      setAgentActivityLabel,
-      setProviderDiagnostics,
-      setRecoveryRuntimeStatus,
-      runToken,
-      isRunCurrent: (token) => activeChatRunTokenRef.current === token,
-      errorMessageOf,
-    });
-    if (releaseChatRun(activeChatRunTokenRef, runToken)) {
-      setChatRunPhase("idle");
+    try {
+      await executeChatTurn({
+        snapshot: { state: nextState, bundled, sideloaded },
+        activeThread: thread,
+        composer: "",
+        attachments: [],
+        activeChatModel,
+        thinkingDepth,
+        overrideMessage: buildArchivePreflightAugmentorPrompt(report),
+        commitReadyState,
+        setComposer,
+        setAttachments,
+        setChatNotice,
+        setChatBusy,
+        setChatRunPhase,
+        setChatRunEvents,
+        setAgentActivityLabel,
+        setProviderDiagnostics,
+        setRecoveryRuntimeStatus,
+        runToken,
+        isRunCurrent: (token) => activeChatRunTokenRef.current === token,
+        errorMessageOf,
+      });
+    } finally {
+      if (releaseChatRun(activeChatRunTokenRef, runToken)) {
+        setChatRunPhase("idle");
+      }
     }
   };
 

--- a/src/modules/archive/ArchiveMemoryOverview.tsx
+++ b/src/modules/archive/ArchiveMemoryOverview.tsx
@@ -141,23 +141,26 @@ export function ArchiveMemoryOverview({
       latestLibrary && shouldInspectImportedLibraryCoverage(message)
         ? await runCoverageInspection(latestLibrary)
         : null;
-    await onAskAugmentor(
-      message,
-      [
-        "Living Archive workspace context for this turn:",
-        "You are helping me configure the Living Archive in ResonantOS.",
-        "Do the work for me where possible. Ask only one necessary question at a time.",
-        "This conversation is happening inside the Living Archive workspace. Do not tell the user to move to the right chat rail.",
-        "Do not claim you will run a check, listing, scan, import, repair, or archive operation unless the host has already returned that result in this turn.",
-        "If host inspection results are supplied below, answer from those results and clearly separate imported, skipped, unsupported, and genuinely missing coverage.",
-        latestLibrary
-          ? `Current imported library: ${latestLibrary.libraryName} at ${latestLibrary.canonicalRoot}.`
-          : "No library is imported yet.",
-        `Recommended next action from the archive system: ${recommendedAction.title}. ${recommendedAction.description}`,
-        inspectionContext ? `\n${inspectionContext}` : "",
-      ].join("\n"),
-    );
-    setAgentStatus(null);
+    try {
+      await onAskAugmentor(
+        message,
+        [
+          "Living Archive workspace context for this turn:",
+          "You are helping me configure the Living Archive in ResonantOS.",
+          "Do the work for me where possible. Ask only one necessary question at a time.",
+          "This conversation is happening inside the Living Archive workspace. Do not tell the user to move to the right chat rail.",
+          "Do not claim you will run a check, listing, scan, import, repair, or archive operation unless the host has already returned that result in this turn.",
+          "If host inspection results are supplied below, answer from those results and clearly separate imported, skipped, unsupported, and genuinely missing coverage.",
+          latestLibrary
+            ? `Current imported library: ${latestLibrary.libraryName} at ${latestLibrary.canonicalRoot}.`
+            : "No library is imported yet.",
+          `Recommended next action from the archive system: ${recommendedAction.title}. ${recommendedAction.description}`,
+          inspectionContext ? `\n${inspectionContext}` : "",
+        ].join("\n"),
+      );
+    } finally {
+      setAgentStatus(null);
+    }
   };
   const runCoverageInspection = async (library: ArchiveImportedLibrarySummary): Promise<string> => {
     setAgentStatus(`Inspecting ${library.libraryName} folder coverage before Augmentor answers...`);


### PR DESCRIPTION
Ensures Strategist, Living Archive Agent, and archive preflight chat runs release active run state in failure paths, and clears archive agent status after failed Augmentor requests. Adds focused failure-path coverage. Verified as part of the all-five local integration branch.