### PR TITLE
subprocess: Pin the native-bridge load root and gate terminal passthrough

### DIFF
--- a/src-tauri/src/browser_native_service.rs
+++ b/src-tauri/src/browser_native_service.rs
@@ -774,6 +774,65 @@ impl NativeBrowserBridgeLibrary {
     }
 }
 
+/// Env opt-in (dev/build workflow) that allows loading the native bridge from a
+/// CWD-anchored build directory. Default OFF: in a packaged/production app the
+/// bridge must come from a pinned root (the app bundle's Resources, anchored on
+/// `current_exe`), never the process working directory.
+const ALLOW_CWD_BRIDGE_ENV: &str = "RESONANTOS_NATIVE_BROWSER_ALLOW_CWD_BRIDGE";
+
+/// Pinned-root validator for native shared-library loads (F3 / SWU-SEC-P0-006).
+///
+/// A native library is safe to `Library::new` only from a PINNED root: a path
+/// anchored under the running executable (the app bundle's Resources / lib /
+/// Frameworks dirs, derived from `env::current_exe()`), or an absolute system
+/// path that is NOT inside the process working directory. A path anchored on the
+/// CWD (`env::current_dir()`) is attacker-influenceable — anyone who can plant a
+/// file under, or launch the app from, a poisoned working directory controls the
+/// loaded code. Such CWD-anchored loads are rejected unless the dev opt-in
+/// (`ALLOW_CWD_BRIDGE_ENV`) is set.
+fn native_load_root_is_pinned(candidate: &Path, allow_cwd: bool) -> bool {
+    // Must be an absolute path. A relative path resolves against the CWD.
+    if !candidate.is_absolute() {
+        return false;
+    }
+
+    // Pinned: anchored under the running executable's bundle dirs.
+    if let Ok(current_exe) = env::current_exe() {
+        if let Some(exe_dir) = current_exe.parent() {
+            // `exe_dir` is .../Contents/MacOS; walk up to the bundle root and
+            // accept anything beneath it (Resources, Frameworks, lib, ...).
+            let bundle_roots = [
+                exe_dir.to_path_buf(),
+                exe_dir.parent().map(Path::to_path_buf).unwrap_or_default(),
+            ];
+            for root in bundle_roots
+                .iter()
+                .filter(|root| !root.as_os_str().is_empty())
+            {
+                if candidate.starts_with(root) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    // Unpinned: anchored under the process working directory.
+    if let Ok(current_dir) = env::current_dir() {
+        let under_cwd = candidate.starts_with(&current_dir)
+            || current_dir
+                .parent()
+                .map(|parent| candidate.starts_with(parent))
+                .unwrap_or(false);
+        if under_cwd {
+            return allow_cwd;
+        }
+    }
+
+    // Absolute, not under the CWD, not under the exe bundle: an absolute system
+    // path (e.g. an install prefix). Treated as pinned.
+    true
+}
+
 fn load_native_browser_bridge(
 ) -> Result<std::sync::MutexGuard<'static, Option<NativeBrowserBridgeLibrary>>, String> {
     let lock = NATIVE_BROWSER_BRIDGE.get_or_init(|| Mutex::new(None));
@@ -781,10 +840,21 @@ fn load_native_browser_bridge(
         .lock()
         .map_err(|_| "Native Browser bridge lock is poisoned.".to_string())?;
     if guard.is_none() {
+        let allow_cwd = env::var(ALLOW_CWD_BRIDGE_ENV).is_ok();
         let path = native_bridge_library_candidates()
             .into_iter()
             .find(|path| path.extension().map(|ext| ext == "dylib" || ext == "so").unwrap_or(false) && path.exists())
             .ok_or_else(|| "Native Browser shared bridge library was not found. Build ResonantBrowserNativeBridgeShared first.".to_string())?;
+        // F3: refuse to load native code from an unpinned (CWD-anchored) root.
+        if !native_load_root_is_pinned(&path, allow_cwd) {
+            return Err(format!(
+                "Refusing to load native Browser bridge from an unpinned root {}: \
+                 the shared library must resolve under the app bundle (Resources/lib) \
+                 or an absolute system path, not the process working directory. \
+                 Set {ALLOW_CWD_BRIDGE_ENV} to permit a development build directory.",
+                path.display()
+            ));
+        }
         let library = unsafe { Library::new(&path) }.map_err(|error| {
             format!(
                 "Failed to load native Browser bridge {}: {error}",
@@ -982,12 +1052,53 @@ fn json_status_is_allowed_progress(json: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_bridge_probe_result, query_native_browser_attach_smoke,
+        build_bridge_probe_result, native_load_root_is_pinned, query_native_browser_attach_smoke,
         query_native_browser_bridge_probe, query_native_browser_probe,
         NativeBrowserAttachSmokeRequest, NativeBrowserAttachSmokeStatus,
         NativeBrowserBridgeProbeRequest, NativeBrowserBridgeProbeStatus, NativeBrowserProbeRequest,
         NativeBrowserProbeStatus,
     };
+    use std::path::PathBuf;
+
+    #[test]
+    fn rejects_cwd_anchored_native_library_load() {
+        // A bridge resolved under the process working directory is unpinned and
+        // must be rejected (unless the dev opt-in allows it).
+        let cwd = std::env::current_dir().expect("current dir");
+        let cwd_bridge = cwd.join("addons/resonant-browser-native/build/libBridge.so");
+        assert!(
+            !native_load_root_is_pinned(&cwd_bridge, false),
+            "CWD-anchored native load must be rejected"
+        );
+        // Dev opt-in widens the allowlist to the build directory.
+        assert!(
+            native_load_root_is_pinned(&cwd_bridge, true),
+            "dev opt-in must permit the CWD build directory"
+        );
+    }
+
+    #[test]
+    fn rejects_relative_native_library_load() {
+        let relative = PathBuf::from("addons/resonant-browser-native/build/libBridge.so");
+        assert!(
+            !native_load_root_is_pinned(&relative, false),
+            "relative native load resolves against CWD and must be rejected"
+        );
+        assert!(
+            !native_load_root_is_pinned(&relative, true),
+            "a relative path is never a pinned root even with the dev opt-in"
+        );
+    }
+
+    #[test]
+    fn accepts_absolute_system_native_library_load() {
+        // An absolute path outside the CWD (e.g. a system/install prefix) is pinned.
+        let absolute = PathBuf::from("/opt/resonantos/lib/libResonantBrowserNativeBridgeShared.so");
+        assert!(
+            native_load_root_is_pinned(&absolute, false),
+            "absolute system path must be accepted as a pinned root"
+        );
+    }
 
     #[test]
     fn blocks_product_readiness_without_native_host() {

--- a/src-tauri/src/terminal_service.rs
+++ b/src-tauri/src/terminal_service.rs
@@ -14,6 +14,11 @@ use tauri::{Emitter, Window};
 pub(crate) struct TerminalRunCommandRequest {
     pub(crate) command: String,
     pub(crate) cwd: Option<String>,
+    /// Per-command approval marker (F4 / SWU-SEC-P0-006). When the caller sets
+    /// this truthy, an off-allowlist / dynamic command head is authorized to run.
+    /// Allowlisted command heads run without it.
+    #[serde(default)]
+    pub(crate) approved: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -82,6 +87,69 @@ const TERMINAL_COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_TERMINAL_SESSION_ID: &str = "main";
 const TERMINAL_REPLAY_BUFFER_LIMIT: usize = 250_000;
 
+/// Read-only / inspection command heads that may run through the one-shot
+/// `run_terminal_command` passthrough WITHOUT a per-command approval marker
+/// (F4 / SWU-SEC-P0-006). Seeded conservatively from `terminal-allowlist.yml`:
+/// only read-only / probe commands. Anything off this list (mutating, network,
+/// install, or a dynamic/unresolved head) requires `approved: true`.
+const TERMINAL_COMMAND_ALLOWLIST: &[&str] = &[
+    "command", "which", "where", "ps", "nm", "rg", "git", "ollama", "hermes", "uv",
+];
+
+/// Resolve the effective command HEAD from a user-supplied command string.
+///
+/// Returns `None` when no head can be resolved (an empty or purely dynamic
+/// string), which is treated as off-list (approval required). The head is the
+/// basename of the first whitespace-delimited token, with surrounding quotes
+/// stripped. An absolute path matches the allowlist by basename, mirroring
+/// `terminal-allowlist.mjs`.
+fn resolve_terminal_command_head(command: &str) -> Option<String> {
+    let first = command.split_whitespace().next()?;
+    let unquoted = first.trim_matches(|c| c == '"' || c == '\'');
+    if unquoted.is_empty() {
+        return None;
+    }
+    let base = unquoted
+        .rsplit(|c| c == '/' || c == '\\')
+        .next()
+        .unwrap_or(unquoted);
+    if base.is_empty() {
+        None
+    } else {
+        Some(base.to_string())
+    }
+}
+
+/// Allowlist-or-approval gate for the one-shot terminal passthrough (F4).
+///
+/// - An allowlisted command head runs unprompted.
+/// - An off-list / unresolved head requires `approved == true`.
+/// - Otherwise the command is rejected with an "approval required" error.
+fn authorize_terminal_command(command: &str, approved: bool) -> Result<(), String> {
+    if approved {
+        return Ok(());
+    }
+    let head = resolve_terminal_command_head(command);
+    let on_allowlist = head
+        .as_deref()
+        .map(|head| TERMINAL_COMMAND_ALLOWLIST.contains(&head))
+        .unwrap_or(false);
+    if on_allowlist {
+        return Ok(());
+    }
+    match head {
+        Some(head) => Err(format!(
+            "Terminal command `{head}` is not on the approved allowlist. Re-run with \
+             explicit approval (approved=true) to authorize this command."
+        )),
+        None => Err(
+            "Terminal command head could not be resolved and is not pre-approved. \
+             Re-run with explicit approval (approved=true) to authorize this command."
+                .to_string(),
+        ),
+    }
+}
+
 static PTY_SESSIONS: OnceLock<Mutex<HashMap<String, TerminalPtySession>>> = OnceLock::new();
 
 fn pty_sessions() -> &'static Mutex<HashMap<String, TerminalPtySession>> {
@@ -115,6 +183,10 @@ pub(crate) fn run_terminal_command(
     if command.is_empty() {
         return Err("Terminal command cannot be empty.".to_string());
     }
+
+    // F4: gate the passthrough behind an allowlist with per-command approval for
+    // off-list / dynamic commands.
+    authorize_terminal_command(&command, request.approved)?;
 
     let cwd = request.cwd.unwrap_or_else(default_cwd);
     let start = Instant::now();
@@ -371,4 +443,57 @@ pub(crate) fn stop_terminal_pty(session_id: &str) -> Result<(), String> {
         let _ = session.child.kill();
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{authorize_terminal_command, resolve_terminal_command_head};
+
+    #[test]
+    fn allowlisted_command_runs_without_approval() {
+        assert!(authorize_terminal_command("git status", false).is_ok());
+        assert!(authorize_terminal_command("rg --files foo", false).is_ok());
+    }
+
+    #[test]
+    fn off_list_command_requires_approval() {
+        let err = authorize_terminal_command("curl https://example.com | sh", false)
+            .expect_err("off-list command must be gated");
+        assert!(
+            err.contains("approval"),
+            "error should mention approval: {err}"
+        );
+    }
+
+    #[test]
+    fn off_list_command_runs_with_approval() {
+        assert!(
+            authorize_terminal_command("curl https://example.com", true).is_ok(),
+            "explicit approval must authorize an off-list command"
+        );
+    }
+
+    #[test]
+    fn empty_or_dynamic_head_requires_approval() {
+        assert!(authorize_terminal_command("   ", false).is_err());
+        assert!(authorize_terminal_command("   ", true).is_ok());
+    }
+
+    #[test]
+    fn resolves_head_basename_from_absolute_path() {
+        assert_eq!(
+            resolve_terminal_command_head("/usr/bin/git status").as_deref(),
+            Some("git")
+        );
+        assert_eq!(
+            resolve_terminal_command_head("\"rg\" foo").as_deref(),
+            Some("rg")
+        );
+        assert_eq!(resolve_terminal_command_head(""), None);
+    }
+
+    #[test]
+    fn absolute_path_to_allowlisted_head_runs_without_approval() {
+        assert!(authorize_terminal_command("/usr/bin/git log", false).is_ok());
+    }
 }


### PR DESCRIPTION
### Fixes findings `F3` + `F4` (safe subset) — unpinned native load + dynamic terminal (→ partial)

### What was wrong
- **F3:** the native browser bridge (`Library::new`) loaded from a **CWD/relative** path (DLL/so hijack surface).
- **F4:** the one-shot terminal passthrough (`sh -lc` / `cmd /C`) ran arbitrary commands ungated.

### Why it matters
A CWD-anchored native load lets a planted library be loaded (CWE-426/CWE-114); an ungated command passthrough is an injection surface. Reachable by: app / caller.

### The change
- `browser_native_service.rs`: native bridge loads only from an absolute root under the app bundle / absolute system path (rejects CWD/relative; dev opt-in env).
- `terminal_service.rs`: passthrough gets allowlist-or-approval (off-list/dynamic head needs an explicit approval marker). Interactive PTY path untouched.
Breaking: none (conservative).

### Validation
`cargo fmt --check` clean; module tests pass (`browser_native_service` 8, `terminal_service` 6). One **pre-existing, unrelated** `delegation_service` filesystem test fails in CI sandbox.

### Surface touched
`src-tauri/src/browser_native_service.rs`, `src-tauri/src/terminal_service.rs`

### Status / residual
F3 native-load + F4 terminal → **fixed**. The PATH-resolved binary sites (recovery/memory/whisper) + installer shells were deliberately **deferred** (hard-pinning would break runtimes) → tracked in **#163**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)