### PR TITLE
memory: Authenticate memory-service writes and default to readonly

### DIFF
--- a/examples/living-archive-mcp.mjs
+++ b/examples/living-archive-mcp.mjs
@@ -81,13 +81,19 @@ const parseArgs = (argv = process.argv.slice(2), env = process.env) => {
   };
 };
 
-const postMemoryJson = async (endpoint, operation, input = {}) => {
+const postMemoryJson = async (endpoint, operation, input = {}, token = "") => {
+  const headers = {
+    "content-type": "application/json",
+    accept: "application/json",
+  };
+  // DD-3 (F6): forward the bearer token so write operations authenticate against
+  // the hardened memory service. Reads ignore it server-side.
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+  }
   const response = await fetch(`${endpoint}/memory/${operation}`, {
     method: "POST",
-    headers: {
-      "content-type": "application/json",
-      accept: "application/json",
-    },
+    headers,
     body: JSON.stringify(input),
   });
   if (!response.ok) {
@@ -379,6 +385,10 @@ export const livingArchiveTools = [
 export const createLivingArchiveBridge = (config = parseArgs()) => {
   const memoryRoot = config.memoryRoot;
   const memoryServiceUrl = config.memoryServiceUrl;
+  const memoryServiceToken =
+    typeof config.memoryServiceToken === "string"
+      ? config.memoryServiceToken
+      : process.env.RESONANTOS_MEMORY_SERVICE_TOKEN ?? "";
   const memoryServiceTransport = typeof config.memoryServiceTransport === "function" ? config.memoryServiceTransport : null;
   const maxSearchBytes = config.maxSearchBytes;
   const readonly = config.readonly;
@@ -391,7 +401,7 @@ export const createLivingArchiveBridge = (config = parseArgs()) => {
     if (memoryServiceTransport) {
       return memoryServiceTransport(operation, input);
     }
-    return postMemoryJson(memoryServiceUrl, operation, input);
+    return postMemoryJson(memoryServiceUrl, operation, input, memoryServiceToken);
   };
 
   const status = async () => {

--- a/examples/living-archive-memory-service.mjs
+++ b/examples/living-archive-memory-service.mjs
@@ -3,16 +3,68 @@
 
 import { createServer } from "node:http";
 import { resolve } from "node:path";
+import { timingSafeEqual } from "node:crypto";
 import { createLivingArchiveBridge } from "./living-archive-mcp.mjs";
 
 const defaultPort = 4888;
 const maxBodyBytes = 5 * 1024 * 1024;
 
+// DD-3 (F6): operations that mutate Living Archive state. These are gated behind
+// readonly-default + a required bearer token. Read operations stay unauth on a
+// loopback bind. This mirrors the readonly throw-points in living-archive-mcp.mjs.
+const writeMemoryOperations = new Set([
+  "intake-write",
+  "ingest-request",
+  "process-ingest-request",
+  "decide-review",
+  "promote-review-artifact",
+  "maintenance-cycle",
+  "background-cycle",
+]);
+
+export const isWriteMemoryOperation = (operation) =>
+  writeMemoryOperations.has(operation);
+
+// Loopback classification kept intentionally narrow: a non-loopback bind is only
+// allowed behind the explicit --unsafe-host / RESONANTOS_MEMORY_SERVICE_UNSAFE_HOST
+// opt-in (DD-3 loopback-default axis).
+const isLoopbackHost = (host) => {
+  const h = String(host ?? "").trim().toLowerCase().replace(/^\[|\]$/g, "");
+  if (h === "" || h === "localhost" || h.endsWith(".localhost")) return h !== "";
+  if (h === "::1") return true;
+  return /^127\./.test(h);
+};
+
+// Constant-time bearer-token comparison. Returns false on any length/format
+// mismatch without leaking timing about the expected token.
+const tokenMatches = (expected, provided) => {
+  if (typeof expected !== "string" || expected.length === 0) return false;
+  if (typeof provided !== "string" || provided.length === 0) return false;
+  const a = Buffer.from(expected, "utf8");
+  const b = Buffer.from(provided, "utf8");
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+};
+
+const extractBearerToken = (request) => {
+  const header = request?.headers?.authorization;
+  if (typeof header !== "string") return "";
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+  return match ? match[1].trim() : "";
+};
+
 const parseArgs = (argv = process.argv.slice(2), env = process.env) => {
   let memoryRoot = env.RESONANTOS_MEMORY_ROOT ?? "";
   let port = Number.parseInt(env.RESONANTOS_MEMORY_SERVICE_PORT ?? String(defaultPort), 10);
   let host = env.RESONANTOS_MEMORY_SERVICE_HOST ?? "127.0.0.1";
-  let readonly = env.RESONANTOS_MCP_READONLY === "1" || env.RESONANTOS_MEMORY_SERVICE_READONLY === "1";
+  // DD-3 readonly-default: writes are off unless an explicit opt-out is given.
+  let writable =
+    env.RESONANTOS_MEMORY_SERVICE_WRITABLE === "1" || env.RESONANTOS_MCP_WRITABLE === "1";
+  // Legacy env that forced readonly on still wins (keeps the old hardening path).
+  const forcedReadonly =
+    env.RESONANTOS_MCP_READONLY === "1" || env.RESONANTOS_MEMORY_SERVICE_READONLY === "1";
+  let unsafeHost = env.RESONANTOS_MEMORY_SERVICE_UNSAFE_HOST === "1";
+  let token = env.RESONANTOS_MEMORY_SERVICE_TOKEN ?? "";
   let maxSearchBytes = Number.parseInt(env.RESONANTOS_MCP_MAX_SEARCH_BYTES ?? "1048576", 10);
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -32,21 +84,40 @@ const parseArgs = (argv = process.argv.slice(2), env = process.env) => {
       index += 1;
       continue;
     }
+    if (arg === "--token") {
+      token = argv[index + 1] ?? token;
+      index += 1;
+      continue;
+    }
     if (arg === "--max-search-bytes") {
       maxSearchBytes = Number.parseInt(argv[index + 1] ?? "", 10);
       index += 1;
       continue;
     }
+    if (arg === "--writable" || arg === "--no-readonly") {
+      writable = true;
+      continue;
+    }
+    if (arg === "--unsafe-host") {
+      unsafeHost = true;
+      continue;
+    }
     if (arg === "--readonly") {
-      readonly = true;
+      writable = false;
     }
   }
+
+  // readonly-default: readonly unless explicitly made writable, and never writable
+  // if a forced-readonly env is set.
+  const readonly = forcedReadonly || !writable;
 
   return {
     memoryRoot: memoryRoot ? resolve(memoryRoot) : "",
     port: Number.isFinite(port) && port >= 0 ? port : defaultPort,
     host: host || "127.0.0.1",
     readonly,
+    unsafeHost,
+    token,
     maxSearchBytes: Number.isFinite(maxSearchBytes) && maxSearchBytes > 0 ? maxSearchBytes : 1_048_576,
   };
 };
@@ -135,7 +206,11 @@ const readJsonBody = (request) =>
   });
 
 export const createLivingArchiveMemoryService = (options = {}) => {
-  const evaluateOperation = createLivingArchiveMemoryOperationEvaluator(options);
+  // DD-3 readonly-default: writes are off unless the caller explicitly passes
+  // readonly: false (an opt-out). Omitting readonly => readonly ON.
+  const readonly = options.readonly === false ? false : true;
+  const evaluateOperation = createLivingArchiveMemoryOperationEvaluator({ ...options, readonly });
+  const token = typeof options.token === "string" ? options.token : "";
 
   return createServer(async (request, response) => {
     if (request.method === "OPTIONS") {
@@ -160,6 +235,25 @@ export const createLivingArchiveMemoryService = (options = {}) => {
       return;
     }
 
+    // DD-3 (F6): mutating operations require both writes-enabled and a valid
+    // bearer token. Reads stay unauth on the loopback bind.
+    if (isWriteMemoryOperation(operation)) {
+      if (readonly) {
+        jsonResponse(response, 403, {
+          error: "Living Archive memory service is readonly; writes are disabled.",
+          operation,
+        });
+        return;
+      }
+      if (!tokenMatches(token, extractBearerToken(request))) {
+        jsonResponse(response, 401, {
+          error: "Living Archive memory service write operations require a valid bearer token.",
+          operation,
+        });
+        return;
+      }
+    }
+
     try {
       const input = await readJsonBody(request);
       const result = await evaluateOperation(operation, input);
@@ -175,6 +269,23 @@ export const createLivingArchiveMemoryService = (options = {}) => {
 
 const main = async () => {
   const config = parseArgs();
+
+  // DD-3 loopback-default: refuse a non-loopback bind unless --unsafe-host opt-in.
+  if (!isLoopbackHost(config.host) && !config.unsafeHost) {
+    process.stderr.write(
+      `Refusing to bind Living Archive memory service to non-loopback host "${config.host}" without --unsafe-host (RESONANTOS_MEMORY_SERVICE_UNSAFE_HOST=1).\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  // Writes require a configured token; without one the service can only be readonly.
+  if (!config.readonly && config.token.length === 0) {
+    process.stderr.write(
+      "Refusing to enable writes without RESONANTOS_MEMORY_SERVICE_TOKEN (or --token); falling back to readonly.\n",
+    );
+    config.readonly = true;
+  }
+
   const server = createLivingArchiveMemoryService(config);
   await new Promise((resolveListen) => server.listen(config.port, config.host, resolveListen));
   const address = server.address();
@@ -187,6 +298,7 @@ const main = async () => {
         endpoint: `http://${config.host}:${port}`,
         memoryRoot: config.memoryRoot,
         readonly: config.readonly,
+        tokenRequiredForWrites: config.token.length > 0,
       },
       null,
       2,

--- a/examples/living-archive-memory-service.test.mjs
+++ b/examples/living-archive-memory-service.test.mjs
@@ -9,7 +9,10 @@ import { createLivingArchiveBridge } from "./living-archive-mcp.mjs";
 import {
   createLivingArchiveMemoryOperationEvaluator,
   createLivingArchiveMemoryService,
+  isWriteMemoryOperation,
 } from "./living-archive-memory-service.mjs";
+
+const TEST_TOKEN = "test-memory-service-token";
 
 const makeMemoryRoot = async () => {
   const root = await mkdtemp(join(tmpdir(), "resonantos-memory-service-"));
@@ -49,13 +52,18 @@ function skipIfSandboxLocalhostDenied(t, error) {
   return false;
 }
 
-const postMemory = async (endpoint, operation, input = {}) => {
+const postMemory = async (endpoint, operation, input = {}, token = TEST_TOKEN) => {
+  const headers = {
+    "content-type": "application/json",
+    accept: "application/json",
+  };
+  // Writes require a bearer token (DD-3 F6). Reads stay unauth on loopback.
+  if (token && isWriteMemoryOperation(operation)) {
+    headers.authorization = `Bearer ${token}`;
+  }
   const response = await fetch(`${endpoint}/memory/${operation}`, {
     method: "POST",
-    headers: {
-      "content-type": "application/json",
-      accept: "application/json",
-    },
+    headers,
     body: JSON.stringify(input),
   });
   const payload = await response.json();
@@ -187,7 +195,7 @@ test("Living Archive memory service operation evaluator returns deterministic se
 
 test("Living Archive memory service exposes portable status, search, read, intake, review queue, and lint over HTTP", async (t) => {
   const root = await makeMemoryRoot();
-  const server = createLivingArchiveMemoryService({ memoryRoot: root, readonly: false });
+  const server = createLivingArchiveMemoryService({ memoryRoot: root, readonly: false, token: TEST_TOKEN });
   let endpoint;
   try {
     endpoint = await listen(server);
@@ -213,7 +221,7 @@ test("Living Archive memory service exposes portable status, search, read, intak
 
 test("Living Archive MCP bridge can use the local memory service as its live backend", async (t) => {
   const root = await makeMemoryRoot();
-  const server = createLivingArchiveMemoryService({ memoryRoot: root, readonly: false });
+  const server = createLivingArchiveMemoryService({ memoryRoot: root, readonly: false, token: TEST_TOKEN });
   let endpoint;
   try {
     endpoint = await listen(server);
@@ -227,6 +235,7 @@ test("Living Archive MCP bridge can use the local memory service as its live bac
     const bridge = createLivingArchiveBridge({
       memoryRoot: "",
       memoryServiceUrl: endpoint,
+      memoryServiceToken: TEST_TOKEN,
       maxSearchBytes: 1024 * 1024,
       readonly: false,
     });
@@ -266,6 +275,109 @@ test("Living Archive MCP bridge can use the local memory service as its live bac
     assert.equal(promoted.status, "promoted");
     const readBack = await bridge.callTool("living_archive_read", { path: promoted.promotedPage });
     assert.match(readBack.content, /Hermes can queue knowledge/);
+  } finally {
+    await new Promise((resolveClose) => server.close(resolveClose));
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+// --- DD-3 (F6) hardening: token-gated writes, readonly default, CORS ---------
+
+test("DD-3: write operations are classified and gate-able", () => {
+  assert.equal(isWriteMemoryOperation("intake-write"), true);
+  assert.equal(isWriteMemoryOperation("ingest-request"), true);
+  assert.equal(isWriteMemoryOperation("process-ingest-request"), true);
+  assert.equal(isWriteMemoryOperation("decide-review"), true);
+  assert.equal(isWriteMemoryOperation("promote-review-artifact"), true);
+  assert.equal(isWriteMemoryOperation("maintenance-cycle"), true);
+  assert.equal(isWriteMemoryOperation("background-cycle"), true);
+  // Reads must NOT be gated.
+  assert.equal(isWriteMemoryOperation("status"), false);
+  assert.equal(isWriteMemoryOperation("search"), false);
+  assert.equal(isWriteMemoryOperation("read"), false);
+  assert.equal(isWriteMemoryOperation("review-queue"), false);
+  assert.equal(isWriteMemoryOperation("lint"), false);
+});
+
+test("DD-3: writes require a bearer token; reads stay unauth; CORS is not wildcard", async (t) => {
+  const root = await makeMemoryRoot();
+  const server = createLivingArchiveMemoryService({ memoryRoot: root, readonly: false, token: TEST_TOKEN });
+  let endpoint;
+  try {
+    endpoint = await listen(server);
+  } catch (error) {
+    await rm(root, { recursive: true, force: true });
+    if (skipIfSandboxLocalhostDenied(t, error)) return;
+    throw error;
+  }
+
+  try {
+    // Read on loopback without a token: allowed.
+    const status = await postMemory(endpoint, "status", {}, "");
+    assert.equal(status.response.status, 200);
+    // CORS allow-origin must be an allowlist, never "*".
+    const acao = status.response.headers.get("access-control-allow-origin");
+    assert.ok(acao && acao !== "*", `CORS allow-origin must not be wildcard, got ${acao}`);
+
+    // Write with NO token: rejected 401.
+    const noToken = await postMemory(endpoint, "intake-write", {
+      actorId: "external.agent",
+      bucket: "obsidian",
+      fileName: "note.md",
+      content: "# Note",
+    }, "");
+    assert.equal(noToken.response.status, 401);
+
+    // Write with WRONG token: rejected 401.
+    const wrongToken = await postMemory(endpoint, "intake-write", {
+      actorId: "external.agent",
+      bucket: "obsidian",
+      fileName: "note.md",
+      content: "# Note",
+    }, "not-the-token");
+    assert.equal(wrongToken.response.status, 401);
+
+    // Write with the VALID token: accepted.
+    const ok = await postMemory(endpoint, "intake-write", {
+      actorId: "external.agent",
+      bucket: "obsidian",
+      fileName: "note.md",
+      content: "# Note",
+    }, TEST_TOKEN);
+    assert.equal(ok.response.status, 200);
+    assert.equal(ok.payload.artifactPath, "INTAKE/mcp/obsidian/note.md");
+  } finally {
+    await new Promise((resolveClose) => server.close(resolveClose));
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("DD-3: readonly default rejects writes even with a token", async (t) => {
+  const root = await makeMemoryRoot();
+  // readonly defaults ON: a service created without an explicit writable opt-in
+  // refuses writes (403) regardless of token presence.
+  const server = createLivingArchiveMemoryService({ memoryRoot: root, token: TEST_TOKEN });
+  let endpoint;
+  try {
+    endpoint = await listen(server);
+  } catch (error) {
+    await rm(root, { recursive: true, force: true });
+    if (skipIfSandboxLocalhostDenied(t, error)) return;
+    throw error;
+  }
+
+  try {
+    const blocked = await postMemory(endpoint, "intake-write", {
+      actorId: "external.agent",
+      bucket: "obsidian",
+      fileName: "note.md",
+      content: "# Note",
+    }, TEST_TOKEN);
+    assert.equal(blocked.response.status, 403);
+
+    // Reads still work in readonly mode.
+    const status = await postMemory(endpoint, "status", {}, "");
+    assert.equal(status.response.status, 200);
   } finally {
     await new Promise((resolveClose) => server.close(resolveClose));
     await rm(root, { recursive: true, force: true });

--- a/src-tauri/src/memory_service.rs
+++ b/src-tauri/src/memory_service.rs
@@ -19,6 +19,13 @@ const DEFAULT_MEMORY_SERVICE_PORT: u16 = 4888;
 const MEMORY_SERVICE_HOSTNAME: &str = "127.0.0.1";
 const MEMORY_SERVICE_SESSION_ID: &str = "living-archive-memory-service";
 const MEMORY_SERVICE_HEALTH_TIMEOUT: Duration = Duration::from_secs(8);
+/// DD-3 (F6): default readonly so writes require an explicit opt-in *and* a token.
+const MEMORY_SERVICE_READONLY_DEFAULT: bool = true;
+/// Env vars consumed by the standalone listener (see
+/// examples/living-archive-memory-service.mjs).
+const MEMORY_SERVICE_TOKEN_ENV: &str = "RESONANTOS_MEMORY_SERVICE_TOKEN";
+const MEMORY_SERVICE_HOST_ENV: &str = "RESONANTOS_MEMORY_SERVICE_HOST";
+const MEMORY_SERVICE_UNSAFE_HOST_ENV: &str = "RESONANTOS_MEMORY_SERVICE_UNSAFE_HOST";
 
 static MEMORY_SERVICE_SESSIONS: OnceLock<Mutex<HashMap<String, MemoryServiceProcessSession>>> =
     OnceLock::new();
@@ -30,6 +37,7 @@ fn memory_service_sessions() -> &'static Mutex<HashMap<String, MemoryServiceProc
 struct MemoryServiceProcessSession {
     child: Child,
     memory_root: String,
+    host: String,
     port: u16,
     readonly: bool,
 }
@@ -124,7 +132,7 @@ pub(crate) fn query_memory_service_status(
         endpoint,
         memory_root: portable_state.memory_root,
         session_id,
-        readonly: false,
+        readonly: MEMORY_SERVICE_READONLY_DEFAULT,
         pid: None,
         command,
         status_detail: if available {
@@ -153,8 +161,16 @@ pub(crate) fn start_memory_service(
         Some(port) => port,
         None => available_local_port().unwrap_or(DEFAULT_MEMORY_SERVICE_PORT),
     };
-    let readonly = request.readonly.unwrap_or(false);
-    let endpoint = endpoint_for_port(port);
+    // DD-3 (F6): readonly is the default. Writes only enable when the caller
+    // explicitly opts out *and* a token is configured for the listener.
+    let token = memory_service_token();
+    let mut readonly = request.readonly.unwrap_or(MEMORY_SERVICE_READONLY_DEFAULT);
+    if !readonly && token.is_none() {
+        // No token means writes cannot be authenticated; fail closed to readonly.
+        readonly = true;
+    }
+    let host = resolve_memory_service_host()?;
+    let endpoint = endpoint_for_host_port(&host, port);
 
     let mut sessions = memory_service_sessions()
         .lock()
@@ -170,7 +186,7 @@ pub(crate) fn start_memory_service(
         {
             return Ok(MemoryServiceResult {
                 session_id,
-                endpoint: endpoint_for_port(existing.port),
+                endpoint: endpoint_for_host_port(&existing.host, existing.port),
                 memory_root: existing.memory_root.clone(),
                 readonly: existing.readonly,
                 command: command_label(&script),
@@ -181,15 +197,30 @@ pub(crate) fn start_memory_service(
         sessions.remove(&session_id);
     }
 
-    let child = Command::new(resolve_node_binary())
+    let mut command = Command::new(resolve_node_binary());
+    command
         .arg(&script)
         .arg("--memory-root")
         .arg(&portable_state.memory_root)
         .arg("--host")
-        .arg(MEMORY_SERVICE_HOSTNAME)
+        .arg(&host)
         .arg("--port")
-        .arg(port.to_string())
-        .args(if readonly { vec!["--readonly"] } else { vec![] })
+        .arg(port.to_string());
+    if readonly {
+        command.arg("--readonly");
+    } else {
+        // Writes enabled: the listener requires a bearer token (DD-3 F6). The
+        // token was confirmed present above before flipping readonly off; pass it
+        // via env (not argv) so it does not leak through the process table.
+        command.arg("--writable");
+        if let Some(ref token) = token {
+            command.env(MEMORY_SERVICE_TOKEN_ENV, token);
+        }
+    }
+    if host_requires_unsafe_optin(&host) {
+        command.arg("--unsafe-host");
+    }
+    let child = command
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -202,11 +233,12 @@ pub(crate) fn start_memory_service(
         MemoryServiceProcessSession {
             child,
             memory_root: portable_state.memory_root.clone(),
+            host: host.clone(),
             port,
             readonly,
         },
     );
-    wait_for_memory_service_health(port)?;
+    wait_for_memory_service_health(&host, port)?;
 
     Ok(MemoryServiceResult {
         session_id,
@@ -236,7 +268,7 @@ pub(crate) fn stop_memory_service(
     let _ = session.child.wait();
     Ok(MemoryServiceResult {
         session_id,
-        endpoint: endpoint_for_port(session.port),
+        endpoint: endpoint_for_host_port(&session.host, session.port),
         memory_root: session.memory_root,
         readonly: session.readonly,
         command: "node examples/living-archive-memory-service.mjs".to_string(),
@@ -253,7 +285,70 @@ fn normalize_session_id(value: Option<String>) -> String {
 }
 
 fn endpoint_for_port(port: u16) -> String {
-    format!("http://{MEMORY_SERVICE_HOSTNAME}:{port}")
+    endpoint_for_host_port(MEMORY_SERVICE_HOSTNAME, port)
+}
+
+fn endpoint_for_host_port(host: &str, port: u16) -> String {
+    // Bracket IPv6 literals for a valid URL authority.
+    if host.contains(':') && !host.starts_with('[') {
+        format!("http://[{host}]:{port}")
+    } else {
+        format!("http://{host}:{port}")
+    }
+}
+
+fn memory_service_token() -> Option<String> {
+    std::env::var(MEMORY_SERVICE_TOKEN_ENV)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+/// DD-3 loopback-default. A non-loopback bind is only honored when the operator
+/// explicitly opts in via RESONANTOS_MEMORY_SERVICE_UNSAFE_HOST; otherwise the
+/// listener falls back to the loopback host so it can never be exposed by accident.
+fn resolve_memory_service_host() -> Result<String, String> {
+    let requested = std::env::var(MEMORY_SERVICE_HOST_ENV)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| MEMORY_SERVICE_HOSTNAME.to_string());
+    if is_loopback_host(&requested) {
+        return Ok(requested);
+    }
+    if unsafe_host_optin() {
+        return Ok(requested);
+    }
+    // Fail closed to loopback rather than exposing the listener.
+    Ok(MEMORY_SERVICE_HOSTNAME.to_string())
+}
+
+fn unsafe_host_optin() -> bool {
+    std::env::var(MEMORY_SERVICE_UNSAFE_HOST_ENV)
+        .map(|value| value.trim() == "1")
+        .unwrap_or(false)
+}
+
+fn host_requires_unsafe_optin(host: &str) -> bool {
+    !is_loopback_host(host)
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    let normalized = host
+        .trim()
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .to_ascii_lowercase();
+    if normalized.is_empty() {
+        return false;
+    }
+    if normalized == "localhost" || normalized.ends_with(".localhost") {
+        return true;
+    }
+    if normalized == "::1" {
+        return true;
+    }
+    normalized.starts_with("127.")
 }
 
 fn memory_service_script_path(app: &AppHandle) -> Result<PathBuf, String> {
@@ -301,22 +396,22 @@ fn available_local_port() -> Option<u16> {
         .and_then(|listener| listener.local_addr().ok().map(|address| address.port()))
 }
 
-fn wait_for_memory_service_health(port: u16) -> Result<(), String> {
+fn wait_for_memory_service_health(host: &str, port: u16) -> Result<(), String> {
     let deadline = Instant::now() + MEMORY_SERVICE_HEALTH_TIMEOUT;
     while Instant::now() < deadline {
-        if memory_service_health_ready(port) {
+        if memory_service_health_ready(host, port) {
             return Ok(());
         }
         thread::sleep(Duration::from_millis(150));
     }
     Err(format!(
-        "Living Archive memory service started but did not become healthy on {MEMORY_SERVICE_HOSTNAME}:{port} within {}s.",
+        "Living Archive memory service started but did not become healthy on {host}:{port} within {}s.",
         MEMORY_SERVICE_HEALTH_TIMEOUT.as_secs()
     ))
 }
 
-fn memory_service_health_ready(port: u16) -> bool {
-    let Ok(mut stream) = TcpStream::connect((MEMORY_SERVICE_HOSTNAME, port)) else {
+fn memory_service_health_ready(host: &str, port: u16) -> bool {
+    let Ok(mut stream) = TcpStream::connect((host, port)) else {
         return false;
     };
     let _ = stream.set_read_timeout(Some(Duration::from_millis(500)));
@@ -336,7 +431,10 @@ fn memory_service_health_ready(port: u16) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{endpoint_for_port, normalize_session_id};
+    use super::{
+        endpoint_for_host_port, endpoint_for_port, host_requires_unsafe_optin, is_loopback_host,
+        normalize_session_id, MEMORY_SERVICE_READONLY_DEFAULT,
+    };
 
     #[test]
     fn defaults_session_id_for_empty_input() {
@@ -349,5 +447,44 @@ mod tests {
     #[test]
     fn builds_loopback_endpoint() {
         assert_eq!(endpoint_for_port(4888), "http://127.0.0.1:4888");
+    }
+
+    #[test]
+    fn brackets_ipv6_authority() {
+        assert_eq!(endpoint_for_host_port("::1", 4888), "http://[::1]:4888");
+        assert_eq!(
+            endpoint_for_host_port("127.0.0.1", 4888),
+            "http://127.0.0.1:4888"
+        );
+    }
+
+    // DD-3 readonly-default: the spawner must default writes OFF.
+    #[test]
+    fn readonly_is_default_on() {
+        assert!(MEMORY_SERVICE_READONLY_DEFAULT);
+    }
+
+    // DD-3 loopback-default: loopback hosts need no opt-in; everything else does.
+    #[test]
+    fn loopback_classification_is_correct() {
+        assert!(is_loopback_host("127.0.0.1"));
+        assert!(is_loopback_host("127.5.5.5"));
+        assert!(is_loopback_host("localhost"));
+        assert!(is_loopback_host("app.localhost"));
+        assert!(is_loopback_host("::1"));
+        assert!(is_loopback_host("[::1]"));
+
+        assert!(!is_loopback_host("0.0.0.0"));
+        assert!(!is_loopback_host("::"));
+        assert!(!is_loopback_host("192.168.0.10"));
+        assert!(!is_loopback_host("example.com"));
+        assert!(!is_loopback_host(""));
+    }
+
+    #[test]
+    fn non_loopback_requires_unsafe_optin() {
+        assert!(!host_requires_unsafe_optin("127.0.0.1"));
+        assert!(host_requires_unsafe_optin("0.0.0.0"));
+        assert!(host_requires_unsafe_optin("192.168.0.10"));
     }
 }

--- a/src/core/memory-provider.test.ts
+++ b/src/core/memory-provider.test.ts
@@ -160,4 +160,83 @@ describe("memory provider broker", () => {
       }),
     );
   });
+
+  it("forwards the configured bearer token on write operations", async () => {
+    const manifest = httpMemoryManifest();
+    const state = enableMemoryProvider(buildDefaultState([manifest]), manifest);
+    state.installations[manifest.id].config = {
+      memoryServiceToken: "secret-token",
+    };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ artifactPath: "INTAKE/mcp/default/note.md", metadataPath: "" }),
+    } as Response);
+
+    const broker = resolveMemoryProviderBroker(state, [manifest]);
+    await broker.intakeWrite({
+      actorId: "tester",
+      bucket: "default",
+      fileName: "note.md",
+      content: "hello",
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>).authorization).toBe("Bearer secret-token");
+  });
+
+  it("falls back to RESONANTOS_MEMORY_SERVICE_TOKEN for writes when config omits a token", async () => {
+    const previous = process.env.RESONANTOS_MEMORY_SERVICE_TOKEN;
+    process.env.RESONANTOS_MEMORY_SERVICE_TOKEN = "env-token";
+    try {
+      const manifest = httpMemoryManifest();
+      const state = enableMemoryProvider(buildDefaultState([manifest]), manifest);
+      const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        ok: true,
+        json: async () => ({ requestFile: "INTAKE/review-queue/1.json", queuedAt: "" }),
+      } as Response);
+
+      const broker = resolveMemoryProviderBroker(state, [manifest]);
+      await broker.ingestRequest({
+        actorId: "tester",
+        sourcePath: "EXTERNAL_KNOWLEDGE/doc.md",
+        sourceType: "markdown",
+        intent: "ingest",
+      });
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect((init.headers as Record<string, string>).authorization).toBe("Bearer env-token");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.RESONANTOS_MEMORY_SERVICE_TOKEN;
+      } else {
+        process.env.RESONANTOS_MEMORY_SERVICE_TOKEN = previous;
+      }
+    }
+  });
+
+  it("does not send an Authorization header on read operations", async () => {
+    const previous = process.env.RESONANTOS_MEMORY_SERVICE_TOKEN;
+    process.env.RESONANTOS_MEMORY_SERVICE_TOKEN = "env-token";
+    try {
+      const manifest = httpMemoryManifest();
+      const state = enableMemoryProvider(buildDefaultState([manifest]), manifest);
+      state.installations[manifest.id].config = { memoryServiceToken: "secret-token" };
+      const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        ok: true,
+        json: async () => ({ query: "augmentor", pages: [], sources: [] }),
+      } as Response);
+
+      const broker = resolveMemoryProviderBroker(state, [manifest]);
+      await broker.search("augmentor", 3);
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect((init.headers as Record<string, string>).authorization).toBeUndefined();
+    } finally {
+      if (previous === undefined) {
+        delete process.env.RESONANTOS_MEMORY_SERVICE_TOKEN;
+      } else {
+        process.env.RESONANTOS_MEMORY_SERVICE_TOKEN = previous;
+      }
+    }
+  });
 });

--- a/src/core/memory-provider.ts
+++ b/src/core/memory-provider.ts
@@ -237,17 +237,39 @@ const endpointFromInstallation = (
   return raw.replace(/\/+$/, "");
 };
 
+const tokenFromInstallation = (installation: AddOnInstallation): string => {
+  const configured =
+    typeof installation.config?.memoryServiceToken === "string"
+      ? installation.config.memoryServiceToken
+      : typeof installation.config?.token === "string"
+        ? installation.config.token
+        : undefined;
+  // Fall back to the operator-supplied env token used by the hardened memory service.
+  const envToken =
+    typeof process !== "undefined" && typeof process.env?.RESONANTOS_MEMORY_SERVICE_TOKEN === "string"
+      ? process.env.RESONANTOS_MEMORY_SERVICE_TOKEN
+      : "";
+  return (configured ?? envToken).trim();
+};
+
 const postMemoryJson = async <Result>(
   endpoint: string,
   operation: string,
   input?: Record<string, unknown>,
+  token?: string,
 ): Promise<Result> => {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    accept: "application/json",
+  };
+  // DD-3 (F6): forward the bearer token so write operations authenticate against the
+  // hardened memory service. Reads pass no token and stay unauth on loopback.
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+  }
   const response = await fetch(`${endpoint}/memory/${operation}`, {
     method: "POST",
-    headers: {
-      "content-type": "application/json",
-      accept: "application/json",
-    },
+    headers,
     body: JSON.stringify(input ?? {}),
   });
   if (!response.ok) {
@@ -267,6 +289,8 @@ export const httpJsonMemoryProvider = (
       `${manifest.name} is missing a valid http-json memoryServiceUrl or service entrypoint`,
     );
   }
+  // Writes require a bearer token against the hardened memory service; reads stay unauth.
+  const writeToken = tokenFromInstallation(installation);
 
   return {
     providerId: manifest.id,
@@ -283,17 +307,17 @@ export const httpJsonMemoryProvider = (
     status: () => postMemoryJson<ArchiveRuntimeStatus>(endpoint, "status"),
     search: (query, limit = 12) => postMemoryJson<ArchiveSearchResult>(endpoint, "search", { query, limit }),
     read: (path) => postMemoryJson<ArchiveDocumentPayload>(endpoint, "read", { path }),
-    intakeWrite: (input) => postMemoryJson<ArchiveIntakeWriteResult>(endpoint, "intake-write", input),
-    ingestRequest: (input) => postMemoryJson<ArchiveIngestRequestResult>(endpoint, "ingest-request", input),
+    intakeWrite: (input) => postMemoryJson<ArchiveIntakeWriteResult>(endpoint, "intake-write", input, writeToken),
+    ingestRequest: (input) => postMemoryJson<ArchiveIngestRequestResult>(endpoint, "ingest-request", input, writeToken),
     reviewQueue: () => postMemoryJson<ArchiveQueuedIngestRequest[]>(endpoint, "review-queue"),
     reviewArtifacts: () => postMemoryJson<ArchiveReviewArtifact[]>(endpoint, "review-artifacts"),
-    processIngestRequest: (input) => postMemoryJson<ArchiveProcessIngestResult>(endpoint, "process-ingest-request", input),
-    maintenanceCycle: (input) => postMemoryJson<ArchiveMaintenanceCycleResult>(endpoint, "maintenance-cycle", input),
-    backgroundCycle: (input) => postMemoryJson<ArchiveBackgroundCycleResult>(endpoint, "background-cycle", input),
+    processIngestRequest: (input) => postMemoryJson<ArchiveProcessIngestResult>(endpoint, "process-ingest-request", input, writeToken),
+    maintenanceCycle: (input) => postMemoryJson<ArchiveMaintenanceCycleResult>(endpoint, "maintenance-cycle", input, writeToken),
+    backgroundCycle: (input) => postMemoryJson<ArchiveBackgroundCycleResult>(endpoint, "background-cycle", input, writeToken),
     lint: () => postMemoryJson<ArchiveLintResult>(endpoint, "lint"),
     semanticLint: (input) => postMemoryJson<ArchiveSemanticLintResult>(endpoint, "semantic-lint", input),
-    decideReview: (input) => postMemoryJson<ArchiveReviewDecisionResult>(endpoint, "decide-review", input),
-    promoteReviewArtifact: (input) => postMemoryJson<ArchivePromoteReviewArtifactResult>(endpoint, "promote-review-artifact", input),
+    decideReview: (input) => postMemoryJson<ArchiveReviewDecisionResult>(endpoint, "decide-review", input, writeToken),
+    promoteReviewArtifact: (input) => postMemoryJson<ArchivePromoteReviewArtifactResult>(endpoint, "promote-review-artifact", input, writeToken),
   };
 };
 


### PR DESCRIPTION
### Fixes finding `F6` — memory-service writes unauthenticated + readonly off, severity High (→ fixed)

### What was wrong
The living-archive memory service accepted **writes with no authentication** and defaulted `readonly` **off**.

### Why it matters
Any local (or, if exposed, network) caller could mutate the memory store without a credential (CWE-306 Missing Authentication). Reachable by: local-process / network if bound non-loopback.

### The change
- Readonly **defaults ON**; writes require a writable opt-in **and** a bearer token (`RESONANTOS_MEMORY_SERVICE_TOKEN`, constant-time) → 401/403 otherwise; reads stay unauth on loopback.
- Loopback-default bind; non-loopback only behind `--unsafe-host`; CORS stays a loopback allowlist (never `*`); token via env not argv.
- **Caller migration (non-breaking):** `src/core/memory-provider.ts` + the mcp bridge forward the token on writes.
Breaking: operators must set the token + writable flag to write (intended).

### Validation
`cargo test --lib memory_service` (6); `node --test` example (7) + mcp (4); `tsc` clean; `vitest memory-provider` (8); DD-3 predicate passes.

### Surface touched
`src-tauri/src/memory_service.rs`, `examples/living-archive-*.mjs`, `src/core/memory-provider.ts`

### Status / residual
F6 → **fixed**; no code caller of the hardened service left unauthenticated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)