### PR TITLE
Parse unquoted Agent Control click targets

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/lib/browser-command-parser.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/browser-command-parser.js
@@ -39,6 +39,17 @@ export const parseQuotedTexts = (message) =>
     .map((match) => match[1]?.trim())
     .filter(Boolean);
 
+function cleanUnquotedClickTarget(value) {
+  const text = String(value ?? "")
+    .replace(/\b(?:then|and\s+(?:then\s+)?(?:read|type|write|enter|scroll|open|go|search|find|summari[sz]e|inspect|click|press|tap|select|choose))\b[\s\S]*$/i, "")
+    .replace(/[.,;:!?]+$/g, "")
+    .replace(/^\s*(?:on|the|a|an)\s+/i, "")
+    .replace(/\s+(?:button|link|tab|menu\s+item|menu|screen|page|section)$/i, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return text || "";
+}
+
 export function parseTypeIntent(message) {
   const normalized = String(message ?? "").trim();
   if (/^\//.test(normalized) || !/\b(type|write|enter|put|insert)\b/i.test(normalized)) {
@@ -55,12 +66,22 @@ export function parseTypeIntent(message) {
 
 export function parseClickIntent(message) {
   const normalized = String(message ?? "").trim();
-  if (/^\//.test(normalized) || !/\b(click|press|tap|select|open)\b/i.test(normalized)) {
+  if (/^\//.test(normalized) || !/\b(click|press|tap|select|choose|open)\b/i.test(normalized)) {
     return null;
   }
   const quotedTexts = parseQuotedTexts(normalized);
   const text = quotedTexts[0] ?? "";
   if (!text) {
+    const directClick = /\b(?:click|press|tap|select|choose)\b\s+([\s\S]{1,280})/i.exec(normalized);
+    if (directClick) {
+      const target = cleanUnquotedClickTarget(directClick[1]);
+      return target ? { text: target } : null;
+    }
+    const openPageTarget = /\bopen\b\s+([\s\S]{1,280})/i.exec(normalized);
+    if (openPageTarget && !browserTargetPattern.test(normalized)) {
+      const target = cleanUnquotedClickTarget(openPageTarget[1]);
+      return target ? { text: target } : null;
+    }
     return null;
   }
   return { text };

--- a/browser-first/test/agent-control-planner.test.mjs
+++ b/browser-first/test/agent-control-planner.test.mjs
@@ -27,6 +27,13 @@ test("agent control planner builds deterministic browser plans from user goals",
     { type: "click", text: "Pricing" },
     { type: "type", text: "hello", submit: false }
   ]);
+
+  assert.deepEqual(planControlSteps("open resonantos.com and click About"), [
+    { type: "inspect" },
+    { type: "open", target: "resonantos.com" },
+    { type: "read" },
+    { type: "click", text: "About" }
+  ]);
 });
 
 test("agent control planner deduplicates repeated steps and labels actions", () => {

--- a/browser-first/test/browser-command-parser.test.mjs
+++ b/browser-first/test/browser-command-parser.test.mjs
@@ -38,6 +38,9 @@ test("browser command parser extracts page read, click, type, and scroll intents
   assert.deepEqual(parseReadPageIntent("what can you see here?"), { action: "read_page" });
   assert.deepEqual(parseReadPageIntent("tell me about the current website"), { action: "read_page" });
   assert.deepEqual(parseClickIntent('click "Add to cart"'), { text: "Add to cart" });
+  assert.deepEqual(parseClickIntent("click About"), { text: "About" });
+  assert.deepEqual(parseClickIntent("open the About screen"), { text: "About" });
+  assert.equal(parseClickIntent("open resonantos.com"), null);
   assert.deepEqual(parseTypeIntent('type "pizza stone" into the search bar'), { text: "pizza stone", submit: true });
   assert.deepEqual(parseScrollIntent("scroll to the bottom"), { direction: "bottom" });
 });


### PR DESCRIPTION
## Summary
- fixes `/control open resonantos.com and click About` so the deterministic plan includes a click step
- supports unquoted click/select/choose targets and phrases like `open the About screen`
- preserves plain navigation behavior so `open resonantos.com` does not become a bogus click

## Validation
- `node --test browser-first/test/browser-command-parser.test.mjs browser-first/test/agent-control-planner.test.mjs`
- `npm run test:browser-first`
- `npm test -- --run`
- `npm run build`
