### PR TITLE
docs: Add SECURITY.md, security workflow, and SHA-pin policy

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,44 @@
+# Security observe workflow.
+#
+# Runs the security-pipeline check registry in OBSERVE mode (non-gating): a
+# finding never fails the workflow and no job here is wired as a required
+# status check or branch-protection gate. Additive alongside alpha-build.yml,
+# which this workflow does not touch.
+#
+# Action refs are pinned to full 40-char commit SHAs per
+# docs/security-pipeline/sha-pin-policy.md (lead by example).
+
+name: security-observe
+
+# Least-privilege default token for the whole workflow.
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [dev]
+  push:
+    branches: [dev]
+  workflow_dispatch:
+
+jobs:
+  security-pipeline:
+    name: "security pipeline (observe)"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # observe/warn: a finding must never fail the workflow at P0.
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        # pin: full 40-char commit SHA per sha-pin-policy.md.
+        # NOTE: verify this SHA at the commit gate before merge.
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup Node.js
+        # pin: full 40-char commit SHA per sha-pin-policy.md.
+        # NOTE: verify this SHA at the commit gate before merge.
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: 22
+      - name: Run security-pipeline registry (observe, non-gating)
+        run: node scripts/security-pipeline/run-check.mjs --config .github/security-pipeline/checks.yml

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,60 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in this project, please
+report it privately. **Do not open a public issue for security reports.**
+
+- **Disclosure contact:** Vladimir Rondelli (rondellivladimir@gmail.com)
+- **Report channel:** email the disclosure contact above with the subject line
+  prefix `[SECURITY]`. Provide a description, reproduction steps, affected
+  version/commit, and impact assessment. PGP key fingerprint: _TBD placeholder_.
+
+The disclosure contact is the single accountable owner for triage and
+coordinated-disclosure decisions for this repository.
+
+## Response SLA
+
+> **Placeholder — to be ratified by the disclosure owner.**
+
+| Stage | Target |
+| --- | --- |
+| Acknowledgement of report | _TBD (placeholder) — e.g. within 3 business days_ |
+| Triage / severity assignment | _TBD (placeholder)_ |
+| Fix or mitigation plan | _TBD (placeholder)_ |
+| Coordinated public disclosure | _TBD (placeholder)_ |
+
+These targets are placeholders pending owner ratification and MUST be filled
+with concrete values.
+
+## Supported Scope
+
+Security reports are accepted for the following in-scope surfaces:
+
+- The application IPC / capability surface (Tauri command handlers and bridge
+  routes).
+- Subprocess / shell invocation and environment handling.
+- Provider URL handling, the memory-service listener, and LAN exposure.
+- Installed-skill trust (`allowed-tools` declarations, allowlist/denylist).
+- The release-trust surface (action pinning, signing, provenance) — see
+  [`docs/security-pipeline/sha-pin-policy.md`](docs/security-pipeline/sha-pin-policy.md)
+  and
+  [`docs/security-pipeline/release-trust-roadmap.md`](docs/security-pipeline/release-trust-roadmap.md)
+  (owner: release-trust lane, Tom Pennington / @tompennington).
+
+**Out of scope** (non-exhaustive): findings in third-party dependencies that
+have no demonstrated impact on this project, social-engineering reports, and
+denial-of-service that requires privileged local access already granted by the
+threat model.
+
+## Supported Versions
+
+| Version / branch | Supported |
+| --- | --- |
+| `dev` (latest) | yes |
+| Tagged releases | _TBD (placeholder)_ |
+
+## Safe Harbor
+
+Good-faith research conducted in accordance with this policy will not be pursued
+or reported as abuse. _Detailed safe-harbor terms: TBD placeholder._

--- a/docs/security-pipeline/release-trust-roadmap.md
+++ b/docs/security-pipeline/release-trust-roadmap.md
@@ -1,0 +1,42 @@
+# Release-Trust Roadmap
+
+- **Owner:** Tom Pennington (@tompennington) — release-trust lane.
+- **Scope:** signing, provenance, and action-pinning hardening for the release
+  pipeline. Paired with `sha-pin-policy.md`.
+
+## Status
+
+- Supply-chain checks run via the security-observe workflow (see
+  `.github/workflows/security.yml`) in **observe/warn** mode only.
+- No check is a required/blocking gate. Promotion requires the release-trust
+  owner's sign-off.
+
+## Milestones
+
+### M1 — Action pinning (observe → enforce)
+- Adopt `sha-pin-policy.md`: pin every `uses:` ref to a full 40-char commit SHA.
+- Stand up the actions-hardening observe check to report unpinned refs.
+- Exit: zero unpinned `uses:` refs across all workflows (still observe).
+
+### M2 — Build provenance (SLSA-style attestation)
+- Emit provenance attestation for release artifacts describing how/where each
+  artifact was built (source commit, builder identity, build parameters).
+- Exit: every release artifact has a verifiable provenance attestation.
+
+### M3 — Artifact signing
+- Sign release artifacts (e.g. Sigstore/cosign or platform code-signing) and
+  publish the public verification material in the release notes / SECURITY.md.
+- Exit: all published artifacts are signed and signatures are verifiable by
+  consumers.
+
+### M4 — Verification + enforcement promotion (gated)
+- Promote pinning/provenance/signing checks from observe to required, gated by
+  the release-trust owner's sign-off. Document the verification command
+  consumers run.
+- Exit: release-trust checks are required gates; provenance + signatures are
+  verified in CI.
+
+## Promotion guardrail
+
+Promotion of any milestone's check from observe/warn to a required/blocking gate
+requires the release-trust owner's sign-off.

--- a/docs/security-pipeline/sha-pin-policy.md
+++ b/docs/security-pipeline/sha-pin-policy.md
@@ -1,0 +1,41 @@
+# Action SHA-Pinning Policy
+
+- **Owner:** Tom Pennington (@tompennington) — release-trust lane.
+
+## Rule
+
+Every GitHub Actions `uses:` reference in any workflow MUST be pinned to a full
+**40-character commit SHA**. Tag refs (`@v4`), branch refs (`@main`), and short
+SHAs are **not** acceptable, because tags and branches are mutable and a
+compromised upstream can repoint them at malicious code.
+
+Required form:
+
+```yaml
+uses: owner/repo@<full-40-char-commit-sha> # vX.Y.Z (human-readable tag in comment)
+```
+
+- The 40-char SHA is the authoritative pin: regex `@[0-9a-f]{40}\b`.
+- A human-readable version MAY be recorded in a trailing comment for review
+  ergonomics, but the comment is advisory only and is never the pin.
+- This rule applies to first-party and third-party actions alike, including
+  re-usable workflows referenced via `uses:`.
+
+## Rationale
+
+Pinning to an immutable commit SHA removes the supply-chain risk of mutable tag
+or branch references being silently repointed. It is the baseline control the
+security-observe workflow (see `.github/workflows/security.yml`) leads by
+example on before any enforcement is promoted.
+
+## Scope
+
+This policy is enforced in **observe/warn** mode only. Promotion to a
+blocking/required check is tracked on the release-trust roadmap and requires the
+release-trust owner's sign-off.
+
+## Verification
+
+A promoted enforcement check would assert, for every `uses:` line, a match of
+`@[0-9a-f]{40}` and reject any tag/branch/short-SHA ref. In observe mode this is
+reported, not enforced.

--- a/scripts/security-pipeline/disclosure-baseline.test.mjs
+++ b/scripts/security-pipeline/disclosure-baseline.test.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Disclosure-baseline presence test (PR-A01).
+ * Uses only node:test and node:assert. Run with: node --test
+ *
+ * Asserts the promoted disclosure baseline is present and correctly shaped:
+ *   - SECURITY.md declares the disclosure-owner contact line.
+ *   - .github/workflows/security.yml declares `permissions: contents: read`
+ *     and references the security-pipeline registry runner.
+ */
+
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import assert from "node:assert";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// scripts/security-pipeline/ -> repo root is two levels up.
+const REPO_ROOT = join(__dirname, "..", "..");
+
+test("SECURITY.md declares the disclosure-owner contact line", () => {
+  const security = readFileSync(join(REPO_ROOT, "SECURITY.md"), "utf8");
+  assert.match(
+    security,
+    /\*\*Disclosure contact:\*\*\s*Vladimir Rondelli/,
+    "SECURITY.md must name the disclosure owner Vladimir Rondelli"
+  );
+  assert.match(
+    security,
+    /rondellivladimir@gmail\.com/,
+    "SECURITY.md must include the disclosure-owner contact email"
+  );
+});
+
+test("security.yml declares least-privilege permissions and runs the registry", () => {
+  const workflow = readFileSync(
+    join(REPO_ROOT, ".github", "workflows", "security.yml"),
+    "utf8"
+  );
+
+  // permissions: contents: read (top-level, with read as the value of contents)
+  assert.match(
+    workflow,
+    /permissions:\s*\n\s*contents:\s*read/,
+    "security.yml must declare permissions: contents: read"
+  );
+
+  // references the registry runner script + the checks registry config
+  assert.match(
+    workflow,
+    /scripts\/security-pipeline\/run-check\.mjs/,
+    "security.yml must reference the registry runner run-check.mjs"
+  );
+  assert.match(
+    workflow,
+    /--config\s+\.github\/security-pipeline\/checks\.yml/,
+    "security.yml must point the runner at the checks registry"
+  );
+
+  // every uses: ref must be SHA-pinned to a full 40-char commit SHA
+  const usesRefs = [...workflow.matchAll(/uses:\s*(\S+)/g)].map((m) => m[1]);
+  assert.ok(usesRefs.length > 0, "security.yml should reference at least one action");
+  for (const ref of usesRefs) {
+    assert.match(
+      ref,
+      /@[0-9a-f]{40}$/,
+      `action ref must be pinned to a full 40-char commit SHA: ${ref}`
+    );
+  }
+});


### PR DESCRIPTION
### Fixes finding `F9` — disclosure & CI guardrails not established (→ baseline shipped)

### What was wrong
No `SECURITY.md`, no security CI workflow, no action-SHA-pinning policy — disclosure/release-trust basics were missing (F9).

### Why it matters
Without a disclosure contact + a least-privilege security workflow, vulnerability reporting and CI hardening have no home; unpinned actions are a supply-chain surface. Reachable by: project/release process.

### The change
- `SECURITY.md` (disclosure contact + process)
- `.github/workflows/security.yml` — runs the pipeline registry in **observe**, `permissions: contents: read`, SHA-pinned actions
- `docs/security-pipeline/{sha-pin-policy,release-trust-roadmap}.md`
- a `node --test` asserting the contact + least-privilege perms. Breaking: none. **`alpha-build.yml` untouched.**

### Validation
`node --test disclosure-baseline.test.mjs` — 2 pass; `run-check.mjs --list` resolves.

### Surface touched
`SECURITY.md`, `.github/workflows/security.yml`, `docs/security-pipeline/**`

### Status / residual
Stacked on #150. Before merge: verify the 2 pinned action SHAs against live GitHub; fill `SECURITY.md` TBDs (SLA/PGP) with the disclosure owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)