### PR TITLE
browser-first: Default to an ephemeral profile and contain CDP exposure

### DIFF
--- a/browser-first/host/browser-launch-config.mjs
+++ b/browser-first/host/browser-launch-config.mjs
@@ -1,0 +1,98 @@
+import os from "node:os";
+import path from "node:path";
+
+// Browser-launch containment for the browser-first native host (PR-R07 / P1-c).
+//
+// Goal: each sensitive launch binds an OWNED EPHEMERAL profile, a contained
+// remote-debugging surface (loopback + port 0 / ephemeral), and a pinned
+// extension set. A PERSISTENT profile is permitted only by an explicit opt-in.
+//
+// These are pure helpers so the launch argv can be asserted statically (no
+// browser launch, no live CDP) — matching the cdp-proof predicate:
+//   safe <=> ephemeral_profile AND (port == 0 OR loopback_bound) AND pinned_extension_set
+
+export const LOOPBACK_ADDRESS = "127.0.0.1";
+
+// Owned root for ephemeral per-session profiles. Kept under the owned
+// ResonantOS user root so cleanup and ownership are unambiguous, falling back
+// to the OS temp dir when no user root is provided.
+export function ephemeralProfileRoot({ userRoot, home = os.homedir(), tmpdir = os.tmpdir() } = {}) {
+  const base = userRoot
+    ? path.join(userRoot, "BrowserFirst", "Profiles", "ephemeral")
+    : path.join(tmpdir, "ResonantOS_BrowserFirst_Profiles");
+  void home;
+  return base;
+}
+
+// True when the caller explicitly opted into a PERSISTENT profile.
+export function persistentProfileOptIn({ args, env = process.env } = {}) {
+  const flag = args?.get?.("persistent-profile");
+  if (flag === "true" || flag === "1") return true;
+  const envValue = String(env.RESONANTOS_BROWSER_PERSISTENT_PROFILE ?? "").trim().toLowerCase();
+  return envValue === "1" || envValue === "true" || envValue === "yes";
+}
+
+// Resolve the profile directory used for the launch.
+//
+// Precedence:
+//   1. Explicit caller-supplied path (`--profile=` / RESONANTOS_BROWSER_FIRST_PROFILE)
+//      — an explicit, intentional choice; honored as-is.
+//   2. Persistent opt-in (`--persistent-profile` / RESONANTOS_BROWSER_PERSISTENT_PROFILE=1)
+//      — uses the durable default persistent profile.
+//   3. Default — a FRESH owned ephemeral profile dir for this session.
+export function resolveBrowserProfile({
+  args,
+  env = process.env,
+  persistentDefaultProfile,
+  userRoot,
+  home = os.homedir(),
+  tmpdir = os.tmpdir(),
+  sessionId,
+} = {}) {
+  const explicit = args?.get?.("profile") ?? env.RESONANTOS_BROWSER_FIRST_PROFILE;
+  if (explicit) {
+    return { profileDir: path.resolve(explicit), mode: "explicit", ephemeral: false };
+  }
+
+  if (persistentProfileOptIn({ args, env })) {
+    return {
+      profileDir: path.resolve(persistentDefaultProfile),
+      mode: "persistent",
+      ephemeral: false,
+    };
+  }
+
+  const root = ephemeralProfileRoot({ userRoot, home, tmpdir });
+  const session = sessionId
+    ?? `session-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+  return { profileDir: path.join(root, session), mode: "ephemeral", ephemeral: true };
+}
+
+// Resolve the contained remote-debugging surface.
+//
+// If no debugging is requested, none is exposed. If debugging IS requested
+// (caller/env), it is contained to loopback + an ephemeral port (0): we never
+// forward a fixed, externally-reachable port. Returns the host-arg fragments to
+// append plus a structured description for diagnostics/tests.
+export function resolveRemoteDebugging({ args, env = process.env } = {}) {
+  const requested = args?.get?.("remote-debugging-port")
+    ?? env.RESONANTOS_BROWSER_FIRST_REMOTE_DEBUGGING_PORT;
+
+  if (requested === undefined || requested === null || requested === "") {
+    return { enabled: false, port: null, loopbackBound: false, hostArgs: [] };
+  }
+
+  // Contain: force ephemeral port 0 + loopback address regardless of the
+  // requested value. A caller-supplied fixed/exposed port is intentionally
+  // dropped (constraint: port == 0 OR loopback_bound).
+  return {
+    enabled: true,
+    port: 0,
+    loopbackBound: true,
+    requestedPort: String(requested),
+    hostArgs: [
+      "--resonantos-remote-debugging-port=0",
+      `--resonantos-remote-debugging-address=${LOOPBACK_ADDRESS}`,
+    ],
+  };
+}

--- a/browser-first/host/run-browser-first.mjs
+++ b/browser-first/host/run-browser-first.mjs
@@ -42,6 +42,7 @@ import {
   seedResonantStartupExperience,
 } from "./browser-profile-service.mjs";
 import { createMemorySourceSettingsService } from "./memory-source-settings-service.mjs";
+import { resolveBrowserProfile, resolveRemoteDebugging } from "./browser-launch-config.mjs";
 import { createProviderHostService } from "./provider-host-service.mjs";
 import {
   memorySourceMoveHistoryPath as sourceMoveHistoryPath,
@@ -124,7 +125,13 @@ function browserLaunchLogPath() {
   return path.join(repoRoot, "logs", "browser-first-installed-app.log");
 }
 
-const profileDir = path.resolve(args.get("profile") ?? process.env.RESONANTOS_BROWSER_FIRST_PROFILE ?? defaultProfile);
+const browserProfile = resolveBrowserProfile({
+  args,
+  env: process.env,
+  persistentDefaultProfile: defaultProfile,
+  userRoot: userRoot(),
+});
+const profileDir = browserProfile.profileDir;
 
 function hermesHome(profileHome) {
   const value = String(profileHome ?? process.env.HERMES_HOME ?? "~/.hermes").trim();
@@ -476,7 +483,7 @@ if (selfTestHandled) {
 const url = args.get("url") ?? defaultMainWorkspaceUrl;
 const autoOpenSidePanel = args.get("auto-open-side-panel") === "true";
 const bridgePort = Number(args.get("bridge-port") ?? process.env.RESONANTOS_BROWSER_FIRST_BRIDGE_PORT ?? defaultBridgePort);
-const remoteDebuggingPort = args.get("remote-debugging-port") ?? process.env.RESONANTOS_BROWSER_FIRST_REMOTE_DEBUGGING_PORT;
+const remoteDebugging = resolveRemoteDebugging({ args, env: process.env });
 
 if (!existsSync(hostBinary)) {
   console.error(`Browser-first host binary is missing: ${hostBinary}`);
@@ -505,7 +512,7 @@ const hostArgs = [
   `--resonantos-user-data-dir=${profileDir}`,
   `--resonantos-extension-dirs=${extensionDirs.join(",")}`,
   `--resonantos-log-path=${browserLaunchLogPath()}`,
-  ...(remoteDebuggingPort ? [`--resonantos-remote-debugging-port=${remoteDebuggingPort}`] : []),
+  ...remoteDebugging.hostArgs,
 ];
 
 const launchThroughMacAppBundle = process.platform === "darwin" && args.get("launch-mode") !== "direct";
@@ -551,7 +558,7 @@ console.log(JSON.stringify({
 }));
 
 console.log("Launching ResonantOS Browser-First host");
-console.log(JSON.stringify({ hostBinary, hostAppBundle, url, profileDir, extensionDirs, phantomLoaded: Boolean(phantomExtension), pinnedExtensions: [resonantExtensionId, phantomExtension ? phantomExtensionId : null].filter(Boolean), bridgeUrl: `http://127.0.0.1:${activeBridgePort}`, bridgeConfigPath, remoteDebuggingPort: remoteDebuggingPort ?? "ephemeral" }, null, 2));
+console.log(JSON.stringify({ hostBinary, hostAppBundle, url, profileDir, extensionDirs, phantomLoaded: Boolean(phantomExtension), pinnedExtensions: [resonantExtensionId, phantomExtension ? phantomExtensionId : null].filter(Boolean), bridgeUrl: `http://127.0.0.1:${activeBridgePort}`, bridgeConfigPath, profileMode: browserProfile.mode, remoteDebugging: remoteDebugging.enabled ? { port: 0, address: "127.0.0.1", requested: remoteDebugging.requestedPort } : "disabled" }, null, 2));
 
 function launchNativeHostDirect() {
   return spawn(hostBinary, hostArgs, {

--- a/browser-first/test/browser-launch-config.test.mjs
+++ b/browser-first/test/browser-launch-config.test.mjs
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  ephemeralProfileRoot,
+  persistentProfileOptIn,
+  resolveBrowserProfile,
+  resolveRemoteDebugging,
+  LOOPBACK_ADDRESS,
+} from "../host/browser-launch-config.mjs";
+import { evaluateLaunchPath } from "../../../.craft/artifacts/security-agent-research/p1-invoke/checks/extension/cdp-proof.mjs";
+
+const PERSISTENT_DEFAULT = path.join(os.homedir(), "ResonantOS_User", "BrowserFirst", "Profiles", "main");
+const USER_ROOT = path.join(os.homedir(), "ResonantOS_User");
+
+function emptyArgs() {
+  return new Map();
+}
+
+function argsWith(entries) {
+  return new Map(Object.entries(entries));
+}
+
+test("default profile is owned + ephemeral, never the persistent Profiles/main", () => {
+  const resolved = resolveBrowserProfile({
+    args: emptyArgs(),
+    env: {},
+    persistentDefaultProfile: PERSISTENT_DEFAULT,
+    userRoot: USER_ROOT,
+  });
+  assert.equal(resolved.mode, "ephemeral");
+  assert.equal(resolved.ephemeral, true);
+  assert.notEqual(resolved.profileDir, PERSISTENT_DEFAULT);
+  // Lives under the owned ephemeral root, not the persistent main profile.
+  const ephemeralRoot = ephemeralProfileRoot({ userRoot: USER_ROOT });
+  assert.ok(resolved.profileDir.startsWith(ephemeralRoot), `expected under ${ephemeralRoot}, got ${resolved.profileDir}`);
+  assert.ok(!resolved.profileDir.includes(path.join("Profiles", "main")));
+});
+
+test("each default launch gets a fresh ephemeral profile dir", () => {
+  const base = {
+    args: emptyArgs(),
+    env: {},
+    persistentDefaultProfile: PERSISTENT_DEFAULT,
+    userRoot: USER_ROOT,
+  };
+  const a = resolveBrowserProfile(base);
+  const b = resolveBrowserProfile(base);
+  assert.notEqual(a.profileDir, b.profileDir);
+});
+
+test("persistent profile only under explicit env opt-in", () => {
+  const resolved = resolveBrowserProfile({
+    args: emptyArgs(),
+    env: { RESONANTOS_BROWSER_PERSISTENT_PROFILE: "1" },
+    persistentDefaultProfile: PERSISTENT_DEFAULT,
+    userRoot: USER_ROOT,
+  });
+  assert.equal(resolved.mode, "persistent");
+  assert.equal(resolved.ephemeral, false);
+  assert.equal(resolved.profileDir, PERSISTENT_DEFAULT);
+});
+
+test("persistent profile only under explicit flag opt-in", () => {
+  const resolved = resolveBrowserProfile({
+    args: argsWith({ "persistent-profile": "true" }),
+    env: {},
+    persistentDefaultProfile: PERSISTENT_DEFAULT,
+    userRoot: USER_ROOT,
+  });
+  assert.equal(resolved.mode, "persistent");
+  assert.equal(resolved.profileDir, PERSISTENT_DEFAULT);
+});
+
+test("explicit --profile path is honored as-is (intentional caller choice)", () => {
+  const target = path.join(os.tmpdir(), "explicit-profile");
+  const resolved = resolveBrowserProfile({
+    args: argsWith({ profile: target }),
+    env: {},
+    persistentDefaultProfile: PERSISTENT_DEFAULT,
+    userRoot: USER_ROOT,
+  });
+  assert.equal(resolved.mode, "explicit");
+  assert.equal(resolved.profileDir, path.resolve(target));
+});
+
+test("persistentProfileOptIn recognizes accepted truthy values", () => {
+  assert.equal(persistentProfileOptIn({ args: emptyArgs(), env: { RESONANTOS_BROWSER_PERSISTENT_PROFILE: "yes" } }), true);
+  assert.equal(persistentProfileOptIn({ args: emptyArgs(), env: { RESONANTOS_BROWSER_PERSISTENT_PROFILE: "0" } }), false);
+  assert.equal(persistentProfileOptIn({ args: emptyArgs(), env: {} }), false);
+});
+
+test("no remote debugging requested => nothing exposed", () => {
+  const result = resolveRemoteDebugging({ args: emptyArgs(), env: {} });
+  assert.equal(result.enabled, false);
+  assert.deepEqual(result.hostArgs, []);
+});
+
+test("requested debug port is contained to port 0 + loopback (caller fixed port dropped)", () => {
+  const result = resolveRemoteDebugging({ args: argsWith({ "remote-debugging-port": "9222" }), env: {} });
+  assert.equal(result.enabled, true);
+  assert.equal(result.port, 0);
+  assert.equal(result.loopbackBound, true);
+  assert.equal(result.requestedPort, "9222");
+  assert.ok(result.hostArgs.includes("--resonantos-remote-debugging-port=0"));
+  assert.ok(result.hostArgs.includes(`--resonantos-remote-debugging-address=${LOOPBACK_ADDRESS}`));
+  // The exposed fixed port is never forwarded.
+  assert.ok(!result.hostArgs.some((a) => a.includes("9222")));
+});
+
+test("env-supplied debug port is also contained", () => {
+  const result = resolveRemoteDebugging({
+    args: emptyArgs(),
+    env: { RESONANTOS_BROWSER_FIRST_REMOTE_DEBUGGING_PORT: "9333" },
+  });
+  assert.equal(result.port, 0);
+  assert.equal(result.loopbackBound, true);
+});
+
+// End-to-end: the resolved launch description satisfies the cdp-proof predicate
+// (ephemeral_profile AND (port==0 OR loopback) AND pinned_extension_set).
+test("default launch passes the cdp-proof predicate", () => {
+  const profile = resolveBrowserProfile({
+    args: emptyArgs(),
+    env: {},
+    persistentDefaultProfile: PERSISTENT_DEFAULT,
+    userRoot: USER_ROOT,
+  });
+  const debugging = resolveRemoteDebugging({ args: argsWith({ "remote-debugging-port": "9222" }), env: {} });
+
+  const verdict = evaluateLaunchPath({
+    id: "browser-first-host-launch",
+    surface: "browser-first/host/run-browser-first.mjs",
+    profile: profile.ephemeral ? "ephemeral" : "persistent",
+    debugPort: debugging.enabled ? debugging.port : 0,
+    loopbackBound: debugging.loopbackBound,
+    extensionSet: "pinned", // owned resonant extension (+ phantom by id), no caller-supplied dirs
+  });
+  assert.equal(verdict.verdict, "pass", JSON.stringify(verdict.reasons));
+});


### PR DESCRIPTION
### Fixes finding `P1-c` — persistent profile + unpinned CDP/extension launch, severity High (JS path → fixed)

### What was wrong
The browser-first launcher defaulted to a **persistent** profile and forwarded **caller-supplied** remote-debugging ports / extension dirs.

### Why it matters
A persistent profile accrues credential/session residue; an unpinned debug port is a CDP-takeover surface; arbitrary extension dirs allow code injection into the browsing context (CWE-668). Reachable by: launch callers.

### The change
- Default to a fresh owned/**ephemeral** profile (persistent only via explicit opt-in; existing profile never deleted).
- Requested remote-debugging contained to **port 0 + loopback** (caller/env fixed port dropped); owned pinned extension set.
Breaking: persistent profile becomes opt-in (intended).

### Validation
`node --test browser-launch-config` — 10 pass; default launch passes the `cdp-proof` predicate.

### Surface touched
`browser-first/host/browser-launch-config.mjs`, `browser-first/host/run-browser-first.mjs`

### Status / residual
P1-c JS launch path → **fixed**. The **native CEF host** (`native_host.cc`) still accepts caller-supplied dirs/port → tracked in **#162**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)