### PR TITLE
Worked on making some CSS more scalable

### DIFF
--- a/src/modules/archive/archive.css
+++ b/src/modules/archive/archive.css
@@ -1,8 +1,8 @@
 .archive-start-panel {
-  border-color: rgba(16, 185, 129, 0.22);
+  border-color: var(--accent-border);
   background:
-    radial-gradient(circle at top left, rgba(16, 185, 129, 0.14), transparent 30rem),
-    rgba(255, 248, 236, 0.04);
+    radial-gradient(circle at top left, var(--accent-surface-md), transparent 30rem),
+    var(--surface-tint-sm);
 }
 
 .archive-start-hero {
@@ -51,7 +51,7 @@
   min-height: 34px;
   padding: 0.5rem 0.7rem;
   border-radius: 999px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   background: rgba(9, 11, 12, 0.22);
   color: var(--text-secondary);
   font-size: 0.78rem;
@@ -59,7 +59,7 @@
 }
 
 .archive-start-summary span.ready {
-  border-color: rgba(16, 185, 129, 0.22);
+  border-color: var(--accent-border);
   color: var(--accent);
 }
 
@@ -78,10 +78,10 @@
   min-width: 0;
   padding: clamp(1rem, 2.5vw, 1.4rem);
   border-radius: 28px;
-  border: 1px solid rgba(16, 185, 129, 0.32);
+  border: 1px solid var(--accent-border-lg);
   background:
     radial-gradient(circle at 0% 0%, rgba(16, 185, 129, 0.24), transparent 18rem),
-    linear-gradient(145deg, rgba(255, 248, 236, 0.06), rgba(16, 185, 129, 0.045)),
+    linear-gradient(145deg, var(--surface-tint), rgba(16, 185, 129, 0.045)),
     rgba(9, 11, 12, 0.28);
   box-shadow: 0 24px 78px rgba(0, 0, 0, 0.2);
 }
@@ -113,7 +113,7 @@
   border-radius: 999px;
   background:
     radial-gradient(circle at 35% 30%, rgba(255, 255, 255, 0.85), transparent 0.32rem),
-    radial-gradient(circle, rgba(16, 185, 129, 0.95), rgba(16, 185, 129, 0.12) 62%, transparent 68%);
+    radial-gradient(circle, rgba(16, 185, 129, 0.95), var(--accent-surface) 62%, transparent 68%);
   box-shadow: 0 0 28px rgba(16, 185, 129, 0.45);
 }
 
@@ -128,7 +128,7 @@
   min-height: 4.2rem;
   max-height: 12rem;
   resize: vertical;
-  border: 1px solid rgba(138, 128, 112, 0.16);
+  border: var(--border-line-lg);
   border-radius: 20px;
   background: rgba(9, 11, 12, 0.28);
   color: var(--text-primary);
@@ -159,7 +159,7 @@
   padding: 0.55rem 0.68rem;
   border-radius: 999px;
   border: 1px solid rgba(16, 185, 129, 0.24);
-  background: rgba(16, 185, 129, 0.08);
+  background: var(--accent-surface-sm);
   color: var(--accent);
   font: 0.72rem/1.35 "JetBrains Mono", monospace;
 }
@@ -174,7 +174,7 @@
   height: 0.58rem;
   border-radius: 999px;
   background: var(--accent);
-  box-shadow: 0 0 0 rgba(16, 185, 129, 0.4);
+  box-shadow: 0 0 0 var(--accent-border-xl);
 }
 
 .archive-agent-live-status.active .archive-agent-pulse {
@@ -206,7 +206,7 @@
   overflow: auto;
   padding: 0.45rem;
   border-radius: 22px;
-  border: 1px solid rgba(138, 128, 112, 0.12);
+  border: var(--border-line-sm);
   background:
     radial-gradient(circle at 12% 0%, rgba(16, 185, 129, 0.09), transparent 16rem),
     rgba(9, 11, 12, 0.18);
@@ -218,13 +218,13 @@
   max-width: min(100%, 62rem);
   padding: 0.72rem 0.85rem;
   border-radius: 18px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   background: rgba(9, 11, 12, 0.22);
 }
 
 .archive-agent-message.user {
   justify-self: end;
-  border-color: rgba(16, 185, 129, 0.22);
+  border-color: var(--accent-border);
   background: rgba(16, 185, 129, 0.1);
 }
 
@@ -233,7 +233,7 @@
 }
 
 .archive-agent-message.thinking {
-  border-color: rgba(16, 185, 129, 0.28);
+  border-color: var(--accent-border-md);
   color: var(--accent);
 }
 
@@ -261,7 +261,7 @@
   min-width: 0;
   padding: 0.9rem;
   border-radius: 22px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   background: rgba(255, 248, 236, 0.025);
 }
 
@@ -283,7 +283,7 @@
   flex: 0 0 auto;
   padding: 0.42rem 0.62rem;
   border-radius: 999px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   color: var(--text-secondary);
   font: 0.68rem/1 "JetBrains Mono", monospace;
   text-transform: uppercase;
@@ -291,7 +291,7 @@
 }
 
 .archive-setup-pill.ready {
-  border-color: rgba(16, 185, 129, 0.28);
+  border-color: var(--accent-border-md);
   color: var(--accent);
 }
 
@@ -404,7 +404,7 @@
   min-height: 34px;
   padding: 0.5rem 0.7rem;
   border-radius: 999px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   background: rgba(9, 11, 12, 0.22);
   color: var(--text-secondary);
   font-size: 0.78rem;
@@ -412,7 +412,7 @@
 }
 
 .archive-subpage-bar span.ready {
-  border-color: rgba(16, 185, 129, 0.22);
+  border-color: var(--accent-border);
   color: var(--accent);
 }
 
@@ -429,9 +429,9 @@
   min-width: 0;
   padding: clamp(1rem, 2.4vw, 1.45rem);
   border-radius: 26px;
-  border: 1px solid rgba(16, 185, 129, 0.32);
+  border: 1px solid var(--accent-border-lg);
   background:
-    radial-gradient(circle at 4% 0%, rgba(16, 185, 129, 0.28), transparent 20rem),
+    radial-gradient(circle at 4% 0%, var(--accent-border-md), transparent 20rem),
     linear-gradient(135deg, rgba(16, 185, 129, 0.13), rgba(245, 158, 11, 0.045)),
     rgba(9, 11, 12, 0.28);
   box-shadow: 0 22px 70px rgba(0, 0, 0, 0.18);
@@ -459,7 +459,7 @@
   margin-top: 0.85rem;
   padding: 0.36rem 0.56rem;
   border-radius: 999px;
-  border: 1px solid rgba(138, 128, 112, 0.18);
+  border: var(--border-line);
   color: var(--text-muted);
   font: 0.66rem/1 "JetBrains Mono", monospace;
   text-transform: uppercase;
@@ -485,9 +485,9 @@
   min-width: 0;
   padding: 1rem;
   border-radius: 22px;
-  border: 1px solid rgba(16, 185, 129, 0.2);
+  border: 1px solid var(--accent-border-sm);
   background:
-    radial-gradient(circle at 12% 0%, rgba(16, 185, 129, 0.16), transparent 24rem),
+    radial-gradient(circle at 12% 0%, var(--accent-surface-lg), transparent 24rem),
     rgba(16, 185, 129, 0.035);
 }
 
@@ -532,7 +532,7 @@
   min-height: 34px;
   padding: 0.48rem 0.66rem;
   border-radius: 999px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   background: rgba(9, 11, 12, 0.18);
   color: var(--text-secondary);
   font-size: 0.76rem;
@@ -549,7 +549,7 @@
 .archive-advanced-tools {
   padding: 0.8rem;
   border-radius: 18px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   background: rgba(255, 248, 236, 0.025);
 }
 
@@ -580,7 +580,7 @@
   align-content: space-between;
   padding: 0.8rem;
   border-radius: 20px;
-  border: 1px solid rgba(138, 128, 112, 0.16);
+  border: var(--border-line-lg);
   background: rgba(255, 248, 236, 0.035);
   overflow: hidden;
 }
@@ -636,7 +636,7 @@
   min-width: 0;
   padding: 0.72rem;
   border-radius: 16px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   background: rgba(9, 11, 12, 0.18);
 }
 
@@ -659,8 +659,8 @@
   min-width: 0;
   padding: 0.85rem;
   border-radius: 18px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
-  background: rgba(255, 248, 236, 0.03);
+  border: var(--border-line-md);
+  background: var(--surface-tint-xs);
 }
 
 .archive-memory-latest strong {
@@ -682,7 +682,7 @@
   gap: 0.35rem;
   padding: 0.85rem;
   border-radius: 16px;
-  border: 1px solid rgba(16, 185, 129, 0.22);
+  border: 1px solid var(--accent-border);
   background: rgba(16, 185, 129, 0.07);
   overflow-wrap: anywhere;
 }
@@ -708,7 +708,7 @@
 
 .archive-memory-latest-tags span {
   border-radius: 999px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   padding: 0.32rem 0.55rem;
   color: var(--text-secondary);
   font-size: 0.68rem;
@@ -725,7 +725,7 @@
   gap: 0.45rem;
   min-width: 0;
   padding: 0.45rem;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   border-radius: 18px;
   background: rgba(9, 11, 12, 0.72);
   backdrop-filter: blur(18px);
@@ -747,8 +747,8 @@
 
 .archive-tabs button:hover,
 .archive-tabs button.active {
-  border-color: rgba(16, 185, 129, 0.22);
-  background: rgba(16, 185, 129, 0.08);
+  border-color: var(--accent-border);
+  background: var(--accent-surface-sm);
   color: var(--text-primary);
 }
 
@@ -766,7 +766,7 @@
   min-width: 0;
   padding: 0.9rem;
   border-radius: 18px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   background: rgba(9, 11, 12, 0.2);
 }
 
@@ -790,10 +790,10 @@
 }
 
 .archive-command-panel {
-  border-color: rgba(16, 185, 129, 0.22);
+  border-color: var(--accent-border);
   background:
-    radial-gradient(circle at top left, rgba(16, 185, 129, 0.12), transparent 30rem),
-    rgba(255, 248, 236, 0.04);
+    radial-gradient(circle at top left, var(--accent-surface), transparent 30rem),
+    var(--surface-tint-sm);
 }
 
 .archive-command-layout {
@@ -854,7 +854,7 @@
   margin-top: 1rem;
   padding: 0.9rem;
   border-radius: 18px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   background: rgba(9, 11, 12, 0.18);
 }
 
@@ -889,7 +889,7 @@
   min-width: 0;
   padding: 0.7rem 0.8rem;
   border-radius: 14px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   background: rgba(255, 248, 236, 0.025);
 }
 
@@ -924,13 +924,13 @@
   min-width: 0;
   padding: 0.78rem 0.85rem;
   border-radius: 16px;
-  border: 1px solid rgba(138, 128, 112, 0.16);
+  border: var(--border-line-lg);
   background: rgba(9, 11, 12, 0.24);
 }
 
 .archive-command-metric.ready {
-  border-color: rgba(16, 185, 129, 0.22);
-  background: rgba(16, 185, 129, 0.06);
+  border-color: var(--accent-border);
+  background: var(--accent-surface-xs);
 }
 
 .archive-command-metric.warning {
@@ -987,12 +987,12 @@
   min-width: 0;
   padding: 0.85rem;
   border-radius: 16px;
-  border: 1px solid rgba(16, 185, 129, 0.14);
+  border: 1px solid var(--accent-surface-md);
   background: rgba(16, 185, 129, 0.045);
 }
 
 .archive-empty-state {
-  border-color: rgba(138, 128, 112, 0.14);
+  border-color: var(--border-md);
   background: rgba(9, 11, 12, 0.2);
 }
 
@@ -1085,7 +1085,7 @@
   min-width: 0;
   padding: 0.75rem;
   border-radius: 16px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   background: rgba(255, 248, 236, 0.035);
 }
 
@@ -1129,7 +1129,7 @@
   min-width: 0;
   padding: 0.9rem;
   border-radius: 18px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   background: rgba(9, 11, 12, 0.18);
 }
 
@@ -1151,8 +1151,8 @@
   min-width: 0;
   padding: 0.78rem;
   border-radius: 15px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
-  background: rgba(255, 248, 236, 0.03);
+  border: var(--border-line-md);
+  background: var(--surface-tint-xs);
 }
 
 .source-root-card {
@@ -1236,7 +1236,7 @@
   min-width: 0;
   padding: 0.62rem 0.75rem 0.62rem 2.35rem;
   border-radius: 14px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   background: rgba(9, 11, 12, 0.22);
   color: var(--text-secondary);
   font-size: 0.84rem;
@@ -1282,8 +1282,8 @@
   min-height: 0;
   padding: 0.9rem;
   border-radius: 18px;
-  border: 1px solid rgba(138, 128, 112, 0.16);
-  background: rgba(255, 248, 236, 0.03);
+  border: var(--border-line-lg);
+  background: var(--surface-tint-xs);
 }
 
 .library-step-card:first-child,
@@ -1296,7 +1296,7 @@
   min-width: 0;
   padding: 0.72rem;
   border-radius: 16px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   background: rgba(255, 248, 236, 0.025);
   color: var(--text-muted);
   font-size: 0.78rem;
@@ -1470,7 +1470,7 @@
   min-width: 0;
   padding: 0.8rem;
   border-radius: 15px;
-  border: 1px solid rgba(16, 185, 129, 0.2);
+  border: 1px solid var(--accent-border-sm);
   background: rgba(16, 185, 129, 0.055);
 }
 
@@ -1505,7 +1505,7 @@
   min-width: 0;
   padding: 0.7rem;
   border-radius: 14px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   background: rgba(9, 11, 12, 0.18);
 }
 
@@ -1570,7 +1570,7 @@
   min-width: 0;
   padding: 0.95rem;
   border-radius: 18px;
-  border: 1px solid rgba(16, 185, 129, 0.22);
+  border: 1px solid var(--accent-border);
   background: rgba(16, 185, 129, 0.055);
 }
 
@@ -1593,7 +1593,7 @@
   max-width: 100%;
   padding: 0.42rem 0.55rem;
   border-radius: 10px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   background: rgba(9, 11, 12, 0.26);
   color: var(--text-secondary);
   font: 0.72rem/1.45 "JetBrains Mono", monospace;
@@ -1612,7 +1612,7 @@
   max-width: 100%;
   padding: 0.34rem 0.5rem;
   border-radius: 999px;
-  border: 1px solid rgba(16, 185, 129, 0.16);
+  border: 1px solid var(--accent-surface-lg);
   background: rgba(16, 185, 129, 0.055);
   color: var(--text-secondary);
   font-size: 0.74rem;
@@ -1656,7 +1656,7 @@
   margin: 0;
   padding: 0.95rem;
   border-radius: 14px;
-  border: 1px solid rgba(138, 128, 112, 0.16);
+  border: var(--border-line-lg);
   background: rgba(9, 11, 12, 0.48);
   color: var(--text-secondary);
   font: 0.78rem/1.5 "JetBrains Mono", monospace;
@@ -1679,7 +1679,7 @@
 }
 
 .archive-focus-target.active .archive-review-hero {
-  box-shadow: 0 0 0 1px rgba(16, 185, 129, 0.2), 0 0 34px rgba(16, 185, 129, 0.12);
+  box-shadow: 0 0 0 1px var(--accent-border-sm), 0 0 34px var(--accent-surface);
 }
 
 .archive-focus-cue {
@@ -1687,7 +1687,7 @@
   max-width: 100%;
   padding: 0.55rem 0.72rem;
   border-radius: 999px;
-  border: 1px solid rgba(16, 185, 129, 0.22);
+  border: 1px solid var(--accent-border);
   background: rgba(16, 185, 129, 0.075);
   color: var(--text-secondary);
   font-size: 0.76rem;
@@ -1697,7 +1697,7 @@
 .archive-review-hero {
   border-color: rgba(16, 185, 129, 0.24);
   background:
-    radial-gradient(circle at top left, rgba(16, 185, 129, 0.12), transparent 34%),
+    radial-gradient(circle at top left, var(--accent-surface), transparent 34%),
     rgba(255, 248, 236, 0.035);
 }
 
@@ -1727,7 +1727,7 @@
   margin-top: 1rem;
   padding: 0.9rem;
   border-radius: 16px;
-  border: 1px solid rgba(16, 185, 129, 0.2);
+  border: 1px solid var(--accent-border-sm);
   background: rgba(16, 185, 129, 0.065);
   overflow-wrap: anywhere;
 }
@@ -1754,7 +1754,7 @@
 
 .segmented-control button.active {
   border-color: rgba(16, 185, 129, 0.55);
-  background: rgba(16, 185, 129, 0.14);
+  background: var(--accent-surface-md);
   color: var(--text-primary);
 }
 
@@ -1764,7 +1764,7 @@
   min-width: 0;
   padding: 0.95rem;
   border-radius: 16px;
-  border: 1px solid rgba(138, 128, 112, 0.16);
+  border: var(--border-line-lg);
   background: rgba(9, 11, 12, 0.22);
 }
 
@@ -1832,7 +1832,7 @@
   min-width: 0;
   padding: 1rem;
   border-radius: 18px;
-  border: 1px solid rgba(138, 128, 112, 0.16);
+  border: var(--border-line-lg);
   background: rgba(255, 248, 236, 0.035);
 }
 
@@ -1861,7 +1861,7 @@
   min-width: 0;
   padding: 0.38rem 0.55rem;
   border-radius: 999px;
-  border: 1px solid rgba(138, 128, 112, 0.16);
+  border: var(--border-line-lg);
   background: rgba(9, 11, 12, 0.22);
   color: var(--text-secondary);
   font-size: 0.78rem;
@@ -1872,7 +1872,7 @@
 .archive-details {
   min-width: 0;
   border-radius: 14px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   background: rgba(9, 11, 12, 0.16);
 }
 
@@ -1897,7 +1897,7 @@
 
 .archive-review-result {
   margin-top: 1rem;
-  border-color: rgba(16, 185, 129, 0.22);
+  border-color: var(--accent-border);
   background: rgba(16, 185, 129, 0.055);
 }
 
@@ -1968,7 +1968,7 @@
   min-width: 0;
   padding: 0.78rem 0.85rem;
   border-radius: 16px;
-  border: 1px solid rgba(138, 128, 112, 0.16);
+  border: var(--border-line-lg);
   background: rgba(9, 11, 12, 0.22);
 }
 
@@ -2021,7 +2021,7 @@
   max-width: 100%;
   padding: 0.32rem 0.48rem;
   border-radius: 999px;
-  border: 1px solid rgba(138, 128, 112, 0.16);
+  border: var(--border-line-lg);
   background: rgba(9, 11, 12, 0.22);
   color: var(--text-secondary);
   font-size: 0.72rem;

--- a/src/modules/browser/browser.css
+++ b/src/modules/browser/browser.css
@@ -17,7 +17,7 @@
   height: 100%;
   padding: 0;
   overflow: hidden;
-  border: 1px solid rgba(138, 128, 112, 0.18);
+  border: var(--border-line);
   border-radius: 24px;
   background: #101112;
 }
@@ -63,7 +63,7 @@
   min-width: 0;
   min-height: 34px;
   padding: 0 0.72rem;
-  border-bottom: 1px solid rgba(255, 248, 236, 0.08);
+  border-bottom: 1px solid var(--surface-tint-md);
   background: #050606;
   color: rgba(255, 248, 236, 0.88);
   overflow-x: auto;
@@ -102,7 +102,7 @@
 
 .browser-menu-bar button:hover {
   color: #ffffff;
-  background: rgba(255, 248, 236, 0.08);
+  background: var(--surface-tint-md);
 }
 
 .browser-menu-popover {
@@ -152,7 +152,7 @@
   gap: 0.42rem;
   min-width: 0;
   padding: 0.45rem 0.58rem 0;
-  border-bottom: 1px solid rgba(255, 248, 236, 0.08);
+  border-bottom: 1px solid var(--surface-tint-md);
   background: linear-gradient(180deg, #1f2022, #151617);
 }
 
@@ -165,7 +165,7 @@
   min-width: 7rem;
   min-height: 38px;
   padding: 0 0.2rem 0 0.62rem;
-  border: 1px solid rgba(255, 248, 236, 0.08);
+  border: 1px solid var(--surface-tint-md);
   border-bottom: 0;
   border-radius: 14px 14px 0 0;
   background: rgba(255, 248, 236, 0.075);
@@ -201,7 +201,7 @@
 
 .browser-tab button:last-child:hover {
   color: var(--text-primary);
-  background: rgba(255, 248, 236, 0.08);
+  background: var(--surface-tint-md);
 }
 
 .browser-toolbar {
@@ -212,7 +212,7 @@
   justify-content: center;
   min-width: 0;
   padding: 0.5rem 0.7rem;
-  border-bottom: 1px solid rgba(255, 248, 236, 0.08);
+  border-bottom: 1px solid var(--surface-tint-md);
   background: #303133;
 }
 
@@ -242,14 +242,14 @@
   border-radius: 999px;
   border: 1px solid rgba(255, 248, 236, 0.1);
   color: rgba(255, 248, 236, 0.76);
-  background: rgba(255, 248, 236, 0.06);
+  background: var(--surface-tint);
   font-size: 1.15rem;
   line-height: 1;
 }
 
 .browser-icon-button:hover:not(:disabled) {
   color: var(--text-primary);
-  background: rgba(255, 248, 236, 0.12);
+  background: var(--surface-tint-lg);
 }
 
 .browser-icon-button:disabled {
@@ -287,7 +287,7 @@
 .browser-extension-button {
   color: #d9f99d;
   border-color: rgba(255, 248, 236, 0.14);
-  background: rgba(255, 248, 236, 0.08);
+  background: var(--surface-tint-md);
   font-size: 0.76rem;
   font-weight: 800;
 }
@@ -320,7 +320,7 @@
   min-width: 0;
   min-height: 34px;
   padding: 0 0.72rem;
-  border-bottom: 1px solid rgba(255, 248, 236, 0.08);
+  border-bottom: 1px solid var(--surface-tint-md);
   background: #202123;
   overflow-x: auto;
   scrollbar-width: none;
@@ -345,7 +345,7 @@
 
 .browser-bookmarks-bar button:hover {
   color: #ffffff;
-  background: rgba(255, 248, 236, 0.08);
+  background: var(--surface-tint-md);
 }
 
 .browser-apps-button {
@@ -678,7 +678,7 @@
   min-width: 0;
   padding: 0.72rem;
   border-radius: 14px;
-  background: rgba(255, 248, 236, 0.06);
+  background: var(--surface-tint);
 }
 
 .browser-extension-list span {
@@ -735,7 +735,7 @@
   padding: 2rem;
   text-align: center;
   background:
-    radial-gradient(circle at center, rgba(255, 248, 236, 0.08), transparent 18rem),
+    radial-gradient(circle at center, var(--surface-tint-md), transparent 18rem),
     #101112;
 }
 

--- a/src/modules/chat/chat-rail.css
+++ b/src/modules/chat/chat-rail.css
@@ -58,7 +58,7 @@
   width: 2px;
   height: 56px;
   border-radius: 999px;
-  background: rgba(255, 248, 236, 0.12);
+  background: var(--surface-tint-lg);
   transform: translateY(-50%);
   opacity: 0;
   transition: opacity 140ms ease;
@@ -96,7 +96,7 @@
 
 .agent-switcher-item.augmentor.active {
   border-color: transparent;
-  background: rgba(16, 185, 129, 0.08);
+  background: var(--accent-surface-sm);
   color: #bbf7d0;
 }
 
@@ -140,7 +140,7 @@
 }
 
 .chat-agent-chip.active {
-  background: rgba(16, 185, 129, 0.08);
+  background: var(--accent-surface-sm);
   color: rgba(187, 247, 208, 0.92);
 }
 
@@ -423,7 +423,7 @@
   display: grid;
   min-width: 92px;
   padding: 0.28rem;
-  border: 1px solid rgba(138, 128, 112, 0.18);
+  border: var(--border-line);
   border-radius: 10px;
   background: rgba(14, 12, 10, 0.98);
   box-shadow: 0 18px 48px rgba(0, 0, 0, 0.34);
@@ -551,7 +551,7 @@
   width: 26px;
   height: 26px;
   border-radius: 999px;
-  background: rgba(16, 185, 129, 0.12);
+  background: var(--accent-surface);
   color: var(--accent);
   font-size: 0.7rem;
   font-weight: 900;
@@ -566,7 +566,7 @@
 .thread-tab:hover {
   transform: translateY(-1px);
   border-color: rgba(16, 185, 129, 0.36);
-  background: rgba(16, 185, 129, 0.08);
+  background: var(--accent-surface-sm);
 }
 
 .chat-toolbar {
@@ -678,7 +678,7 @@
   padding: 0.72rem;
   border-radius: 18px;
   background:
-    radial-gradient(circle at 12% 0%, rgba(16, 185, 129, 0.12), transparent 34%),
+    radial-gradient(circle at 12% 0%, var(--accent-surface), transparent 34%),
     rgba(255, 248, 236, 0.035);
   box-shadow: inset 0 0 0 1px rgba(255, 248, 236, 0.055);
 }
@@ -714,7 +714,7 @@
   padding: 0.28rem 0.62rem;
   border: 0;
   border-radius: 999px;
-  background: rgba(16, 185, 129, 0.14);
+  background: var(--accent-surface-md);
   color: rgba(187, 247, 208, 0.95);
   font-size: 0.68rem;
   font-weight: 800;
@@ -749,7 +749,7 @@
   height: 9px;
   overflow: hidden;
   border-radius: 999px;
-  background: rgba(255, 248, 236, 0.08);
+  background: var(--surface-tint-md);
 }
 
 .context-memory-meter-used {
@@ -792,7 +792,7 @@
   place-items: center;
   padding: 0.28rem;
   border-radius: 12px;
-  background: rgba(255, 248, 236, 0.04);
+  background: var(--surface-tint-sm);
   color: rgba(138, 128, 112, 0.92);
   font-size: 0.62rem;
   line-height: 1.15;
@@ -901,7 +901,7 @@
 }
 
 .context-memory-editor-actions button:first-child {
-  background: rgba(16, 185, 129, 0.16);
+  background: var(--accent-surface-lg);
   color: rgba(187, 247, 208, 0.96);
 }
 
@@ -946,7 +946,7 @@
   gap: 0.58rem;
   min-width: 0;
   padding-bottom: 0.62rem;
-  border-bottom: 1px solid rgba(255, 248, 236, 0.12);
+  border-bottom: 1px solid var(--surface-tint-lg);
 }
 
 .chat-run-status-head strong {

--- a/src/modules/chat/messages.css
+++ b/src/modules/chat/messages.css
@@ -27,7 +27,7 @@
   justify-self: end;
   padding-left: 0.86rem;
   padding-right: 0.86rem;
-  background: rgba(16, 185, 129, 0.14);
+  background: var(--accent-surface-md);
   border: 0;
 }
 
@@ -172,7 +172,7 @@
   max-width: 100%;
   padding: 0.65rem 0.75rem;
   border-radius: 12px;
-  background: rgba(255, 248, 236, 0.06);
+  background: var(--surface-tint);
 }
 
 .message-renderer pre code {
@@ -215,7 +215,7 @@
 
 .identity-card {
   padding: 1rem;
-  border: 1px dashed rgba(16, 185, 129, 0.32);
+  border: 1px dashed var(--accent-border-lg);
   border-radius: var(--radius);
-  background: rgba(16, 185, 129, 0.06);
+  background: var(--accent-surface-xs);
 }

--- a/src/modules/delegation/delegation.css
+++ b/src/modules/delegation/delegation.css
@@ -8,7 +8,7 @@
 .delegation-list-panel,
 .delegation-detail-panel {
   min-width: 0;
-  border: 1px solid rgba(138, 128, 112, 0.16);
+  border: var(--border-line-lg);
   border-radius: 24px;
   background:
     radial-gradient(circle at top right, rgba(16, 185, 129, 0.1), transparent 14rem),
@@ -39,7 +39,7 @@
 }
 
 .delegation-notice {
-  border: 1px solid rgba(16, 185, 129, 0.2);
+  border: 1px solid var(--accent-border-sm);
   border-radius: 18px;
   background: rgba(16, 185, 129, 0.07);
 }
@@ -55,7 +55,7 @@
 .goal-monitor-panel,
 .goal-monitor-card {
   min-width: 0;
-  border: 1px solid rgba(138, 128, 112, 0.16);
+  border: var(--border-line-lg);
   background: rgba(9, 11, 12, 0.22);
 }
 
@@ -96,7 +96,7 @@
   padding: 1rem;
   border-radius: 24px;
   background:
-    radial-gradient(circle at top left, rgba(16, 185, 129, 0.08), transparent 12rem),
+    radial-gradient(circle at top left, var(--accent-surface-sm), transparent 12rem),
     rgba(19, 16, 13, 0.62);
 }
 
@@ -140,7 +140,7 @@
 
 .goal-monitor-meta span,
 .goal-monitor-blockers span {
-  border: 1px solid rgba(138, 128, 112, 0.16);
+  border: var(--border-line-lg);
   border-radius: 999px;
   padding: 0.28rem 0.48rem;
   color: var(--text-secondary);
@@ -188,8 +188,8 @@
 .delegation-task-card:hover {
   border-color: rgba(16, 185, 129, 0.42);
   background:
-    radial-gradient(circle at top right, rgba(16, 185, 129, 0.14), transparent 10rem),
-    rgba(16, 185, 129, 0.06);
+    radial-gradient(circle at top right, var(--accent-surface-md), transparent 10rem),
+    var(--accent-surface-xs);
 }
 
 .delegation-task-orb {
@@ -267,7 +267,7 @@
   gap: 0.85rem;
   min-width: 0;
   padding: 0.85rem;
-  border: 1px solid rgba(138, 128, 112, 0.16);
+  border: var(--border-line-lg);
   border-radius: 20px;
   background: rgba(9, 11, 12, 0.18);
 }
@@ -284,14 +284,14 @@
   max-height: 420px;
   overflow: auto;
   padding: 0.85rem;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   border-radius: 18px;
   background: rgba(7, 9, 10, 0.28);
 }
 
 .delegation-review-card.result {
   background:
-    radial-gradient(circle at top left, rgba(16, 185, 129, 0.08), transparent 11rem),
+    radial-gradient(circle at top left, var(--accent-surface-sm), transparent 11rem),
     rgba(7, 9, 10, 0.28);
 }
 
@@ -317,7 +317,7 @@
 .delegation-path-card {
   min-width: 0;
   padding: 0.75rem;
-  border: 1px solid rgba(138, 128, 112, 0.16);
+  border: var(--border-line-lg);
   border-radius: 18px;
   background: rgba(9, 11, 12, 0.22);
 }

--- a/src/modules/hermes/hermes-workspace.css
+++ b/src/modules/hermes/hermes-workspace.css
@@ -34,7 +34,7 @@
 
 .hermes-settings-drawer,
 .hermes-dashboard-frame {
-  border: 1px solid rgba(138, 128, 112, 0.12);
+  border: var(--border-line-sm);
   background: rgba(255, 248, 236, 0.028);
 }
 
@@ -57,7 +57,7 @@
 }
 
 .hermes-pill.ready {
-  background: rgba(16, 185, 129, 0.12);
+  background: var(--accent-surface);
   color: var(--accent);
 }
 

--- a/src/modules/obsidian/obsidian-workspace.css
+++ b/src/modules/obsidian/obsidian-workspace.css
@@ -24,7 +24,7 @@
 .obsidian-workspace-header,
 .obsidian-workspace-alert {
   padding: 0.9rem 1rem;
-  border: 1px solid rgba(138, 128, 112, 0.12);
+  border: var(--border-line-sm);
   border-radius: 16px;
   background: rgba(255, 248, 236, 0.028);
 }
@@ -633,7 +633,7 @@
   width: 100%;
   min-height: 2.15rem;
   padding: 0.45rem 0.55rem;
-  border: 1px solid rgba(138, 128, 112, 0.12);
+  border: var(--border-line-sm);
   border-radius: 9px;
   background: rgba(255, 248, 236, 0.035);
   color: var(--text-primary);

--- a/src/modules/opencode/opencode-workspace.css
+++ b/src/modules/opencode/opencode-workspace.css
@@ -39,7 +39,7 @@
 .opencode-warning,
 .opencode-error,
 .opencode-embed-shell {
-  border: 1px solid rgba(138, 128, 112, 0.12);
+  border: var(--border-line-sm);
   border-radius: 18px;
   background: rgba(255, 248, 236, 0.028);
 }
@@ -90,7 +90,7 @@
   place-items: center;
   width: 1.62rem;
   height: 1.62rem;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   border-radius: 999px;
   background: rgba(255, 248, 236, 0.035);
   color: var(--text-secondary);
@@ -123,7 +123,7 @@
 }
 
 .opencode-runtime-pill.ready {
-  background: rgba(16, 185, 129, 0.12);
+  background: var(--accent-surface);
   color: var(--accent);
 }
 
@@ -234,7 +234,7 @@
   gap: 0.45rem;
   min-width: 0;
   padding: 0.32rem 0.55rem;
-  border-bottom: 1px solid rgba(138, 128, 112, 0.12);
+  border-bottom: var(--border-line-sm);
   font-size: 0.68rem;
 }
 
@@ -252,7 +252,7 @@
 }
 
 .opencode-trust-kernel.ready {
-  background: rgba(16, 185, 129, 0.06);
+  background: var(--accent-surface-xs);
 }
 
 .opencode-trust-kernel.attention {

--- a/src/modules/paperclip/paperclip-workspace.css
+++ b/src/modules/paperclip/paperclip-workspace.css
@@ -39,7 +39,7 @@
 .paperclip-warning,
 .paperclip-error,
 .paperclip-embed-shell {
-  border: 1px solid rgba(138, 128, 112, 0.12);
+  border: var(--border-line-sm);
   border-radius: 18px;
   background: rgba(255, 248, 236, 0.028);
 }
@@ -84,7 +84,7 @@
   place-items: center;
   width: 1.62rem;
   height: 1.62rem;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   border-radius: 999px;
   background: rgba(255, 248, 236, 0.035);
   color: var(--text-secondary);
@@ -108,7 +108,7 @@
 }
 
 .paperclip-runtime-pill.ready {
-  background: rgba(16, 185, 129, 0.12);
+  background: var(--accent-surface);
   color: var(--accent);
 }
 
@@ -160,7 +160,7 @@
 .paperclip-field input {
   width: 100%;
   min-width: 0;
-  border: 1px solid rgba(138, 128, 112, 0.16);
+  border: var(--border-line-lg);
   border-radius: 12px;
   background: rgba(0, 0, 0, 0.22);
   color: var(--text-primary);
@@ -173,7 +173,7 @@
   min-width: 0;
   min-height: 5rem;
   resize: vertical;
-  border: 1px solid rgba(138, 128, 112, 0.16);
+  border: var(--border-line-lg);
   border-radius: 12px;
   background: rgba(0, 0, 0, 0.22);
   color: var(--text-primary);
@@ -196,7 +196,7 @@
 
 .paperclip-summary-card {
   min-width: 0;
-  border: 1px solid rgba(138, 128, 112, 0.12);
+  border: var(--border-line-sm);
   border-radius: 16px;
   background: rgba(255, 248, 236, 0.026);
   padding: 0.7rem;
@@ -220,7 +220,7 @@
   width: 100%;
   min-width: 0;
   margin-top: 0.35rem;
-  border: 1px solid rgba(138, 128, 112, 0.16);
+  border: var(--border-line-lg);
   border-radius: 10px;
   background: rgba(0, 0, 0, 0.24);
   color: var(--text-primary);
@@ -249,8 +249,8 @@
 }
 
 .paperclip-success {
-  border: 1px solid rgba(16, 185, 129, 0.22);
-  background: rgba(16, 185, 129, 0.06);
+  border: 1px solid var(--accent-border);
+  background: var(--accent-surface-xs);
   color: var(--accent);
 }
 

--- a/src/modules/recovery/recovery.css
+++ b/src/modules/recovery/recovery.css
@@ -3,7 +3,7 @@
 }
 
 .archive-action-card.active {
-  border-color: rgba(16, 185, 129, 0.4);
+  border-color: var(--accent-border-xl);
 }
 
 .archive-action-card.warning {
@@ -135,8 +135,8 @@
 .recovery-log-entry {
   padding: 0.85rem;
   border-radius: var(--radius);
-  border: 1px solid var(--border);
-  background: rgba(255, 248, 236, 0.03);
+  border: var(--border-line-md);
+  background: var(--surface-tint-xs);
   min-width: 0;
 }
 
@@ -146,8 +146,8 @@
 }
 
 .recovery-dashboard-card.recommended {
-  border-color: rgba(16, 185, 129, 0.28);
-  background: rgba(16, 185, 129, 0.08);
+  border-color: var(--accent-border-md);
+  background: var(--accent-surface-sm);
 }
 
 .recovery-dashboard-card-head {
@@ -186,7 +186,7 @@
 }
 
 .recovery-checklist-step.complete {
-  border-color: rgba(16, 185, 129, 0.28);
+  border-color: var(--accent-border-md);
 }
 
 .recovery-log-list {
@@ -198,7 +198,7 @@
   flex: 0 0 auto;
   border-radius: 999px;
   padding: 0.25rem 0.55rem;
-  background: rgba(255, 248, 236, 0.04);
+  background: var(--surface-tint-sm);
   font-size: 0.72rem;
   white-space: nowrap;
 }
@@ -230,8 +230,8 @@
 .chat-sidebar,
 .inline-notice {
   border-radius: var(--radius);
-  border: 1px solid var(--border);
-  background: rgba(255, 248, 236, 0.03);
+  border: var(--border-line-md);
+  background: var(--surface-tint-xs);
 }
 
 .message-stack {
@@ -242,7 +242,7 @@
   overflow: auto;
   flex: 1 1 auto;
   min-height: 0;
-  border: 1px solid rgba(138, 128, 112, 0.16);
+  border: var(--border-line-lg);
   border-radius: 18px;
   background: rgba(9, 11, 12, 0.18);
 }
@@ -283,13 +283,13 @@
   margin: 0 0.95rem;
   padding: 0.75rem 0.8rem;
   border-radius: 14px;
-  border: 1px solid rgba(138, 128, 112, 0.18);
-  background: rgba(255, 248, 236, 0.03);
+  border: var(--border-line);
+  background: var(--surface-tint-xs);
 }
 
 .agent-activity-rail.live {
   border-color: rgba(16, 185, 129, 0.26);
-  background: rgba(16, 185, 129, 0.08);
+  background: var(--accent-surface-sm);
 }
 
 .agent-activity-pulse {
@@ -337,7 +337,7 @@
   padding: 0.82rem;
   border-radius: 14px;
   border: 1px solid rgba(248, 113, 113, 0.18);
-  background: rgba(255, 248, 236, 0.03);
+  background: var(--surface-tint-xs);
 }
 
 .recovery-candidates-list {
@@ -352,12 +352,12 @@
   padding: 0.7rem 0.75rem;
   border-radius: 12px;
   border: 1px solid rgba(248, 113, 113, 0.12);
-  background: rgba(255, 248, 236, 0.03);
+  background: var(--surface-tint-xs);
 }
 
 .recovery-candidate.recommended {
   border-color: rgba(16, 185, 129, 0.26);
-  background: rgba(16, 185, 129, 0.08);
+  background: var(--accent-surface-sm);
 }
 
 .recovery-candidate-copy {
@@ -471,7 +471,7 @@
 @keyframes activity-pulse {
   0%,
   100% {
-    box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.08);
+    box-shadow: 0 0 0 0 var(--accent-surface-sm);
     transform: scale(1);
   }
   50% {

--- a/src/modules/settings/settings.css
+++ b/src/modules/settings/settings.css
@@ -30,8 +30,8 @@
   gap: 0.18rem;
   padding: 0.72rem 0.76rem;
   border-radius: 12px;
-  border: 1px solid rgba(16, 185, 129, 0.22);
-  background: rgba(16, 185, 129, 0.06);
+  border: 1px solid var(--accent-border);
+  background: var(--accent-surface-xs);
 }
 
 .provider-smoke-result span {
@@ -58,8 +58,8 @@
   gap: 0.16rem;
   padding: 0.72rem 0.76rem;
   border-radius: 12px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
-  background: rgba(255, 248, 236, 0.03);
+  border: var(--border-line-md);
+  background: var(--surface-tint-xs);
 }
 
 .provider-diagnostics-list span {
@@ -83,7 +83,7 @@
   flex-wrap: wrap;
   padding: 0.55rem 0.68rem;
   border-radius: 12px;
-  border: 1px solid rgba(138, 128, 112, 0.12);
+  border: var(--border-line-sm);
   background: rgba(255, 248, 236, 0.025);
 }
 
@@ -102,7 +102,7 @@
   padding: 1rem;
   border-radius: 22px;
   background:
-    radial-gradient(circle at 8% 0%, rgba(16, 185, 129, 0.12), transparent 34%),
+    radial-gradient(circle at 8% 0%, var(--accent-surface), transparent 34%),
     rgba(255, 248, 236, 0.035);
 }
 
@@ -210,7 +210,7 @@
   display: grid;
   gap: 0;
   border-radius: 18px;
-  background: rgba(255, 248, 236, 0.03);
+  background: var(--surface-tint-xs);
   overflow: hidden;
 }
 
@@ -289,7 +289,7 @@
   grid-template-columns: repeat(auto-fit, minmax(min(100%, 12rem), 1fr));
   gap: 0.7rem;
   padding-top: 0.75rem;
-  border-top: 1px solid rgba(138, 128, 112, 0.12);
+  border-top: var(--border-line-sm);
 }
 
 .provider-detail-grid p {
@@ -326,7 +326,7 @@
   width: min(100%, 31rem);
   padding: 1rem;
   border-radius: 24px;
-  border: 1px solid rgba(255, 248, 236, 0.12);
+  border: 1px solid var(--surface-tint-lg);
   background: rgba(20, 22, 20, 0.96);
   box-shadow: 0 28px 80px rgba(0, 0, 0, 0.45);
 }
@@ -354,8 +354,8 @@
   display: grid;
   gap: 0.24rem;
   padding: 0.78rem 0;
-  border-top: 1px solid rgba(138, 128, 112, 0.12);
-  border-bottom: 1px solid rgba(138, 128, 112, 0.12);
+  border-top: var(--border-line-sm);
+  border-bottom: var(--border-line-sm);
 }
 
 .provider-template-note p {
@@ -380,8 +380,8 @@
   gap: 0.85rem;
   padding: 0.95rem;
   border-radius: var(--radius);
-  border: 1px solid var(--border);
-  background: rgba(255, 248, 236, 0.03);
+  border: var(--border-line-md);
+  background: var(--surface-tint-xs);
   align-self: start;
   position: sticky;
   top: 0;
@@ -417,7 +417,7 @@
 .settings-nav-item.active,
 .settings-nav-item:hover {
   border-color: rgba(16, 185, 129, 0.36);
-  background: rgba(16, 185, 129, 0.08);
+  background: var(--accent-surface-sm);
 }
 
 .settings-content {
@@ -430,7 +430,7 @@
   margin-top: 1rem;
   padding: 1rem;
   border-radius: var(--radius);
-  border: 1px solid rgba(16, 185, 129, 0.22);
+  border: 1px solid var(--accent-border);
   background: rgba(255, 248, 236, 0.035);
 }
 
@@ -450,7 +450,7 @@
   margin-top: 1rem;
   padding: 1rem;
   border-radius: var(--radius);
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   background: rgba(255, 248, 236, 0.025);
 }
 
@@ -497,7 +497,7 @@
   color: var(--text-primary);
   font: inherit;
   text-align: left;
-  border: 1px solid rgba(138, 128, 112, 0.16);
+  border: var(--border-line-lg);
   background: rgba(4, 6, 5, 0.14);
   cursor: pointer;
 }
@@ -532,7 +532,7 @@
   min-height: 2.4rem;
   padding: 0.55rem 0.7rem;
   color: var(--text-primary);
-  border: 1px solid rgba(138, 128, 112, 0.18);
+  border: var(--border-line);
   border-radius: 10px;
   background: rgba(4, 6, 5, 0.2);
 }
@@ -588,7 +588,7 @@
   gap: 0.8rem;
   align-content: start;
   padding: 0.85rem;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   border-radius: 14px;
   background: rgba(4, 6, 5, 0.14);
   min-width: 0;
@@ -637,7 +637,7 @@
 }
 
 .logician-flow-node-delegation {
-  border-color: rgba(16, 185, 129, 0.28);
+  border-color: var(--accent-border-md);
 }
 
 .logician-flow-node-gate {
@@ -696,7 +696,7 @@
   display: grid;
   gap: 0.32rem;
   padding: 0.78rem;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   border-radius: 14px;
   background: rgba(4, 6, 5, 0.16);
   min-width: 0;
@@ -736,7 +736,7 @@
 }
 
 .logician-node-verification {
-  border-color: rgba(16, 185, 129, 0.28);
+  border-color: var(--accent-border-md);
 }
 
 .logician-settings-columns {
@@ -765,7 +765,7 @@
 
 .logician-runtime-grid span {
   padding: 0.42rem 0.6rem;
-  border: 1px solid var(--border);
+  border: var(--border-line-md);
   border-radius: 999px;
   background: rgba(255, 248, 236, 0.035);
 }
@@ -800,7 +800,7 @@
   gap: 1rem;
   padding: 1rem;
   border-radius: 18px;
-  border: 1px solid rgba(16, 185, 129, 0.22);
+  border: 1px solid var(--accent-border);
   background:
     radial-gradient(circle at 12% 10%, rgba(16, 185, 129, 0.13), transparent 38%),
     rgba(255, 248, 236, 0.035);

--- a/src/modules/terminal/terminal.css
+++ b/src/modules/terminal/terminal.css
@@ -25,14 +25,14 @@
   gap: 0.35rem;
   min-width: 0;
   padding: 0.42rem 0.55rem 0;
-  border-bottom: 1px solid rgba(255, 248, 236, 0.08);
+  border-bottom: 1px solid var(--surface-tint-md);
   background: #141817;
 }
 
 .terminal-tab,
 .terminal-tab-add {
   min-height: 34px;
-  border: 1px solid rgba(255, 248, 236, 0.08);
+  border: 1px solid var(--surface-tint-md);
   border-bottom: 0;
   border-radius: 10px 10px 0 0;
   background: rgba(255, 248, 236, 0.055);
@@ -177,7 +177,7 @@
   justify-content: space-between;
   gap: 1rem;
   padding: 0.85rem 1rem;
-  border-bottom: 1px solid rgba(255, 248, 236, 0.08);
+  border-bottom: 1px solid var(--surface-tint-md);
   background: #141817;
 }
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -3,23 +3,87 @@
 :root {
   color-scheme: dark;
   font-family: "DM Sans", system-ui, sans-serif;
-  --bg-primary: #151413;
+
+  /* Background */
+  --bg-primary:   #151413;
   --bg-secondary: #201d1a;
-  --bg-tertiary: #29241f;
-  --bg-elevated: rgba(255, 248, 236, 0.04);
-  --text-primary: #e8e3d8;
+  --bg-tertiary:  #29241f;
+
+  /* Text */
+  --text-primary:   #e8e3d8;
   --text-secondary: #c4baa8;
-  --text-muted: #8a8070;
-  --accent: #10b981;
+  --text-muted:     #8a8070;
+
+  /* Brand colors */
+  --accent:       #10b981;
   --accent-hover: #059669;
-  --accent-muted: rgba(16, 185, 129, 0.15);
-  --secondary: #d97706;
-  --secondary-muted: rgba(217, 119, 6, 0.15);
-  --info: #60a5fa;
-  --warning: #fbbf24;
-  --danger: #f87171;
-  --border: rgba(138, 128, 112, 0.18);
-  --shadow: 0 24px 60px rgba(0, 0, 0, 0.3);
+  --secondary:    #d97706;
+  --info:         #60a5fa;
+  --warning:      #fbbf24;
+  --danger:       #f87171;
+
+  /* Primitive: color channels */
+  /* Use with rgb(var(--ch-X) / alpha). Internal to design system. */
+  --ch-accent:    16 185 129;   /* #10b981 */
+  --ch-surface:   255 248 236;  /* warm white */
+  --ch-warm:      138 128 112;  /* warm gray */
+  --ch-secondary: 217 119 6;    /* #d97706 */
+
+  /* Primitive: opacity scale */
+  --alpha-3:  0.03;
+  --alpha-4:  0.04;
+  --alpha-6:  0.06;
+  --alpha-8:  0.08;
+  --alpha-12: 0.12;
+  --alpha-14: 0.14;
+  --alpha-16: 0.16;
+  --alpha-18: 0.18;
+  --alpha-20: 0.20;
+  --alpha-22: 0.22;
+  --alpha-28: 0.28;
+  --alpha-32: 0.32;
+  --alpha-40: 0.40;
+
+  /* Semantic: warm-gray borders */
+  --border-sm: rgb(var(--ch-warm) / var(--alpha-12));
+  --border-md: rgb(var(--ch-warm) / var(--alpha-14));
+  --border-lg: rgb(var(--ch-warm) / var(--alpha-16));
+  --border:    rgb(var(--ch-warm) / var(--alpha-18));
+  /* Compound border shorthands */
+  --border-line:    1px solid var(--border);
+  --border-line-lg: 1px solid var(--border-lg);
+  --border-line-md: 1px solid var(--border-md);
+  --border-line-sm: 1px solid var(--border-sm);
+
+  /* Semantic: accent (green) surfaces */
+  --accent-surface-xs: rgb(var(--ch-accent) / var(--alpha-6));
+  --accent-surface-sm: rgb(var(--ch-accent) / var(--alpha-8));
+  --accent-surface:    rgb(var(--ch-accent) / var(--alpha-12));
+  --accent-surface-md: rgb(var(--ch-accent) / var(--alpha-14));
+  --accent-surface-lg: rgb(var(--ch-accent) / var(--alpha-16));
+  --accent-muted:      rgb(var(--ch-accent) / var(--alpha-16));
+
+  /* Semantic: accent (green) borders */
+  --accent-border-sm: rgb(var(--ch-accent) / var(--alpha-20));
+  --accent-border:    rgb(var(--ch-accent) / var(--alpha-22));
+  --accent-border-md: rgb(var(--ch-accent) / var(--alpha-28));
+  --accent-border-lg: rgb(var(--ch-accent) / var(--alpha-32));
+  --accent-border-xl: rgb(var(--ch-accent) / var(--alpha-40));
+
+  /* Semantic: warm surface tints */
+  --surface-tint-xs:   rgb(var(--ch-surface) / var(--alpha-3));
+  --surface-tint-sm:   rgb(var(--ch-surface) / var(--alpha-4));
+  --surface-tint:      rgb(var(--ch-surface) / var(--alpha-6));
+  --surface-tint-md:   rgb(var(--ch-surface) / var(--alpha-8));
+  --surface-tint-lg:   rgb(var(--ch-surface) / var(--alpha-12));
+  --bg-elevated:       var(--surface-tint-sm);
+
+  /* Secondary muted */
+  --secondary-muted: rgb(var(--ch-secondary) / var(--alpha-16));
+
+  /* Shadow & radius */
+  --shadow:      0 24px 60px rgba(0, 0, 0, 0.3);
+  --shadow-soft: 0 8px 32px rgba(0, 0, 0, 0.18);
   --radius: 18px;
 }
 
@@ -86,8 +150,7 @@ input,
 select {
   width: 100%;
   border: 1px solid var(--border);
-  background: rgba(255, 248, 236, 0.04);
+  background: var(--bg-elevated);
   color: var(--text-primary);
   padding: 0.8rem 0.9rem;
 }
-

--- a/src/styles/shell.css
+++ b/src/styles/shell.css
@@ -95,7 +95,7 @@
   border: 0;
   padding: 0.7rem;
   background:
-    radial-gradient(circle at 18% 4%, rgba(16, 185, 129, 0.14), transparent 20rem),
+    radial-gradient(circle at 18% 4%, var(--accent-surface-md), transparent 20rem),
     rgba(14, 12, 10, 0.94);
 }
 
@@ -203,7 +203,7 @@
 
 .system-icon-button:hover {
   color: var(--text-primary);
-  background: rgba(255, 248, 236, 0.04);
+  background: var(--surface-tint-sm);
 }
 
 .system-health {
@@ -249,7 +249,7 @@
   border: 1px solid var(--border);
   border-radius: 28px;
   padding: 2rem;
-  background: rgba(255, 248, 236, 0.04);
+  background: var(--surface-tint-sm);
   box-shadow: var(--shadow);
 }
 
@@ -295,7 +295,7 @@
 }
 
 .rail-toggle:hover {
-  border-color: rgba(16, 185, 129, 0.4);
+  border-color: var(--accent-border-xl);
   color: var(--accent);
 }
 
@@ -319,7 +319,7 @@
 .status-badge {
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  background: rgba(255, 248, 236, 0.04);
+  background: var(--surface-tint-sm);
   min-width: 0;
 }
 
@@ -525,7 +525,7 @@
   padding: 0.58rem 0.72rem;
   border-radius: 14px;
   border: 1px solid var(--border);
-  background: rgba(255, 248, 236, 0.04);
+  background: var(--surface-tint-sm);
 }
 
 .topbar-pill span {
@@ -606,7 +606,7 @@
 .overview-workspace .service-card,
 .overview-workspace .workspace-card,
 .overview-workspace .addon-card {
-  border-color: rgba(138, 128, 112, 0.12);
+  border-color: var(--border-sm);
   background: rgba(255, 248, 236, 0.025);
 }
 
@@ -663,7 +663,7 @@
   padding: 0.78rem 0.85rem;
   border-radius: 14px;
   border: 1px solid var(--border);
-  background: rgba(255, 248, 236, 0.03);
+  background: var(--surface-tint-xs);
 }
 
 .workspace-snapshot span {
@@ -768,7 +768,7 @@
 
 .tone-active {
   color: var(--accent);
-  border-color: rgba(16, 185, 129, 0.4);
+  border-color: var(--accent-border-xl);
   background: var(--accent-muted);
 }
 
@@ -819,7 +819,7 @@
   overflow: hidden;
   border-radius: 999px;
   border: 1px solid var(--border);
-  background: rgba(255, 248, 236, 0.03);
+  background: var(--surface-tint-xs);
 }
 
 .progress-fill {
@@ -848,7 +848,7 @@
   min-width: 0;
   border: 1px solid var(--border);
   border-radius: 24px;
-  background: rgba(255, 248, 236, 0.04);
+  background: var(--surface-tint-sm);
   box-shadow: var(--shadow);
 }
 
@@ -859,9 +859,9 @@
   align-items: center;
   padding: 1rem;
   background:
-    radial-gradient(circle at top left, rgba(16, 185, 129, 0.16), transparent 30rem),
+    radial-gradient(circle at top left, var(--accent-surface-lg), transparent 30rem),
     radial-gradient(circle at top right, rgba(217, 119, 6, 0.1), transparent 24rem),
-    rgba(255, 248, 236, 0.04);
+    var(--surface-tint-sm);
 }
 
 .home-hero-copy h2 {
@@ -970,7 +970,7 @@
   text-align: left;
   border-radius: 20px;
   background:
-    radial-gradient(circle at top right, rgba(255, 248, 236, 0.06), transparent 9rem),
+    radial-gradient(circle at top right, var(--surface-tint), transparent 9rem),
     rgba(9, 11, 12, 0.24);
 }
 
@@ -978,7 +978,7 @@
 .app-tile:hover {
   border-color: rgba(16, 185, 129, 0.42);
   background:
-    radial-gradient(circle at top right, rgba(16, 185, 129, 0.14), transparent 10rem),
+    radial-gradient(circle at top right, var(--accent-surface-md), transparent 10rem),
     rgba(16, 185, 129, 0.055);
 }
 
@@ -1031,13 +1031,13 @@
   max-width: 100%;
   padding: 0.25rem 0.44rem;
   border-radius: 999px;
-  border: 1px solid rgba(138, 128, 112, 0.16);
+  border: var(--border-line-lg);
   background: rgba(255, 248, 236, 0.035);
 }
 
 .app-status-active {
   color: var(--accent);
-  border-color: rgba(16, 185, 129, 0.32);
+  border-color: var(--accent-border-lg);
   background: rgba(16, 185, 129, 0.09);
 }
 
@@ -1056,7 +1056,7 @@
 .workspace-preview {
   min-height: clamp(320px, 43vh, 560px);
   border-radius: 22px;
-  border: 1px solid rgba(138, 128, 112, 0.16);
+  border: var(--border-line-lg);
   overflow: hidden;
 }
 
@@ -1072,7 +1072,7 @@
 
 .workspace-preview.system {
   background:
-    radial-gradient(circle at top left, rgba(16, 185, 129, 0.12), transparent 18rem),
+    radial-gradient(circle at top left, var(--accent-surface), transparent 18rem),
     rgba(9, 11, 12, 0.24);
 }
 
@@ -1160,11 +1160,11 @@
 .home-health-pill,
 .workspace-preview,
 .running-app-card {
-  border-color: rgba(138, 128, 112, 0.12);
+  border-color: var(--border-sm);
   background-color: rgba(255, 248, 236, 0.025);
 }
 
 .app-tile {
-  border-color: rgba(138, 128, 112, 0.1);
+  border-color: var(--border-sm);
   background: rgba(9, 11, 12, 0.18);
 }

--- a/src/styles/workspace-cards.css
+++ b/src/styles/workspace-cards.css
@@ -36,7 +36,7 @@
   padding: 1rem;
   border-radius: var(--radius);
   border: 1px solid var(--border);
-  background: rgba(255, 248, 236, 0.03);
+  background: var(--surface-tint-xs);
 }
 
 .mono-list,
@@ -129,7 +129,7 @@
   padding: 1rem;
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  background: rgba(255, 248, 236, 0.03);
+  background: var(--surface-tint-xs);
 }
 
 .addon-registry-summary strong {
@@ -156,7 +156,7 @@
   border-radius: 999px;
   padding: 0.45rem 0.75rem;
   border: 1px solid var(--border);
-  background: rgba(255, 248, 236, 0.04);
+  background: var(--surface-tint-sm);
 }
 
 .grant-chip.granted {
@@ -215,8 +215,8 @@
 }
 
 .recovery-toggle.active {
-  border-color: rgba(16, 185, 129, 0.32);
-  background: rgba(16, 185, 129, 0.08);
+  border-color: var(--accent-border-lg);
+  background: var(--accent-surface-sm);
   color: var(--accent);
 }
 
@@ -254,7 +254,7 @@
   place-items: center;
   padding: 1.25rem;
   background:
-    radial-gradient(circle at 50% 20%, rgba(16, 185, 129, 0.16), transparent 26rem),
+    radial-gradient(circle at 50% 20%, var(--accent-surface-lg), transparent 26rem),
     rgba(8, 7, 6, 0.74);
   backdrop-filter: blur(18px);
 }
@@ -296,7 +296,7 @@
   padding: 0.9rem;
   border: 1px solid var(--border);
   border-radius: 18px;
-  background: rgba(255, 248, 236, 0.04);
+  background: var(--surface-tint-sm);
 }
 
 .first-run-choice input {
@@ -348,11 +348,11 @@
 
 .browser-addon-panel {
   padding: 1rem;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   border-radius: 18px;
   background:
     radial-gradient(circle at top right, rgba(96, 165, 250, 0.12), transparent 14rem),
-    rgba(255, 248, 236, 0.03);
+    var(--surface-tint-xs);
 }
 
 .browser-addon-panel h3 {
@@ -367,9 +367,9 @@
 
 .hermes-addon-panel {
   padding: 1rem;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   border-radius: 18px;
-  background: rgba(255, 248, 236, 0.03);
+  background: var(--surface-tint-xs);
 }
 
 .hermes-addon-head,
@@ -422,7 +422,7 @@
 }
 
 .hermes-install-log {
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   border-radius: 12px;
   padding: 0.7rem;
   background: rgba(10, 14, 18, 0.2);
@@ -448,7 +448,7 @@
   gap: 0.25rem;
   padding: 0.75rem;
   border-radius: 12px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   background: rgba(10, 14, 18, 0.16);
 }
 
@@ -526,12 +526,12 @@
   gap: 0.75rem;
   padding: 0.85rem;
   border-radius: 16px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   background: rgba(255, 248, 236, 0.025);
 }
 
 .obsidian-sync-box {
-  border-color: rgba(16, 185, 129, 0.16);
+  border-color: var(--accent-surface-lg);
   background: rgba(16, 185, 129, 0.035);
 }
 
@@ -545,7 +545,7 @@
   min-width: 0;
   padding: 0.55rem 0.62rem;
   border-radius: 12px;
-  border: 1px solid rgba(138, 128, 112, 0.12);
+  border: var(--border-line-sm);
   background: rgba(0, 0, 0, 0.12);
   color: var(--text-muted);
   font-size: 0.78rem;
@@ -572,7 +572,7 @@
   gap: 0.22rem;
   padding: 0.62rem;
   border-radius: 12px;
-  border: 1px solid rgba(138, 128, 112, 0.12);
+  border: var(--border-line-sm);
   background: rgba(0, 0, 0, 0.12);
 }
 
@@ -604,7 +604,7 @@
 
 .obsidian-success-box {
   border: 1px solid rgba(16, 185, 129, 0.25);
-  background: rgba(16, 185, 129, 0.08);
+  background: var(--accent-surface-sm);
   color: var(--accent);
   overflow-wrap: anywhere;
 }
@@ -628,7 +628,7 @@
   min-width: 0;
   padding: 0.62rem;
   border-radius: 12px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   background: rgba(0, 0, 0, 0.14);
 }
 
@@ -705,14 +705,14 @@
   padding: 0.65rem;
   border-radius: 12px;
   border: 1px solid rgba(138, 128, 112, 0.15);
-  background: rgba(255, 248, 236, 0.03);
+  background: var(--surface-tint-xs);
   color: var(--text-primary);
   text-align: left;
 }
 
 .obsidian-note-buttons button.active {
   border-color: rgba(16, 185, 129, 0.38);
-  background: rgba(16, 185, 129, 0.08);
+  background: var(--accent-surface-sm);
 }
 
 .obsidian-note-buttons strong {
@@ -727,7 +727,7 @@
   flex: 0 0 auto;
   padding: 0.12rem 0.42rem;
   border-radius: 999px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   color: var(--text-muted);
   font-size: 0.64rem;
   font-weight: 800;
@@ -736,7 +736,7 @@
 }
 
 .obsidian-sync-pill.unqueued {
-  border-color: rgba(16, 185, 129, 0.28);
+  border-color: var(--accent-border-md);
   color: var(--accent);
 }
 
@@ -773,7 +773,7 @@
   margin: 0;
   padding: 0.9rem;
   border-radius: 14px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
+  border: var(--border-line-md);
   background: rgba(0, 0, 0, 0.18);
   color: var(--text-secondary);
   font: 0.82rem/1.55 "IBM Plex Mono", "SFMono-Regular", monospace;
@@ -814,8 +814,8 @@
   gap: 0.35rem;
   padding: 0.82rem;
   border-radius: 14px;
-  border: 1px solid rgba(138, 128, 112, 0.14);
-  background: rgba(255, 248, 236, 0.03);
+  border: var(--border-line-md);
+  background: var(--surface-tint-xs);
 }
 
 .strategy-chain-block ul,


### PR DESCRIPTION
- Add primitive color channels (--ch-accent, --ch-surface, --ch-warm, --ch-secondary)
- Add opacity scale (--alpha-3 through --alpha-40, 13 values)
- Migrate border tokens to rgb() primitives; add --border-line-* shorthands
- Add accent surface tokens (--accent-surface-xs through -lg)
- Add accent border tokens (--accent-border-sm through -xl)
- Add warm surface tint tokens (--surface-tint-xs through -lg)
- Replace ~70 hardcoded rgba(138,128,112) border instances with tokens
- Replace 137 on-scale rgba(16,185,129) and rgba(255,248,236) instances with tokens"