### PR TITLE
Route main workspace control slash commands

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/lib/main-workspace-action-controller.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/main-workspace-action-controller.js
@@ -16,6 +16,7 @@ import {
   parseHermesSlashCommand,
   parseMemorySlashCommand,
   parseOpenCodeSlashCommand,
+  parseControlSlashCommand,
   planMainWorkspacePrompt
 } from "./main-workspace-prompt-router.js";
 
@@ -60,12 +61,14 @@ export function createMainWorkspaceActionController({
   let activeChatAbortController = null;
 
   async function handoffToBrowserControl(prompt) {
-    const amazon = parseAmazonShoppingTask(prompt);
-    const browserIntent = parseNaturalBrowserIntent(prompt);
+    const controlGoal = parseControlSlashCommand(prompt);
+    const goal = controlGoal !== null ? controlGoal : prompt;
+    const amazon = parseAmazonShoppingTask(goal);
+    const browserIntent = parseNaturalBrowserIntent(goal);
     const target = amazon?.url || browserIntent?.target || "";
     await chromeApi.storage.local.set({
       augmentorPendingSidebarPrompt: {
-        prompt: `/control ${prompt}`,
+        prompt: `/control ${goal}`.trim(),
         createdAt: new Date().toISOString()
       }
     });

--- a/browser-first/resonantos-side-panel-extension/src/lib/main-workspace-prompt-router.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/main-workspace-prompt-router.js
@@ -50,6 +50,11 @@ export const parseIntakeSlashCommand = (value) => {
   return { action: "page", body };
 };
 
+export const parseControlSlashCommand = (value) => {
+  const match = /^\/\s*control(?:\s+([\s\S]*))?$/i.exec(String(value ?? "").trim());
+  return match ? (match[1] ?? "").trim() : null;
+};
+
 export const parseWalletSlashCommand = (value) => {
   const match = /^\/\s*wallet(?:\s+([\s\S]*))?$/i.exec(String(value ?? "").trim());
   if (!match) return null;
@@ -73,6 +78,8 @@ export const parseDaoSlashCommand = (value) => {
 export function planMainWorkspacePrompt(value) {
   const prompt = String(value ?? "").trim();
   if (!prompt) return { action: "empty" };
+  const controlGoal = parseControlSlashCommand(prompt);
+  if (controlGoal !== null) return { action: "control", goal: controlGoal };
   const memoryQuery = parseMemorySlashCommand(prompt);
   if (memoryQuery !== null) return { action: "memory", query: memoryQuery };
   const openCodeMission = parseOpenCodeSlashCommand(prompt);

--- a/browser-first/test/main-workspace-action-controller.test.mjs
+++ b/browser-first/test/main-workspace-action-controller.test.mjs
@@ -136,6 +136,23 @@ test("main workspace action controller routes browser work into sidebar control 
   assert.equal(harness.events.some((event) => event[0] === "open-sidebar"), false);
 });
 
+test("main workspace action controller routes explicit control slash commands into sidebar control mode", async () => {
+  const harness = createHarness({ prompt: "/control go to disney.com" });
+
+  await harness.controller.handleSubmit({ preventDefault() {} });
+
+  assert.ok(harness.events.some((event) =>
+    event[0] === "storage-set" &&
+    event[1].augmentorPendingSidebarPrompt.prompt === "/control go to disney.com"
+  ));
+  assert.ok(harness.events.some((event) =>
+    event[0] === "runtime-message" &&
+    event[1].type === "browser_control_handoff" &&
+    event[1].targetUrl === "https://disney.com/"
+  ));
+  assert.equal(harness.events.some((event) => event[0] === "bridge" && event[1] === "/augmentor/chat"), false);
+});
+
 test("main workspace action controller falls back when atomic browser handoff is unavailable", async () => {
   const harness = createHarness({
     prompt: "go to https://resonantos.com and summarize it",

--- a/browser-first/test/main-workspace-prompt-router.test.mjs
+++ b/browser-first/test/main-workspace-prompt-router.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   parseDaoSlashCommand,
+  parseControlSlashCommand,
   parseDraftSlashCommand,
   parseHermesSlashCommand,
   parseIntakeSlashCommand,
@@ -14,6 +15,8 @@ import {
 
 test("main workspace prompt router parses explicit workspace slash commands", () => {
   assert.equal(parseMemorySlashCommand("/memory augmentatism"), "augmentatism");
+  assert.equal(parseControlSlashCommand("/control go to disney.com"), "go to disney.com");
+  assert.equal(parseControlSlashCommand("/control"), "");
   assert.equal(parseMemorySlashCommand("/archive"), "");
   assert.equal(parseHermesSlashCommand("/hermes coordinate research"), "coordinate research");
   assert.equal(parseOpenCodeSlashCommand("/open code inspect tests"), "inspect tests");
@@ -123,6 +126,10 @@ test("main workspace prompt router preserves explicit command priority", () => {
   assert.equal(planMainWorkspacePrompt("/wallet status").action, "wallet");
   assert.equal(planMainWorkspacePrompt("/dao review proposal").action, "dao");
   assert.equal(planMainWorkspacePrompt("/calendar Planning | body: Tuesday 10").action, "draft");
+  assert.deepEqual(planMainWorkspacePrompt("/control go to disney.com"), {
+    action: "control",
+    goal: "go to disney.com"
+  });
 });
 
 test("main workspace prompt router separates browser control from normal chat", () => {


### PR DESCRIPTION
## Summary
- Route explicit /control slash commands from the main Augmentor composer into Agent Control instead of provider chat.
- Preserve the exact sidebar prompt as /control <goal> without duplicating the command prefix.
- Add regression coverage proving /control go to disney.com targets https://disney.com/ and does not call /augmentor/chat.

## Validation
- node --test browser-first/test/main-workspace-prompt-router.test.mjs browser-first/test/main-workspace-action-controller.test.mjs
- npm run test:browser-first
- npm test -- --run
- npm run build
- git diff --check