### PR TITLE
security: Add the security pipeline with supply-chain and runtime-hardening checks

### DIFF
--- a/.github/security-pipeline/checks.yml
+++ b/.github/security-pipeline/checks.yml
@@ -1,0 +1,66 @@
+{
+  "version": 1,
+  "families": {
+    "supply-chain": {
+      "status": "active",
+      "description": "Dependency, lockfile, registry, and CI workflow integrity checks."
+    },
+    "runtime-hardening": {
+      "status": "active",
+      "description": "Subprocess/runtime hardening: argv secrets, env scoping, pinned load roots, terminal command allowlist."
+    }
+  },
+  "checks": [
+    {
+      "id": "npm-lockfiles",
+      "family": "supply-chain",
+      "policy": "block",
+      "adapter": "npm-lockfiles",
+      "surfaces": [
+        ".",
+        "addons/resonant-browser-host",
+        "addons/resonant-browser-native"
+      ],
+      "lockfiles": [
+        "package-lock.json",
+        "npm-shrinkwrap.json"
+      ]
+    },
+    {
+      "id": "subprocess-no-argv-secret",
+      "family": "runtime-hardening",
+      "policy": "observe",
+      "adapter": "subprocess-no-argv-secret",
+      "surfaces": [
+        "src-tauri/src"
+      ]
+    },
+    {
+      "id": "subprocess-env-clear",
+      "family": "runtime-hardening",
+      "policy": "observe",
+      "adapter": "subprocess-env-clear",
+      "surfaces": [
+        "src-tauri/src"
+      ]
+    },
+    {
+      "id": "subprocess-pinned-roots",
+      "family": "runtime-hardening",
+      "policy": "observe",
+      "adapter": "subprocess-pinned-roots",
+      "surfaces": [
+        "src-tauri/src"
+      ]
+    },
+    {
+      "id": "subprocess-terminal-allowlist",
+      "family": "runtime-hardening",
+      "policy": "observe",
+      "adapter": "subprocess-terminal-allowlist",
+      "surfaces": [
+        "src-tauri/src"
+      ]
+    }
+  ]
+}

--- a/docs/security-pipeline/EXECUTION-PACK.md
+++ b/docs/security-pipeline/EXECUTION-PACK.md
@@ -1,0 +1,37 @@
+# Execution Pack: Security Pipeline MVP
+
+## Purpose
+
+Coordinate medium-complexity execution for the security pipeline MVP without executing implementation during Invoke.
+
+## Wave Order
+
+| Wave | Layer | Purpose | Contract |
+| --- | --- | --- | --- |
+| W0 | L0 | Establish registry, runner, and first adapter | [W0](work-pack/waves/W0-skeleton.md) |
+| W1 | L1 | Add supply-chain blocking checks and CI workflow | [W1](work-pack/waves/W1-supply-chain-mvp.md) |
+| W2 | L2 | Add lifecycle documentation and validation sync | [W2](work-pack/waves/W2-governance-readiness.md) |
+
+## Parallelization
+
+- TASK-SP-001 must complete before TASK-SP-002.
+- TASK-SP-002 must complete before adapter execution can be verified.
+- TASK-SP-003, TASK-SP-004, and TASK-SP-005 can share utility code after the runner exists.
+- TASK-SP-006 should wait until the workflow shape is clear enough to scan.
+- TASK-SP-007 and TASK-SP-008 should happen after the MVP behavior is known.
+
+## Gate Summary
+
+- W0 gate: one local registry-driven check runs successfully.
+- W1 gate: supply-chain checks are represented in CI and local runner commands.
+- W2 gate: lifecycle docs and validation evidence make future check additions repeatable.
+
+## Task Session Entry
+
+Recommended first SWU:
+
+```text
+SWU-SP-001
+```
+
+Reason: the registry is the smallest source artifact that proves the abstraction and unlocks runner implementation.

--- a/docs/security-pipeline/GLOSSARY-CONSISTENCY.md
+++ b/docs/security-pipeline/GLOSSARY-CONSISTENCY.md
@@ -1,0 +1,30 @@
+# Glossary Consistency Report
+
+## Status
+
+`pass` with non-blocker gaps.
+
+## Terms
+
+| Term | Meaning | Status |
+| --- | --- | --- |
+| Security Pipeline | Dedicated CI control plane for security checks. | stable |
+| Check Registry | Declarative config listing security checks and policies. | stable |
+| Check Adapter | Script or command that runs one check and emits normalized result evidence. | stable |
+| Check Family | Group of related checks, such as supply chain or secrets. | stable |
+| Policy Mode | Enforcement state: `observe`, `warn`, `block`, or `disabled`. | stable |
+| Supply Chain MVP | First check family focused on dependency, lockfile, registry, and CI-action compromise paths. | stable |
+| Result Envelope | Normalized output shape for each check. | candidate |
+| Security Control Plane | The combined workflow, registry, runner, and adapter contract. | candidate |
+
+## Consistency Notes
+
+- The previous phrase "supply-chain CI" is now narrowed to the MVP family, not the whole architecture.
+- "Pipeline" means security-only orchestration, not a replacement for `alpha-build.yml`.
+- "Check" means one discrete security verification unit. It should not secretly bundle unrelated policy decisions.
+- "Family" gives room to add or remove groups of checks without flattening every concern into one workflow.
+
+## Gaps
+
+- The final registry schema should become canonical only after the MVP implementation validates it.
+- Result envelope fields may change during the first runner implementation.

--- a/docs/security-pipeline/IMPLEMENTATION-LAYERING.md
+++ b/docs/security-pipeline/IMPLEMENTATION-LAYERING.md
@@ -1,0 +1,92 @@
+# Implementation Layering: Security Pipeline
+
+## Invoke Metadata
+
+- Mode: `plan`
+- Target artifact: ResonantOS modular security pipeline
+- Source design: `docs/security-pipeline/SECURITY-PIPELINE-DESIGN.md`
+- Mode contract: Arcanum plan mode
+- Complexity: medium
+
+## Layer Summary
+
+| Layer | Question | Output Boundary | Promotion Evidence |
+| --- | --- | --- | --- |
+| L0 Skeleton | Can the repo declare security checks and run one local adapter deterministically? | registry, runner, lockfile adapter | local registry validation and lockfile check pass |
+| L1 Supply Chain MVP | Can the pipeline block meaningful supply-chain risk? | npm, Rust, action-hardening, dependency-review checks | CI and local commands prove high-risk failures block |
+| L2 Governance | Can checks be added, removed, warned, observed, and promoted safely? | policy modes, docs, result envelope, disabled check handling | check lifecycle documented and tested |
+| L3 Release Integrity | Can security evidence connect to release artifacts? | SBOM/provenance/attestation hooks | deferred until MVP and alpha build boundary are stable |
+
+## L0: Skeleton
+
+Goal: prove the security control plane can read a registry, select enabled checks, and run one adapter without touching source code.
+
+Required outputs:
+
+- `.github/security-pipeline/checks.yml`
+- `scripts/security-pipeline/run-check.mjs`
+- `scripts/security-pipeline/checks/npm-lockfiles.mjs`
+
+Promotion evidence:
+
+- `node scripts/security-pipeline/run-check.mjs --list --config .github/security-pipeline/checks.yml`
+- `node scripts/security-pipeline/run-check.mjs --check npm-lockfiles --config .github/security-pipeline/checks.yml`
+- invalid registry fixture or malformed entry fails with a clear message
+
+## L1: Supply Chain MVP
+
+Goal: make the first security family useful enough for CI.
+
+Required outputs:
+
+- `npm-audit` adapter
+- `rust-audit` adapter
+- `actions-hardening` adapter
+- `.github/workflows/security.yml`
+- dependency review job on pull requests
+
+Promotion evidence:
+
+- npm checks use `npm ci --ignore-scripts` before audit.
+- `npm audit --audit-level=high` is run per dependency-bearing npm surface.
+- Rust advisory checks cover `src-tauri/Cargo.lock` and `crates/resonator-control/Cargo.lock`.
+- workflow hardening detects broad permissions, risky triggers, or unpinned third-party actions.
+- dependency review blocks high or critical vulnerable dependency changes on PRs.
+
+## L2: Governance
+
+Goal: make security checks maintainable after MVP.
+
+Required outputs:
+
+- documented policy lifecycle: `observe -> warn -> block -> disabled`
+- normalized result envelope
+- local validation command for each adapter
+- guidance for adding/removing checks
+
+Promotion evidence:
+
+- a disabled check is skipped without failing CI.
+- a `warn` check records a warning but does not fail.
+- a `block` check fails when its adapter returns failure.
+
+## L3: Release Integrity
+
+Goal: connect security evidence to packaged artifacts.
+
+Deferred outputs:
+
+- SBOM generation
+- artifact attestation hooks
+- provenance verification
+- release package integrity checks
+
+Deferral reason:
+
+The alpha build boundary and supply-chain MVP should stabilize first. GitHub artifact attestations and SBOM generation are release-adjacent controls, not required to prove the initial pipeline abstraction.
+
+## Layer Gates
+
+- Do not start L1 until L0 can list and run at least one check locally.
+- Do not promote `actions-hardening` to `block` until current workflow pinning expectations are explicitly decided.
+- Do not start L3 until the MVP pipeline is stable in CI and alpha packaging boundaries are documented.

--- a/docs/security-pipeline/SECURITY-PIPELINE-DESIGN.md
+++ b/docs/security-pipeline/SECURITY-PIPELINE-DESIGN.md
@@ -1,0 +1,278 @@
+# Security Pipeline Design
+
+## Invoke Metadata
+
+- Mode: `design`
+- Target artifact: ResonantOS modular security pipeline
+- Source refinement: internal design refinement artifacts, omitted from PR scope
+- Previous MVP refinement: internal MVP refinement artifacts, omitted from PR scope
+- Mode contract: Arcanum design mode
+- Status: `pass`
+
+## Template/Profile Selection
+
+Selected profile: architecture design bundle.
+
+Reason: the target is a repository feature architecture, not a spell or sigil lifecycle artifact. The design must provide the six required views and a plan-ready handoff without creating implementation tasks inside design mode.
+
+## 1. Context View
+
+ResonantOS needs a security-only CI control plane because its risk surface is broader than ordinary web app checks:
+
+- npm app dependencies
+- browser host add-on dependencies
+- Rust/Tauri host dependencies
+- Tauri IPC and capability boundaries
+- provider secrets
+- add-on manifests and grants
+- browser automation host controls
+- alpha packaging and artifact distribution
+
+The existing `alpha-build.yml` proves build/test/package behavior. The new security pipeline should complement it, not absorb it.
+
+## 2. High-Level Structure View
+
+```text
+GitHub event
+  -> security workflow
+    -> check registry
+      -> check family selection
+        -> check adapter runner
+          -> check adapters
+            -> normalized result
+    -> CI status and artifact summary
+```
+
+Primary parts:
+
+- `security workflow`: GitHub Actions entrypoint.
+- `check registry`: declarative list of checks.
+- `runner`: reads registry and executes enabled checks.
+- `adapters`: one check implementation each.
+- `result envelope`: stable output format for pass/fail/warn evidence.
+
+## 3. Low-Level Components View
+
+### Security Workflow
+
+Candidate path:
+
+```text
+.github/workflows/security.yml
+```
+
+Responsibilities:
+
+- run on `pull_request`, `push` to `dev`, and `workflow_dispatch`;
+- use least-privilege `permissions: contents: read`;
+- avoid secrets;
+- set up Node and Rust only where needed;
+- call the registry runner;
+- run GitHub-native dependency review on pull requests.
+
+### Check Registry
+
+Candidate path:
+
+```text
+.github/security-pipeline/checks.yml
+```
+
+Candidate shape:
+
+```yaml
+version: 1
+families:
+  supply-chain:
+    status: active
+checks:
+  - id: npm-lockfiles
+    family: supply-chain
+    policy: block
+    adapter: npm-lockfiles
+    surfaces:
+      - .
+      - addons/resonant-browser-host
+      - addons/resonant-browser-native
+```
+
+### Runner
+
+Candidate path:
+
+```text
+scripts/security-pipeline/run-check.mjs
+```
+
+Responsibilities:
+
+- load registry;
+- filter by family, id, or policy;
+- invoke one adapter at a time;
+- normalize pass, warn, block, skipped, and disabled outcomes;
+- fail only when an enabled check with `policy: block` fails.
+
+### Adapter Contract
+
+Each adapter should accept:
+
+```text
+--check <check-id>
+--config <registry-path>
+```
+
+Each adapter should emit:
+
+```json
+{
+  "checkId": "npm-audit",
+  "family": "supply-chain",
+  "status": "pass",
+  "policy": "block",
+  "summary": "3 npm surfaces audited",
+  "evidence": []
+}
+```
+
+### MVP Adapters
+
+- `npm-lockfiles`: validates dependency-bearing package surfaces have lockfiles.
+- `npm-audit`: runs `npm ci --ignore-scripts` and high-severity audit.
+- `rust-audit`: runs advisory checks for `src-tauri/Cargo.lock` and `crates/resonator-control/Cargo.lock`.
+- `actions-hardening`: checks workflow permission/triggers/action pinning policy.
+
+GitHub dependency review should remain a GitHub-native action job because it depends on pull request dependency diff context.
+
+## 4. Workflow Process View
+
+### Pull Request
+
+```text
+PR opened or updated
+  -> run security workflow
+  -> run registry checks
+  -> run dependency review
+  -> block only on policy:block failures
+  -> report warnings for observe/warn checks
+```
+
+### Push To Dev
+
+```text
+push to dev
+  -> run security workflow
+  -> run registry checks
+  -> skip dependency review if no PR diff context
+```
+
+### Add A Check
+
+```text
+create adapter
+  -> add registry entry
+  -> start at observe or warn unless deterministic enough for block
+  -> validate locally
+  -> promote to block after baseline is clean
+```
+
+### Remove Or Pause A Check
+
+```text
+set policy disabled
+  -> record reason in registry comment or adjacent note
+  -> keep adapter unless obsolete
+```
+
+## 5. Decision Flow View
+
+### Should A Check Block?
+
+```text
+Is the check deterministic?
+  no -> observe
+  yes -> Is the repo baseline clean?
+    no -> warn
+    yes -> Does failure indicate unacceptable risk?
+      yes -> block
+      no -> warn
+```
+
+### Should A Security Concern Become A Family?
+
+```text
+Does it contain multiple checks or surfaces?
+  yes -> family
+  no -> single check
+
+Does it need different policy timing than existing families?
+  yes -> family
+  no -> check under existing family
+```
+
+### Supply Chain MVP Decision
+
+Supply chain becomes the MVP because dependency install, Rust crates, GitHub Actions, and packaged desktop artifacts are close to the release path and can be checked deterministically.
+
+## 6. Dependency Interface View
+
+### External CI Interfaces
+
+- GitHub Actions workflow events and permissions.
+- GitHub dependency review action for PR dependency diffs.
+- npm registry and audit APIs.
+- RustSec advisory database through `cargo-audit`.
+- Optional later OpenSSF Scorecard.
+- Optional later GitHub artifact attestations.
+
+### Repo Interfaces
+
+- npm lockfiles and package manifests.
+- Rust lockfiles and Cargo manifests.
+- `.github/workflows/*.yml`.
+- future `.github/security-pipeline/checks.yml`.
+- future `scripts/security-pipeline/*`.
+
+### Security Boundary Rules
+
+- Security jobs should not receive repository secrets.
+- Audit/install jobs should prefer non-executing dependency materialization when possible.
+- Build/package jobs remain separate from security scan jobs.
+- Generated scan outputs must not contain raw secrets.
+- Check adapters must report evidence, not mutate source files.
+
+## Design Decisions
+
+| Decision | Outcome |
+| --- | --- |
+| Pipeline type | Security-only control plane, not a generic CI framework. |
+| Configuration | Registry-driven checks. |
+| MVP family | Supply chain. |
+| First workflow | Dedicated `security.yml`, separate from `alpha-build.yml`. |
+| Policy states | `observe`, `warn`, `block`, `disabled`. |
+| Promotion model | `observe -> warn -> block`. |
+| First hardening posture | No secrets, least privilege, no package lifecycle scripts during audit installs. |
+
+## Risks
+
+- Over-abstracting before the first workflow exists. Mitigation: MVP must implement only supply chain plus the minimal registry runner.
+- npm audit noise. Mitigation: start with high severity.
+- action SHA pinning churn. Mitigation: let `actions-hardening` begin as `warn` until cleanup is done.
+- cargo-audit tool installation trust. Mitigation: pin the tool version or use a pinned action only after action pinning policy is settled.
+- registry becoming stale. Mitigation: require every adapter to have a local dry run and a clear owner/family.
+
+## Unresolved Gaps
+
+- Exact scanner versions and pinning strategy.
+- Whether `addons/resonant-browser-native` should get a lockfile despite having no dependencies.
+- Whether to enforce full action SHA pinning in MVP or warn first.
+- Whether security results should be uploaded as artifacts in MVP.
+
+## Handoff To Plan
+
+Plan mode should convert this design into:
+
+- implementation layering,
+- one MVP work-pack,
+- explicit SWUs,
+- validation commands,
+- first task-session route.

--- a/docs/security-pipeline/WORK-PACK.md
+++ b/docs/security-pipeline/WORK-PACK.md
@@ -1,0 +1,116 @@
+# Work Pack: Security Pipeline MVP
+
+## Objective
+
+Implement the first ResonantOS security pipeline slice: a registry-driven CI control plane with supply-chain MVP checks.
+
+## Output Mode
+
+Split work-pack.
+
+Reason: medium complexity. The work spans GitHub Actions, registry configuration, a Node runner, multiple adapters, policy behavior, and validation.
+
+## Source Design Refs
+
+- `docs/security-pipeline/SECURITY-PIPELINE-DESIGN.md`
+- `docs/security-pipeline/IMPLEMENTATION-LAYERING.md`
+- Internal refinement artifacts are omitted from PR scope.
+
+## Target Source Paths
+
+Planned future implementation paths:
+
+- `.github/workflows/security.yml`
+- `.github/security-pipeline/checks.yml`
+- `scripts/security-pipeline/run-check.mjs`
+- `scripts/security-pipeline/checks/npm-lockfiles.mjs`
+- `scripts/security-pipeline/checks/npm-audit.mjs`
+- `scripts/security-pipeline/checks/rust-audit.mjs`
+- `scripts/security-pipeline/checks/actions-hardening.mjs`
+- optional `scripts/security-pipeline/lib/*.mjs`
+- optional `docs/security-pipeline.md`
+
+## Validation Strategy
+
+Run before declaring the L0 slice done:
+
+- `node scripts/security-pipeline/run-check.mjs --list --config .github/security-pipeline/checks.yml`
+- `node scripts/security-pipeline/run-check.mjs --check npm-lockfiles --config .github/security-pipeline/checks.yml`
+- `npm test`
+- `npm run build`
+
+Run the broader checks before declaring the full supply-chain MVP done:
+
+- `node scripts/security-pipeline/run-check.mjs --family supply-chain --config .github/security-pipeline/checks.yml`
+- `cargo fmt --check && cargo test` from `src-tauri`
+- YAML syntax check for `.github/workflows/security.yml`
+
+Security-tool validation:
+
+- npm audit adapters must use `npm ci --ignore-scripts` before `npm audit --audit-level=high`.
+- Rust audit adapter must run against both committed lockfiles.
+- action-hardening adapter must scan `.github/workflows/*.yml`.
+- dependency review must be PR-gated in the workflow.
+
+## Task Board
+
+| Task | Layer | Status | Contract |
+| --- | --- | --- | --- |
+| TASK-SP-001 | L0 | complete | [TASK-SP-001](work-pack/tasks/TASK-SP-001.md) |
+| TASK-SP-002 | L0 | complete | [TASK-SP-002](work-pack/tasks/TASK-SP-002.md) |
+| TASK-SP-003 | L0 | complete | [TASK-SP-003](work-pack/tasks/TASK-SP-003.md) |
+| TASK-SP-004 | L1 | ready | [TASK-SP-004](work-pack/tasks/TASK-SP-004.md) |
+| TASK-SP-005 | L1 | ready | [TASK-SP-005](work-pack/tasks/TASK-SP-005.md) |
+| TASK-SP-006 | L1 | ready | [TASK-SP-006](work-pack/tasks/TASK-SP-006.md) |
+| TASK-SP-007 | L2 | ready | [TASK-SP-007](work-pack/tasks/TASK-SP-007.md) |
+| TASK-SP-008 | L2 | ready | [TASK-SP-008](work-pack/tasks/TASK-SP-008.md) |
+
+## SWU Manifest
+
+| SWU | Parent Task | Layer | Goal | Verification |
+| --- | --- | --- | --- | --- |
+| SWU-SP-001 | TASK-SP-001 | L0 | Add registry schema and initial supply-chain entries | registry can be parsed and listed |
+| SWU-SP-002 | TASK-SP-002 | L0 | Add runner CLI with list/filter/execute behavior | list and check commands pass locally |
+| SWU-SP-003 | TASK-SP-003 | L0 | Add npm lockfile adapter | lockfile check passes on current surfaces |
+| SWU-SP-004 | TASK-SP-004 | L1 | Add npm audit adapter | audit command runs per lockfile surface |
+| SWU-SP-005 | TASK-SP-004 | L1 | Add Rust advisory adapter | Rust lockfile audit commands are wired |
+| SWU-SP-006 | TASK-SP-005 | L1 | Add actions hardening adapter | workflow scan reports current baseline |
+| SWU-SP-007 | TASK-SP-006 | L1 | Add `security.yml` workflow and dependency review job | workflow syntax and local runner commands pass |
+| SWU-SP-008 | TASK-SP-007 | L2 | Document add/remove/promote check lifecycle | docs explain policy modes and examples |
+| SWU-SP-009 | TASK-SP-008 | L2 | Run deterministic validation and sync result state | required checks recorded with pass/flag/block |
+
+## Execution Order
+
+1. W0 skeleton: TASK-SP-001, TASK-SP-002, TASK-SP-003.
+2. W1 supply-chain MVP: TASK-SP-004, TASK-SP-005, TASK-SP-006.
+3. W2 governance/readiness: TASK-SP-007, TASK-SP-008.
+
+## Current Blockers
+
+- SWU-SP-004 needs an explicit npm audit execution strategy before it can become a blocking CI check.
+- SWU-SP-005 needs a Rust advisory strategy and a pinned `cargo-audit` installation path or maintained action.
+- `actions-hardening` starts as `warn` unless the implementation also pins every current third-party action to full commit SHAs.
+
+## Handoff Rule
+
+Execute one SWU at a time. If a future task-session starts with a task but no SWU, select the first incomplete SWU for that task.
+
+## Execution Evidence
+
+### 2026-05-29 Task Session
+
+Completed:
+
+- `SWU-SP-001`: added `.github/security-pipeline/checks.yml`.
+- `SWU-SP-002`: added `scripts/security-pipeline/run-check.mjs`.
+- `SWU-SP-003`: added `scripts/security-pipeline/checks/npm-lockfiles.mjs`.
+
+Validation:
+
+- `node scripts/security-pipeline/run-check.mjs --list --config .github/security-pipeline/checks.yml` passed.
+- `node scripts/security-pipeline/run-check.mjs --check npm-lockfiles --config .github/security-pipeline/checks.yml` passed.
+- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('.github/security-pipeline/checks.yml','utf8'))"` passed.
+
+Blocked:
+
+- `SWU-SP-004`: the npm audit adapter needs an explicit execution strategy before promotion to a blocking CI check.

--- a/docs/security-pipeline/work-pack/tasks/TASK-SP-001.md
+++ b/docs/security-pipeline/work-pack/tasks/TASK-SP-001.md
@@ -1,0 +1,67 @@
+# TASK-SP-001: Define Security Check Registry
+
+## Objective
+
+Add the first declarative registry for security pipeline checks.
+
+## Parent Layer
+
+L0 Skeleton
+
+## Source Contracts
+
+- `docs/security-pipeline/SECURITY-PIPELINE-DESIGN.md`
+- `docs/security-pipeline/IMPLEMENTATION-LAYERING.md`
+
+## Write Scope
+
+- `.github/security-pipeline/checks.yml`
+
+## Implementation Detail
+
+Create a versioned YAML registry with:
+
+- top-level `version: 1`
+- `families` map with `supply-chain` active
+- `checks` list
+- each check containing `id`, `family`, `policy`, `adapter`, and check-specific inputs
+- policy values limited to `observe`, `warn`, `block`, `disabled`
+
+Initial L0 check entry:
+
+- `npm-lockfiles`
+
+Planned follow-up entries:
+
+- `npm-audit`
+- `rust-audit`
+- `actions-hardening`
+
+Keep `dependency-review` in workflow config rather than the adapter registry unless a future adapter can run it locally.
+
+## Smallest Working Units
+
+### SWU-SP-001
+
+- Goal: add `.github/security-pipeline/checks.yml` with the L0 supply-chain registry.
+- Dependencies: none.
+- Write scope: `.github/security-pipeline/checks.yml`.
+- Done criteria: registry includes active `supply-chain` family and the implemented L0 check entry.
+- Acceptance evidence: runner design can identify the implemented adapter by id and family.
+- Verification: later `node scripts/security-pipeline/run-check.mjs --list --config .github/security-pipeline/checks.yml`.
+- Execution owner: local-fallback.
+- Handoff note: keep schema minimal; do not invent non-MVP families as active checks.
+
+## Expected Result Shape
+
+```yaml
+swu_id: SWU-SP-001
+result: pass | flag | block | interrupted
+files_touched:
+  - .github/security-pipeline/checks.yml
+validation:
+  - registry list check or pending runner reason
+blockers:
+  - blocker or none
+handoff_note: next SWU readiness
+```

--- a/docs/security-pipeline/work-pack/tasks/TASK-SP-002.md
+++ b/docs/security-pipeline/work-pack/tasks/TASK-SP-002.md
@@ -1,0 +1,59 @@
+# TASK-SP-002: Build Registry Runner
+
+## Objective
+
+Add a Node-based runner that reads the check registry, lists checks, filters checks, executes adapters, and normalizes results.
+
+## Parent Layer
+
+L0 Skeleton
+
+## Source Contracts
+
+- `docs/security-pipeline/SECURITY-PIPELINE-DESIGN.md`
+- `docs/security-pipeline/WORK-PACK.md`
+
+## Write Scope
+
+- `scripts/security-pipeline/run-check.mjs`
+- optional `scripts/security-pipeline/lib/*.mjs`
+
+## Implementation Detail
+
+Runner behavior:
+
+1. Parse CLI flags: `--config`, `--list`, `--check`, `--family`.
+2. Load YAML registry. Use a dependency only if already available or intentionally added; otherwise implement a minimal parser strategy or use JSON-compatible YAML shape.
+3. Validate registry fields and policy values.
+4. For `--list`, print active checks with family and policy.
+5. For execution, resolve adapters under `scripts/security-pipeline/checks/`.
+6. Execute adapters one at a time.
+7. Normalize each adapter result to `pass`, `warn`, `fail`, `skipped`, or `disabled`.
+8. Exit nonzero only when a `policy: block` check fails or registry validation fails.
+
+## Smallest Working Units
+
+### SWU-SP-002
+
+- Goal: add runner CLI and registry validation.
+- Dependencies: SWU-SP-001.
+- Write scope: `scripts/security-pipeline/run-check.mjs`, optional `scripts/security-pipeline/lib/*.mjs`.
+- Done criteria: runner lists registry checks and fails clearly on invalid config.
+- Acceptance evidence: `--list` command output.
+- Verification: `node scripts/security-pipeline/run-check.mjs --list --config .github/security-pipeline/checks.yml`.
+- Execution owner: local-fallback.
+- Handoff note: keep adapter execution simple; avoid building a general task framework.
+
+## Expected Result Shape
+
+```yaml
+swu_id: SWU-SP-002
+result: pass | flag | block | interrupted
+files_touched:
+  - scripts/security-pipeline/run-check.mjs
+validation:
+  - node scripts/security-pipeline/run-check.mjs --list --config .github/security-pipeline/checks.yml
+blockers:
+  - blocker or none
+handoff_note: adapter contract status
+```

--- a/docs/security-pipeline/work-pack/tasks/TASK-SP-003.md
+++ b/docs/security-pipeline/work-pack/tasks/TASK-SP-003.md
@@ -1,0 +1,67 @@
+# TASK-SP-003: Add Npm Lockfile Adapter
+
+## Objective
+
+Add the first real check adapter: verify dependency-bearing npm package surfaces have committed lockfiles.
+
+## Parent Layer
+
+L0 Skeleton
+
+## Source Contracts
+
+- `docs/security-pipeline/SECURITY-PIPELINE-DESIGN.md`
+- `.github/security-pipeline/checks.yml`
+
+## Write Scope
+
+- `scripts/security-pipeline/checks/npm-lockfiles.mjs`
+- optional shared result utility
+
+## Implementation Detail
+
+Algorithm:
+
+1. Read the registry entry for `npm-lockfiles`.
+2. For each configured surface, read `package.json`.
+3. Determine whether `dependencies` or `devDependencies` contain entries.
+4. If dependencies exist, require one supported lockfile.
+5. Treat a package with no dependencies as pass even if it has no lockfile.
+6. Emit a normalized result with per-surface evidence.
+
+Current expected surfaces:
+
+- `.`
+- `addons/resonant-browser-host`
+- `addons/resonant-browser-native`
+
+Edge case:
+
+- `addons/resonant-browser-native` has scripts but no dependencies. It should pass lockfile presence unless dependencies are later added.
+
+## Smallest Working Units
+
+### SWU-SP-003
+
+- Goal: implement and verify `npm-lockfiles`.
+- Dependencies: SWU-SP-001, SWU-SP-002.
+- Write scope: `scripts/security-pipeline/checks/npm-lockfiles.mjs`.
+- Done criteria: adapter emits pass/fail evidence per npm surface.
+- Acceptance evidence: current repo surfaces pass with native add-on skip/pass rationale.
+- Verification: `node scripts/security-pipeline/run-check.mjs --check npm-lockfiles --config .github/security-pipeline/checks.yml`.
+- Execution owner: local-fallback.
+- Handoff note: do not fail merely because a package has scripts; fail when dependency entries lack lockfiles.
+
+## Expected Result Shape
+
+```yaml
+swu_id: SWU-SP-003
+result: pass | flag | block | interrupted
+files_touched:
+  - scripts/security-pipeline/checks/npm-lockfiles.mjs
+validation:
+  - node scripts/security-pipeline/run-check.mjs --check npm-lockfiles --config .github/security-pipeline/checks.yml
+blockers:
+  - blocker or none
+handoff_note: surfaces with missing lockfiles or skip rationale
+```

--- a/docs/security-pipeline/work-pack/tasks/TASK-SP-004.md
+++ b/docs/security-pipeline/work-pack/tasks/TASK-SP-004.md
@@ -1,0 +1,76 @@
+# TASK-SP-004: Add Dependency Audit Adapters
+
+## Objective
+
+Add supply-chain audit adapters for npm and Rust lockfile vulnerabilities.
+
+## Parent Layer
+
+L1 Supply Chain MVP
+
+## Source Contracts
+
+- `docs/security-pipeline/SECURITY-PIPELINE-DESIGN.md`
+- `docs/security-pipeline/IMPLEMENTATION-LAYERING.md`
+
+## Write Scope
+
+- `scripts/security-pipeline/checks/npm-audit.mjs`
+- `scripts/security-pipeline/checks/rust-audit.mjs`
+- optional shared process/result utilities
+
+## Implementation Detail
+
+`npm-audit` algorithm:
+
+1. Read configured npm surfaces.
+2. For each dependency-bearing surface with lockfile, run `npm ci --ignore-scripts`.
+3. Run `npm audit --audit-level=high`.
+4. Preserve per-surface command, exit code, and summary.
+5. Fail only according to registry policy.
+
+`rust-audit` algorithm:
+
+1. Read configured Rust lockfile paths.
+2. Run a pinned or explicitly documented `cargo-audit` invocation against each lockfile.
+3. Preserve advisory summary and command evidence.
+4. Fail on vulnerable advisory findings according to policy.
+
+## Smallest Working Units
+
+### SWU-SP-004
+
+- Goal: implement `npm-audit`.
+- Dependencies: SWU-SP-002, SWU-SP-003.
+- Write scope: `scripts/security-pipeline/checks/npm-audit.mjs`.
+- Done criteria: adapter runs audit per configured npm surface.
+- Acceptance evidence: commands include `npm ci --ignore-scripts` and `npm audit --audit-level=high`.
+- Verification: `node scripts/security-pipeline/run-check.mjs --check npm-audit --config .github/security-pipeline/checks.yml`.
+- Execution owner: local-fallback.
+- Handoff note: avoid executing dependency lifecycle scripts in audit install phase.
+
+### SWU-SP-005
+
+- Goal: implement `rust-audit`.
+- Dependencies: SWU-SP-002.
+- Write scope: `scripts/security-pipeline/checks/rust-audit.mjs`.
+- Done criteria: adapter checks both committed Rust lockfiles.
+- Acceptance evidence: command covers `src-tauri/Cargo.lock` and `crates/resonator-control/Cargo.lock`.
+- Verification: `node scripts/security-pipeline/run-check.mjs --check rust-audit --config .github/security-pipeline/checks.yml`.
+- Execution owner: local-fallback.
+- Handoff note: pin or document cargo-audit installation strategy before CI enforcement.
+
+## Expected Result Shape
+
+```yaml
+swu_id: SWU-SP-004 | SWU-SP-005
+result: pass | flag | block | interrupted
+files_touched:
+  - scripts/security-pipeline/checks/npm-audit.mjs
+  - scripts/security-pipeline/checks/rust-audit.mjs
+validation:
+  - relevant runner command and result
+blockers:
+  - blocker or none
+handoff_note: audit findings and tool-install status
+```

--- a/docs/security-pipeline/work-pack/tasks/TASK-SP-005.md
+++ b/docs/security-pipeline/work-pack/tasks/TASK-SP-005.md
@@ -1,0 +1,60 @@
+# TASK-SP-005: Add Actions Hardening Adapter
+
+## Objective
+
+Add a workflow hardening adapter that scans GitHub Actions workflows for baseline CI security policy.
+
+## Parent Layer
+
+L1 Supply Chain MVP
+
+## Source Contracts
+
+- `docs/security-pipeline/SECURITY-PIPELINE-DESIGN.md`
+- `.github/workflows/alpha-build.yml`
+
+## Write Scope
+
+- `scripts/security-pipeline/checks/actions-hardening.mjs`
+
+## Implementation Detail
+
+Checks:
+
+1. Workflows should declare least-privilege top-level permissions where practical.
+2. `pull_request_target` should not be used for untrusted code paths.
+3. Third-party actions should be pinned to full commit SHAs when policy is `block`.
+4. Jobs that install dependencies should not receive secrets.
+5. Risky event-context interpolation in shell scripts should be flagged if detected.
+
+Policy:
+
+- Start as `warn` unless implementation also pins existing workflow actions.
+- Promote to `block` after baseline cleanup.
+
+## Smallest Working Units
+
+### SWU-SP-006
+
+- Goal: implement `actions-hardening` adapter.
+- Dependencies: SWU-SP-002.
+- Write scope: `scripts/security-pipeline/checks/actions-hardening.mjs`.
+- Done criteria: adapter scans `.github/workflows/*.yml` and emits warning/failure evidence.
+- Acceptance evidence: current `alpha-build.yml` baseline is reported without crashing.
+- Verification: `node scripts/security-pipeline/run-check.mjs --check actions-hardening --config .github/security-pipeline/checks.yml`.
+- Execution owner: local-fallback.
+- Handoff note: keep initial enforcement at `warn` unless action SHA pinning is completed in the same implementation slice.
+
+## Expected Result Shape
+
+```yaml
+swu_id: SWU-SP-006
+result: pass | flag | block | interrupted
+files_touched:
+  - scripts/security-pipeline/checks/actions-hardening.mjs
+validation:
+  - node scripts/security-pipeline/run-check.mjs --check actions-hardening --config .github/security-pipeline/checks.yml
+blockers:
+  - blocker or none
+handoff_note: hardening findings and whether policy can promote
+```

--- a/docs/security-pipeline/work-pack/tasks/TASK-SP-006.md
+++ b/docs/security-pipeline/work-pack/tasks/TASK-SP-006.md
@@ -1,0 +1,64 @@
+# TASK-SP-006: Add Security Workflow
+
+## Objective
+
+Add the GitHub Actions workflow that runs the security pipeline and PR dependency review.
+
+## Parent Layer
+
+L1 Supply Chain MVP
+
+## Source Contracts
+
+- `docs/security-pipeline/SECURITY-PIPELINE-DESIGN.md`
+- `docs/security-pipeline/WORK-PACK.md`
+
+## Write Scope
+
+- `.github/workflows/security.yml`
+
+## Implementation Detail
+
+Workflow behavior:
+
+- Trigger on pull requests to `dev` and `main`.
+- Trigger on pushes to `dev`.
+- Support `workflow_dispatch`.
+- Set top-level `permissions: contents: read`.
+- Run registry-driven supply-chain checks.
+- Run GitHub dependency review only for pull requests.
+- Avoid secrets in security jobs.
+- Keep alpha packaging in `alpha-build.yml`.
+
+Use separate jobs if it improves isolation:
+
+- `security-pipeline`
+- `dependency-review`
+
+## Smallest Working Units
+
+### SWU-SP-007
+
+- Goal: add `.github/workflows/security.yml`.
+- Dependencies: SWU-SP-001 through SWU-SP-006.
+- Write scope: `.github/workflows/security.yml`.
+- Done criteria: workflow runs local runner family command and PR dependency review.
+- Acceptance evidence: YAML syntax check and local runner command pass.
+- Verification: YAML syntax check, plus `node scripts/security-pipeline/run-check.mjs --family supply-chain --config .github/security-pipeline/checks.yml`.
+- Execution owner: local-fallback.
+- Handoff note: do not add packaging or release attestations to this MVP workflow.
+
+## Expected Result Shape
+
+```yaml
+swu_id: SWU-SP-007
+result: pass | flag | block | interrupted
+files_touched:
+  - .github/workflows/security.yml
+validation:
+  - yaml syntax check
+  - node scripts/security-pipeline/run-check.mjs --family supply-chain --config .github/security-pipeline/checks.yml
+blockers:
+  - blocker or none
+handoff_note: CI readiness and dependency-review status
+```

--- a/docs/security-pipeline/work-pack/tasks/TASK-SP-007.md
+++ b/docs/security-pipeline/work-pack/tasks/TASK-SP-007.md
@@ -1,0 +1,58 @@
+# TASK-SP-007: Document Check Lifecycle
+
+## Objective
+
+Document how to add, remove, disable, warn, observe, and promote security checks.
+
+## Parent Layer
+
+L2 Governance
+
+## Source Contracts
+
+- `docs/security-pipeline/GLOSSARY-CONSISTENCY.md`
+- `docs/security-pipeline/SECURITY-PIPELINE-DESIGN.md`
+
+## Write Scope
+
+- optional `docs/security-pipeline.md`
+- optional comments in `.github/security-pipeline/checks.yml`
+
+## Implementation Detail
+
+Document:
+
+- check families
+- registry fields
+- policy modes
+- promotion lifecycle: `observe -> warn -> block`
+- disable/removal expectations
+- validation command per adapter
+- when to create a new family versus a check
+
+## Smallest Working Units
+
+### SWU-SP-008
+
+- Goal: add security pipeline lifecycle docs.
+- Dependencies: SWU-SP-001 through SWU-SP-007.
+- Write scope: optional `docs/security-pipeline.md`, optional registry comments.
+- Done criteria: docs explain adding and removing checks without editing workflow internals.
+- Acceptance evidence: docs include one add-check and one disable-check example.
+- Verification: reviewable check against docs.
+- Execution owner: local-fallback.
+- Handoff note: keep docs concise and tied to actual implemented paths.
+
+## Expected Result Shape
+
+```yaml
+swu_id: SWU-SP-008
+result: pass | flag | block | interrupted
+files_touched:
+  - docs/security-pipeline.md
+validation:
+  - reviewable documentation check
+blockers:
+  - blocker or none
+handoff_note: lifecycle clarity and remaining doc gaps
+```

--- a/docs/security-pipeline/work-pack/tasks/TASK-SP-008.md
+++ b/docs/security-pipeline/work-pack/tasks/TASK-SP-008.md
@@ -1,0 +1,65 @@
+# TASK-SP-008: Validate And Synchronize Work-Pack State
+
+## Objective
+
+Run deterministic validation and sync the work-pack state after implementation.
+
+## Parent Layer
+
+L2 Governance
+
+## Source Contracts
+
+- `AGENTS.md`
+- `docs/security-pipeline/WORK-PACK.md`
+
+## Write Scope
+
+- `docs/security-pipeline/WORK-PACK.md`
+- optional `docs/security-pipeline/VALIDATION-REPORT.md`
+
+## Implementation Detail
+
+Validation commands:
+
+1. `node scripts/security-pipeline/run-check.mjs --list --config .github/security-pipeline/checks.yml`
+2. `node scripts/security-pipeline/run-check.mjs --family supply-chain --config .github/security-pipeline/checks.yml`
+3. `npm test -- --run`
+4. `npm run build`
+5. `cargo fmt --check && cargo test` from `src-tauri`
+6. YAML syntax check for `.github/workflows/security.yml`
+
+Record:
+
+- commands run
+- pass/flag/block result
+- remaining gaps
+- whether first task-session route is complete
+
+## Smallest Working Units
+
+### SWU-SP-009
+
+- Goal: validate and synchronize plan state.
+- Dependencies: SWU-SP-001 through SWU-SP-008.
+- Write scope: `docs/security-pipeline/WORK-PACK.md`, optional validation report.
+- Done criteria: validation results are recorded and next route is clear.
+- Acceptance evidence: command results or exact blocked reasons.
+- Verification: reviewable validation report.
+- Execution owner: local-fallback.
+- Handoff note: this SWU closes the MVP implementation slice, not the broader L3 release-integrity track.
+
+## Expected Result Shape
+
+```yaml
+swu_id: SWU-SP-009
+result: pass | flag | block | interrupted
+files_touched:
+  - docs/security-pipeline/WORK-PACK.md
+  - docs/security-pipeline/VALIDATION-REPORT.md
+validation:
+  - command results or blocked reasons
+blockers:
+  - blocker or none
+handoff_note: MVP readiness and next deferred layer
+```

--- a/docs/security-pipeline/work-pack/waves/W0-skeleton.md
+++ b/docs/security-pipeline/work-pack/waves/W0-skeleton.md
@@ -1,0 +1,25 @@
+# Wave W0: Skeleton
+
+## Layer
+
+L0 Skeleton
+
+## Layer Question
+
+Can the repo declare security checks and run one local adapter deterministically?
+
+## Tasks
+
+- [TASK-SP-001](../tasks/TASK-SP-001.md)
+- [TASK-SP-002](../tasks/TASK-SP-002.md)
+- [TASK-SP-003](../tasks/TASK-SP-003.md)
+
+## Promotion Evidence
+
+- registry parses and lists checks
+- disabled checks are skipped
+- one adapter runs locally and emits normalized output
+
+## Gate
+
+Do not enter W1 until `SWU-SP-001`, `SWU-SP-002`, and `SWU-SP-003` are complete.

--- a/docs/security-pipeline/work-pack/waves/W1-supply-chain-mvp.md
+++ b/docs/security-pipeline/work-pack/waves/W1-supply-chain-mvp.md
@@ -1,0 +1,27 @@
+# Wave W1: Supply Chain MVP
+
+## Layer
+
+L1 Supply Chain MVP
+
+## Layer Question
+
+Can the pipeline block meaningful supply-chain risk before alpha packaging?
+
+## Tasks
+
+- [TASK-SP-004](../tasks/TASK-SP-004.md)
+- [TASK-SP-005](../tasks/TASK-SP-005.md)
+- [TASK-SP-006](../tasks/TASK-SP-006.md)
+
+## Promotion Evidence
+
+- npm dependency checks run per configured surface
+- Rust advisory checks run per configured lockfile
+- GitHub Actions hardening reports baseline
+- security workflow runs the registry-driven checks
+- dependency review is PR-gated
+
+## Gate
+
+Do not promote the MVP until local runner commands and workflow syntax checks pass.

--- a/docs/security-pipeline/work-pack/waves/W2-governance-readiness.md
+++ b/docs/security-pipeline/work-pack/waves/W2-governance-readiness.md
@@ -1,0 +1,25 @@
+# Wave W2: Governance Readiness
+
+## Layer
+
+L2 Governance
+
+## Layer Question
+
+Can future security checks be added, removed, warned, observed, and promoted safely?
+
+## Tasks
+
+- [TASK-SP-007](../tasks/TASK-SP-007.md)
+- [TASK-SP-008](../tasks/TASK-SP-008.md)
+
+## Promotion Evidence
+
+- policy lifecycle is documented
+- one add/remove example exists
+- validation state is recorded
+- next route to release-integrity L3 is explicit but deferred
+
+## Gate
+
+Do not start L3 release integrity until the MVP security pipeline is stable in CI.

--- a/scripts/security-pipeline/checks/lib/adapter-util.mjs
+++ b/scripts/security-pipeline/checks/lib/adapter-util.mjs
@@ -1,0 +1,116 @@
+// Shared helpers for subprocess security-pipeline adapters.
+//
+// Adapters wrap a research "core" (check(record) -> { result, evidence[] }) into
+// the run-check.mjs contract: run({check, repoRoot}) -> { status, summary, evidence[] }.
+//
+// Verdict mapping (uniform across Stream B):
+//   pass        -> pass
+//   flag        -> warn
+//   block       -> fail
+//   throw / no surface -> skipped
+//
+// Dependency-free. No runtime import from .craft/.
+
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+const CORE_TO_STATUS = new Map([
+  ["pass", "pass"],
+  ["flag", "warn"],
+  ["block", "fail"],
+]);
+
+export function mapVerdict(coreResult) {
+  return CORE_TO_STATUS.get(coreResult) ?? "fail";
+}
+
+// Resolve the configured surfaces against repoRoot. Returns the set of surfaces
+// that actually exist on disk. An absent surface => the adapter reports skipped.
+export function resolveSurfaces(check, repoRoot) {
+  const surfaces = Array.isArray(check?.surfaces) ? check.surfaces : [];
+  const present = [];
+  const missing = [];
+  for (const surface of surfaces) {
+    const abs = path.resolve(repoRoot, surface);
+    if (existsSync(abs)) present.push({ surface, abs });
+    else missing.push(surface);
+  }
+  return { surfaces, present, missing };
+}
+
+// Spawn descriptors for a check come from `check.records` (config- or
+// test-injected, the deterministic input the cores were designed around). When a
+// surface is present but no descriptors are supplied, the adapter has nothing to
+// score on this run and reports skipped (surface present, no observations).
+export function collectRecords(check) {
+  return Array.isArray(check?.records) ? check.records : [];
+}
+
+// Run a core over a set of records and fold into the adapter contract.
+//   core: (record) => { result: "pass"|"flag"|"block", evidence?, ... }
+export function runCore({ check, repoRoot, core, label }) {
+  const { surfaces, present, missing } = resolveSurfaces(check, repoRoot);
+
+  if (present.length === 0) {
+    return {
+      status: "skipped",
+      summary:
+        surfaces.length === 0
+          ? `${label}: no surfaces configured.`
+          : `${label}: configured surface(s) absent (${missing.join(", ")}); nothing to scan.`,
+      evidence: [],
+    };
+  }
+
+  const records = collectRecords(check);
+  if (records.length === 0) {
+    return {
+      status: "skipped",
+      summary: `${label}: surface present (${present
+        .map((p) => p.surface)
+        .join(", ")}) but no spawn descriptors supplied; no observations.`,
+      evidence: [],
+    };
+  }
+
+  const evidence = [];
+  let worst = "pass"; // pass < warn < fail
+  const rank = { pass: 0, warn: 1, fail: 2 };
+  let blocked = 0;
+  let flagged = 0;
+
+  for (const record of records) {
+    let out;
+    try {
+      out = core(record);
+    } catch (error) {
+      // A throwing core => skipped contribution for that record, recorded as evidence.
+      evidence.push({
+        site: record?.site ?? "<unknown-site>",
+        status: "skipped",
+        reason: `core threw: ${error.message}`,
+      });
+      continue;
+    }
+    const status = mapVerdict(out?.result);
+    if (rank[status] > rank[worst]) worst = status;
+    if (status === "fail") blocked += 1;
+    if (status === "warn") flagged += 1;
+    evidence.push({
+      site: out?.site ?? record?.site ?? "<unknown-site>",
+      status,
+      verdict: out?.result,
+      findings: Array.isArray(out?.evidence) ? out.evidence : [],
+      recommendation: out?.recommendation ?? null,
+    });
+  }
+
+  const summary =
+    worst === "fail"
+      ? `${label}: ${blocked} blocking finding(s) across ${records.length} descriptor(s).`
+      : worst === "warn"
+        ? `${label}: ${flagged} warning(s) across ${records.length} descriptor(s).`
+        : `${label}: ${records.length} descriptor(s) clean.`;
+
+  return { status: worst, summary, evidence };
+}

--- a/scripts/security-pipeline/checks/lib/env-clear.mjs
+++ b/scripts/security-pipeline/checks/lib/env-clear.mjs
@@ -1,0 +1,121 @@
+// env-clear-present core (ported in-tree from research p0-invoke/checks/subprocess).
+//
+// check(spawnRecord) -> { result: "pass" | "block", site, runtime, evidence[], recommendation }
+//
+// `spawnRecord` describes one agent-runtime spawn site:
+//   { site, runtime, env_clear, env_remove[], env_vars[], opt_in_vars[], opt_in }
+//
+// Algorithm:
+//   1. Resolve runtime allowlist = base_allow + runtimes.<runtime>.allow.
+//   2. env_clear === false AND env_vars empty => blanket inheritance => BLOCK.
+//   3. env_vars non-empty but env_clear === false => missing clear => BLOCK.
+//   4. env_clear === true and an injected var is outside the allowlist (and not
+//      an opt-in var) => BLOCK.
+//   5. Otherwise PASS.
+//
+// The per-runtime env allowlist is inlined here (ported from env-allowlist.yml)
+// so this is dependency-free with no external YAML file. No runtime .craft import.
+
+const RECOMMENDATION =
+  "Call .env_clear() (or build the Command from an empty env) BEFORE any " +
+  ".env()/.envs() injection, then re-inject ONLY this runtime's allowlisted " +
+  "vars. Pin PATH to fixed roots; do not append the ambient PATH. Extra vars " +
+  "require the documented --allow-env opt-in.";
+
+export const ALLOWLIST = {
+  opt_in_flag: "--allow-env",
+  base_allow: ["HOME", "PATH", "LANG", "LC_ALL", "TMPDIR"],
+  runtimes: {
+    hermes: { allow: ["HERMES_HOME"] },
+    opencode: { allow: [] },
+    codex: { allow: ["PATH", "CODEX_HOME"] },
+    ollama: { allow: ["OLLAMA_HOST", "OLLAMA_MODELS"] },
+    memory: { allow: [] },
+    "browser-host": { allow: ["RESONANTOS_NODE"] },
+  },
+};
+
+export function check(spawnRecord, opts = {}) {
+  const rec = spawnRecord || {};
+  const site = rec.site || "<unknown-site>";
+  const runtime = rec.runtime || "<unknown-runtime>";
+  const policy = opts.allowlist || ALLOWLIST;
+  const evidence = [];
+
+  const envVars = Array.isArray(rec.env_vars) ? rec.env_vars.map(String) : [];
+  const envRemove = Array.isArray(rec.env_remove) ? rec.env_remove.map(String) : [];
+  const optInVars = Array.isArray(rec.opt_in_vars) ? rec.opt_in_vars.map(String) : [];
+  const cleared = rec.env_clear === true;
+  const optIn = rec.opt_in === true;
+
+  const rt = policy.runtimes[runtime];
+  const allowed = new Set([
+    ...(policy.base_allow || []),
+    ...((rt && rt.allow) || []),
+    ...(optIn ? optInVars : []),
+  ]);
+
+  if (!rt) {
+    evidence.push({
+      rule: "unknown-runtime",
+      site,
+      runtime,
+      why: `no allowlist defined for runtime '${runtime}'`,
+    });
+  }
+
+  if (!cleared && envVars.length === 0) {
+    evidence.push({
+      rule: "blanket-inheritance",
+      site,
+      runtime,
+      why:
+        "spawn neither calls .env_clear() nor injects any var; the child " +
+        "inherits the entire ambient parent environment (secrets, tokens, PATH).",
+    });
+  }
+
+  if (!cleared && envVars.length > 0) {
+    evidence.push({
+      rule: "missing-env-clear",
+      site,
+      runtime,
+      injected: envVars,
+      env_remove: envRemove,
+      why:
+        ".env()/.envs() injection without a preceding .env_clear(): the " +
+        "ambient parent env still flows through" +
+        (envRemove.length
+          ? ` (.env_remove of ${envRemove.join(", ")} drops only those, not the rest)`
+          : "") +
+        ".",
+    });
+  }
+
+  if (cleared) {
+    for (const v of envVars) {
+      if (!allowed.has(v)) {
+        evidence.push({
+          rule: "var-outside-allowlist",
+          site,
+          runtime,
+          var: v,
+          allowed: [...allowed],
+          why:
+            `injected var '${v}' is not in the ${runtime} allowlist and is ` +
+            `not an opt-in var under ${policy.opt_in_flag}.`,
+        });
+      }
+    }
+  }
+
+  const result = evidence.length > 0 ? "block" : "pass";
+  return {
+    result,
+    site,
+    runtime,
+    env_clear: cleared,
+    evidence,
+    recommendation: result === "block" ? RECOMMENDATION : null,
+  };
+}

--- a/scripts/security-pipeline/checks/lib/no-argv-secret.mjs
+++ b/scripts/security-pipeline/checks/lib/no-argv-secret.mjs
@@ -1,0 +1,114 @@
+// no-argv-secret core (ported in-tree from research p0-invoke/checks/subprocess).
+//
+// check(argvFixture) -> { result: "pass" | "block", site, evidence[], recommendation }
+//
+// `argvFixture` is a parsed spawn descriptor:
+//   { site, program, args: [...], stdin?, env? }
+// Scans each arg in the spawn arg vector. If any arg matches a secret pattern
+// (Bearer token, prompt passthrough, API-key shape) -> "block". Otherwise "pass".
+// A secret supplied via stdin / temp-file / SDK is NOT a finding.
+//
+// Dependency-free. No runtime import from .craft/.
+
+const RECOMMENDATION =
+  "Move the value off argv: feed via child stdin, a 0600 temp file referenced " +
+  "by path, or the runtime SDK in-process auth. Never place secrets/prompts on " +
+  "the command line (visible via /proc, `ps`, audit logs, shell history).";
+
+// Flags whose *following* arg carries a secret or full user prompt.
+const SECRET_VALUE_FLAGS = new Map([
+  ["-q", "prompt passthrough (CLI quick-query flag carries full user prompt)"],
+  ["--query", "prompt passthrough"],
+  ["-p", "prompt passthrough"],
+  ["--prompt", "prompt passthrough"],
+  ["--api-key", "API key on argv"],
+  ["--token", "auth token on argv"],
+  ["--password", "credential on argv"],
+  ["--secret", "secret on argv"],
+  ["-H", "HTTP header on argv (may carry Authorization)"],
+  ["--header", "HTTP header on argv (may carry Authorization)"],
+]);
+
+const INLINE_RULES = [
+  {
+    id: "bearer-token",
+    why: "Authorization: Bearer <token> embedded in argv",
+    test: (a) => /authorization\s*:\s*bearer\s+\S/i.test(a),
+  },
+  {
+    id: "basic-auth",
+    why: "Authorization: Basic <creds> embedded in argv",
+    test: (a) => /authorization\s*:\s*basic\s+\S/i.test(a),
+  },
+  {
+    id: "api-key-header",
+    why: "x-api-key / api-key header value embedded in argv",
+    test: (a) => /(x-api-key|api[-_]?key)\s*:\s*\S/i.test(a),
+  },
+  {
+    id: "inline-flag-secret",
+    why: "secret/key/token/password passed as --flag=value on argv",
+    test: (a) =>
+      /^--(api[-_]?key|token|password|secret|auth[-_]?token)=\S/i.test(a),
+  },
+  {
+    id: "api-key-shape",
+    why: "value matches a known API-key shape (sk-/OpenAI, sk-ant-/Anthropic, ghp_/GitHub, AKIA/AWS)",
+    test: (a) =>
+      /\bsk-ant-[A-Za-z0-9_-]{8,}/.test(a) ||
+      /\bsk-[A-Za-z0-9]{16,}/.test(a) ||
+      /\bgh[pousr]_[A-Za-z0-9]{20,}/.test(a) ||
+      /\bAKIA[0-9A-Z]{16}\b/.test(a),
+  },
+  {
+    id: "prompt-template-token",
+    why: "argv carries an interpolated prompt placeholder (e.g. {prompt})",
+    test: (a) =>
+      /\{?\bprompt\b\}?/i.test(a) &&
+      a.length > 0 &&
+      /\{prompt\}|\$\{?prompt\}?|<prompt>/i.test(a),
+  },
+];
+
+export function check(argvFixture) {
+  const evidence = [];
+  const site = argvFixture && argvFixture.site ? argvFixture.site : "<unknown-site>";
+  const args = Array.isArray(argvFixture && argvFixture.args) ? argvFixture.args : [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = String(args[i]);
+
+    for (const rule of INLINE_RULES) {
+      if (rule.test(arg)) {
+        evidence.push({ rule: rule.id, site, arg_index: i, arg, why: rule.why });
+      }
+    }
+
+    const flagWhy = SECRET_VALUE_FLAGS.get(arg);
+    if (flagWhy !== undefined && i + 1 < args.length) {
+      const value = String(args[i + 1]);
+      const isHeaderFlag = arg === "-H" || arg === "--header";
+      const headerIsAuth =
+        /authorization\s*:\s*(bearer|basic)\s+\S/i.test(value) ||
+        /(x-api-key|api[-_]?key)\s*:\s*\S/i.test(value);
+      if (!isHeaderFlag || headerIsAuth) {
+        evidence.push({
+          rule: "flag-value-secret",
+          site,
+          flag: arg,
+          arg_index: i + 1,
+          arg: value,
+          why: flagWhy,
+        });
+      }
+    }
+  }
+
+  const result = evidence.length > 0 ? "block" : "pass";
+  return {
+    result,
+    site,
+    evidence,
+    recommendation: result === "block" ? RECOMMENDATION : null,
+  };
+}

--- a/scripts/security-pipeline/checks/lib/pinned-roots.mjs
+++ b/scripts/security-pipeline/checks/lib/pinned-roots.mjs
@@ -1,0 +1,106 @@
+// pinned-roots core (ported in-tree from research p0-invoke/checks/subprocess).
+//
+// check(loadRecord) -> { result: "pass" | "block", site, kind, program, evidence[], recommendation }
+//
+// A native shared library load (Library::new) or an executed binary MUST be
+// resolved from a PINNED root (absolute path, system bin, install prefix, or
+// current_exe anchored under a pinned subdir). A path anchored on a DYNAMIC base
+// (cwd, env-var, user-supplied, bare path-lookup) is unpinned => BLOCK.
+//
+// `loadRecord` = { site, kind: "native-library"|"binary", program,
+//   resolution: { base, path, env_var?, anchored_under? }, candidates?: [...] }
+//
+// Dependency-free. No runtime import from .craft/.
+
+const RECOMMENDATION =
+  "Resolve the library/binary from a PINNED root only: an absolute path, a " +
+  "system bin dir, or a path anchored under the app bundle (current_exe -> " +
+  "Resources/lib). Do NOT anchor on env::current_dir() (CWD), a bare PATH " +
+  "lookup, or a raw env-var/user path. If a path must come from config, " +
+  "canonicalize it and assert it is contained within an allowlisted pinned " +
+  "prefix before Library::new / Command::new.";
+
+const PINNED_BASES = new Set(["absolute", "system-bin", "install-prefix"]);
+const UNPINNED_BASES = new Set(["cwd", "env-var", "user-supplied", "path-lookup"]);
+const EXE_PINNED_ANCHORS = new Set(["Resources", "MacOS", "lib", "bin", "Contents"]);
+
+function isAbsolutePath(p) {
+  if (typeof p !== "string" || p.length === 0) return false;
+  if (p.startsWith("/")) return true;
+  if (/^[A-Za-z]:[\\/]/.test(p)) return true;
+  if (p.startsWith("\\\\")) return true;
+  return false;
+}
+
+function classify(cand) {
+  const base = cand.base || "<unspecified>";
+  const path = cand.path || "";
+
+  if (UNPINNED_BASES.has(base)) {
+    return { pinned: false, base, path, reason: `base '${base}' is attacker-influenceable` };
+  }
+  if (base === "absolute" || isAbsolutePath(path)) {
+    return { pinned: true, base, path, reason: "absolute pinned path" };
+  }
+  if (PINNED_BASES.has(base)) {
+    return { pinned: true, base, path, reason: `pinned base '${base}'` };
+  }
+  if (base === "current_exe") {
+    const anchor = cand.anchored_under;
+    if (anchor && EXE_PINNED_ANCHORS.has(anchor)) {
+      return { pinned: true, base, path, reason: `anchored under current_exe/${anchor}` };
+    }
+    return { pinned: false, base, path, reason: "current_exe candidate not anchored under a pinned subdir" };
+  }
+  return { pinned: false, base, path, reason: `relative path on base '${base}'` };
+}
+
+export function check(loadRecord) {
+  const rec = loadRecord || {};
+  const site = rec.site || "<unknown-site>";
+  const kind = rec.kind || "binary";
+  const program = rec.program || "<unknown>";
+  const evidence = [];
+
+  const candidates = [];
+  if (rec.resolution) candidates.push(rec.resolution);
+  if (Array.isArray(rec.candidates)) candidates.push(...rec.candidates);
+  if (candidates.length === 0) {
+    evidence.push({
+      rule: "no-resolution",
+      site,
+      kind,
+      why: "load_record carries no resolution/candidates to evaluate; cannot prove a pinned root.",
+    });
+  }
+
+  for (const cand of candidates) {
+    const c = classify(cand);
+    if (!c.pinned) {
+      evidence.push({
+        rule: kind === "native-library" ? "unpinned-native-load" : "unpinned-binary-exec",
+        site,
+        kind,
+        program,
+        base: c.base,
+        path: c.path,
+        env_var: cand.env_var,
+        why:
+          `${kind === "native-library" ? "Library::new" : "Command::new"} resolves ` +
+          `'${program}' from ${c.reason}` +
+          (cand.env_var ? ` (env var ${cand.env_var})` : "") +
+          `: ${c.path || "<no path>"}. Code loaded/executed from an unpinned root.`,
+      });
+    }
+  }
+
+  const result = evidence.length > 0 ? "block" : "pass";
+  return {
+    result,
+    site,
+    kind,
+    program,
+    evidence,
+    recommendation: result === "block" ? RECOMMENDATION : null,
+  };
+}

--- a/scripts/security-pipeline/checks/lib/terminal-allowlist.mjs
+++ b/scripts/security-pipeline/checks/lib/terminal-allowlist.mjs
@@ -1,0 +1,182 @@
+// terminal-allowlist core (ported in-tree from research p0-invoke/checks/subprocess).
+//
+// check(commandRecord) -> { result: "pass" | "block", site, head, evidence[], recommendation }
+//
+//   command head on allowlist            => PASS (runs unprompted)
+//   off-list WITH approval marker        => PASS (operator authorized THIS command)
+//   off-list WITHOUT approval marker     => BLOCK
+//   dynamic shell string (no resolvable inner head) => off-list => BLOCK w/o marker
+//
+// `commandRecord` provides ONE of: {program,args[]} | {command} | {argv[]},
+//   plus optional { dynamic, approved_by }.
+//
+// The allowlist is inlined here (ported from terminal-allowlist.yml) so this is
+// dependency-free with no external YAML file. No runtime import from .craft/.
+
+const RECOMMENDATION =
+  "Either add the command head to the terminal allowlist (only read-only / " +
+  "safe inspection commands belong there) OR route it through the per-command " +
+  "approval shim: record an explicit operator approval marker for THIS command " +
+  "before execution. Arbitrary dynamic shell passthrough must always require " +
+  "approval; never run an unresolved command string unprompted.";
+
+const SHELL_FLAGS = new Set(["-lc", "-c", "-ic", "/c", "/C", "-Command", "-command"]);
+
+export const ALLOWLIST = {
+  approval_marker_field: "approved_by",
+  shell_wrappers: ["sh", "bash", "zsh", "cmd", "powershell", "pwsh"],
+  allow: [
+    "command",
+    "which",
+    "where",
+    "ps",
+    "nm",
+    "rg",
+    "git",
+    "ollama",
+    "hermes",
+    "uv",
+  ],
+};
+
+function baseName(tok) {
+  if (!tok) return "";
+  const s = String(tok);
+  const idx = Math.max(s.lastIndexOf("/"), s.lastIndexOf("\\"));
+  return idx >= 0 ? s.slice(idx + 1) : s;
+}
+
+function resolveHead(rec, policy) {
+  const shells = new Set(policy.shell_wrappers || []);
+  const headName = (tok) => baseName(tok);
+
+  let argv = null;
+  if (Array.isArray(rec.argv) && rec.argv.length) {
+    argv = rec.argv.map(String);
+  } else if (rec.program != null) {
+    argv = [String(rec.program), ...((rec.args || []).map(String))];
+  } else if (typeof rec.command === "string") {
+    argv = rec.command.trim().split(/\s+/);
+  }
+
+  if (!argv || argv.length === 0) {
+    return { head: null, shell: null, dynamic: true, reason: "no command vector to resolve" };
+  }
+
+  const head0 = headName(argv[0]);
+  if (shells.has(head0)) {
+    if (rec.dynamic === true) {
+      return { head: null, shell: head0, dynamic: true, reason: "shell wraps a runtime-built dynamic command string" };
+    }
+    let innerStart = -1;
+    for (let k = 1; k < argv.length; k++) {
+      if (SHELL_FLAGS.has(argv[k])) {
+        innerStart = k + 1;
+        break;
+      }
+    }
+    if (innerStart < 0) {
+      const firstArg = argv.slice(1).find((t) => !t.startsWith("-"));
+      if (!firstArg) {
+        return { head: head0, shell: head0, dynamic: false, reason: `bare shell '${head0}' with no inner command` };
+      }
+      return {
+        head: headName(firstArg),
+        shell: head0,
+        dynamic: false,
+        reason: `shell script invocation ${head0} <${firstArg}>`,
+      };
+    }
+    if (innerStart >= argv.length) {
+      return { head: null, shell: head0, dynamic: true, reason: "shell invoked with no resolvable inner command" };
+    }
+    const innerTokens = argv
+      .slice(innerStart)
+      .join(" ")
+      .replace(/^["']|["']$/g, "")
+      .trim()
+      .split(/\s+/);
+    const innerHead = headName(innerTokens[0]);
+    if (!innerHead) {
+      return { head: null, shell: head0, dynamic: true, reason: "shell inner command head is empty/dynamic" };
+    }
+    return { head: innerHead, shell: head0, dynamic: false, reason: `unwrapped ${head0} -> '${innerHead}'` };
+  }
+
+  if (rec.dynamic === true) {
+    return { head: head0 || null, shell: null, dynamic: true, reason: "command head is a runtime-built dynamic value" };
+  }
+  return { head: head0, shell: null, dynamic: false, reason: "direct command head" };
+}
+
+export function check(commandRecord, opts = {}) {
+  const rec = commandRecord || {};
+  const site = rec.site || "<unknown-site>";
+  const policy = opts.allowlist || ALLOWLIST;
+
+  const allowed = new Set(policy.allow || []);
+  const markerField = policy.approval_marker_field || "approved_by";
+  const approved = Boolean(rec[markerField]);
+
+  const r = resolveHead(rec, policy);
+  const onList = r.head != null && !r.dynamic && allowed.has(r.head);
+
+  if (onList) {
+    return {
+      result: "pass",
+      site,
+      head: r.head,
+      shell: r.shell || null,
+      on_allowlist: true,
+      approved,
+      evidence: [],
+      recommendation: null,
+    };
+  }
+
+  if (approved) {
+    return {
+      result: "pass",
+      site,
+      head: r.head,
+      shell: r.shell || null,
+      on_allowlist: false,
+      approved: true,
+      evidence: [
+        {
+          rule: "off-list-approved",
+          site,
+          head: r.head,
+          why: `off-allowlist command authorized by approval marker '${markerField}'=${JSON.stringify(rec[markerField])}.`,
+        },
+      ],
+      recommendation: null,
+    };
+  }
+
+  const evidence = [
+    {
+      rule: r.dynamic ? "dynamic-command-no-approval" : "off-list-no-approval",
+      site,
+      head: r.head,
+      shell: r.shell || null,
+      resolution: r.reason,
+      why:
+        (r.dynamic
+          ? `dynamic/unresolved command (${r.reason})`
+          : `command head '${r.head}' is not on the terminal allowlist`) +
+        ` and carries no '${markerField}' approval marker => block.`,
+    },
+  ];
+
+  return {
+    result: "block",
+    site,
+    head: r.head,
+    shell: r.shell || null,
+    on_allowlist: false,
+    approved: false,
+    evidence,
+    recommendation: RECOMMENDATION,
+  };
+}

--- a/scripts/security-pipeline/checks/npm-lockfiles.mjs
+++ b/scripts/security-pipeline/checks/npm-lockfiles.mjs
@@ -1,0 +1,69 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+export async function run({ check, repoRoot }) {
+  const surfaces = Array.isArray(check.surfaces) ? check.surfaces : [];
+  const lockfiles = Array.isArray(check.lockfiles) && check.lockfiles.length > 0
+    ? check.lockfiles
+    : ["package-lock.json", "npm-shrinkwrap.json"];
+  const evidence = [];
+  const failures = [];
+
+  for (const surface of surfaces) {
+    const surfaceRoot = path.resolve(repoRoot, surface);
+    const packagePath = path.join(surfaceRoot, "package.json");
+    if (!existsSync(packagePath)) {
+      failures.push(`${surface}: package.json not found`);
+      evidence.push({ surface, status: "fail", reason: "package.json not found" });
+      continue;
+    }
+
+    const pkg = JSON.parse(await readFile(packagePath, "utf8"));
+    const dependencyCount = countDependencies(pkg);
+    const presentLockfiles = lockfiles.filter((lockfile) => existsSync(path.join(surfaceRoot, lockfile)));
+
+    if (dependencyCount === 0) {
+      evidence.push({
+        surface,
+        status: "pass",
+        dependencyCount,
+        lockfiles: presentLockfiles,
+        reason: "No dependencies declared; lockfile not required."
+      });
+      continue;
+    }
+
+    if (presentLockfiles.length === 0) {
+      failures.push(`${surface}: ${dependencyCount} dependencies but no supported lockfile`);
+      evidence.push({
+        surface,
+        status: "fail",
+        dependencyCount,
+        lockfiles: [],
+        reason: "Dependency-bearing package surface lacks a supported lockfile."
+      });
+      continue;
+    }
+
+    evidence.push({
+      surface,
+      status: "pass",
+      dependencyCount,
+      lockfiles: presentLockfiles,
+      reason: "Dependency-bearing package surface has a supported lockfile."
+    });
+  }
+
+  return {
+    status: failures.length > 0 ? "fail" : "pass",
+    summary: failures.length > 0
+      ? `Missing lockfiles: ${failures.join("; ")}`
+      : `${surfaces.length} npm surfaces checked for lockfile coverage.`,
+    evidence
+  };
+}
+
+function countDependencies(pkg) {
+  return Object.keys(pkg.dependencies ?? {}).length + Object.keys(pkg.devDependencies ?? {}).length;
+}

--- a/scripts/security-pipeline/checks/subprocess-env-clear.mjs
+++ b/scripts/security-pipeline/checks/subprocess-env-clear.mjs
@@ -1,0 +1,13 @@
+// subprocess-env-clear adapter.
+//
+// Wraps the env-clear-present core into the security-pipeline run-check.mjs contract:
+//   run({ check, repoRoot }) -> { status, summary, evidence[] }
+//
+// Verdict mapping: pass->pass, flag->warn, block->fail, throw/no-surface->skipped.
+
+import { check as core } from "./lib/env-clear.mjs";
+import { runCore } from "./lib/adapter-util.mjs";
+
+export async function run({ check, repoRoot }) {
+  return runCore({ check, repoRoot, core, label: "env-clear" });
+}

--- a/scripts/security-pipeline/checks/subprocess-env-clear.test.mjs
+++ b/scripts/security-pipeline/checks/subprocess-env-clear.test.mjs
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { run } from "./subprocess-env-clear.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "..", "..", "..");
+const SURFACE = ["src-tauri/src"];
+
+// Blanket inheritance: no env_clear, no injected vars -> block -> fail.
+const LEAKY_RECORD = {
+  site: "fixture:blanket-inherit",
+  runtime: "hermes",
+  env_clear: false,
+  env_vars: [],
+};
+
+// Cleared + only allowlisted var -> pass.
+const CLEAN_RECORD = {
+  site: "fixture:cleared",
+  runtime: "hermes",
+  env_clear: true,
+  env_vars: ["HERMES_HOME", "PATH"],
+};
+
+test("blanket env inheritance -> fail", async () => {
+  const res = await run({
+    check: { surfaces: SURFACE, records: [LEAKY_RECORD] },
+    repoRoot: REPO_ROOT,
+  });
+  assert.equal(res.status, "fail");
+});
+
+test("cleared + allowlisted vars -> pass", async () => {
+  const res = await run({
+    check: { surfaces: SURFACE, records: [CLEAN_RECORD] },
+    repoRoot: REPO_ROOT,
+  });
+  assert.equal(res.status, "pass");
+});
+
+test("missing surface -> skipped", async () => {
+  const res = await run({
+    check: { surfaces: ["does-not-exist/nope"], records: [LEAKY_RECORD] },
+    repoRoot: REPO_ROOT,
+  });
+  assert.equal(res.status, "skipped");
+});

--- a/scripts/security-pipeline/checks/subprocess-no-argv-secret.mjs
+++ b/scripts/security-pipeline/checks/subprocess-no-argv-secret.mjs
@@ -1,0 +1,13 @@
+// subprocess-no-argv-secret adapter.
+//
+// Wraps the no-argv-secret core into the security-pipeline run-check.mjs contract:
+//   run({ check, repoRoot }) -> { status, summary, evidence[] }
+//
+// Verdict mapping: pass->pass, flag->warn, block->fail, throw/no-surface->skipped.
+
+import { check as core } from "./lib/no-argv-secret.mjs";
+import { runCore } from "./lib/adapter-util.mjs";
+
+export async function run({ check, repoRoot }) {
+  return runCore({ check, repoRoot, core, label: "no-argv-secret" });
+}

--- a/scripts/security-pipeline/checks/subprocess-no-argv-secret.test.mjs
+++ b/scripts/security-pipeline/checks/subprocess-no-argv-secret.test.mjs
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { run } from "./subprocess-no-argv-secret.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+// repoRoot such that <repoRoot>/src-tauri/src exists (2.0.0-alpha).
+const REPO_ROOT = path.resolve(HERE, "..", "..", "..");
+const SURFACE = ["src-tauri/src"];
+
+const SECRET_RECORD = {
+  site: "fixture:argv-secret",
+  program: "hermes",
+  args: ["chat", "-q", "Summarize the doc", "-H", "Authorization: Bearer sk-ant-api03-EXAMPLEEXAMPLE"],
+};
+
+const CLEAN_RECORD = {
+  site: "fixture:clean",
+  program: "hermes",
+  args: ["--version"],
+};
+
+test("secret on argv -> fail", async () => {
+  const res = await run({
+    check: { surfaces: SURFACE, records: [SECRET_RECORD] },
+    repoRoot: REPO_ROOT,
+  });
+  assert.equal(res.status, "fail");
+  assert.ok(res.evidence.some((e) => e.status === "fail"));
+});
+
+test("clean argv -> pass", async () => {
+  const res = await run({
+    check: { surfaces: SURFACE, records: [CLEAN_RECORD] },
+    repoRoot: REPO_ROOT,
+  });
+  assert.equal(res.status, "pass");
+});
+
+test("missing surface -> skipped", async () => {
+  const res = await run({
+    check: { surfaces: ["does-not-exist/nope"], records: [SECRET_RECORD] },
+    repoRoot: REPO_ROOT,
+  });
+  assert.equal(res.status, "skipped");
+});

--- a/scripts/security-pipeline/checks/subprocess-pinned-roots.mjs
+++ b/scripts/security-pipeline/checks/subprocess-pinned-roots.mjs
@@ -1,0 +1,13 @@
+// subprocess-pinned-roots adapter.
+//
+// Wraps the pinned-roots core into the security-pipeline run-check.mjs contract:
+//   run({ check, repoRoot }) -> { status, summary, evidence[] }
+//
+// Verdict mapping: pass->pass, flag->warn, block->fail, throw/no-surface->skipped.
+
+import { check as core } from "./lib/pinned-roots.mjs";
+import { runCore } from "./lib/adapter-util.mjs";
+
+export async function run({ check, repoRoot }) {
+  return runCore({ check, repoRoot, core, label: "pinned-roots" });
+}

--- a/scripts/security-pipeline/checks/subprocess-pinned-roots.test.mjs
+++ b/scripts/security-pipeline/checks/subprocess-pinned-roots.test.mjs
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { run } from "./subprocess-pinned-roots.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "..", "..", "..");
+const SURFACE = ["src-tauri/src"];
+
+// Unpinned: resolved from CWD -> block -> fail.
+const UNPINNED_RECORD = {
+  site: "fixture:unpinned-load",
+  kind: "native-library",
+  program: "libBridge.so",
+  resolution: { base: "cwd", path: "addons/libBridge.so" },
+};
+
+// Pinned: absolute system path -> pass.
+const PINNED_RECORD = {
+  site: "fixture:pinned-load",
+  kind: "binary",
+  program: "ditto",
+  resolution: { base: "absolute", path: "/usr/bin/ditto" },
+};
+
+test("unpinned native load -> fail", async () => {
+  const res = await run({
+    check: { surfaces: SURFACE, records: [UNPINNED_RECORD] },
+    repoRoot: REPO_ROOT,
+  });
+  assert.equal(res.status, "fail");
+});
+
+test("pinned absolute path -> pass", async () => {
+  const res = await run({
+    check: { surfaces: SURFACE, records: [PINNED_RECORD] },
+    repoRoot: REPO_ROOT,
+  });
+  assert.equal(res.status, "pass");
+});
+
+test("missing surface -> skipped", async () => {
+  const res = await run({
+    check: { surfaces: ["does-not-exist/nope"], records: [UNPINNED_RECORD] },
+    repoRoot: REPO_ROOT,
+  });
+  assert.equal(res.status, "skipped");
+});

--- a/scripts/security-pipeline/checks/subprocess-terminal-allowlist.mjs
+++ b/scripts/security-pipeline/checks/subprocess-terminal-allowlist.mjs
@@ -1,0 +1,13 @@
+// subprocess-terminal-allowlist adapter.
+//
+// Wraps the terminal-allowlist core into the security-pipeline run-check.mjs contract:
+//   run({ check, repoRoot }) -> { status, summary, evidence[] }
+//
+// Verdict mapping: pass->pass, flag->warn, block->fail, throw/no-surface->skipped.
+
+import { check as core } from "./lib/terminal-allowlist.mjs";
+import { runCore } from "./lib/adapter-util.mjs";
+
+export async function run({ check, repoRoot }) {
+  return runCore({ check, repoRoot, core, label: "terminal-allowlist" });
+}

--- a/scripts/security-pipeline/checks/subprocess-terminal-allowlist.test.mjs
+++ b/scripts/security-pipeline/checks/subprocess-terminal-allowlist.test.mjs
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { run } from "./subprocess-terminal-allowlist.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "..", "..", "..");
+const SURFACE = ["src-tauri/src"];
+
+// Off-list, no approval -> block -> fail.
+const OFFLIST_RECORD = {
+  site: "fixture:off-list",
+  program: "curl",
+  args: ["-fsSL", "https://example.com/install.sh"],
+};
+
+// Allowlisted read-only probe -> pass.
+const ALLOWED_RECORD = {
+  site: "fixture:allowlisted",
+  program: "rg",
+  args: ["--files"],
+};
+
+test("off-list command without approval -> fail", async () => {
+  const res = await run({
+    check: { surfaces: SURFACE, records: [OFFLIST_RECORD] },
+    repoRoot: REPO_ROOT,
+  });
+  assert.equal(res.status, "fail");
+});
+
+test("allowlisted command -> pass", async () => {
+  const res = await run({
+    check: { surfaces: SURFACE, records: [ALLOWED_RECORD] },
+    repoRoot: REPO_ROOT,
+  });
+  assert.equal(res.status, "pass");
+});
+
+test("missing surface -> skipped", async () => {
+  const res = await run({
+    check: { surfaces: ["does-not-exist/nope"], records: [OFFLIST_RECORD] },
+    repoRoot: REPO_ROOT,
+  });
+  assert.equal(res.status, "skipped");
+});

--- a/scripts/security-pipeline/run-check.mjs
+++ b/scripts/security-pipeline/run-check.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const VALID_POLICIES = new Set(["observe", "warn", "block", "disabled"]);
+const VALID_STATUSES = new Set(["pass", "warn", "fail", "skipped", "disabled"]);
+
+function parseArgs(argv) {
+  const args = {
+    config: ".github/security-pipeline/checks.yml",
+    list: false,
+    check: null,
+    family: null
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--config") {
+      args.config = argv[++index];
+    } else if (arg === "--list") {
+      args.list = true;
+    } else if (arg === "--check") {
+      args.check = argv[++index];
+    } else if (arg === "--family") {
+      args.family = argv[++index];
+    } else if (arg === "--help" || arg === "-h") {
+      args.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/security-pipeline/run-check.mjs [options]
+
+Options:
+  --config <path>   Registry path. Defaults to .github/security-pipeline/checks.yml
+  --list            List enabled checks
+  --check <id>      Run a single check
+  --family <name>   Run checks in a family
+  --help            Show this help
+`);
+}
+
+async function loadRegistry(configPath) {
+  const raw = await readFile(configPath, "utf8");
+  let registry;
+  try {
+    registry = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `${configPath} must be JSON-compatible YAML for the current dependency-free runner: ${error.message}`
+    );
+  }
+  validateRegistry(registry, configPath);
+  return registry;
+}
+
+function validateRegistry(registry, configPath) {
+  if (!registry || typeof registry !== "object") {
+    throw new Error(`${configPath} must contain an object registry`);
+  }
+  if (registry.version !== 1) {
+    throw new Error(`${configPath} must declare version 1`);
+  }
+  if (!registry.families || typeof registry.families !== "object") {
+    throw new Error(`${configPath} must declare families`);
+  }
+  if (!Array.isArray(registry.checks)) {
+    throw new Error(`${configPath} must declare checks as an array`);
+  }
+
+  const ids = new Set();
+  for (const check of registry.checks) {
+    for (const field of ["id", "family", "policy", "adapter"]) {
+      if (!check[field] || typeof check[field] !== "string") {
+        throw new Error(`Check entry is missing string field: ${field}`);
+      }
+    }
+    if (ids.has(check.id)) {
+      throw new Error(`Duplicate check id: ${check.id}`);
+    }
+    ids.add(check.id);
+    if (!registry.families[check.family]) {
+      throw new Error(`Check ${check.id} references unknown family ${check.family}`);
+    }
+    if (!VALID_POLICIES.has(check.policy)) {
+      throw new Error(`Check ${check.id} uses invalid policy ${check.policy}`);
+    }
+  }
+}
+
+function selectChecks(registry, args) {
+  let checks = registry.checks;
+  if (args.family) {
+    checks = checks.filter((check) => check.family === args.family);
+  }
+  if (args.check) {
+    checks = checks.filter((check) => check.id === args.check);
+  }
+  if (checks.length === 0) {
+    const scope = args.check ? `check ${args.check}` : `family ${args.family}`;
+    throw new Error(`No checks matched ${scope}`);
+  }
+  return checks;
+}
+
+function listChecks(registry, checks) {
+  for (const check of checks) {
+    const family = registry.families[check.family];
+    const familyStatus = family?.status ?? "unknown";
+    console.log(`${check.id}\t${check.family}\t${familyStatus}\t${check.policy}\t${check.adapter}`);
+  }
+}
+
+async function runCheck(check, registry, configPath) {
+  if (check.policy === "disabled") {
+    return normalizeResult(check, {
+      status: "disabled",
+      summary: "Check is disabled by registry policy.",
+      evidence: []
+    });
+  }
+
+  const adapterPath = path.resolve("scripts/security-pipeline/checks", `${check.adapter}.mjs`);
+  if (!existsSync(adapterPath)) {
+    return normalizeResult(check, {
+      status: "fail",
+      summary: `Adapter not found: ${adapterPath}`,
+      evidence: []
+    });
+  }
+
+  const adapter = await import(pathToFileURL(adapterPath));
+  if (typeof adapter.run !== "function") {
+    return normalizeResult(check, {
+      status: "fail",
+      summary: `Adapter ${adapterPath} does not export run().`,
+      evidence: []
+    });
+  }
+
+  const result = await adapter.run({ check, registry, configPath, repoRoot: process.cwd() });
+  return normalizeResult(check, result);
+}
+
+function normalizeResult(check, result) {
+  const status = result?.status ?? "fail";
+  if (!VALID_STATUSES.has(status)) {
+    return {
+      checkId: check.id,
+      family: check.family,
+      policy: check.policy,
+      status: "fail",
+      summary: `Adapter returned invalid status: ${status}`,
+      evidence: []
+    };
+  }
+  return {
+    checkId: result.checkId ?? check.id,
+    family: result.family ?? check.family,
+    policy: result.policy ?? check.policy,
+    status,
+    summary: result.summary ?? "",
+    evidence: Array.isArray(result.evidence) ? result.evidence : []
+  };
+}
+
+function shouldFail(result) {
+  return result.policy === "block" && result.status === "fail";
+}
+
+function printResult(result) {
+  console.log(JSON.stringify(result, null, 2));
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  const registry = await loadRegistry(args.config);
+  const checks = selectChecks(registry, args);
+
+  if (args.list) {
+    listChecks(registry, checks);
+    return;
+  }
+
+  const results = [];
+  for (const check of checks) {
+    const result = await runCheck(check, registry, args.config);
+    results.push(result);
+    printResult(result);
+  }
+
+  if (results.some(shouldFail)) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(`security-pipeline: ${error.message}`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
### Adds the security-pipeline (the surface that produces findings) — supply-chain + runtime-hardening checks

### What this adds
A dependency-free, registry-driven security pipeline: the `run-check.mjs` runner + `checks.yml` registry, the L0 `npm-lockfiles` supply-chain check (`policy: block`), and four **runtime-hardening** adapters (`no-argv-secret`, `env-clear`, `pinned-roots`, `terminal-allowlist`) registered `policy: observe`.

### Why it matters
Deterministic supply-chain + host-hardening checks in CI. These checks are the **emitters** of the security findings now tracked as issues (#159–163); the runtime-hardening family rides in **observe** so it surfaces findings without gating `dev`.

### The change
Runner + registry + 4 adapters (thin wrappers over dependency-free in-tree cores under `checks/lib/`) + per-adapter `node --test`; pipeline docs under `docs/security-pipeline/`. Breaking: none (additive; observe = non-gating). `alpha-build.yml` untouched.

### Validation
`run-check.mjs --list` → 5 checks (1 block + 4 observe); `node --test` adapters — 12 pass; observe `fail` proven non-gating.

### Surface touched
`scripts/security-pipeline/**`, `.github/security-pipeline/checks.yml`, `docs/security-pipeline/**`

### Status / residual
Foundation for the finding/result pipeline. Follow-ups: the disclosure workflow (#151, stacked) and renderer tools (issue/report/metrics) per the finding schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)