### PR TITLE
Stabilize Windows browser host click test

### DIFF
--- a/addons/resonant-browser-host/test/browser-host.test.mjs
+++ b/addons/resonant-browser-host/test/browser-host.test.mjs
@@ -87,7 +87,7 @@ after(async () => {
 });
 
 describe("ResonantBrowserHost", () => {
-  it("opens, reads, clicks, types, captures evidence, and closes a Chromium session", { timeout: 60_000 }, async (t) => {
+  it("opens, reads, clicks, types, captures evidence, and closes a Chromium session", { timeout: 90_000 }, async (t) => {
     if (localhostBindDenied) {
       t.skip("localhost bind is denied in this sandbox; browser-host live Chromium behavior must be verified outside sandboxed CI.");
       return;
@@ -108,7 +108,7 @@ describe("ResonantBrowserHost", () => {
     assert.match(read.text, /Resonant Browser Host Fixture/);
     assert.equal(read.links[0].href, `${baseUrl}/next`);
 
-    await host.click({ selector: "#change-status" });
+    await host.click({ selector: "#change-status", timeoutMs: 20_000 });
     const clicked = await host.readPage();
     assert.match(clicked.text, /Clicked/);
 


### PR DESCRIPTION
## Summary
- gives the live Chromium browser-host contract more time for selector click actionability on slow Windows runners
- keeps the change test-scoped; production browser-host click behavior is unchanged

## Validation
- npm run test:browser-host

## Context
- Follow-up to post-merge dev alpha-build failure in Windows Run browser host tests where Playwright found #change-status but timed out waiting for actionability/stability before click.