### PR TITLE
subprocess: Add opt-in scoped env (env_clear + per-runtime allowlist)

### DIFF
--- a/src-tauri/src/browser_host_service.rs
+++ b/src-tauri/src/browser_host_service.rs
@@ -9,6 +9,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tauri::{AppHandle, Manager};
 
+use crate::scoped_env::apply_scoped_env;
+
 static BROWSER_HOST: OnceLock<Mutex<Option<BrowserHostProcess>>> = OnceLock::new();
 static BROWSER_VISIBLE_HOST: OnceLock<Mutex<Option<BrowserHostProcess>>> = OnceLock::new();
 
@@ -191,18 +193,19 @@ fn send_rpc(
 fn start_browser_host_process(app: &AppHandle) -> Result<BrowserHostProcess, String> {
     let script = resolve_browser_host_script(app)?;
     let node = env::var("RESONANTOS_NODE").unwrap_or_else(|_| "node".to_string());
-    let mut child = Command::new(node)
+    let mut command = Command::new(node);
+    command
         .arg(&script)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .map_err(|error| {
-            format!(
-                "Failed to start Browser host service at {}: {error}",
-                script.display()
-            )
-        })?;
+        .stderr(Stdio::null());
+    apply_scoped_env(&mut command, "browser-host");
+    let mut child = command.spawn().map_err(|error| {
+        format!(
+            "Failed to start Browser host service at {}: {error}",
+            script.display()
+        )
+    })?;
     let stdin = child
         .stdin
         .take()
@@ -222,19 +225,20 @@ fn start_browser_visible_host_process(app: &AppHandle) -> Result<BrowserHostProc
     let script = resolve_browser_visible_host_script(app)?;
     let electron = resolve_browser_visible_host_electron(app)?;
     repair_macos_electron_framework_layout(&electron)?;
-    let mut child = Command::new(&electron)
+    let mut command = Command::new(&electron);
+    command
         .arg(&script)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .map_err(|error| {
-            format!(
-                "Failed to start visible Browser host service with {} at {}: {error}",
-                electron.display(),
-                script.display()
-            )
-        })?;
+        .stderr(Stdio::null());
+    apply_scoped_env(&mut command, "browser-host");
+    let mut child = command.spawn().map_err(|error| {
+        format!(
+            "Failed to start visible Browser host service with {} at {}: {error}",
+            electron.display(),
+            script.display()
+        )
+    })?;
     let stdin = child
         .stdin
         .take()

--- a/src-tauri/src/hermes_service.rs
+++ b/src-tauri/src/hermes_service.rs
@@ -11,6 +11,8 @@ use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::scoped_env::apply_scoped_env;
+
 const DEFAULT_HERMES_HOME: &str = ".hermes";
 const DEFAULT_HERMES_DASHBOARD_HOST: &str = "127.0.0.1";
 const DEFAULT_HERMES_DASHBOARD_PORT: u16 = 9119;
@@ -294,13 +296,15 @@ pub(crate) fn execute_hermes_chat(request: HermesChatRequest) -> Result<HermesCh
     if let Some(model) = selected_model.as_deref() {
         process.arg("-m").arg(model);
     }
-    let output = process
+    process
         .arg("-q")
         .arg(prompt)
         .env("HERMES_HOME", &home)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+        .stderr(Stdio::piped());
+    apply_scoped_env(&mut process, "hermes");
+    let output = process
         .output()
         .map_err(|error| format!("Failed to run Hermes chat: {error}"))?;
 
@@ -366,10 +370,11 @@ pub(crate) fn install_hermes(request: HermesInstallRequest) -> Result<HermesInst
     curl.arg("-fsSL")
         .arg(HERMES_INSTALLER_URL)
         .arg("-o")
-        .arg(&installer_path);
-    let curl_output = curl
+        .arg(&installer_path)
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+        .stderr(Stdio::piped());
+    apply_scoped_env(&mut curl, "hermes");
+    let curl_output = curl
         .output()
         .map_err(|error| format!("Failed to download Hermes installer: {error}"))?;
     if !curl_output.status.success() {
@@ -394,6 +399,7 @@ pub(crate) fn install_hermes(request: HermesInstallRequest) -> Result<HermesInst
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    apply_scoped_env(&mut installer, "hermes");
     let output = installer
         .output()
         .map_err(|error| format!("Failed to run Hermes installer: {error}"))?;
@@ -523,6 +529,7 @@ pub(crate) fn start_hermes_dashboard(
     if request.include_tui.unwrap_or(true) {
         process.arg("--tui");
     }
+    apply_scoped_env(&mut process, "hermes");
     process
         .spawn()
         .map_err(|error| format!("Failed to start Hermes dashboard: {error}"))?;
@@ -706,10 +713,13 @@ fn resolve_hermes_command(home: &Path) -> Option<String> {
             .map(clean_output)
             .filter(|value| !value.is_empty())
             .or_else(|| {
-                Command::new("hermes")
+                let mut version_check = Command::new("hermes");
+                version_check
                     .arg("--version")
                     .stdout(Stdio::null())
-                    .stderr(Stdio::null())
+                    .stderr(Stdio::null());
+                apply_scoped_env(&mut version_check, "hermes");
+                version_check
                     .status()
                     .ok()
                     .filter(|status| status.success())
@@ -744,11 +754,12 @@ fn hermes_command(binary: &str) -> Command {
 }
 
 fn command_output(command: &mut Command) -> Result<String, String> {
-    let output = command
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .map_err(|error| error.to_string())?;
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    // All command_output callers invoke the Hermes CLI (or its checkout via git /
+    // the `command -v hermes` probe) as part of Hermes runtime status; scope them
+    // under the hermes allowlist.
+    apply_scoped_env(command, "hermes");
+    let output = command.output().map_err(|error| error.to_string())?;
     if output.status.success() {
         Ok(String::from_utf8_lossy(&output.stdout).to_string())
     } else {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ mod opencode_service;
 mod paperclip_service;
 mod provider_service;
 mod recovery_service;
+mod scoped_env;
 mod telegram_service;
 mod terminal_service;
 

--- a/src-tauri/src/memory_service.rs
+++ b/src-tauri/src/memory_service.rs
@@ -13,6 +13,8 @@ use std::time::{Duration, Instant};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager};
 
+use crate::scoped_env::apply_scoped_env;
+
 use crate::host_state::ensure_portable_user_state;
 
 const DEFAULT_MEMORY_SERVICE_PORT: u16 = 4888;
@@ -181,7 +183,8 @@ pub(crate) fn start_memory_service(
         sessions.remove(&session_id);
     }
 
-    let child = Command::new(resolve_node_binary())
+    let mut command = Command::new(resolve_node_binary());
+    command
         .arg(&script)
         .arg("--memory-root")
         .arg(&portable_state.memory_root)
@@ -192,7 +195,9 @@ pub(crate) fn start_memory_service(
         .args(if readonly { vec!["--readonly"] } else { vec![] })
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stderr(Stdio::null());
+    apply_scoped_env(&mut command, "memory");
+    let child = command
         .spawn()
         .map_err(|error| format!("Failed to start Living Archive memory service: {error}"))?;
     let pid = child.id();

--- a/src-tauri/src/opencode_service.rs
+++ b/src-tauri/src/opencode_service.rs
@@ -9,6 +9,8 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::{Mutex, OnceLock};
 use std::thread;
+
+use crate::scoped_env::apply_scoped_env;
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
@@ -159,9 +161,9 @@ pub(crate) fn query_opencode_status() -> OpenCodeStatus {
             command
                 .arg("--version")
                 .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .output()
-                .ok()
+                .stderr(Stdio::piped());
+            apply_scoped_env(&mut command, "opencode");
+            command.output().ok()
         })
         .and_then(|output| {
             if output.status.success() {
@@ -228,7 +230,8 @@ pub(crate) fn start_opencode_service(
 
     let mode_arg = opencode_command_arg_for_mode(&mode);
     let trust_kernel = start_trust_kernel_advisory(&workspace, &session_id, mode_arg);
-    let child = Command::new(&binary)
+    let mut command = Command::new(&binary);
+    command
         .arg(mode_arg)
         .arg("--hostname")
         .arg(OPENCODE_HOSTNAME)
@@ -243,7 +246,9 @@ pub(crate) fn start_opencode_service(
         .current_dir(&workspace)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stderr(Stdio::null());
+    apply_scoped_env(&mut command, "opencode");
+    let child = command
         .spawn()
         .map_err(|error| format!("Failed to start OpenCode {mode_arg} with {binary}: {error}"))?;
     let pid = child.id();
@@ -703,12 +708,15 @@ fn build_trust_hook_event_args(
 }
 
 fn run_trust_kernel_command(root: &Path, args: &[&str]) -> Result<String, String> {
-    let mut child = Command::new("uv")
+    let mut command = Command::new("uv");
+    command
         .args(args)
         .current_dir(root)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+        .stderr(Stdio::piped());
+    apply_scoped_env(&mut command, "opencode");
+    let mut child = command
         .spawn()
         .map_err(|error| format!("Failed to start Trust Kernel advisory command: {error}"))?;
     let deadline = Instant::now() + TRUST_KERNEL_COMMAND_TIMEOUT;
@@ -808,10 +816,13 @@ fn resolve_opencode_binary() -> Option<String> {
     } else {
         ("which", vec!["opencode"])
     };
-    Command::new(command.0)
+    let mut which_command = Command::new(command.0);
+    which_command
         .args(command.1)
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
+        .stderr(Stdio::null());
+    apply_scoped_env(&mut which_command, "opencode");
+    which_command
         .output()
         .ok()
         .filter(|output| output.status.success())

--- a/src-tauri/src/provider_service.rs
+++ b/src-tauri/src/provider_service.rs
@@ -17,6 +17,7 @@ use tauri::{AppHandle, Emitter, Window};
 use crate::host_state::{
     ensure_portable_user_state, read_runtime_state_value, resolve_provider_secret,
 };
+use crate::scoped_env::apply_scoped_env;
 
 static ABORTED_CHAT_RUNS: LazyLock<Mutex<HashSet<String>>> =
     LazyLock::new(|| Mutex::new(HashSet::new()));
@@ -121,6 +122,10 @@ fn codex_command_path() -> String {
 
 fn codex_command_builder() -> Command {
     let mut command = Command::new(codex_command());
+    // Scoped-env (opt-in) clears inherited env first; set the pinned PATH AFTER so
+    // it survives the clear. When scoped-env is OFF this is an unchanged no-op and
+    // the pinned PATH still prepends the ambient PATH tail as before.
+    apply_scoped_env(&mut command, "codex");
     command.env("PATH", codex_command_path());
     command
 }
@@ -1269,14 +1274,15 @@ async fn ensure_local_runtime_ready(base_url: &str) -> Result<(), String> {
         return Ok(());
     }
 
-    Command::new("ollama")
+    let mut serve_command = Command::new("ollama");
+    serve_command
         .arg("serve")
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .map_err(|error| {
-            format!("Failed to launch local runtime service via `ollama serve`: {error}")
-        })?;
+        .stderr(Stdio::null());
+    apply_scoped_env(&mut serve_command, "ollama");
+    serve_command.spawn().map_err(|error| {
+        format!("Failed to launch local runtime service via `ollama serve`: {error}")
+    })?;
 
     for _ in 0..10 {
         thread::sleep(Duration::from_millis(400));
@@ -1293,25 +1299,30 @@ pub(crate) fn query_local_runtime_status(target_model: Option<String>) -> LocalR
         resolve_local_runtime_model(target_model.as_deref().unwrap_or("local/creative"))
             .to_string();
 
-    let (available, installed_models, ollama_list_raw) =
-        match Command::new("ollama").arg("list").output() {
-            Ok(output) if output.status.success() => {
-                let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-                (true, parse_ollama_model_names(&stdout), stdout)
-            }
-            Ok(output) => (
-                false,
-                Vec::new(),
-                String::from_utf8_lossy(&output.stderr).to_string(),
-            ),
-            Err(error) => (
-                false,
-                Vec::new(),
-                format!("Failed to run `ollama list`: {error}"),
-            ),
-        };
+    let mut list_command = Command::new("ollama");
+    list_command.arg("list");
+    apply_scoped_env(&mut list_command, "ollama");
+    let (available, installed_models, ollama_list_raw) = match list_command.output() {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+            (true, parse_ollama_model_names(&stdout), stdout)
+        }
+        Ok(output) => (
+            false,
+            Vec::new(),
+            String::from_utf8_lossy(&output.stderr).to_string(),
+        ),
+        Err(error) => (
+            false,
+            Vec::new(),
+            format!("Failed to run `ollama list`: {error}"),
+        ),
+    };
 
-    let (running_models, ollama_ps_raw) = match Command::new("ollama").arg("ps").output() {
+    let mut ps_command = Command::new("ollama");
+    ps_command.arg("ps");
+    apply_scoped_env(&mut ps_command, "ollama");
+    let (running_models, ollama_ps_raw) = match ps_command.output() {
         Ok(output) if output.status.success() => {
             let stdout = String::from_utf8_lossy(&output.stdout).to_string();
             (parse_ollama_model_names(&stdout), stdout)

--- a/src-tauri/src/scoped_env.rs
+++ b/src-tauri/src/scoped_env.rs
@@ -1,0 +1,298 @@
+// Intent citation: PR-R04 (finding F2) — agent-runtime subprocess spawns leak
+// the full host environment; no env_clear anywhere.
+//
+// Scoped subprocess environment for agent-runtime spawns.
+//
+// SAFETY / ROLLOUT POSTURE — DEFAULT-OFF, OPT-IN:
+//   env_clear() on the agent runtimes (hermes / opencode / codex / ollama /
+//   memory / browser-host) is the highest-risk change in the security set: if
+//   the per-runtime allowlist misses any variable a runtime actually needs, the
+//   runtime breaks, and these runtimes cannot be exercised in CI/here to verify
+//   allowlist completeness. Therefore the scoped-env behaviour is gated behind an
+//   explicit operator opt-in:
+//
+//     RESONANTOS_SCOPED_ENV=1   (or true / yes / on)
+//
+//   When the flag is OFF (the default), `apply_scoped_env` is a strict NO-OP:
+//   spawn behaviour is byte-for-byte unchanged — no env_clear, no allowlist, no
+//   regression. Existing `.env(...)` injections at each spawn site continue to
+//   layer on top of the inherited ambient environment exactly as before.
+//
+//   When the flag is ON, `apply_scoped_env` calls `Command::env_clear()` and then
+//   re-injects only a small base allowlist (HOME, PATH, LANG, LC_ALL, TMPDIR,
+//   forwarded from the parent if present) plus the named per-runtime allowlist
+//   below. The existing `.env(...)` calls at each spawn site then re-assert the
+//   runtime-specific allowlisted vars (HERMES_HOME, CODEX_HOME pinned PATH, etc.)
+//   over that cleared base. Operators may forward additional named vars via the
+//   documented opt-in flag:
+//
+//     RESONANTOS_SCOPED_ENV_ALLOW=DISPLAY,WAYLAND_DISPLAY   (comma-separated)
+//
+//   Ported from p0-invoke/checks/subprocess/env-allowlist.yml.
+
+use std::process::Command;
+
+/// Environment flag that turns scoped-env ON. Any truthy value enables it.
+const SCOPED_ENV_FLAG: &str = "RESONANTOS_SCOPED_ENV";
+
+/// Documented opt-in escape hatch: a comma-separated list of additional variable
+/// names to forward from the parent environment after `env_clear` (only honoured
+/// when scoped-env is ON). Mirrors `opt_in_flag` in env-allowlist.yml.
+const SCOPED_ENV_ALLOW_FLAG: &str = "RESONANTOS_SCOPED_ENV_ALLOW";
+
+/// Universally safe vars to re-inject after `env_clear`, for any runtime that
+/// needs a minimal usable shell environment. Kept small on purpose.
+/// Ported from `base_allow` in env-allowlist.yml.
+///   HOME   — resolve user home for runtime config/profile discovery
+///   PATH   — should be pinned per spawn site; forwarded here as a usable default
+///   LANG   — locale for correct text handling
+///   LC_ALL — locale override
+///   TMPDIR — scoped temp dir
+const BASE_ALLOW: &[&str] = &["HOME", "PATH", "LANG", "LC_ALL", "TMPDIR"];
+
+/// Per-runtime allowlist of variables to forward from the parent environment
+/// after `env_clear`, in addition to `BASE_ALLOW`. Ported from
+/// `runtimes.<name>.allow` in env-allowlist.yml.
+///
+/// Note: the spawn sites also call `.env(VAR, value)` directly for the
+/// runtime-specific vars (e.g. HERMES_HOME, the pinned codex PATH); those calls
+/// re-assert the value after the clear regardless of whether the var was present
+/// in the parent env. This table additionally forwards a var's *parent* value
+/// when present, which matters for vars a site reads from the ambient env.
+fn runtime_allow(runtime: &str) -> &'static [&'static str] {
+    match runtime {
+        // Only HERMES_HOME is functionally required beyond base. The install path
+        // additionally needs PYTHONPATH / PYTHONHOME absent; under env_clear they
+        // are simply never injected, which satisfies that intent.
+        "hermes" => &["HERMES_HOME"],
+        // OpenCode server is configured entirely via CLI flags; nothing beyond
+        // base is required.
+        "opencode" => &[],
+        // Codex resolution needs a pinned PATH (re-asserted at the site) and an
+        // optional CODEX_HOME config/credential home.
+        "codex" => &["CODEX_HOME"],
+        // `ollama serve` / list / ps: listener bind target + model store location.
+        "ollama" => &["OLLAMA_HOST", "OLLAMA_MODELS"],
+        // Living Archive memory service (node): all config via CLI flags.
+        "memory" => &[],
+        // Browser host (node) and visible host (electron): RESONANTOS_NODE is read
+        // by the parent to pick the binary; if a forwarded value is present it must
+        // be explicit. Electron may also need DISPLAY / WAYLAND_DISPLAY on Linux —
+        // forward those via RESONANTOS_SCOPED_ENV_ALLOW when a visible-host platform
+        // requires them.
+        "browser-host" => &["RESONANTOS_NODE"],
+        // Unknown runtime: base allowlist only.
+        _ => &[],
+    }
+}
+
+/// Returns true when the scoped-env opt-in flag is set to a truthy value.
+fn scoped_env_enabled() -> bool {
+    matches!(
+        std::env::var(SCOPED_ENV_FLAG).ok().as_deref(),
+        Some("1")
+            | Some("true")
+            | Some("TRUE")
+            | Some("yes")
+            | Some("YES")
+            | Some("on")
+            | Some("ON")
+    )
+}
+
+/// Operator-supplied extra var names to forward (comma-separated). Empty when the
+/// opt-in flag is unset.
+fn opt_in_vars() -> Vec<String> {
+    std::env::var(SCOPED_ENV_ALLOW_FLAG)
+        .ok()
+        .map(|raw| {
+            raw.split(',')
+                .map(str::trim)
+                .filter(|name| !name.is_empty())
+                .map(ToString::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Apply the scoped-environment policy to a `Command` immediately before spawn.
+///
+/// - When `RESONANTOS_SCOPED_ENV` is NOT truthy (the default): NO-OP. The command
+///   is left exactly as the caller built it; behaviour is unchanged.
+/// - When it IS truthy: `cmd.env_clear()`, then re-inject ONLY the allowlisted
+///   vars (base allowlist + this runtime's allowlist + operator opt-in vars). For
+///   each allowlisted name, a caller-injected value (set via `.env(...)` BEFORE
+///   this call, e.g. `HERMES_HOME` / the pinned codex `PATH`) takes precedence;
+///   otherwise the value is forwarded from the parent process environment when
+///   present. Any caller-injected var that is NOT allowlisted is dropped by the
+///   clear and never re-injected.
+///
+/// Because `env_clear()` also discards the caller's pending `.env(...)` calls,
+/// this MUST run AFTER the site has set its allowlisted vars. All wired sites call
+/// it right before `.spawn()` / `.output()` / `.status()`.
+pub(crate) fn apply_scoped_env(cmd: &mut Command, runtime: &str) {
+    if !scoped_env_enabled() {
+        return;
+    }
+
+    // The set of names allowed to survive the clear.
+    let allowed: Vec<String> = BASE_ALLOW
+        .iter()
+        .map(|s| s.to_string())
+        .chain(runtime_allow(runtime).iter().map(|s| s.to_string()))
+        .chain(opt_in_vars())
+        .collect();
+
+    // Capture the caller's already-injected env (.env(...) calls made before this
+    // helper). These take precedence over the parent-process value.
+    let mut caller_injected: Vec<(String, String)> = Vec::new();
+    for (key, value) in cmd.get_envs() {
+        if let (Some(k), Some(v)) = (key.to_str(), value.and_then(|v| v.to_str())) {
+            caller_injected.push((k.to_string(), v.to_string()));
+        }
+    }
+
+    // Resolve each allowlisted name to a value: caller-injected first, else parent.
+    let mut forward: Vec<(String, String)> = Vec::new();
+    for name in &allowed {
+        if forward.iter().any(|(existing, _)| existing == name) {
+            continue;
+        }
+        if let Some((_, value)) = caller_injected.iter().find(|(k, _)| k == name) {
+            forward.push((name.clone(), value.clone()));
+        } else if let Ok(value) = std::env::var(name) {
+            forward.push((name.clone(), value));
+        }
+    }
+
+    cmd.env_clear();
+    for (name, value) in forward {
+        cmd.env(name, value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+    use std::sync::Mutex;
+
+    // Env mutation is process-global; serialize the tests that touch it.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Snapshot the env vars a built Command will set, as (name, value) pairs.
+    fn command_envs(cmd: &Command) -> Vec<(String, String)> {
+        cmd.get_envs()
+            .filter_map(|(k, v)| {
+                v.map(|v| {
+                    (
+                        k.to_string_lossy().into_owned(),
+                        v.to_string_lossy().into_owned(),
+                    )
+                })
+            })
+            .collect()
+    }
+
+    #[test]
+    fn off_by_default_is_noop() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var(SCOPED_ENV_FLAG);
+        std::env::remove_var(SCOPED_ENV_ALLOW_FLAG);
+
+        let mut cmd = Command::new("true");
+        cmd.env("HERMES_HOME", "/tmp/hermes");
+        let before = command_envs(&cmd);
+
+        apply_scoped_env(&mut cmd, "hermes");
+
+        let after = command_envs(&cmd);
+        // No-op: the only injected env is the caller's own, untouched.
+        assert_eq!(before, after);
+        assert_eq!(after.len(), 1);
+        assert_eq!(after[0].0, "HERMES_HOME");
+    }
+
+    #[test]
+    fn on_clears_and_injects_allowlist() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var(SCOPED_ENV_FLAG, "1");
+        std::env::remove_var(SCOPED_ENV_ALLOW_FLAG);
+
+        // Parent env: one allowlisted (HERMES_HOME) + one NOT allowlisted (secret).
+        std::env::set_var("HERMES_HOME", "/tmp/hermes-on");
+        std::env::set_var("PATH", "/usr/bin:/bin");
+        std::env::set_var("RESONANTOS_SECRET_TOKEN", "leak-me");
+
+        let mut cmd = Command::new("true");
+        apply_scoped_env(&mut cmd, "hermes");
+
+        let envs = command_envs(&cmd);
+        let names: Vec<&str> = envs.iter().map(|(k, _)| k.as_str()).collect();
+
+        // Allowlisted parent vars are forwarded.
+        assert!(names.contains(&"HERMES_HOME"), "HERMES_HOME forwarded");
+        assert!(names.contains(&"PATH"), "PATH forwarded (base allow)");
+        // Non-allowlisted ambient var is absent.
+        assert!(
+            !names.contains(&"RESONANTOS_SECRET_TOKEN"),
+            "non-allowlisted ambient var must NOT be forwarded"
+        );
+
+        std::env::remove_var(SCOPED_ENV_FLAG);
+        std::env::remove_var("RESONANTOS_SECRET_TOKEN");
+    }
+
+    #[test]
+    fn on_applies_env_clear_flag() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var(SCOPED_ENV_FLAG, "1");
+        let mut cmd = Command::new("true");
+        // Caller injects a runtime var BEFORE the scoped call; it must survive.
+        cmd.env("HERMES_HOME", "/tmp/keep");
+        apply_scoped_env(&mut cmd, "hermes");
+        // After env_clear + re-inject, the caller's var is still present.
+        let envs = command_envs(&cmd);
+        assert!(envs
+            .iter()
+            .any(|(k, v)| k == "HERMES_HOME" && v == "/tmp/keep"));
+        std::env::remove_var(SCOPED_ENV_FLAG);
+    }
+
+    #[test]
+    fn opt_in_vars_forwarded_only_when_named() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var(SCOPED_ENV_FLAG, "1");
+        std::env::set_var("DISPLAY", ":0");
+
+        // Without the opt-in flag, DISPLAY is not forwarded for browser-host.
+        std::env::remove_var(SCOPED_ENV_ALLOW_FLAG);
+        let mut cmd = Command::new("true");
+        apply_scoped_env(&mut cmd, "browser-host");
+        let names: Vec<String> = command_envs(&cmd).into_iter().map(|(k, _)| k).collect();
+        assert!(!names.contains(&"DISPLAY".to_string()));
+
+        // With the opt-in flag naming DISPLAY, it is forwarded.
+        std::env::set_var(SCOPED_ENV_ALLOW_FLAG, "DISPLAY,WAYLAND_DISPLAY");
+        let mut cmd2 = Command::new("true");
+        apply_scoped_env(&mut cmd2, "browser-host");
+        let names2: Vec<String> = command_envs(&cmd2).into_iter().map(|(k, _)| k).collect();
+        assert!(names2.contains(&"DISPLAY".to_string()));
+
+        std::env::remove_var(SCOPED_ENV_FLAG);
+        std::env::remove_var(SCOPED_ENV_ALLOW_FLAG);
+        std::env::remove_var("DISPLAY");
+    }
+
+    #[test]
+    fn flag_must_be_truthy() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var(SCOPED_ENV_FLAG, "0");
+        let mut cmd = Command::new("true");
+        cmd.env("HERMES_HOME", "/tmp/x");
+        apply_scoped_env(&mut cmd, "hermes");
+        // "0" is not truthy => no-op => only the caller's var.
+        assert_eq!(command_envs(&cmd).len(), 1);
+        std::env::remove_var(SCOPED_ENV_FLAG);
+    }
+}


### PR DESCRIPTION
### Mitigates finding `F2` — agent-runtime env inheritance, severity High (→ opt-in mitigation)

### What was wrong
All 13 agent-runtime subprocess spawns inherited the **full host environment** (no `env_clear`), leaking ambient credentials/config to hermes/opencode/codex/ollama/memory/browser-host.

### Why it matters
Spawned runtimes (some of which execute remote/agent instructions) receive every host env var, including secrets unrelated to them (CWE-200 exposure). Reachable by: any agent-runtime spawn.

### The change
- New `scoped_env` module wired into all 13 spawn sites. **DEFAULT-OFF** (`RESONANTOS_SCOPED_ENV` unset ⇒ byte-for-byte unchanged, no regression).
- When enabled: `env_clear()` then inject only a base allowlist (`HOME`/`PATH`/`LANG`/`LC_ALL`/`TMPDIR`) + a per-runtime allowlist + `RESONANTOS_SCOPED_ENV_ALLOW` opt-in vars. No blanket inheritance.
Breaking: none by default (opt-in).

### Validation
`cargo fmt --check` clean; `cargo build --lib` 0 errors; `cargo test --lib scoped_env` — 5 pass (off = no-op; on = clear + allowlist).

### Surface touched
`src-tauri/src/scoped_env.rs` (new) + `lib.rs` + the 6 runtime service modules

### Status / residual
F2 → **mitigation available, opt-in**. Allowlist completeness for the ON path is **runtime-unverified** (can't run the runtimes in CI); enable + verify each runtime, then promote to default-on. May need a trivial rebase after #152/#153 merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)