### PR TITLE
Harden alpha release validation

### DIFF
--- a/.github/workflows/alpha-build.yml
+++ b/.github/workflows/alpha-build.yml
@@ -138,9 +138,19 @@ jobs:
         run: npm run test:engineer-runner
 
       - name: Package browser-first extension
+        if: runner.os != 'Windows'
         run: |
           cd browser-first/resonantos-side-panel-extension
           zip -r ../../resonantos-side-panel-extension.zip . -x "*.DS_Store"
+
+      - name: Package browser-first extension (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Compress-Archive `
+            -Path browser-first/resonantos-side-panel-extension/* `
+            -DestinationPath resonantos-side-panel-extension.zip `
+            -Force
 
       - name: Upload extension artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/alpha-build.yml
+++ b/.github/workflows/alpha-build.yml
@@ -115,6 +115,8 @@ jobs:
         run: npm run test:browser-host
 
       - name: Run Electron host tests
+        env:
+          RESONANTOS_WALLET_BROWSER_HEADLESS: "1"
         run: npm run test:electron-host
 
       - name: Run native browser tests

--- a/.github/workflows/alpha-build.yml
+++ b/.github/workflows/alpha-build.yml
@@ -105,11 +105,13 @@ jobs:
 
       - name: Install browser host Playwright browser and Linux dependencies
         if: matrix.platform == 'ubuntu-22.04'
-        run: npm --prefix addons/resonant-browser-host exec playwright -- install --with-deps chromium
+        working-directory: addons/resonant-browser-host
+        run: node node_modules/playwright/cli.js install --with-deps chromium
 
       - name: Install browser host Playwright browser
         if: matrix.platform != 'ubuntu-22.04'
-        run: npm --prefix addons/resonant-browser-host exec playwright -- install chromium
+        working-directory: addons/resonant-browser-host
+        run: node node_modules/playwright/cli.js install chromium
 
       - name: Audit browser host dependencies
         run: npm audit --prefix addons/resonant-browser-host --audit-level=high

--- a/.github/workflows/alpha-build.yml
+++ b/.github/workflows/alpha-build.yml
@@ -103,6 +103,14 @@ jobs:
       - name: Install browser host dependencies
         run: npm ci --prefix addons/resonant-browser-host
 
+      - name: Install browser host Playwright browser and Linux dependencies
+        if: matrix.platform == 'ubuntu-22.04'
+        run: npm --prefix addons/resonant-browser-host exec playwright -- install --with-deps chromium
+
+      - name: Install browser host Playwright browser
+        if: matrix.platform != 'ubuntu-22.04'
+        run: npm --prefix addons/resonant-browser-host exec playwright -- install chromium
+
       - name: Audit browser host dependencies
         run: npm audit --prefix addons/resonant-browser-host --audit-level=high
 

--- a/.github/workflows/alpha-build.yml
+++ b/.github/workflows/alpha-build.yml
@@ -103,16 +103,6 @@ jobs:
       - name: Install browser host dependencies
         run: npm ci --prefix addons/resonant-browser-host
 
-      - name: Install browser host Playwright browser and Linux dependencies
-        if: matrix.platform == 'ubuntu-22.04'
-        working-directory: addons/resonant-browser-host
-        run: node node_modules/playwright/cli.js install --with-deps chromium
-
-      - name: Install browser host Playwright browser
-        if: matrix.platform != 'ubuntu-22.04'
-        working-directory: addons/resonant-browser-host
-        run: node node_modules/playwright/cli.js install chromium
-
       - name: Audit browser host dependencies
         run: npm audit --prefix addons/resonant-browser-host --audit-level=high
 
@@ -120,6 +110,8 @@ jobs:
         run: npm test -- --run
 
       - name: Run browser host tests
+        env:
+          RESONANTOS_BROWSER_HOST_CHANNEL: chrome
         run: npm run test:browser-host
 
       - name: Run Electron host tests

--- a/.github/workflows/alpha-build.yml
+++ b/.github/workflows/alpha-build.yml
@@ -78,11 +78,41 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
 
+      - name: Audit frontend dependencies
+        run: npm audit --audit-level=high
+
+      - name: Install browser host dependencies
+        run: npm ci --prefix addons/resonant-browser-host
+
+      - name: Audit browser host dependencies
+        run: npm audit --prefix addons/resonant-browser-host --audit-level=high
+
       - name: Run frontend tests
         run: npm test -- --run
 
+      - name: Run browser host tests
+        run: npm run test:browser-host
+
+      - name: Run Electron host tests
+        run: npm run test:electron-host
+
+      - name: Run native browser tests
+        run: npm run test:browser-native
+
       - name: Run browser-first tests
         run: npm run test:browser-first
+
+      - name: Run Living Archive memory service tests
+        run: npm run test:living-archive-memory-service
+
+      - name: Run Living Archive MCP tests
+        run: npm run test:living-archive-mcp
+
+      - name: Run health checks
+        run: npm run test:health
+
+      - name: Run engineer runner tests
+        run: npm run test:engineer-runner
 
       - name: Package browser-first extension
         run: |

--- a/.github/workflows/alpha-build.yml
+++ b/.github/workflows/alpha-build.yml
@@ -2,6 +2,25 @@ name: alpha-build
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+      - dev
+    paths:
+      - ".github/workflows/alpha-build.yml"
+      - "addons/**"
+      - "browser-first/**"
+      - "docs/**"
+      - "package-lock.json"
+      - "package.json"
+      - "public/**"
+      - "scripts/**"
+      - "src/**"
+      - "src/sdk/**"
+      - "src-tauri/**"
+      - "index.html"
+      - "vite.config.ts"
+      - "tsconfig*.json"
   push:
     branches:
       - main

--- a/addons/resonant-browser-host/src/browser-host.mjs
+++ b/addons/resonant-browser-host/src/browser-host.mjs
@@ -8,10 +8,33 @@ import { assertContained } from "./lib/path-contains.mjs";
 
 const DEFAULT_HOME_URL = "https://resonantos.com";
 const DEFAULT_VIEWPORT = { width: 1440, height: 1000 };
+const DEFAULT_CHROMIUM_ARGS = ["--password-store=basic", "--use-mock-keychain"];
 const MAX_TEXT_CHARS = 12000;
 const MAX_LINKS = 80;
 
 const nowIso = () => new Date().toISOString();
+
+function optionalString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function resolveChromiumLaunchOptions({ headless = true, params = {}, env = process.env } = {}) {
+  const executablePath =
+    optionalString(params.executablePath) ?? optionalString(env.RESONANTOS_BROWSER_HOST_EXECUTABLE_PATH);
+  const channel = optionalString(params.browserChannel) ?? optionalString(env.RESONANTOS_BROWSER_HOST_CHANNEL);
+  const launchOptions = {
+    headless,
+    args: DEFAULT_CHROMIUM_ARGS,
+  };
+
+  if (executablePath) {
+    launchOptions.executablePath = executablePath;
+  } else if (channel) {
+    launchOptions.channel = channel;
+  }
+
+  return launchOptions;
+}
 
 function createSessionId() {
   return `browser-${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
@@ -74,16 +97,19 @@ export class ResonantBrowserHost {
     const defaultUrl = assertSafeHttpUrl(params.defaultUrl ?? DEFAULT_HOME_URL);
     this.headless = params.headless ?? this.headless;
     this.sessionId = createSessionId();
-    this.browser = await chromium.launch({
-      headless: this.headless,
-      args: ["--password-store=basic", "--use-mock-keychain"],
-    });
+    const launchOptions = resolveChromiumLaunchOptions({ headless: this.headless, params });
+    this.browser = await chromium.launch(launchOptions);
     this.context = await this.browser.newContext({
       viewport: params.viewport ?? this.viewport,
       deviceScaleFactor: 1,
     });
     this.page = await this.context.newPage();
-    this.record("session.started", { engine: "chromium", headless: this.headless });
+    this.record("session.started", {
+      engine: "chromium",
+      headless: this.headless,
+      channel: launchOptions.channel ?? null,
+      executablePathConfigured: Boolean(launchOptions.executablePath),
+    });
     await this.openUrl({ url: defaultUrl });
     return this.health();
   }

--- a/addons/resonant-browser-host/test/browser-host.test.mjs
+++ b/addons/resonant-browser-host/test/browser-host.test.mjs
@@ -6,7 +6,7 @@ import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, before, describe, it } from "node:test";
-import { ResonantBrowserHost, handleJsonRpcLine } from "../src/browser-host.mjs";
+import { ResonantBrowserHost, handleJsonRpcLine, resolveChromiumLaunchOptions } from "../src/browser-host.mjs";
 
 let server;
 let baseUrl;
@@ -114,6 +114,25 @@ describe("ResonantBrowserHost", () => {
     const host = new ResonantBrowserHost({ headless: true });
 
     await assert.rejects(() => host.start({ defaultUrl: "file:///etc/passwd" }), /http and https URLs/);
+  });
+
+  it("supports a configured Chrome channel without requiring a bundled Chromium download", () => {
+    const channelOptions = resolveChromiumLaunchOptions({
+      headless: true,
+      params: {},
+      env: { RESONANTOS_BROWSER_HOST_CHANNEL: "chrome" },
+    });
+    assert.equal(channelOptions.channel, "chrome");
+    assert.equal(channelOptions.executablePath, undefined);
+    assert.deepEqual(channelOptions.args, ["--password-store=basic", "--use-mock-keychain"]);
+
+    const executableOptions = resolveChromiumLaunchOptions({
+      headless: true,
+      params: { executablePath: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" },
+      env: { RESONANTOS_BROWSER_HOST_CHANNEL: "chrome" },
+    });
+    assert.equal(executableOptions.channel, undefined);
+    assert.equal(executableOptions.executablePath, "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome");
   });
 
   it("handles stdio JSON-RPC method lines", async (t) => {

--- a/addons/resonant-browser-host/test/browser-host.test.mjs
+++ b/addons/resonant-browser-host/test/browser-host.test.mjs
@@ -11,6 +11,7 @@ import { ResonantBrowserHost, handleJsonRpcLine, resolveChromiumLaunchOptions } 
 let server;
 let baseUrl;
 let localhostBindDenied = false;
+const serverSockets = new Set();
 
 function html(body) {
   return `<!doctype html>
@@ -47,6 +48,10 @@ before(async () => {
       </main>`),
     );
   });
+  server.on("connection", (socket) => {
+    serverSockets.add(socket);
+    socket.once("close", () => serverSockets.delete(socket));
+  });
 
   try {
     await new Promise((resolveListen, rejectListen) => {
@@ -68,19 +73,30 @@ before(async () => {
 });
 
 after(async () => {
-  if (server?.listening) {
-    await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+  if (!server) {
+    return;
+  }
+  server.closeIdleConnections?.();
+  server.closeAllConnections?.();
+  for (const socket of serverSockets) {
+    socket.destroy();
+  }
+  if (server.listening) {
+    await new Promise((resolve) => server.close(() => resolve()));
   }
 });
 
 describe("ResonantBrowserHost", () => {
-  it("opens, reads, clicks, types, captures evidence, and closes a Chromium session", async (t) => {
+  it("opens, reads, clicks, types, captures evidence, and closes a Chromium session", { timeout: 60_000 }, async (t) => {
     if (localhostBindDenied) {
       t.skip("localhost bind is denied in this sandbox; browser-host live Chromium behavior must be verified outside sandboxed CI.");
       return;
     }
     const artifactsDir = await mkdtemp(join(tmpdir(), "resonant-browser-host-"));
     const host = new ResonantBrowserHost({ headless: true });
+    t.after(async () => {
+      await host.close().catch(() => undefined);
+    });
 
     const start = await host.start({ defaultUrl: baseUrl });
     assert.equal(start.ready, true);
@@ -135,12 +151,15 @@ describe("ResonantBrowserHost", () => {
     assert.equal(executableOptions.executablePath, "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome");
   });
 
-  it("handles stdio JSON-RPC method lines", async (t) => {
+  it("handles stdio JSON-RPC method lines", { timeout: 60_000 }, async (t) => {
     if (localhostBindDenied) {
       t.skip("localhost bind is denied in this sandbox; browser-host JSON-RPC live Chromium behavior must be verified outside sandboxed CI.");
       return;
     }
     const host = new ResonantBrowserHost({ headless: true });
+    t.after(async () => {
+      await host.close().catch(() => undefined);
+    });
 
     const response = await handleJsonRpcLine(
       host,

--- a/addons/resonant-browser-host/test/path-contains.test.mjs
+++ b/addons/resonant-browser-host/test/path-contains.test.mjs
@@ -86,8 +86,8 @@ describe("captureEvidence artifactsDir containment (P1-d, browser-host)", () => 
     const host = hostWithFakePage(captured);
     const evidence = await host.captureEvidence({ artifactsDir, reason: "ok" });
     assert.equal(captured.length, 1);
-    assert.ok(captured[0].startsWith(`${artifactsDir}${path.sep}`));
-    assert.ok(evidence.evidenceRef.startsWith(`${artifactsDir}${path.sep}`));
+    assert.equal(pathContains(artifactsDir, captured[0]).result, "pass");
+    assert.equal(pathContains(artifactsDir, evidence.evidenceRef).result, "pass");
   });
 
   it("rejects a screenshot leaf that traverses out of the artifacts root", async () => {

--- a/addons/resonant-browser-native/README.md
+++ b/addons/resonant-browser-native/README.md
@@ -96,6 +96,11 @@ Resolve the current CEF binary candidate without downloading it:
 npm run browser-native:cef:plan
 ```
 
+The fetch planner is pinned to the CEF/Chromium build declared in
+`scripts/cef-build-config.mjs`. If the upstream index no longer contains that
+archive, the planner fails instead of silently moving to a different Chromium
+build.
+
 Download/extract CEF only when ready to build the native host:
 
 ```bash
@@ -138,4 +143,19 @@ Run the native smoke directly:
 
 ```bash
 addons/resonant-browser-native/build/ResonantBrowserNativeHost.app/Contents/MacOS/ResonantBrowserNativeHost --resonantos-smoke --url=https://example.com
+```
+
+Strict production-sandbox verification must run from a normal macOS
+Terminal/Finder session:
+
+```bash
+npm run browser-native:verify-live
+```
+
+Codex Desktop can inherit a macOS app sandbox that blocks CEF helper framework
+loads during in-process `NSView` bridge tests. For local diagnostics only, the
+bridge path can be checked with:
+
+```bash
+RESONANTOS_CEF_NO_SANDBOX=1 npm run browser-native:verify-live
 ```

--- a/addons/resonant-browser-native/native_host/src/resonant_browser_native_host.cc
+++ b/addons/resonant-browser-native/native_host/src/resonant_browser_native_host.cc
@@ -400,8 +400,10 @@ class ResonantBrowserClient final : public CefClient,
                 << "\"providerInjected\":true,"
                 << "\"extensionId\":\"bfnaelmomeimhlpmgjnjophhpkkoljpa\","
                 << "\"verdict\":\"phantom-provider-ready\"}" << std::endl;
-      browser->GetHost()->CloseBrowser(true);
-      CefPostDelayedTask(TID_UI, new QuitMessageLoopTask(), 250);
+      // Phantom smoke is a one-shot hidden verification process; Chrome
+      // Runtime can keep extension helper surfaces alive after CloseBrowser().
+      std::cout.flush();
+      std::exit(0);
       return;
     }
     if (phantom_extension_smoke_ &&
@@ -412,8 +414,10 @@ class ResonantBrowserClient final : public CefClient,
                 << "\"providerInjected\":false,"
                 << "\"extensionId\":\"bfnaelmomeimhlpmgjnjophhpkkoljpa\","
                 << "\"verdict\":\"phantom-provider-blocked\"}" << std::endl;
-      browser->GetHost()->CloseBrowser(true);
-      CefPostDelayedTask(TID_UI, new QuitMessageLoopTask(), 250);
+      // Phantom smoke is a one-shot hidden verification process; Chrome
+      // Runtime can keep extension helper surfaces alive after CloseBrowser().
+      std::cout.flush();
+      std::exit(0);
       return;
     }
     if (local_extension_smoke_ && title_text.find("resonant-extension-loaded") != std::string::npos &&
@@ -422,8 +426,11 @@ class ResonantBrowserClient final : public CefClient,
       std::cout << "{\"event\":\"browser.native.local_extension_execution\","
                 << "\"contentScriptExecuted\":true,"
                 << "\"verdict\":\"local-extension-ready\"}" << std::endl;
-      browser->GetHost()->CloseBrowser(true);
-      CefPostDelayedTask(TID_UI, new QuitMessageLoopTask(), 250);
+      // Local extension smoke is a one-shot hidden verification process;
+      // exit after evidence is emitted so the test cannot hang on Chromium
+      // extension helper lifetime.
+      std::cout.flush();
+      std::exit(0);
     }
     if (permission_smoke_ && title_text.find("permission-denied") != std::string::npos && !quit_requested_) {
       quit_requested_ = true;
@@ -511,8 +518,11 @@ class ResonantBrowserClient final : public CefClient,
                     << "\"chromeWebStoreLoaded\":" << (web_store_loaded ? "true" : "false") << ","
                     << "\"chromeWebStoreConsentGate\":" << (web_store_consent_gate ? "true" : "false") << ","
                     << "\"verdict\":\"" << verdict << "\"}" << std::endl;
-          browser->GetHost()->CloseBrowser(true);
-          CefPostDelayedTask(TID_UI, new QuitMessageLoopTask(), 250);
+          // Extension entrypoint smoke is a one-shot hidden verification
+          // process; exit after evidence is emitted so Chrome Runtime helper
+          // surfaces cannot hold the test process open.
+          std::cout.flush();
+          std::exit(0);
         }
         return;
       }

--- a/addons/resonant-browser-native/scripts/cef-build-config.mjs
+++ b/addons/resonant-browser-native/scripts/cef-build-config.mjs
@@ -1,0 +1,14 @@
+export const cefBuild = Object.freeze({
+  cefVersion: "147.0.10+gd58e84d+chromium-147.0.7727.118",
+  chromiumVersion: "147.0.7727.118",
+  channel: "stable",
+  fileType: "standard",
+});
+
+export function cefBuildDirectoryName(platform) {
+  return `cef_binary_${cefBuild.cefVersion}_${platform}`;
+}
+
+export function cefArchiveName(platform) {
+  return `${cefBuildDirectoryName(platform)}.tar.bz2`;
+}

--- a/addons/resonant-browser-native/scripts/fetch-cef.mjs
+++ b/addons/resonant-browser-native/scripts/fetch-cef.mjs
@@ -7,6 +7,7 @@ import path from "node:path";
 import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
 import { spawn } from "node:child_process";
+import { cefArchiveName, cefBuild, cefBuildDirectoryName } from "./cef-build-config.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const cefIndexUrl = "https://cef-builds.spotifycdn.com/index.json";
@@ -18,8 +19,8 @@ const argValue = (name, fallback) => {
 };
 
 const platform = argValue("--platform", detectCefPlatform());
-const fileType = argValue("--type", "standard");
-const channel = argValue("--channel", "stable");
+const fileType = argValue("--type", cefBuild.fileType);
+const channel = argValue("--channel", cefBuild.channel);
 const download = args.has("--download");
 const outDir = path.resolve(argValue("--out", path.join(root, "vendor", "cef")));
 
@@ -34,8 +35,10 @@ const manifest = {
   platform,
   fileType,
   channel,
+  pinned: true,
   cefVersion: selection.version.cef_version,
   chromiumVersion: selection.version.chromium_version,
+  buildDirectory: cefBuildDirectoryName(platform),
   file: selection.file,
   url: `https://cef-builds.spotifycdn.com/${selection.file.name}`,
 };
@@ -71,16 +74,21 @@ function selectCefBuild(index, input) {
   if (!platformIndex) {
     throw new Error(`CEF platform ${input.platform} is not present in the build index.`);
   }
+  const expectedArchive = cefArchiveName(input.platform);
   for (const version of platformIndex.versions) {
-    if (version.channel !== input.channel) {
+    if (
+      version.channel !== input.channel ||
+      version.cef_version !== cefBuild.cefVersion ||
+      version.chromium_version !== cefBuild.chromiumVersion
+    ) {
       continue;
     }
-    const file = version.files.find((candidate) => candidate.type === input.fileType);
+    const file = version.files.find((candidate) => candidate.type === input.fileType && candidate.name === expectedArchive);
     if (file) {
       return { version, file };
     }
   }
-  throw new Error(`No ${input.channel} ${input.fileType} CEF build found for ${input.platform}.`);
+  throw new Error(`Pinned CEF archive ${expectedArchive} was not found in the build index.`);
 }
 
 function fetchJson(url) {

--- a/addons/resonant-browser-native/test/native-cef-embed.test.mjs
+++ b/addons/resonant-browser-native/test/native-cef-embed.test.mjs
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { promisify } from "node:util";
+import { cefBuildDirectoryName } from "../scripts/cef-build-config.mjs";
 
 const execFileAsync = promisify(execFile);
 const addonRoot = path.resolve(import.meta.dirname, "..");
@@ -14,7 +15,7 @@ const cefFramework = path.join(
   addonRoot,
   "vendor",
   "cef",
-  "cef_binary_147.0.10+gd58e84d+chromium-147.0.7727.118_macosarm64",
+  cefBuildDirectoryName("macosarm64"),
   "Release",
   "Chromium Embedded Framework.framework",
 );
@@ -55,6 +56,12 @@ const latestPhantomExtensionDir = existsSync(phantomExtensionRoot)
 function nativeBridgeLiveSkipReason(testName) {
   if (process.env.CODEX_SANDBOX) {
     return `${testName} requires an unsandboxed macOS desktop session; Codex sandbox blocks Chromium profile sockets and helper process IPC.`;
+  }
+  if (
+    !process.env.RESONANTOS_CEF_NO_SANDBOX &&
+    (process.env.CODEX_CI || process.env.CODEX_INTERNAL_ORIGINATOR_OVERRIDE)
+  ) {
+    return `${testName} requires a normal macOS Terminal/Finder session; Codex Desktop's app sandbox blocks CEF helper framework loads.`;
   }
   if (process.platform !== "darwin" || !existsSync(bridgeDylib) || !existsSync(cefFramework) || !existsSync(helper)) {
     return "macOS native bridge, CEF framework, and helper app are required for embedded smoke.";

--- a/addons/resonant-browser-native/test/native-host-contract.test.mjs
+++ b/addons/resonant-browser-native/test/native-host-contract.test.mjs
@@ -3,6 +3,8 @@ import { execFile } from "node:child_process";
 import test from "node:test";
 import { promisify } from "node:util";
 import path from "node:path";
+import { readFile } from "node:fs/promises";
+import { cefArchiveName, cefBuild, cefBuildDirectoryName } from "../scripts/cef-build-config.mjs";
 
 const execFileAsync = promisify(execFile);
 const addonRoot = path.resolve(import.meta.dirname, "..");
@@ -28,4 +30,25 @@ test("bundled Browser add-on manifest stays aligned with the native product path
   assert.equal(result.driftAuditOk, true);
   assert.equal(result.addonId, "addon.browser");
   assert.equal(result.protocol, "host-command");
+});
+
+test("CEF fetch, build, and native tests use the same pinned Chromium build", async () => {
+  assert.equal(cefBuild.cefVersion, "147.0.10+gd58e84d+chromium-147.0.7727.118");
+  assert.equal(cefBuild.chromiumVersion, "147.0.7727.118");
+  assert.equal(
+    cefArchiveName("macosarm64"),
+    "cef_binary_147.0.10+gd58e84d+chromium-147.0.7727.118_macosarm64.tar.bz2",
+  );
+
+  const repoRoot = path.resolve(addonRoot, "..", "..");
+  const [fetchScript, buildScript, embedTest] = await Promise.all([
+    readFile(path.join(addonRoot, "scripts", "fetch-cef.mjs"), "utf8"),
+    readFile(path.join(repoRoot, "scripts", "build-native-browser.mjs"), "utf8"),
+    readFile(path.join(addonRoot, "test", "native-cef-embed.test.mjs"), "utf8"),
+  ]);
+
+  assert.match(fetchScript, /cefArchiveName/);
+  assert.match(buildScript, /cefBuildDirectoryName/);
+  assert.match(embedTest, /cefBuildDirectoryName/);
+  assert.equal(cefBuildDirectoryName("unsupported"), "cef_binary_147.0.10+gd58e84d+chromium-147.0.7727.118_unsupported");
 });

--- a/browser-first/host/addon-delegation-service.mjs
+++ b/browser-first/host/addon-delegation-service.mjs
@@ -297,8 +297,9 @@ export function createAddonDelegationService(dependencies) {
   }
 
   function sectionFromMarkdown(content, heading) {
+    const normalizedContent = String(content ?? "").replace(/\r\n?/g, "\n");
     const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const match = new RegExp(`## ${escaped}\\n([\\s\\S]*?)(?=\\n## |$)`, "i").exec(content);
+    const match = new RegExp(`## ${escaped}\\n([\\s\\S]*?)(?=\\n## |$)`, "i").exec(normalizedContent);
     return match ? match[1].trim() : "";
   }
 

--- a/browser-first/host/archive-review-host-service.mjs
+++ b/browser-first/host/archive-review-host-service.mjs
@@ -52,7 +52,8 @@ export function markdownTitle(content, fallback) {
 export function artifactKind(content, filePath) {
   if (content.includes("# Browser Job Report")) return "browser-job-report";
   if (content.includes("# Browser Agent Control Report")) return "browser-control-report";
-  if (filePath.includes(`${path.sep}browser${path.sep}`)) return "browser-intake";
+  const portablePath = String(filePath ?? "").replace(/\\/g, "/");
+  if (portablePath.includes("/browser/")) return "browser-intake";
   return "intake";
 }
 

--- a/browser-first/host/browser-first-host-utils.mjs
+++ b/browser-first/host/browser-first-host-utils.mjs
@@ -50,14 +50,30 @@ export function executableCandidates(commandName) {
     .flatMap((entry) => names.map((name) => path.join(entry, name)));
 }
 
+function quoteWindowsCommandArg(value) {
+  const escaped = String(value ?? "")
+    .replace(/\r?\n/g, " ")
+    .replace(/%/g, "%%")
+    .replace(/\^/g, "^^")
+    .replace(/"/g, '^"')
+    .replace(/[&|<>]/g, (match) => `^${match}`);
+  return `"${escaped}"`;
+}
+
 export async function execFileStdout(command, args, options = {}) {
   return new Promise((resolve, reject) => {
     const needsWindowsCommandShell = process.platform === "win32" && /\.(?:cmd|bat)$/i.test(String(command));
-    execFile(command, args, {
+    const file = needsWindowsCommandShell ? process.env.ComSpec ?? "cmd.exe" : command;
+    const commandArgs = needsWindowsCommandShell
+      ? ["/d", "/s", "/c", ["call", command, ...args].map(quoteWindowsCommandArg).join(" ")]
+      : args;
+    const execOptions = needsWindowsCommandShell
+      ? (({ shell: _shell, ...rest }) => rest)(options)
+      : options;
+    execFile(file, commandArgs, {
       timeout: 120_000,
       windowsHide: true,
-      shell: needsWindowsCommandShell,
-      ...options,
+      ...execOptions,
     }, (error, stdout, stderr) => {
       if (error) {
         reject(new Error(String(stderr || error.message || "Command failed.").trim()));

--- a/browser-first/host/browser-first-host-utils.mjs
+++ b/browser-first/host/browser-first-host-utils.mjs
@@ -50,30 +50,14 @@ export function executableCandidates(commandName) {
     .flatMap((entry) => names.map((name) => path.join(entry, name)));
 }
 
-function quoteWindowsCommandArg(value) {
-  const escaped = String(value ?? "")
-    .replace(/\r?\n/g, " ")
-    .replace(/%/g, "%%")
-    .replace(/\^/g, "^^")
-    .replace(/"/g, '^"')
-    .replace(/[&|<>]/g, (match) => `^${match}`);
-  return `"${escaped}"`;
-}
-
 export async function execFileStdout(command, args, options = {}) {
   return new Promise((resolve, reject) => {
     const needsWindowsCommandShell = process.platform === "win32" && /\.(?:cmd|bat)$/i.test(String(command));
-    const file = needsWindowsCommandShell ? process.env.ComSpec ?? "cmd.exe" : command;
-    const commandArgs = needsWindowsCommandShell
-      ? ["/d", "/s", "/c", ["call", command, ...args].map(quoteWindowsCommandArg).join(" ")]
-      : args;
-    const execOptions = needsWindowsCommandShell
-      ? (({ shell: _shell, ...rest }) => rest)(options)
-      : options;
-    execFile(file, commandArgs, {
+    execFile(command, args, {
       timeout: 120_000,
       windowsHide: true,
-      ...execOptions,
+      shell: needsWindowsCommandShell,
+      ...options,
     }, (error, stdout, stderr) => {
       if (error) {
         reject(new Error(String(stderr || error.message || "Command failed.").trim()));

--- a/browser-first/host/browser-first-host-utils.mjs
+++ b/browser-first/host/browser-first-host-utils.mjs
@@ -52,7 +52,13 @@ export function executableCandidates(commandName) {
 
 export async function execFileStdout(command, args, options = {}) {
   return new Promise((resolve, reject) => {
-    execFile(command, args, { timeout: 120_000, windowsHide: true, ...options }, (error, stdout, stderr) => {
+    const needsWindowsCommandShell = process.platform === "win32" && /\.(?:cmd|bat)$/i.test(String(command));
+    execFile(command, args, {
+      timeout: 120_000,
+      windowsHide: true,
+      shell: needsWindowsCommandShell,
+      ...options,
+    }, (error, stdout, stderr) => {
       if (error) {
         reject(new Error(String(stderr || error.message || "Command failed.").trim()));
         return;

--- a/browser-first/host/browser-first-self-test-service.mjs
+++ b/browser-first/host/browser-first-self-test-service.mjs
@@ -10,6 +10,23 @@ import {
   startBridgeServer,
 } from "./bridge-server.mjs";
 
+function cmdEchoLine(line) {
+  const escaped = String(line)
+    .replace(/\^/g, "^^")
+    .replace(/&/g, "^&")
+    .replace(/\|/g, "^|")
+    .replace(/</g, "^<")
+    .replace(/>/g, "^>");
+  return escaped ? `echo ${escaped}` : "echo.";
+}
+
+function fakeCliScript(output) {
+  if (process.platform === "win32") {
+    return ["@echo off", ...String(output).split("\n").map(cmdEchoLine), ""].join("\r\n");
+  }
+  return `#!/bin/sh\ncat <<'EOF'\n${output}\nEOF\n`;
+}
+
 export async function runBrowserFirstSelfTest(context) {
   const {
     args,
@@ -488,9 +505,7 @@ export async function runBrowserFirstSelfTest(context) {
         "- Local Hermes CLI process was invoked through the host boundary.",
       ].join("\n");
       await mkdir(path.dirname(fakeHermes), { recursive: true });
-      await writeFile(fakeHermes, process.platform === "win32"
-        ? `@echo off\r\necho ${fakeOutput.replaceAll("\n", "\r\necho ")}\r\n`
-        : `#!/bin/sh\ncat <<'EOF'\n${fakeOutput}\nEOF\n`);
+      await writeFile(fakeHermes, fakeCliScript(fakeOutput));
       await chmod(fakeHermes, 0o755).catch(() => undefined);
       process.env.HERMES_COMMAND = fakeHermes;
       server = await startBridgeServer({
@@ -599,9 +614,7 @@ export async function runBrowserFirstSelfTest(context) {
         "- Local Hermes CLI process was invoked through the host boundary.",
       ].join("\n");
       await mkdir(path.dirname(fakeHermes), { recursive: true });
-      await writeFile(fakeHermes, process.platform === "win32"
-        ? `@echo off\r\necho ${fakeOutput.replaceAll("\n", "\r\necho ")}\r\n`
-        : `#!/bin/sh\ncat <<'EOF'\n${fakeOutput}\nEOF\n`);
+      await writeFile(fakeHermes, fakeCliScript(fakeOutput));
       await chmod(fakeHermes, 0o755).catch(() => undefined);
       process.env.HERMES_COMMAND = fakeHermes;
       const request = async (routePath, { method = "POST", body = {}, capabilityToken = "" } = {}) => {
@@ -859,9 +872,7 @@ export async function runBrowserFirstSelfTest(context) {
         "- Local OpenCode CLI process was invoked through the host boundary.",
       ].join("\n");
       await mkdir(path.dirname(fakeOpenCode), { recursive: true });
-      await writeFile(fakeOpenCode, process.platform === "win32"
-        ? `@echo off\r\necho ${fakeOutput.replaceAll("\n", "\r\necho ")}\r\n`
-        : `#!/bin/sh\ncat <<'EOF'\n${fakeOutput}\nEOF\n`);
+      await writeFile(fakeOpenCode, fakeCliScript(fakeOutput));
       await chmod(fakeOpenCode, 0o755).catch(() => undefined);
       process.env.OPENCODE_COMMAND = fakeOpenCode;
       server = await startBridgeServer({
@@ -972,9 +983,7 @@ export async function runBrowserFirstSelfTest(context) {
         "- Local OpenCode CLI process was invoked through the host boundary.",
       ].join("\n");
       await mkdir(path.dirname(fakeOpenCode), { recursive: true });
-      await writeFile(fakeOpenCode, process.platform === "win32"
-        ? `@echo off\r\necho ${fakeOutput.replaceAll("\n", "\r\necho ")}\r\n`
-        : `#!/bin/sh\ncat <<'EOF'\n${fakeOutput}\nEOF\n`);
+      await writeFile(fakeOpenCode, fakeCliScript(fakeOutput));
       await chmod(fakeOpenCode, 0o755).catch(() => undefined);
       process.env.OPENCODE_COMMAND = fakeOpenCode;
       const request = async (routePath, { method = "POST", body = {}, capabilityToken = "" } = {}) => {

--- a/browser-first/host/browser-profile-service.mjs
+++ b/browser-first/host/browser-profile-service.mjs
@@ -19,23 +19,23 @@ function latestManifestDirectory(root) {
 export function chromeProfileRoots({ home = os.homedir(), platform = process.platform, env = process.env } = {}) {
   if (platform === "darwin") {
     return [
-      path.join(home, "Library", "Application Support", "Google", "Chrome"),
-      path.join(home, "Library", "Application Support", "BraveSoftware", "Brave-Browser"),
-      path.join(home, "Library", "Application Support", "Chromium"),
+      path.posix.join(home, "Library", "Application Support", "Google", "Chrome"),
+      path.posix.join(home, "Library", "Application Support", "BraveSoftware", "Brave-Browser"),
+      path.posix.join(home, "Library", "Application Support", "Chromium"),
     ];
   }
   if (platform === "win32") {
-    const local = env.LOCALAPPDATA ?? path.join(home, "AppData", "Local");
+    const local = env.LOCALAPPDATA ?? path.win32.join(home, "AppData", "Local");
     return [
-      path.join(local, "Google", "Chrome", "User Data"),
-      path.join(local, "BraveSoftware", "Brave-Browser", "User Data"),
-      path.join(local, "Chromium", "User Data"),
+      path.win32.join(local, "Google", "Chrome", "User Data"),
+      path.win32.join(local, "BraveSoftware", "Brave-Browser", "User Data"),
+      path.win32.join(local, "Chromium", "User Data"),
     ];
   }
   return [
-    path.join(home, ".config", "google-chrome"),
-    path.join(home, ".config", "BraveSoftware", "Brave-Browser"),
-    path.join(home, ".config", "chromium"),
+    path.posix.join(home, ".config", "google-chrome"),
+    path.posix.join(home, ".config", "BraveSoftware", "Brave-Browser"),
+    path.posix.join(home, ".config", "chromium"),
   ];
 }
 

--- a/browser-first/test/addon-cli-execution-inprocess-self-test.test.mjs
+++ b/browser-first/test/addon-cli-execution-inprocess-self-test.test.mjs
@@ -4,6 +4,7 @@ import { promisify } from "node:util";
 import test from "node:test";
 
 const execFileAsync = promisify(execFile);
+const toPortablePath = (value) => String(value ?? "").replace(/\\/g, "/");
 
 async function runSelfTest(flag) {
   const { stdout } = await execFileAsync(process.execPath, [
@@ -37,7 +38,7 @@ test("Hermes CLI execution bridge routes pass in-process deterministic smoke tes
   assert.equal(result.hermesMode, "local-hermes-cli");
   assert.equal(result.statusAfter, "completed");
   assert.match(result.summary, /Hermes CLI adapter completed/);
-  assert.ok(result.artifactPath.includes("BrowserFirst/DelegationArtifacts/hermes/"));
+  assert.ok(toPortablePath(result.artifactPath).includes("BrowserFirst/DelegationArtifacts/hermes/"));
 });
 
 test("OpenCode CLI execution bridge routes pass in-process deterministic smoke test", async () => {
@@ -48,5 +49,5 @@ test("OpenCode CLI execution bridge routes pass in-process deterministic smoke t
   assert.equal(result.opencodeMode, "local-opencode-cli");
   assert.equal(result.statusAfter, "completed");
   assert.match(result.summary, /OpenCode CLI adapter completed/);
-  assert.ok(result.artifactPath.includes("BrowserFirst/DelegationArtifacts/opencode/"));
+  assert.ok(toPortablePath(result.artifactPath).includes("BrowserFirst/DelegationArtifacts/opencode/"));
 });

--- a/browser-first/test/archive-promotion-paths.test.mjs
+++ b/browser-first/test/archive-promotion-paths.test.mjs
@@ -3,6 +3,8 @@ import test from "node:test";
 
 import { promotionBackupFilename, promotionBackupPath } from "../host/archive-promotion-paths.mjs";
 
+const toPortablePath = (value) => String(value ?? "").replace(/\\/g, "/");
+
 test("promotion backup filenames include the full wiki-relative path identity", () => {
   const first = promotionBackupFilename("AI_MEMORY/wiki/projects/dao/index.md");
   const second = promotionBackupFilename("AI_MEMORY/wiki/people/dao/index.md");
@@ -37,6 +39,6 @@ test("promotion backup paths stay under the selected backup category", () => {
     category: "restores",
   });
 
-  assert.match(promotionPath, /AI_MEMORY\/backups\/promotions\/2026-06-01T10-00-00-000Z\/projects-dao-index-[a-f0-9]{12}\.md$/);
-  assert.match(restorePath, /AI_MEMORY\/backups\/restores\/2026-06-01T10-00-00-000Z\/projects-dao-index-[a-f0-9]{12}\.md$/);
+  assert.match(toPortablePath(promotionPath), /AI_MEMORY\/backups\/promotions\/2026-06-01T10-00-00-000Z\/projects-dao-index-[a-f0-9]{12}\.md$/);
+  assert.match(toPortablePath(restorePath), /AI_MEMORY\/backups\/restores\/2026-06-01T10-00-00-000Z\/projects-dao-index-[a-f0-9]{12}\.md$/);
 });

--- a/browser-first/test/browser-first-contract.test.mjs
+++ b/browser-first/test/browser-first-contract.test.mjs
@@ -42,7 +42,11 @@ function skipIfLocalhostBindDenied(t, result) {
 }
 
 function runBridgeSelfTest(t, args, timeout = 15_000) {
-  const effectiveArgs = process.platform === "win32" ? args.map((arg) => windowsSelfTestFlags.get(arg) ?? arg) : args;
+  const effectiveArgs = process.platform === "win32"
+    ? args
+      .map((arg) => windowsSelfTestFlags.get(arg) ?? arg)
+      .filter((arg) => !/^--(?:bridge-token|bridge-port|addon-execution-settings-token)=/.test(arg))
+    : args;
   const result = spawnSync("node", [path.join(browserFirstRoot, "host", "run-browser-first.mjs"), ...effectiveArgs], {
     cwd: repoRoot,
     encoding: "utf8",

--- a/browser-first/test/browser-first-contract.test.mjs
+++ b/browser-first/test/browser-first-contract.test.mjs
@@ -1657,7 +1657,7 @@ test("browser-first bridge hardens selected Living Archive source file intake", 
     "--memory-settings-token=settings-token",
     "--memory-source-file-intake-token=file-intake-token",
     "--bridge-port=0",
-  ]);
+  ], 30_000);
   if (!payload) return;
 
   assert.equal(payload.ok, true);

--- a/browser-first/test/browser-first-contract.test.mjs
+++ b/browser-first/test/browser-first-contract.test.mjs
@@ -10,6 +10,16 @@ const extensionRoot = path.join(browserFirstRoot, "resonantos-side-panel-extensi
 
 const readJson = async (filePath) => JSON.parse(await readFile(filePath, "utf8"));
 const readText = (filePath) => readFile(filePath, "utf8");
+const toPortablePath = (value) => String(value ?? "").replace(/\\/g, "/");
+
+const windowsSelfTestFlags = new Map([
+  ["--bridge-auth-self-test=true", "--bridge-auth-inprocess-self-test=true"],
+  ["--hermes-delegation-self-test=true", "--hermes-delegation-inprocess-self-test=true"],
+  ["--hermes-cli-execution-self-test=true", "--hermes-cli-execution-inprocess-self-test=true"],
+  ["--opencode-delegation-self-test=true", "--opencode-delegation-inprocess-self-test=true"],
+  ["--opencode-cli-execution-self-test=true", "--opencode-cli-execution-inprocess-self-test=true"],
+  ["--addon-execution-settings-self-test=true", "--addon-execution-settings-inprocess-self-test=true"],
+]);
 
 async function readCssWithImports(filePath) {
   const css = await readText(filePath);
@@ -32,7 +42,8 @@ function skipIfLocalhostBindDenied(t, result) {
 }
 
 function runBridgeSelfTest(t, args, timeout = 15_000) {
-  const result = spawnSync("node", [path.join(browserFirstRoot, "host", "run-browser-first.mjs"), ...args], {
+  const effectiveArgs = process.platform === "win32" ? args.map((arg) => windowsSelfTestFlags.get(arg) ?? arg) : args;
+  const result = spawnSync("node", [path.join(browserFirstRoot, "host", "run-browser-first.mjs"), ...effectiveArgs], {
     cwd: repoRoot,
     encoding: "utf8",
     timeout,
@@ -1517,7 +1528,7 @@ test("browser-first bridge completes deterministic Hermes delegation lifecycle",
   if (!payload) return;
 
   assert.equal(payload.ok, true);
-  assert.match(payload.artifactPath, /BrowserFirst\/DelegationArtifacts\/hermes/);
+  assert.match(toPortablePath(payload.artifactPath), /BrowserFirst\/DelegationArtifacts\/hermes/);
   assert.equal(payload.statusAfter, "completed");
   assert.ok(payload.listed >= 1);
 });
@@ -1535,7 +1546,7 @@ test("browser-first bridge executes enabled Hermes CLI adapter through host boun
   assert.equal(payload.adapter, "hermes-cli");
   assert.equal(payload.hermesMode, "local-hermes-cli");
   assert.equal(payload.statusAfter, "completed");
-  assert.match(payload.artifactPath, /BrowserFirst\/DelegationArtifacts\/hermes/);
+  assert.match(toPortablePath(payload.artifactPath), /BrowserFirst\/DelegationArtifacts\/hermes/);
   assert.match(payload.summary, /Hermes CLI adapter completed/);
 });
 
@@ -1552,7 +1563,7 @@ test("browser-first bridge executes enabled OpenCode CLI adapter through host bo
   assert.equal(payload.adapter, "opencode-cli");
   assert.equal(payload.opencodeMode, "local-opencode-cli");
   assert.equal(payload.statusAfter, "completed");
-  assert.match(payload.artifactPath, /BrowserFirst\/DelegationArtifacts\/opencode/);
+  assert.match(toPortablePath(payload.artifactPath), /BrowserFirst\/DelegationArtifacts\/opencode/);
   assert.match(payload.summary, /OpenCode CLI adapter completed/);
 });
 
@@ -1565,7 +1576,7 @@ test("browser-first bridge completes deterministic OpenCode delegation lifecycle
   if (!payload) return;
 
   assert.equal(payload.ok, true);
-  assert.match(payload.artifactPath, /BrowserFirst\/DelegationArtifacts\/opencode/);
+  assert.match(toPortablePath(payload.artifactPath), /BrowserFirst\/DelegationArtifacts\/opencode/);
   assert.equal(payload.gatedStatus, "blocked");
   assert.equal(payload.statusAfter, "completed");
   assert.ok(payload.listed >= 1);

--- a/browser-first/test/browser-first-desktop-proof.test.mjs
+++ b/browser-first/test/browser-first-desktop-proof.test.mjs
@@ -9,26 +9,47 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 const repoRoot = path.resolve(import.meta.dirname, "..", "..");
 
+async function writeNpmShim(bin, rules) {
+  const shimPath = path.join(bin, process.platform === "win32" ? "npm.cmd" : "npm");
+  if (process.platform === "win32") {
+    await writeFile(shimPath, [
+      "@echo off",
+      ...rules.flatMap(({ script, stdout, exitCode }) => [
+        `if "%2"=="${script}" (`,
+        stdout ? `  echo ${stdout}` : "",
+        `  exit /b ${exitCode}`,
+        ")",
+      ]),
+      "echo unexpected npm command: %* 1>&2",
+      "exit /b 9",
+      "",
+    ].filter((line) => line !== "").join("\r\n"));
+  } else {
+    await writeFile(shimPath, [
+      "#!/bin/sh",
+      ...rules.flatMap(({ script, stdout, exitCode }) => [
+        `if [ "$2" = "${script}" ]; then`,
+        stdout ? `  echo '${stdout}'` : "",
+        `  exit ${exitCode}`,
+        "fi",
+      ]),
+      "echo \"unexpected npm command: $@\" >&2",
+      "exit 9",
+      "",
+    ].join("\n"));
+    await chmod(shimPath, 0o755);
+  }
+}
+
 test("desktop proof runner passes only when verification and audit pass", async () => {
   const tmp = await mkdtemp(path.join(os.tmpdir(), "resonantos-desktop-proof-"));
   try {
     const bin = path.join(tmp, "bin");
     await mkdir(bin, { recursive: true });
-    await writeFile(path.join(bin, "npm"), [
-      "#!/bin/sh",
-      "if [ \"$2\" = \"browser-first:verify-desktop\" ]; then",
-      "  echo '{\"status\":\"ready\",\"step\":\"verify\"}'",
-      "  exit 0",
-      "fi",
-      "if [ \"$2\" = \"browser-first:audit-desktop\" ]; then",
-      "  echo '{\"status\":\"ready\",\"step\":\"audit\"}'",
-      "  exit 0",
-      "fi",
-      "echo \"unexpected npm command: $@\" >&2",
-      "exit 9",
-      ""
-    ].join("\n"));
-    await chmod(path.join(bin, "npm"), 0o755);
+    await writeNpmShim(bin, [
+      { script: "browser-first:verify-desktop", stdout: "{\"status\":\"ready\",\"step\":\"verify\"}", exitCode: 0 },
+      { script: "browser-first:audit-desktop", stdout: "{\"status\":\"ready\",\"step\":\"audit\"}", exitCode: 0 },
+    ]);
 
     const { stdout } = await execFileAsync("node", [
       path.join(repoRoot, "scripts", "prove-browser-first-desktop.mjs"),
@@ -51,20 +72,10 @@ test("desktop proof runner fails when audit fails after verification", async () 
   try {
     const bin = path.join(tmp, "bin");
     await mkdir(bin, { recursive: true });
-    await writeFile(path.join(bin, "npm"), [
-      "#!/bin/sh",
-      "if [ \"$2\" = \"browser-first:verify-desktop\" ]; then",
-      "  echo '{\"status\":\"ready\",\"step\":\"verify\"}'",
-      "  exit 0",
-      "fi",
-      "if [ \"$2\" = \"browser-first:audit-desktop\" ]; then",
-      "  echo '{\"status\":\"attention\",\"issues\":[\"missing proof\"]}'",
-      "  exit 2",
-      "fi",
-      "exit 9",
-      ""
-    ].join("\n"));
-    await chmod(path.join(bin, "npm"), 0o755);
+    await writeNpmShim(bin, [
+      { script: "browser-first:verify-desktop", stdout: "{\"status\":\"ready\",\"step\":\"verify\"}", exitCode: 0 },
+      { script: "browser-first:audit-desktop", stdout: "{\"status\":\"attention\",\"issues\":[\"missing proof\"]}", exitCode: 2 },
+    ]);
 
     await assert.rejects(
       execFileAsync("node", [

--- a/browser-first/test/browser-first-desktop-proof.test.mjs
+++ b/browser-first/test/browser-first-desktop-proof.test.mjs
@@ -55,7 +55,7 @@ test("desktop proof runner passes only when verification and audit pass", async 
       path.join(repoRoot, "scripts", "prove-browser-first-desktop.mjs"),
     ], {
       cwd: repoRoot,
-      env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
+      env: { ...process.env, PATH: `${bin}${path.delimiter}${process.env.PATH}` },
     });
     const output = JSON.parse(stdout);
 
@@ -82,7 +82,7 @@ test("desktop proof runner fails when audit fails after verification", async () 
         path.join(repoRoot, "scripts", "prove-browser-first-desktop.mjs"),
       ], {
         cwd: repoRoot,
-        env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
+        env: { ...process.env, PATH: `${bin}${path.delimiter}${process.env.PATH}` },
       }),
       (error) => {
         const output = JSON.parse(error.stdout);

--- a/browser-first/test/browser-first-desktop-verifier.test.mjs
+++ b/browser-first/test/browser-first-desktop-verifier.test.mjs
@@ -75,7 +75,7 @@ test("desktop verifier captures parsed child verifier JSON in the durable report
       `--report=${reportPath}`,
     ], {
       cwd: repoRoot,
-      env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
+      env: { ...process.env, PATH: `${bin}${path.delimiter}${process.env.PATH}` },
     });
     const output = JSON.parse(stdout);
     const report = JSON.parse(await readFile(reportPath, "utf8"));

--- a/browser-first/test/browser-first-desktop-verifier.test.mjs
+++ b/browser-first/test/browser-first-desktop-verifier.test.mjs
@@ -9,6 +9,36 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 const repoRoot = path.resolve(import.meta.dirname, "..", "..");
 
+async function writeNpmShim(bin) {
+  const shimPath = path.join(bin, process.platform === "win32" ? "npm.cmd" : "npm");
+  if (process.platform === "win32") {
+    await writeFile(shimPath, [
+      "@echo off",
+      "if \"%2\"==\"browser-first:verify-installed\" (",
+      "  echo ^> fake npm wrapper",
+      "  echo {\"status\":\"ready\",\"step\":\"installed\"}",
+      "  exit /b 0",
+      ")",
+      "echo {\"status\":\"ready\",\"step\":\"native\"}",
+      "exit /b 0",
+      "",
+    ].join("\r\n"));
+  } else {
+    await writeFile(shimPath, [
+      "#!/bin/sh",
+      "if [ \"$2\" = \"browser-first:verify-installed\" ]; then",
+      "  echo '> fake npm wrapper'",
+      "  echo '{\"status\":\"ready\",\"step\":\"installed\"}'",
+      "  exit 0",
+      "fi",
+      "echo '{\"status\":\"ready\",\"step\":\"native\"}'",
+      "exit 0",
+      ""
+    ].join("\n"));
+    await chmod(shimPath, 0o755);
+  }
+}
+
 test("desktop verifier dry-run writes the command plan and report path", async () => {
   const tmp = await mkdtemp(path.join(os.tmpdir(), "resonantos-desktop-verifier-"));
   try {
@@ -33,23 +63,12 @@ test("desktop verifier dry-run writes the command plan and report path", async (
 });
 
 test("desktop verifier captures parsed child verifier JSON in the durable report", async () => {
-    const tmp = await mkdtemp(path.join(os.tmpdir(), "resonantos-desktop-verifier-parse-"));
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "resonantos-desktop-verifier-parse-"));
   try {
     const bin = path.join(tmp, "bin");
     const reportPath = path.join(tmp, "desktop-report.json");
     await mkdir(bin, { recursive: true });
-    await writeFile(path.join(bin, "npm"), [
-      "#!/bin/sh",
-      "if [ \"$2\" = \"browser-first:verify-installed\" ]; then",
-      "  echo '> fake npm wrapper'",
-      "  echo '{\"status\":\"ready\",\"step\":\"installed\"}'",
-      "  exit 0",
-      "fi",
-      "echo '{\"status\":\"ready\",\"step\":\"native\"}'",
-      "exit 0",
-      ""
-    ].join("\n"));
-    await chmod(path.join(bin, "npm"), 0o755);
+    await writeNpmShim(bin);
 
     const { stdout } = await execFileAsync("node", [
       path.join(repoRoot, "scripts", "verify-browser-first-desktop.mjs"),

--- a/browser-first/test/browser-profile-service.test.mjs
+++ b/browser-first/test/browser-profile-service.test.mjs
@@ -89,8 +89,8 @@ test("browser profile roots are platform specific and portable", () => {
     "/home/user/.config/chromium",
   ]);
   assert.deepEqual(chromeProfileRoots({ home: "C:\\Users\\User", platform: "win32", env: { LOCALAPPDATA: "C:\\Users\\User\\AppData\\Local" } }), [
-    path.join("C:\\Users\\User\\AppData\\Local", "Google", "Chrome", "User Data"),
-    path.join("C:\\Users\\User\\AppData\\Local", "BraveSoftware", "Brave-Browser", "User Data"),
-    path.join("C:\\Users\\User\\AppData\\Local", "Chromium", "User Data"),
+    path.win32.join("C:\\Users\\User\\AppData\\Local", "Google", "Chrome", "User Data"),
+    path.win32.join("C:\\Users\\User\\AppData\\Local", "BraveSoftware", "Brave-Browser", "User Data"),
+    path.win32.join("C:\\Users\\User\\AppData\\Local", "Chromium", "User Data"),
   ]);
 });

--- a/browser-first/test/delegation-bridge-inprocess-self-test.test.mjs
+++ b/browser-first/test/delegation-bridge-inprocess-self-test.test.mjs
@@ -4,6 +4,7 @@ import { promisify } from "node:util";
 import test from "node:test";
 
 const execFileAsync = promisify(execFile);
+const toPortablePath = (value) => String(value ?? "").replace(/\\/g, "/");
 
 async function runSelfTest(flag) {
   const { stdout } = await execFileAsync(process.execPath, [
@@ -24,7 +25,7 @@ test("Hermes delegation bridge routes pass in-process deterministic smoke test",
   assert.equal(result.gatedStatus, "blocked");
   assert.equal(result.statusAfter, "completed");
   assert.equal(result.hermesMode, "local-hermes-cli-disabled");
-  assert.ok(result.artifactPath.includes("BrowserFirst/DelegationArtifacts/hermes/"));
+  assert.ok(toPortablePath(result.artifactPath).includes("BrowserFirst/DelegationArtifacts/hermes/"));
   assert.equal(result.listed >= 1, true);
 });
 
@@ -34,6 +35,6 @@ test("OpenCode delegation bridge routes pass in-process deterministic smoke test
   assert.equal(result.mode, "in-process");
   assert.equal(result.gatedStatus, "blocked");
   assert.equal(result.statusAfter, "completed");
-  assert.ok(result.artifactPath.includes("BrowserFirst/DelegationArtifacts/opencode/"));
+  assert.ok(toPortablePath(result.artifactPath).includes("BrowserFirst/DelegationArtifacts/opencode/"));
   assert.equal(result.listed >= 1, true);
 });

--- a/browser-first/test/main-workspace-settings.test.mjs
+++ b/browser-first/test/main-workspace-settings.test.mjs
@@ -52,6 +52,17 @@ function setupDom() {
   };
 }
 
+async function waitForCondition(predicate, { timeout = 2_000, interval = 20 } = {}) {
+  const started = Date.now();
+  let lastValue;
+  while (Date.now() - started < timeout) {
+    lastValue = await predicate();
+    if (lastValue) return lastValue;
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+  return lastValue;
+}
+
 test("settings workspace renders provider status without exposing credentials", async () => {
   const { container, cleanup } = setupDom();
   const calls = [];
@@ -1273,7 +1284,7 @@ test("settings memory section completes real move-on-import and rollback against
     confirmationInput.value = `MOVE ${path.basename(source)}`;
     confirmationInput.dispatchEvent(new Event("input", { bubbles: true }));
     executeMoveButton.click();
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await waitForCondition(() => sources.length === 1 && !existsSync(source));
 
     assert.equal(existsSync(source), false);
     assert.equal(sources.length, 1);
@@ -1286,7 +1297,7 @@ test("settings memory section completes real move-on-import and rollback against
     assert.match(container.textContent, /Rollback/);
 
     [...container.querySelectorAll("button")].find((button) => button.textContent === "Rollback").click();
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await waitForCondition(() => sources.length === 0 && existsSync(path.join(source, "note.md")));
 
     assert.equal(sources.length, 0);
     assert.equal(existsSync(path.join(source, "note.md")), true);

--- a/browser-first/test/memory-source-file-intake-inprocess-self-test.test.mjs
+++ b/browser-first/test/memory-source-file-intake-inprocess-self-test.test.mjs
@@ -4,6 +4,7 @@ import { promisify } from "node:util";
 import test from "node:test";
 
 const execFileAsync = promisify(execFile);
+const toPortablePath = (value) => String(value ?? "").replace(/\\/g, "/");
 
 test("source-file intake bridge routes pass in-process deterministic smoke test", async () => {
   const { stdout } = await execFileAsync(process.execPath, [
@@ -45,19 +46,19 @@ test("source-file intake bridge routes pass in-process deterministic smoke test"
   assert.equal(result.syncHistoryBounded, true);
   assert.ok(result.boundedSyncHistoryCount <= 50);
   assert.equal(result.syncHistoryEligibleFileSample, "manual.md");
-  assert.match(result.syncHistoryCreatedArtifactSample, /^INTAKE\/sources\//);
-  assert.match(result.syncHistorySourcePathSample, /^\[path\]\//);
+  assert.match(toPortablePath(result.syncHistoryCreatedArtifactSample), /^INTAKE\/sources\//);
+  assert.match(toPortablePath(result.syncHistorySourcePathSample), /^\[path\]\//);
   assert.equal(result.corruptReviewStatus, 200);
   assert.equal(result.corruptCandidateStatus, "version-manifest-unavailable");
   assert.equal(result.unauthorizedRepairStatus, 403);
   assert.equal(result.missingConfirmationRepairStatus, 500);
   assert.equal(result.repairStatus, 200);
   assert.equal(result.repairPayloadStatus, "repaired");
-  assert.match(result.repairBackupPath, /^CONFIG\/source-file-history\/repairs\//);
+  assert.match(toPortablePath(result.repairBackupPath), /^CONFIG\/source-file-history\/repairs\//);
   assert.ok(result.repairHistoryCount >= 1);
   assert.equal(result.repairHistoryLatestStatus, "repaired");
-  assert.match(result.repairHistorySourcePathSample, /^\[path\]\//);
-  assert.match(result.repairHistoryBackupPath, /^CONFIG\/source-file-history\/repairs\//);
+  assert.match(toPortablePath(result.repairHistorySourcePathSample), /^\[path\]\//);
+  assert.match(toPortablePath(result.repairHistoryBackupPath), /^CONFIG\/source-file-history\/repairs\//);
   assert.equal(result.repairHistoryRedactsSourcePaths, true);
   assert.equal(result.repairedCandidateStatus, "new");
   assert.equal(result.sourceIdCollisionAvoided, true);

--- a/browser-first/test/memory-source-move-inprocess-self-test.test.mjs
+++ b/browser-first/test/memory-source-move-inprocess-self-test.test.mjs
@@ -4,6 +4,7 @@ import { promisify } from "node:util";
 import test from "node:test";
 
 const execFileAsync = promisify(execFile);
+const toPortablePath = (value) => String(value ?? "").replace(/\\/g, "/");
 
 test("move-on-import bridge routes pass in-process deterministic smoke test", async () => {
   const { stdout } = await execFileAsync(process.execPath, [
@@ -37,10 +38,10 @@ test("move-on-import bridge routes pass in-process deterministic smoke test", as
   assert.ok(result.moveHistory.count >= 4);
   assert.equal(result.moveHistory.latestAction, "move-rollback");
   assert.equal(result.moveHistory.latestStatus, "partial");
-  assert.match(result.moveHistory.sourcePathSample, /^\[path\]\//);
-  assert.match(result.moveHistory.latestOriginalPath, /^\[path\]\//);
-  assert.match(result.moveHistory.latestManagedPath, /^INTAKE\/imports\/mixed\/partial-rollback-vault-/);
-  assert.match(result.moveHistory.latestManifestPath, /^CONFIG\/move-imports\//);
-  assert.match(result.moveHistory.ledgerPathSample, /^CONFIG\/move-imports\//);
+  assert.match(toPortablePath(result.moveHistory.sourcePathSample), /^\[path\]\//);
+  assert.match(toPortablePath(result.moveHistory.latestOriginalPath), /^\[path\]\//);
+  assert.match(toPortablePath(result.moveHistory.latestManagedPath), /^INTAKE\/imports\/mixed\/partial-rollback-vault-/);
+  assert.match(toPortablePath(result.moveHistory.latestManifestPath), /^CONFIG\/move-imports\//);
+  assert.match(toPortablePath(result.moveHistory.ledgerPathSample), /^CONFIG\/move-imports\//);
   assert.equal(result.moveHistory.redactsSourcePaths, true);
 });

--- a/electron-host/wallet-browser-host.mjs
+++ b/electron-host/wallet-browser-host.mjs
@@ -85,6 +85,10 @@ function normalizeHttpUrl(value = DEFAULT_URL) {
   return parsed.toString();
 }
 
+function envFlag(value) {
+  return /^(1|true|yes)$/i.test(String(value ?? "").trim());
+}
+
 async function getFreePort() {
   const server = createServer();
   await new Promise((resolve, reject) => {
@@ -147,6 +151,7 @@ export async function startWalletBrowserHost(params = {}) {
   const userDataDir = String(params.profileDir || defaultProfilePath());
   await mkdir(userDataDir, { recursive: true });
   const endpoint = `http://127.0.0.1:${port}`;
+  const headless = params.headless ?? envFlag(process.env.RESONANTOS_WALLET_BROWSER_HEADLESS);
   const args = [
     `--remote-debugging-port=${port}`,
     `--user-data-dir=${userDataDir}`,
@@ -154,6 +159,7 @@ export async function startWalletBrowserHost(params = {}) {
     "--no-default-browser-check",
     "--disable-backgrounding-occluded-windows",
     "--disable-renderer-backgrounding",
+    ...(headless ? ["--headless=new", "--disable-gpu", "--no-sandbox"] : []),
     "--new-window",
     url,
   ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,13 +96,13 @@
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -111,9 +111,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -121,21 +121,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -152,14 +152,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -169,14 +169,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -186,9 +186,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -196,29 +196,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -238,9 +238,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -248,9 +248,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -258,9 +258,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -268,27 +268,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -340,33 +340,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -374,14 +374,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2294,9 +2294,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.21",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
-      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
+      "version": "2.10.38",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2351,9 +2351,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001790",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
-      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -2563,9 +2563,9 @@
       "peer": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.343",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.343.tgz",
-      "integrity": "sha512-YHnQ3MXI08icvL9ZKnEBy05F2EQ8ob01UaMOuMbM8l+4UcAq6MPPbBTJBbsBUg3H8JeZNt+O4fjsoWth3p6IFg==",
+      "version": "1.5.376",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
+      "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3885,11 +3885,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "version": "2.0.48",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
+      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -4533,9 +4536,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4696,9 +4699,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/scripts/audit-browser-first-desktop-report.mjs
+++ b/scripts/audit-browser-first-desktop-report.mjs
@@ -91,6 +91,6 @@ async function main() {
   process.exit(audit.status === "ready" ? 0 : 2);
 }
 
-if (process.argv[1] && import.meta.url === new URL(process.argv[1], "file:").href) {
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   await main();
 }

--- a/scripts/build-native-browser.mjs
+++ b/scripts/build-native-browser.mjs
@@ -3,6 +3,7 @@ import { copyFileSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
+import { cefBuildDirectoryName } from "../addons/resonant-browser-native/scripts/cef-build-config.mjs";
 
 const root = process.cwd();
 const args = new Set(process.argv.slice(2));
@@ -14,7 +15,7 @@ const cefRoot = path.join(
   addonRoot,
   "vendor",
   "cef",
-  `cef_binary_147.0.10+gd58e84d+chromium-147.0.7727.118_${cefPlatform ?? "unsupported"}`,
+  cefBuildDirectoryName(cefPlatform ?? "unsupported"),
 );
 const nativeHostSource = path.join(addonRoot, "native_host");
 const buildDir = path.join(addonRoot, "build");

--- a/scripts/engineer-runner.mjs
+++ b/scripts/engineer-runner.mjs
@@ -14,6 +14,10 @@ import { spawnSync } from "node:child_process";
 const DEFAULT_TIMEOUT_MS = 120_000;
 const VALID_STATUSES = new Set(["verified", "failed"]);
 
+function toPortablePath(value) {
+  return String(value ?? "").replace(/\\/g, "/");
+}
+
 export function loadTaskContract(contractPath) {
   if (!contractPath) {
     throw new Error("Missing task contract path.");
@@ -108,10 +112,10 @@ export function parseGitStatusPorcelain(stdout) {
     }
     if (pathSpec.includes(" -> ")) {
       for (const part of pathSpec.split(" -> ")) {
-        changed.add(part.trim().replace(/^"|"$/g, ""));
+        changed.add(toPortablePath(part.trim().replace(/^"|"$/g, "")));
       }
     } else {
-      changed.add(pathSpec.trim().replace(/^"|"$/g, ""));
+      changed.add(toPortablePath(pathSpec.trim().replace(/^"|"$/g, "")));
     }
   }
   return Array.from(changed).sort();
@@ -223,14 +227,14 @@ function normalizeRepoRelativePath(file, repo, field) {
     if (rel.startsWith("..") || isAbsolute(rel)) {
       throw new Error(`Task contract field '${field}' includes a path outside repo: ${file}`);
     }
-    return rel;
+    return toPortablePath(rel);
   }
   const resolved = resolve(repo, file);
   const rel = relative(repo, resolved);
   if (rel.startsWith("..") || isAbsolute(rel)) {
     throw new Error(`Task contract field '${field}' includes a path outside repo: ${file}`);
   }
-  return rel;
+  return toPortablePath(rel);
 }
 
 function printUsage() {

--- a/scripts/engineer-runner.test.mjs
+++ b/scripts/engineer-runner.test.mjs
@@ -69,11 +69,12 @@ test("evaluateScope fails when changed files include files outside allowed set",
 test("parseGitStatusPorcelain includes modified, renamed, and untracked files", () => {
   const files = parseGitStatusPorcelain([
     " M scripts/allowed.txt",
+    " M scripts\\windows.txt",
     "?? scripts/new-file.mjs",
     "R  docs/old.md -> docs/new.md",
     "",
   ].join("\n"));
-  assert.deepEqual(files, ["docs/new.md", "docs/old.md", "scripts/allowed.txt", "scripts/new-file.mjs"]);
+  assert.deepEqual(files, ["docs/new.md", "docs/old.md", "scripts/allowed.txt", "scripts/new-file.mjs", "scripts/windows.txt"]);
 });
 
 test("verifyTaskContract verifies scoped changes and required commands", () => {

--- a/scripts/health-check.test.mjs
+++ b/scripts/health-check.test.mjs
@@ -6,7 +6,7 @@
 
 import { readFileSync, writeFileSync, unlinkSync, existsSync } from "node:fs";
 import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { test } from "node:test";
 import assert from "node:assert";
 import { spawnSync } from "node:child_process";
@@ -15,7 +15,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, "..");
 
 // Dynamically import the module under test
-const healthCheck = await import(join(REPO_ROOT, "scripts", "health-check.mjs"));
+const healthCheck = await import(pathToFileURL(join(REPO_ROOT, "scripts", "health-check.mjs")));
 
 const { redactSecretValue, extractProviderUrls, extractModelIdentifiers, parseDefaults } = healthCheck;
 

--- a/scripts/prove-browser-first-desktop.mjs
+++ b/scripts/prove-browser-first-desktop.mjs
@@ -17,6 +17,7 @@ function runStep(id, args) {
   const result = spawnSync("npm", ["run", ...args], {
     cwd: repoRoot,
     encoding: "utf8",
+    shell: process.platform === "win32",
     env: {
       ...process.env,
       RESONANTOS_DESKTOP_PROOF: "1",

--- a/scripts/verify-browser-first-desktop.mjs
+++ b/scripts/verify-browser-first-desktop.mjs
@@ -60,6 +60,7 @@ function runCommand(step) {
   const result = spawnSync(step.command, step.args, {
     cwd: repoRoot,
     encoding: "utf8",
+    shell: process.platform === "win32",
     env: {
       ...process.env,
       // Preserve normal desktop env; this marker is for downstream reports.

--- a/scripts/verify-browser-native-live.mjs
+++ b/scripts/verify-browser-native-live.mjs
@@ -45,6 +45,22 @@ if (process.env.CODEX_SANDBOX) {
   process.exit(2);
 }
 
+if (
+  !process.env.RESONANTOS_CEF_NO_SANDBOX &&
+  (process.env.CODEX_CI || process.env.CODEX_INTERNAL_ORIGINATOR_OVERRIDE)
+) {
+  console.log(JSON.stringify({
+    status: "attention",
+    reason: "native-live-verification-requires-normal-desktop-terminal",
+    issues: [
+      "Native Chromium live verification cannot be completed from Codex Desktop because the inherited macOS app sandbox blocks CEF helper framework loads during in-process NSView bridge tests.",
+      "Run this command from a normal macOS Terminal/Finder session for the production-sandbox gate, or set RESONANTOS_CEF_NO_SANDBOX=1 only for local bridge diagnostics.",
+    ],
+    command: "npm run browser-native:verify-live",
+  }, null, 2));
+  process.exit(2);
+}
+
 const result = spawnSync("node", ["--test", "--test-reporter=tap", ...testFiles], {
   cwd: repoRoot,
   encoding: "utf8",

--- a/src-tauri/src/delegation_service.rs
+++ b/src-tauri/src/delegation_service.rs
@@ -752,6 +752,12 @@ mod tests {
             .expect("HOME should exist")
             .join("Desktop")
             .join(format!("OpenCodeBridgeTest-{}", std::process::id()));
+        fs::create_dir_all(
+            target_root
+                .parent()
+                .expect("target folder should have a parent"),
+        )
+        .expect("target parent should exist");
         let _ = fs::remove_dir_all(&root);
         let _ = fs::remove_dir_all(&target_root);
         create_task_workspace_with_root(

--- a/src-tauri/src/delegation_service.rs
+++ b/src-tauri/src/delegation_service.rs
@@ -355,8 +355,9 @@ pub(crate) fn finish_task_workspace_with_root(
 
 fn home_dir() -> Result<PathBuf, String> {
     std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
         .map(PathBuf::from)
-        .ok_or_else(|| "Unable to resolve HOME for OpenCode task execution.".to_string())
+        .ok_or_else(|| "Unable to resolve user home for OpenCode task execution.".to_string())
 }
 
 fn expand_user_path(value: &str) -> Result<PathBuf, String> {
@@ -410,7 +411,7 @@ fn extract_safe_create_folder_target(mission: &str) -> Result<PathBuf, String> {
         .collect::<Vec<_>>();
     let candidate = tokens
         .iter()
-        .find(|token| token.starts_with("~/") || token.starts_with('/'))
+        .find(|token| token.starts_with("~/") || Path::new(token).is_absolute())
         .ok_or_else(|| {
             "Create-folder task must include an explicit ~/... or absolute path.".to_string()
         })?;
@@ -422,7 +423,7 @@ fn extract_safe_create_folder_target(mission: &str) -> Result<PathBuf, String> {
         .map_err(|error| format!("Failed to resolve create-folder parent: {error}"))?;
     let home = home_dir()?
         .canonicalize()
-        .map_err(|error| format!("Failed to resolve HOME: {error}"))?;
+        .map_err(|error| format!("Failed to resolve user home: {error}"))?;
     if !canonical_parent.starts_with(&home) {
         return Err(
             "OpenCode create-folder bridge only writes inside the user's home directory."
@@ -594,7 +595,7 @@ pub(crate) fn execute_opencode_task_workspace(
 mod tests {
     use super::{
         create_task_workspace_with_root, execute_opencode_task_workspace_with_root,
-        finish_task_workspace_with_root, list_task_workspaces_with_root,
+        finish_task_workspace_with_root, home_dir, list_task_workspaces_with_root,
         read_task_workspace_with_root, CreateTaskWorkspaceRequest, ExecuteOpenCodeTaskRequest,
         FinishTaskWorkspaceRequest, ReadTaskWorkspaceRequest,
     };
@@ -747,9 +748,8 @@ mod tests {
             "resonantos-opencode-task-workspace-test-{}",
             std::process::id()
         ));
-        let target_root = std::env::var_os("HOME")
-            .map(std::path::PathBuf::from)
-            .expect("HOME should exist")
+        let target_root = home_dir()
+            .expect("user home should exist")
             .join("Desktop")
             .join(format!("OpenCodeBridgeTest-{}", std::process::id()));
         fs::create_dir_all(

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2936,7 +2936,7 @@ describe("App boot flow", () => {
 
     expect(screen.getByText("What model are you using?")).toBeTruthy();
     expect(await screen.findByText("This is a live Strategist test reply from MiniMax-M3.")).toBeTruthy();
-  });
+  }, 15_000);
 
   it("swaps the main workspace and chat rail while keeping the app dock fixed", async () => {
     const { container } = render(<App />);


### PR DESCRIPTION
## Summary
- expand alpha CI to audit root and browser-host npm surfaces and run browser host, Electron host, native browser, Living Archive, health, and engineer-runner suites
- pin CEF fetch/build/test paths to the same Chromium 147 archive so upstream stable drift cannot silently break native Browser builds
- make native CEF one-shot smoke modes exit deterministically after final JSON evidence and document strict vs diagnostic native-live verification
- refresh package-lock via npm audit fix; npm audit now reports zero vulnerabilities on root and browser-host surfaces

## Validation
- npm audit --audit-level=high: pass, 0 vulnerabilities
- npm audit --prefix addons/resonant-browser-host --audit-level=high: pass, 0 vulnerabilities
- npm test -- --run: pass, 37 files / 310 tests
- npm run build: pass; existing large chunk warning remains
- npm run test:browser-host: pass, 22 tests
- npm run test:electron-host: pass, 6 tests
- npm run test:browser-native: pass, 11 pass / 3 Codex Desktop bridge skips
- RESONANTOS_CEF_NO_SANDBOX=1 npm run browser-native:verify-live: ready, 0 skips diagnostic
- npm run test:browser-first: pass, 597 tests / 0 skipped
- npm run test:living-archive-memory-service: pass, 7 tests
- npm run test:living-archive-mcp: pass, 4 tests
- npm run test:health: pass, 30 tests
- npm run test:engineer-runner: pass, 8 tests
- node scripts/security-pipeline/run-check.mjs: blocking npm-lockfiles pass; observe subprocess checks skipped due no descriptors
- local-provider smoke against loopback OpenAI-compatible server: pass, including non-private endpoint rejection
- cargo fmt --check && cargo test from src-tauri after cargo clean: pass, 144 passed / 3 ignored
- npm run tauri:build: pass, produced ResonantOS.app and ResonantOS_0.1.0_aarch64.dmg with native browser assets staged
- npm run browser-first:install: pass, installed ~/Applications/ResonantOS Browser.app and registered Launch Services
- npm run browser-first:verify-installed: installed app launch path passed CEF/AppKit/main workspace/bridge/Phantom checks; exits attention only because strict native-live gate requires normal Terminal outside Codex Desktop
- npm run browser-first:verify-desktop: attention, installed-app passed and native-live failed due Codex Desktop sandbox boundary
- RESONANTOS_CEF_NO_SANDBOX=1 npm run browser-first:verify-desktop -- --report=logs/browser-first-desktop-verification-nosandbox.json: ready diagnostic
- RESONANTOS_CEF_NO_SANDBOX=1 npm run browser-first:audit-desktop -- --report=logs/browser-first-desktop-verification-nosandbox.json: ready diagnostic

## Remaining release gate
Strict production-sandbox native-live verification still needs to be run from a normal macOS Terminal/Finder session, not from Codex Desktop. Codex Desktop blocks CEF helper framework loads during in-process NSView bridge tests; the no-sandbox diagnostic proves the bridge path works, but it is not a substitute for the production-sandbox gate.