### PR TITLE
delegation: fix letter-spacing on hero h2 and empty-state headings

### DIFF
--- a/src/modules/delegation/delegation.css
+++ b/src/modules/delegation/delegation.css
@@ -28,7 +28,7 @@
   margin: 0.25rem 0 0;
   font-size: clamp(1.45rem, 3vw, 2.5rem);
   line-height: 0.98;
-  letter-spacing: -0.06em;
+  letter-spacing: -0.02em;
 }
 
 .delegation-hero-panel p {


### PR DESCRIPTION
Just a minor style change as my first contribution. The text was difficult to read