### PR TITLE
sdk: Gate add-on systemSlots and mark missing provenance as unreviewed

### DIFF
--- a/public/addons/augmentor-chat.json
+++ b/public/addons/augmentor-chat.json
@@ -57,6 +57,12 @@
       "granted": false,
       "scope": "shared",
       "revocationBehavior": "degrade"
+    },
+    {
+      "capability": "agent-delegation",
+      "granted": false,
+      "scope": "system",
+      "revocationBehavior": "hard-stop"
     }
   ],
   "provenance": {

--- a/src/core/defaults.ts
+++ b/src/core/defaults.ts
@@ -838,14 +838,17 @@ export const archiveAutomationPolicy: ArchiveAutomationPolicy = {
   aiMemoryBuilds: "off",
 };
 
+// P1-e: do not trust by omission. A bundled manifest with NO provenance is
+// marked dev/internal/unreviewed (sideloaded-unverified / unverified) rather than
+// silently defaulting to curated-signed / verified.
 const defaultProvenanceTier = (manifest: AddOnManifest, source: AddOnInstallation["source"]): AddOnInstallation["provenanceTier"] =>
-  source === "sideload" ? "sideloaded-unverified" : (manifest.provenance?.tier ?? "curated-signed");
+  source === "sideload" || !manifest.provenance ? "sideloaded-unverified" : (manifest.provenance.tier ?? "curated-signed");
 
 const defaultVerificationState = (
   manifest: AddOnManifest,
   source: AddOnInstallation["source"],
 ): AddOnInstallation["verificationState"] =>
-  source === "sideload" ? "unverified" : (manifest.provenance?.verificationState ?? "verified");
+  source === "sideload" || !manifest.provenance ? "unverified" : (manifest.provenance.verificationState ?? "verified");
 
 export const createDefaultInstallation = (manifest: AddOnManifest, source: AddOnInstallation["source"]): AddOnInstallation => ({
   addonId: manifest.id,

--- a/src/modules/shell/system-slots.ts
+++ b/src/modules/shell/system-slots.ts
@@ -22,14 +22,21 @@ export const hasSystemSlotManifest = (manifests: AddOnManifest[], slotId: System
 export const recommendedSystemSlotManifests = (manifests: AddOnManifest[]): AddOnManifest[] =>
   manifests.filter((manifest) => manifest.systemSlots?.some((slot) => slot.recommended));
 
-const capabilityForSlot = (slotId: SystemSlotId): CapabilityGrant["capability"] | null => {
-  if (slotId === "chat-interface") {
-    return "chat-interface";
+// Every SystemSlotId maps to a backing capability so a manifest cannot seize a
+// slot (and become its active provider) without requesting — and the user
+// granting — that capability. Previously primary-agent and communication-channel
+// returned null, leaving those slots with NO capability gate (P1-b bypass).
+export const capabilityForSlot = (slotId: SystemSlotId): CapabilityGrant["capability"] => {
+  switch (slotId) {
+    case "chat-interface":
+      return "chat-interface";
+    case "memory-system":
+      return "memory-provider";
+    case "primary-agent":
+      return "agent-delegation";
+    case "communication-channel":
+      return "notifications";
   }
-  if (slotId === "memory-system") {
-    return "memory-provider";
-  }
-  return null;
 };
 
 export const activeSystemSlotProvider = (
@@ -43,7 +50,7 @@ export const activeSystemSlotProvider = (
       continue;
     }
     const requiredCapability = capabilityForSlot(slotId);
-    if (requiredCapability && !installation.grantedCapabilities.some((grant) => grant.capability === requiredCapability && grant.granted)) {
+    if (!installation.grantedCapabilities.some((grant) => grant.capability === requiredCapability && grant.granted)) {
       continue;
     }
     return { manifest, installation };

--- a/src/sdk/addons/registry.test.ts
+++ b/src/sdk/addons/registry.test.ts
@@ -39,6 +39,8 @@ const manifest = (id: string, overrides: Partial<AddOnManifest> = {}): AddOnMani
 describe("add-on registry snapshot", () => {
   it("keeps bundled catalog entries separate from installed add-ons", () => {
     const addon = manifest("addon.obsidian", {
+      // P1-e: this manifest carries no provenance, so it must NOT be trusted by
+      // omission. It resolves to dev/internal/unreviewed instead of curated-signed.
       grantPresets: [
         {
           id: "obsidian-basic",
@@ -54,13 +56,37 @@ describe("add-on registry snapshot", () => {
     });
 
     expect(entry.registrySource).toBe("bundled-catalog");
-    expect(entry.provenanceTier).toBe("curated-signed");
-    expect(entry.verificationState).toBe("verified");
-    expect(entry.reviewState).toBe("reviewed");
+    expect(entry.provenanceTier).toBe("sideloaded-unverified");
+    expect(entry.verificationState).toBe("unverified");
     expect(entry.installState).toBe("available");
     expect(entry.installed).toBe(false);
     expect(entry.enabled).toBe(false);
     expect(entry.recommendedGrantPresetIds).toContain("obsidian-basic");
+  });
+
+  it("marks a bundled manifest with NO provenance as dev/internal/unreviewed (P1-e, no trust by omission)", () => {
+    const addon = manifest("addon.no-provenance");
+    const entry = createAddOnRegistryEntry(addon, { registrySource: "bundled-catalog" });
+
+    expect(entry.provenanceTier).toBe("sideloaded-unverified");
+    expect(entry.verificationState).toBe("unverified");
+    expect(entry.reviewState).toBe("unreviewed");
+  });
+
+  it("keeps a signed bundled manifest verified (P1-e)", () => {
+    const addon = manifest("addon.signed", {
+      provenance: {
+        tier: "curated-signed",
+        verificationState: "verified",
+        signed: true,
+        signer: "ResonantOS bundled catalog",
+      },
+    });
+    const entry = createAddOnRegistryEntry(addon, { registrySource: "bundled-catalog" });
+
+    expect(entry.provenanceTier).toBe("curated-signed");
+    expect(entry.verificationState).toBe("verified");
+    expect(entry.reviewState).toBe("reviewed");
   });
 
   it("marks sideloaded add-ons as untrusted registry entries by default", () => {

--- a/src/sdk/addons/registry.ts
+++ b/src/sdk/addons/registry.ts
@@ -50,9 +50,22 @@ const sourceDefaults = (
     };
   }
 
+  // P1-e: a bundled-catalog manifest with NO provenance must NOT be trusted by
+  // omission. Previously an absent provenance silently defaulted to
+  // curated-signed/verified/reviewed. Instead, mark a manifest lacking any
+  // provenance metadata as dev/internal/unreviewed (sideloaded-unverified /
+  // unverified / unreviewed) so missing provenance is visible, never crashing.
+  if (!manifest.provenance) {
+    return {
+      provenanceTier: "sideloaded-unverified",
+      verificationState: "unverified",
+      reviewState: "unreviewed",
+    };
+  }
+
   return {
-    provenanceTier: manifest.provenance?.tier ?? "curated-signed",
-    verificationState: manifest.provenance?.verificationState ?? "verified",
+    provenanceTier: manifest.provenance.tier ?? "curated-signed",
+    verificationState: manifest.provenance.verificationState ?? "verified",
     reviewState: "reviewed",
   };
 };

--- a/src/sdk/addons/validation.test.ts
+++ b/src/sdk/addons/validation.test.ts
@@ -721,4 +721,56 @@ describe("add-on SDK manifest validation", () => {
     expect(result.issues.some((issue) => issue.code === "memory-access-knowledge-write-forbidden")).toBe(true);
     expect(result.issues.some((issue) => issue.code === "smoke-test-unrequested-capability")).toBe(true);
   });
+
+  it("rejects a systemSlot claim whose backing capability is not declared (P1-b ungated slot bypass)", () => {
+    const result = validateAddOnManifest(
+      validManifest({
+        // Claims the primary-agent slot but does NOT declare agent-delegation,
+        // so the runtime grant gate (activeSystemSlotProvider) can never apply.
+        systemSlots: [
+          { id: "primary-agent", role: "default-provider", replaceable: true },
+        ],
+      }),
+    );
+
+    expect(result.valid).toBe(false);
+    expect(
+      result.issues.some(
+        (issue) => issue.code === "system-slot-undeclared-capability" && issue.path === "systemSlots[0].id",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a systemSlot claim with an unknown slot id", () => {
+    const result = validateAddOnManifest(
+      validManifest({
+        systemSlots: [
+          { id: "root-controller" as never, role: "default-provider", replaceable: true },
+        ],
+      }),
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((issue) => issue.code === "system-slot-unknown")).toBe(true);
+  });
+
+  it("accepts a properly capability-gated systemSlot claim", () => {
+    const base = validManifest();
+    const result = validateAddOnManifest(
+      validManifest({
+        // primary-agent's backing capability (agent-delegation) is declared, so
+        // the runtime grant gate can apply -> covered.
+        requestedCapabilities: [
+          ...base.requestedCapabilities,
+          { capability: "agent-delegation", granted: false, scope: "system", revocationBehavior: "hard-stop" },
+        ],
+        systemSlots: [
+          { id: "primary-agent", role: "default-provider", replaceable: true },
+        ],
+      }),
+    );
+
+    expect(result.issues.filter((issue) => issue.code.startsWith("system-slot"))).toEqual([]);
+    expect(result.valid).toBe(true);
+  });
 });

--- a/src/sdk/addons/validation.ts
+++ b/src/sdk/addons/validation.ts
@@ -10,6 +10,7 @@ import type {
   DelegationArtifactType,
   RevocationBehavior,
   RuntimeIsolationBoundary,
+  SystemSlotId,
 } from "../../core/contracts";
 import {
   ADDON_CAPABILITIES,
@@ -91,6 +92,20 @@ const hookEvents = [
   "after-archive-intake",
 ] as const;
 const hookFailurePolicies = ["block", "degrade", "warn"] as const;
+
+// systemSlots coverage (P1-b). A manifest that declares a systemSlot becomes the
+// active provider for that slot (activeSystemSlotProvider), replacing a built-in
+// surface. Each known SystemSlotId maps to a backing capability that MUST be
+// declared in requestedCapabilities so the runtime grant gate
+// (system-slots.ts capabilityForSlot / activeSystemSlotProvider) can apply.
+// This map mirrors capabilityForSlot in src/modules/shell/system-slots.ts.
+const systemSlotIds: readonly SystemSlotId[] = ["primary-agent", "chat-interface", "memory-system", "communication-channel"];
+const slotBackingCapability: Record<SystemSlotId, Capability> = {
+  "primary-agent": "agent-delegation",
+  "chat-interface": "chat-interface",
+  "memory-system": "memory-provider",
+  "communication-channel": "notifications",
+};
 
 const addonIdPattern = /^addon\.[a-z0-9][a-z0-9-]*(?:\.[a-z0-9][a-z0-9-]*)*$/;
 const semanticVersionPattern = /^\d+\.\d+\.\d+(?:[-+][a-z0-9.-]+)?$/i;
@@ -1088,6 +1103,47 @@ export const validateAddOnManifest = (
         "Smoke tests may only require capabilities requested by the manifest.",
       );
     });
+  }
+
+  // systemSlots coverage (P1-b). systemSlots is inside the manifest type but was
+  // never validated, so a manifest could claim an active-provider slot (e.g.
+  // primary-agent) that bypassed manifest capability validation. A slot claim is
+  // only accepted when it uses a known SystemSlotId AND declares the slot's
+  // backing capability in requestedCapabilities (so the runtime grant gate can
+  // apply). Mirrors the block rule in
+  // .craft/.../checks/containment/addon-provenance.mjs.
+  if (candidate.systemSlots !== undefined) {
+    if (!Array.isArray(candidate.systemSlots)) {
+      pushIssue(issues, "error", "system-slots-array", "systemSlots", "systemSlots must be an array when present.");
+    } else {
+      candidate.systemSlots.forEach((slot, index) => {
+        const path = `systemSlots[${index}]`;
+        if (!isRecord(slot)) {
+          pushIssue(issues, "error", "system-slot-object", path, "Each systemSlots entry must be an object.");
+          return;
+        }
+        if (!isString(slot.id) || !systemSlotIds.includes(slot.id as SystemSlotId)) {
+          pushIssue(
+            issues,
+            "error",
+            "system-slot-unknown",
+            `${path}.id`,
+            `systemSlots id must be a known SystemSlotId (${systemSlotIds.join(", ")}).`,
+          );
+          return;
+        }
+        const backingCapability = slotBackingCapability[slot.id as SystemSlotId];
+        if (!requestedCapabilitySet.has(backingCapability)) {
+          pushIssue(
+            issues,
+            "error",
+            "system-slot-undeclared-capability",
+            `${path}.id`,
+            `System slot "${slot.id}" requires capability "${backingCapability}" to be declared in requestedCapabilities so the runtime grant gate can apply; without it the slot claim bypasses manifest capability validation.`,
+          );
+        }
+      });
+    }
   }
 
   if (source === "sideload" && isRecord(candidate.provenance) && candidate.provenance.tier !== "sideloaded-unverified") {


### PR DESCRIPTION
### Fixes findings `P1-b` + `P1-e` — ungated systemSlot + provenance trust-by-omission (→ fixed)

### What was wrong
- **P1-b:** an add-on could declare a `primary-agent` systemSlot that **bypassed capability validation** (the real offender: `augmentor-chat.json`).
- **P1-e:** a bundled manifest with **no provenance** silently resolved to `curated-signed`/`verified` (trust-by-omission).

### Why it matters
An ungated slot grants a privileged runtime role without a capability check; trust-by-omission marks unsigned add-ons as verified — both let untrusted add-on code gain trust it didn't earn (CWE-862 / CWE-345). Reachable by: installed add-ons.

### The change
- `capabilityForSlot` maps all 4 slots to real capabilities; `validateAddOnManifest` rejects ungated/unknown systemSlots; fixed `augmentor-chat.json` to declare its capability.
- Provenance trust-by-omission fixed on **both** the registry-source and installation (`defaults.ts`) paths → unsigned bundled manifests default to `sideloaded-unverified`/`unreviewed`.
Breaking: 8 unsigned bundled manifests now surface as unreviewed (intended); no shipped add-on broken.

### Validation
`tsc --noEmit` clean; vitest (validation/registry/public-manifests/system-slots/shell/policies) — 80 pass.

### Surface touched
`src/modules/shell/system-slots.ts`, `src/sdk/addons/{validation,registry}.ts`, `src/core/defaults.ts`, `public/addons/augmentor-chat.json`

### Status / residual
P1-b + P1-e → **fixed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)