### PR TITLE
subprocess: Move provider secrets and prompts off subprocess argv

### DIFF
--- a/src-tauri/src/audio2tol_service.rs
+++ b/src-tauri/src/audio2tol_service.rs
@@ -1364,6 +1364,56 @@ fn strip_think_blocks(content: &str) -> String {
     cleaned
 }
 
+/// Write a single `Authorization: Bearer <token>` header line to `path` with
+/// owner-only (0600) permissions on Unix so the credential is readable only by
+/// the current user and never appears on a child process argv.
+fn write_curl_header_file(path: &Path, api_key: &str) -> Result<(), String> {
+    let contents = format!("Authorization: Bearer {api_key}\n");
+    fs::write(path, contents.as_bytes())
+        .map_err(|error| format!("Could not write temporary LLM auth header: {error}"))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+            .map_err(|error| format!("Could not secure temporary LLM auth header: {error}"))?;
+    }
+    Ok(())
+}
+
+/// Build the curl `Command` for an LLM request. The Authorization header, when
+/// present, is referenced via `-H @<header_path>` so the bearer credential is
+/// never inlined as an argv value.
+fn build_curl_command(
+    url: &str,
+    payload_path: &Path,
+    response_path: &Path,
+    header_path: Option<&Path>,
+) -> Command {
+    let mut command = Command::new("curl");
+    command
+        .arg("-sS")
+        .arg("-L")
+        .arg("-o")
+        .arg(response_path)
+        .arg("-w")
+        .arg("%{http_code}")
+        .arg("--connect-timeout")
+        .arg("30")
+        .arg("--max-time")
+        .arg("300")
+        .arg(url)
+        .arg("-H")
+        .arg("Content-Type: application/json")
+        .arg("--data-binary")
+        .arg(format!("@{}", payload_path.display()));
+
+    if let Some(header_path) = header_path {
+        command.arg("-H").arg(format!("@{}", header_path.display()));
+    }
+
+    command
+}
+
 fn post_json_with_curl(
     url: &str,
     api_key: &str,
@@ -1391,34 +1441,34 @@ fn post_json_with_curl(
     )
     .map_err(|error| format!("Could not write temporary LLM payload: {error}"))?;
 
-    let mut command = Command::new("curl");
-    command
-        .arg("-sS")
-        .arg("-L")
-        .arg("-o")
-        .arg(&response_path)
-        .arg("-w")
-        .arg("%{http_code}")
-        .arg("--connect-timeout")
-        .arg("30")
-        .arg("--max-time")
-        .arg("300")
-        .arg(url)
-        .arg("-H")
-        .arg("Content-Type: application/json")
-        .arg("--data-binary")
-        .arg(format!("@{}", payload_path.display()));
+    // Keep the bearer credential off the child argv (visible via /proc, ps,
+    // shell history). curl reads extra headers from a file with `-H @file`, so
+    // we write the Authorization header to a 0600 temp file and reference it by
+    // path instead of inlining the secret as a command-line argument.
+    let header_path = if api_key.trim().is_empty() {
+        None
+    } else {
+        let header_path = std::env::temp_dir().join(format!(
+            "audio2tol-llm-header-{}-{}.txt",
+            std::process::id(),
+            chrono::Local::now()
+                .timestamp_nanos_opt()
+                .unwrap_or_default()
+        ));
+        write_curl_header_file(&header_path, api_key.trim())?;
+        Some(header_path)
+    };
 
-    if !api_key.trim().is_empty() {
-        command
-            .arg("-H")
-            .arg(format!("Authorization: Bearer {}", api_key.trim()));
-    }
+    let mut command =
+        build_curl_command(url, &payload_path, &response_path, header_path.as_deref());
 
     let output = command
         .output()
         .map_err(|error| format!("Could not start curl for LLM request: {error}"));
     let _ = fs::remove_file(&payload_path);
+    if let Some(header_path) = header_path.as_ref() {
+        let _ = fs::remove_file(header_path);
+    }
     let output = output?;
     let status_text = String::from_utf8_lossy(&output.stdout).trim().to_string();
     let response_body = fs::read_to_string(&response_path).unwrap_or_default();
@@ -1743,4 +1793,80 @@ fn scan_folder(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_curl_command, write_curl_header_file};
+    use std::path::Path;
+
+    /// Mirrors the no-argv-secret rule set: no argv value may contain an inline
+    /// `Authorization: Bearer` header shape. The bearer credential must travel
+    /// via a `-H @file` reference, never as a literal argv value.
+    #[test]
+    fn curl_command_keeps_bearer_off_argv() {
+        let secret = "sk-super-secret-token-value";
+        let payload_path = Path::new("/tmp/audio2tol-payload.json");
+        let response_path = Path::new("/tmp/audio2tol-response.json");
+        let header_path = std::env::temp_dir().join(format!(
+            "audio2tol-llm-header-test-{}.txt",
+            std::process::id()
+        ));
+        write_curl_header_file(&header_path, secret).expect("header file should be written");
+
+        let command = build_curl_command(
+            "https://example.test/v1",
+            payload_path,
+            response_path,
+            Some(&header_path),
+        );
+
+        let args: Vec<String> = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().to_string())
+            .collect();
+
+        assert!(
+            args.iter()
+                .all(|arg| !arg.contains("Authorization: Bearer")),
+            "curl argv must not inline the Authorization: Bearer header: {args:?}"
+        );
+        assert!(
+            args.iter().all(|arg| !arg.contains(secret)),
+            "curl argv must not contain the bearer token value: {args:?}"
+        );
+        assert!(
+            args.iter()
+                .any(|arg| arg == &format!("@{}", header_path.display())),
+            "curl argv must reference the header file via @path: {args:?}"
+        );
+
+        // The header file itself carries the credential.
+        let contents = std::fs::read_to_string(&header_path).expect("header file should be read");
+        assert!(contents.contains("Authorization: Bearer"));
+        assert!(contents.contains(secret));
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&header_path)
+                .expect("header file metadata should be read")
+                .permissions()
+                .mode();
+            assert_eq!(mode & 0o777, 0o600, "header file must be owner-only (0600)");
+        }
+        let _ = std::fs::remove_file(&header_path);
+    }
+
+    #[test]
+    fn curl_command_without_api_key_has_no_auth_header() {
+        let payload_path = Path::new("/tmp/audio2tol-payload.json");
+        let response_path = Path::new("/tmp/audio2tol-response.json");
+        let command =
+            build_curl_command("https://example.test/v1", payload_path, response_path, None);
+        let args: Vec<String> = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().to_string())
+            .collect();
+        assert!(args.iter().all(|arg| !arg.contains("Authorization")));
+    }
 }

--- a/src-tauri/src/provider_service.rs
+++ b/src-tauri/src/provider_service.rs
@@ -180,29 +180,58 @@ fn prompt_for_codex_subscription(
     Ok(sections.join("\n\n"))
 }
 
-fn execute_codex_subscription_chat_with_usage(
-    request: &ProviderServiceChatRequest,
-) -> Result<ProviderServiceChatResponse, String> {
-    let output_path = codex_output_path();
-    let prompt = prompt_for_codex_subscription(&request.system_prompt, &request.messages)?;
-    let output = codex_command_builder()
+/// Build the `codex exec` command for a subscription chat. The prompt argument
+/// is `-`, which tells codex to read the prompt from stdin, so the prompt text
+/// is never placed on the child argv.
+fn build_codex_exec_command(output_path: &Path, model: &str, reasoning_effort: &str) -> Command {
+    let mut command = codex_command_builder();
+    command
         .args([
             "exec",
             "--full-auto",
             "--skip-git-repo-check",
             "-m",
-            &request.model,
+            model,
             "-c",
-            &format!(
-                "model_reasoning_effort={}",
-                codex_reasoning_effort(&request.reasoning_effort)
-            ),
+            &format!("model_reasoning_effort={reasoning_effort}"),
             "-o",
         ])
-        .arg(&output_path)
-        .arg(prompt)
-        .stdin(Stdio::null())
-        .output()
+        .arg(output_path)
+        .arg("-");
+    command
+}
+
+fn execute_codex_subscription_chat_with_usage(
+    request: &ProviderServiceChatRequest,
+) -> Result<ProviderServiceChatResponse, String> {
+    let output_path = codex_output_path();
+    let prompt = prompt_for_codex_subscription(&request.system_prompt, &request.messages)?;
+    // Keep the full user prompt off the child argv (visible via /proc, ps,
+    // shell history). `codex exec` reads the prompt from stdin when the prompt
+    // argument is `-`, so we pipe the prompt instead of inlining it as an arg.
+    let mut command = build_codex_exec_command(
+        &output_path,
+        &request.model,
+        codex_reasoning_effort(&request.reasoning_effort),
+    );
+    let mut child = command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| format!("Failed to run Codex subscription provider: {error}"))?;
+    {
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| "Codex subscription stdin was not available.".to_string())?;
+        stdin
+            .write_all(prompt.as_bytes())
+            .map_err(|error| format!("Failed to send Codex subscription prompt: {error}"))?;
+        // Dropping stdin closes the pipe so codex sees EOF and starts work.
+    }
+    let output = child
+        .wait_with_output()
         .map_err(|error| format!("Failed to run Codex subscription provider: {error}"))?;
     let content = fs::read_to_string(&output_path).unwrap_or_default();
     let _ = fs::remove_file(&output_path);
@@ -2648,20 +2677,53 @@ pub(crate) async fn execute_archive_ingest_probe(
 #[cfg(test)]
 mod tests {
     use super::{
-        append_provider_request_audit_to_logs_root, audit_error_summary, endpoint_host,
-        ensure_runtime_kind_supported, extract_assistant_content, extract_cloud_usage,
-        extract_local_assistant_content, extract_local_usage, extract_ollama_tag_model_ids,
-        extract_openai_compatible_model_ids, filter_think_stream_delta, http_probe_outcome,
-        models_endpoint_for_openai_compatible, ollama_tags_endpoint, parse_ollama_model_names,
-        request_messages_with_system_prompt, resolve_local_runtime_model,
-        resolve_provider_base_url, resolve_provider_execution_adapter, sanitize_assistant_content,
-        sanitize_stream_delta, strip_think_blocks, ChatMessageInput, ProviderExecutionAdapter,
-        ProviderServiceChatRequest,
+        append_provider_request_audit_to_logs_root, audit_error_summary, build_codex_exec_command,
+        endpoint_host, ensure_runtime_kind_supported, extract_assistant_content,
+        extract_cloud_usage, extract_local_assistant_content, extract_local_usage,
+        extract_ollama_tag_model_ids, extract_openai_compatible_model_ids,
+        filter_think_stream_delta, http_probe_outcome, models_endpoint_for_openai_compatible,
+        ollama_tags_endpoint, parse_ollama_model_names, request_messages_with_system_prompt,
+        resolve_local_runtime_model, resolve_provider_base_url, resolve_provider_execution_adapter,
+        sanitize_assistant_content, sanitize_stream_delta, strip_think_blocks, ChatMessageInput,
+        ProviderExecutionAdapter, ProviderServiceChatRequest,
     };
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use serde_json::{json, Value};
+
+    /// Mirrors the no-argv-secret rule set: the codex prompt must not appear as
+    /// an argv value (it is piped via stdin, with `-` as the prompt marker).
+    #[test]
+    fn codex_exec_command_keeps_prompt_off_argv() {
+        let secret_prompt = "SECRET-USER-PROMPT-do-not-leak-on-argv";
+        let command = build_codex_exec_command(
+            std::path::Path::new("/tmp/codex-out.json"),
+            "gpt-test",
+            "high",
+        );
+        let args: Vec<String> = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().to_string())
+            .collect();
+        assert!(
+            args.iter().all(|arg| !arg.contains(secret_prompt)),
+            "codex argv must not contain the prompt text: {args:?}"
+        );
+        // The prompt position is the stdin marker, never inline prompt content.
+        assert_eq!(
+            args.last().map(String::as_str),
+            Some("-"),
+            "codex prompt argument must be the stdin marker `-`: {args:?}"
+        );
+        // No value flag carries the prompt inline.
+        for flag in ["-p", "--prompt", "-q"] {
+            assert!(
+                !args.iter().any(|arg| arg == flag),
+                "codex argv must not use an inline prompt flag {flag}: {args:?}"
+            );
+        }
+    }
 
     #[test]
     fn strips_minimax_thinking_blocks() {


### PR DESCRIPTION
### Fixes finding `F1` — subprocess argv disclosure, severity Medium (2 of 3 sites → fixed)

### What was wrong
Two confirmed secrets/prompts were passed on subprocess **argv**: the `audio2tol` `Authorization: Bearer <api_key>` header and the `codex` prompt.

### Why it matters
argv is world-readable to any local process via `ps` / `/proc/<pid>/cmdline` and persists in shell history / audit logs (CWE-214). Reachable by: any local process.

### The change
- `audio2tol_service.rs`: Bearer header written to a `0600` temp file, passed via `curl -H @file` (off argv).
- `provider_service.rs`: codex prompt piped via **stdin** instead of on the command line.
Breaking: none (behaviour preserved).

### Validation
`cargo fmt --check` clean; `cargo test --lib` — 3 argv-no-secret tests pass.

### Surface touched
`src-tauri/src/audio2tol_service.rs`, `src-tauri/src/provider_service.rs`

### Status / residual
F1 audio2tol + codex → **fixed**. The **hermes** site is deferred (its CLI has no stdin/file input) → tracked in **#161**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)