### PR TITLE
Complete main workspace self inspection locally

### DIFF
--- a/browser-first/host/browser-diagnostics-host-service.mjs
+++ b/browser-first/host/browser-diagnostics-host-service.mjs
@@ -84,6 +84,7 @@ export function createBrowserDiagnosticsHostService({
     executeSystemStatus,
     browserDiagnosticsRoutes: [
       { method: "GET", path: "/status", handler: executeSystemStatus },
+      { method: "GET", path: "/workspace/inspect", handler: service.executeWorkspaceInspection },
       { method: "GET", path: "/browser/downloads", handler: service.executeBrowserDownloads },
       { method: "GET", path: "/browser/launch-diagnostics", handler: service.executeBrowserLaunchDiagnostics },
       {

--- a/browser-first/host/browser-diagnostics-service.mjs
+++ b/browser-first/host/browser-diagnostics-service.mjs
@@ -134,6 +134,176 @@ export function createBrowserDiagnosticsService({
     }
   }
 
+  async function readJsonFile(filePath) {
+    try {
+      return JSON.parse(await readFile(filePath, "utf8"));
+    } catch {
+      return null;
+    }
+  }
+
+  async function readTextFile(filePath) {
+    try {
+      return await readFile(filePath, "utf8");
+    } catch {
+      return "";
+    }
+  }
+
+  function uniqueEntries(entries) {
+    const byId = new Map();
+    for (const entry of entries.filter(Boolean)) {
+      const id = String(entry.id ?? entry.label ?? entry.name ?? "").toLowerCase();
+      if (!id || byId.has(id)) continue;
+      byId.set(id, entry);
+    }
+    return [...byId.values()];
+  }
+
+  function packageDependencies(pkg) {
+    return new Set([
+      ...Object.keys(pkg?.dependencies ?? {}),
+      ...Object.keys(pkg?.devDependencies ?? {}),
+      ...Object.keys(pkg?.peerDependencies ?? {}),
+      ...Object.keys(pkg?.optionalDependencies ?? {}),
+    ]);
+  }
+
+  async function collectWorkspaceFiles(root, limit = 20_000) {
+    const skipDirs = new Set([
+      ".git",
+      ".next",
+      ".turbo",
+      ".vite",
+      ".cache",
+      "build",
+      "coverage",
+      "dist",
+      "node_modules",
+      "target",
+    ]);
+    const files = [];
+    async function walk(dir) {
+      if (files.length >= limit) return;
+      const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+      for (const entry of entries) {
+        if (files.length >= limit || entry.name.startsWith(".")) continue;
+        const filePath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (!skipDirs.has(entry.name)) await walk(filePath);
+          continue;
+        }
+        if (entry.isFile()) files.push(filePath);
+      }
+    }
+    await walk(root);
+    return files;
+  }
+
+  function languageInventory(files) {
+    const labels = new Map([
+      [".css", "CSS"],
+      [".html", "HTML"],
+      [".js", "JavaScript"],
+      [".jsx", "JavaScript/React"],
+      [".mjs", "JavaScript"],
+      [".cjs", "JavaScript"],
+      [".json", "JSON"],
+      [".md", "Markdown"],
+      [".py", "Python"],
+      [".rs", "Rust"],
+      [".sh", "Shell"],
+      [".toml", "TOML"],
+      [".ts", "TypeScript"],
+      [".tsx", "TypeScript/React"],
+      [".yaml", "YAML"],
+      [".yml", "YAML"],
+    ]);
+    const counts = new Map();
+    for (const filePath of files) {
+      const label = labels.get(path.extname(filePath).toLowerCase());
+      if (!label) continue;
+      counts.set(label, (counts.get(label) ?? 0) + 1);
+    }
+    return [...counts.entries()]
+      .map(([label, count]) => ({ label, count }))
+      .sort((left, right) => right.count - left.count || left.label.localeCompare(right.label));
+  }
+
+  function detectFrameworks({ dependencies, cargoToml, extensionManifest }) {
+    return uniqueEntries([
+      dependencies.has("react") ? { id: "react", label: "React", detail: "react dependency" } : null,
+      dependencies.has("vite") ? { id: "vite", label: "Vite", detail: "vite dependency" } : null,
+      dependencies.has("vitest") ? { id: "vitest", label: "Vitest", detail: "vitest dependency" } : null,
+      dependencies.has("@testing-library/react") ? { id: "testing-library", label: "Testing Library", detail: "@testing-library/react dependency" } : null,
+      dependencies.has("lucide-react") ? { id: "lucide-react", label: "Lucide React", detail: "lucide-react dependency" } : null,
+      /\btauri\b/i.test(cargoToml) ? { id: "tauri", label: "Tauri", detail: "src-tauri Cargo metadata" } : null,
+      extensionManifest?.manifest_version === 3 ? { id: "chrome-mv3", label: "Chrome Extension MV3", detail: "extension manifest" } : null,
+    ]);
+  }
+
+  function detectRuntimes({ dependencies, cargoToml, extensionManifest }) {
+    return uniqueEntries([
+      { id: "node", label: "Node.js", detail: "npm scripts and browser-first host services" },
+      dependencies.has("typescript") ? { id: "typescript", label: "TypeScript compiler", detail: "typescript dependency" } : null,
+      dependencies.has("vite") ? { id: "vite-dev-server", label: "Vite dev/build runtime", detail: "vite dependency" } : null,
+      /\btauri\b/i.test(cargoToml) ? { id: "tauri-runtime", label: "Tauri native host", detail: "Rust desktop shell" } : null,
+      cargoToml ? { id: "rust", label: "Rust/Cargo", detail: "Cargo.toml metadata" } : null,
+      extensionManifest?.manifest_version === 3 ? { id: "chromium", label: "Chromium extension runtime", detail: "Manifest V3 side panel" } : null,
+    ]);
+  }
+
+  function detectPackageManagers(pkg) {
+    return uniqueEntries([
+      existsSync(path.join(repoRoot, "package-lock.json")) || /^npm@/i.test(String(pkg?.packageManager ?? ""))
+        ? { id: "npm", label: "npm", detail: "package-lock.json/package.json" }
+        : null,
+      existsSync(path.join(repoRoot, "pnpm-lock.yaml")) || /^pnpm@/i.test(String(pkg?.packageManager ?? ""))
+        ? { id: "pnpm", label: "pnpm", detail: "pnpm lock/packageManager field" }
+        : null,
+      existsSync(path.join(repoRoot, "yarn.lock")) || /^yarn@/i.test(String(pkg?.packageManager ?? ""))
+        ? { id: "yarn", label: "Yarn", detail: "yarn.lock/packageManager field" }
+        : null,
+      existsSync(path.join(repoRoot, "Cargo.toml")) || existsSync(path.join(repoRoot, "src-tauri", "Cargo.toml"))
+        ? { id: "cargo", label: "Cargo", detail: "Rust/Tauri metadata" }
+        : null,
+    ]);
+  }
+
+  async function executeWorkspaceInspection() {
+    const [pkg, extensionManifest, cargoToml, rootCargoToml, files] = await Promise.all([
+      readJsonFile(path.join(repoRoot, "package.json")),
+      readJsonFile(path.join(resonantExtension, "manifest.json")),
+      readTextFile(path.join(repoRoot, "src-tauri", "Cargo.toml")),
+      readTextFile(path.join(repoRoot, "Cargo.toml")),
+      collectWorkspaceFiles(repoRoot),
+    ]);
+    const dependencies = packageDependencies(pkg);
+    const combinedCargoToml = [cargoToml, rootCargoToml].filter(Boolean).join("\n");
+    const evidence = [
+      existsSync(path.join(repoRoot, "package.json")) ? { label: "package.json", detail: "project scripts and npm dependencies" } : null,
+      existsSync(path.join(repoRoot, "package-lock.json")) ? { label: "package-lock.json", detail: "npm lockfile" } : null,
+      cargoToml ? { label: "src-tauri/Cargo.toml", detail: "Tauri/Rust host metadata" } : null,
+      extensionManifest ? { label: "browser-first extension manifest", detail: `Manifest V${extensionManifest.manifest_version ?? "?"}` } : null,
+      { label: "source file scan", detail: `${files.length} file(s) sampled outside build/vendor directories` },
+    ];
+    return {
+      generatedAt: new Date().toISOString(),
+      project: {
+        name: String(pkg?.name ?? "resonantos-workspace"),
+        version: String(pkg?.version ?? ""),
+        packageManager: String(pkg?.packageManager ?? ""),
+        root: redactPathForDiagnostics(repoRoot),
+      },
+      languages: languageInventory(files),
+      frameworks: detectFrameworks({ dependencies, cargoToml: combinedCargoToml, extensionManifest }),
+      runtimes: detectRuntimes({ dependencies, cargoToml: combinedCargoToml, extensionManifest }),
+      packageManagers: detectPackageManagers(pkg),
+      evidence: evidence.filter(Boolean),
+      boundary: "Read-only metadata inspection. Provider credentials, bridge tokens, wallet secrets, private keys, and full home paths are excluded or redacted.",
+    };
+  }
+
   async function executeBrowserLaunchDiagnostics() {
     const logPath = browserLaunchLogPath();
     let logContent = "";
@@ -316,5 +486,6 @@ export function createBrowserDiagnosticsService({
     executeBrowserDownloads,
     executeBrowserLaunchDiagnostics,
     executeDiagnosticsReport,
+    executeWorkspaceInspection,
   };
 }

--- a/browser-first/resonantos-side-panel-extension/src/lib/main-workspace-action-controller.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/main-workspace-action-controller.js
@@ -27,6 +27,28 @@ const providerMessagesFromHistory = (messages, limit = 18) => messages
   .slice(-limit)
   .map((message) => ({ role: message.role, content: message.content }));
 
+const formatList = (items, fallback = "None detected") => {
+  const values = Array.isArray(items) ? items.map((item) => {
+    if (typeof item === "string") return item;
+    const label = String(item?.label ?? item?.name ?? item?.id ?? "").trim();
+    const detail = String(item?.detail ?? item?.reason ?? "").trim();
+    const count = Number.isFinite(Number(item?.count)) ? ` (${Number(item.count)})` : "";
+    return [label ? `${label}${count}` : "", detail].filter(Boolean).join(" - ");
+  }).filter(Boolean) : [];
+  return values.length ? values.join(", ") : fallback;
+};
+
+const formatWorkspaceInspectionMessage = (report) => [
+  "Workspace inspection completed.",
+  `Project: ${[report?.project?.name, report?.project?.version].filter(Boolean).join(" ") || "ResonantOS workspace"}`,
+  `Languages: ${formatList(report?.languages)}`,
+  `Frameworks: ${formatList(report?.frameworks)}`,
+  `Runtimes: ${formatList(report?.runtimes)}`,
+  `Package managers: ${formatList(report?.packageManagers)}`,
+  `Evidence: ${formatList(report?.evidence, "Metadata scan completed")}`,
+  "Boundary: read-only workspace metadata scan. No OpenCode/Hermes delegation, shell execution, provider secrets, wallet actions, or trusted memory writes were used."
+].join("\n");
+
 export function createMainWorkspaceActionController({
   addMessage,
   bridgeRequest,
@@ -185,6 +207,13 @@ export function createMainWorkspaceActionController({
     updateConnectionLine("Ready");
   }
 
+  async function runWorkspaceInspectionCommand() {
+    updateConnectionLine("Inspecting workspace");
+    const result = await bridge()("/workspace/inspect", { method: "GET" });
+    await addMessage("system", formatWorkspaceInspectionMessage(result));
+    updateConnectionLine("Ready");
+  }
+
   async function runMemoryCommand(prompt) {
     const query = parseMemorySlashCommand(prompt);
     setActiveWorkspace("memory", { persist: true });
@@ -282,6 +311,8 @@ export function createMainWorkspaceActionController({
       await runNaturalDelegation(promptPlan.intent);
     } else if (promptPlan.action === "delegations") {
       await runDelegationsCommand(promptPlan.filter);
+    } else if (promptPlan.action === "workspace-inspection") {
+      await runWorkspaceInspectionCommand();
     } else if (promptPlan.action === "wallet") {
       const command = promptPlan.command;
       if (command?.action === "audit") {

--- a/browser-first/resonantos-side-panel-extension/src/lib/main-workspace-prompt-router.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/main-workspace-prompt-router.js
@@ -55,6 +55,22 @@ export const parseControlSlashCommand = (value) => {
   return match ? (match[1] ?? "").trim() : null;
 };
 
+export const parseWorkspaceInspectionIntent = (value) => {
+  const prompt = String(value ?? "").trim();
+  if (!prompt) return null;
+  const controlGoal = parseControlSlashCommand(prompt);
+  const text = (controlGoal !== null ? controlGoal : prompt).trim();
+  if (!text) return null;
+  const asksForInspection = /\b(inspect|scan|summari[sz]e|inventory|diagnos|audit|list|what(?:'s| is| are)?|which)\b/i.test(text) ||
+    /\b(technology\s+stack|tech\s+stack|languages?|frameworks?|runtimes?|package\s+managers?|dependencies)\b/i.test(text);
+  const targetsWorkspace = /\b(this|current|local|resonantos|code)\s+(workspace|repo|repository|codebase|project)\b/i.test(text) ||
+    /\b(self[-\s]?inspection|technology\s+stack|tech\s+stack)\b/i.test(text) ||
+    /\b(your|its)\s+(languages?|frameworks?|runtimes?|package\s+managers?|dependencies)\b/i.test(text);
+  return asksForInspection && targetsWorkspace
+    ? { query: text, source: controlGoal !== null ? "control-slash" : "main-workspace" }
+    : null;
+};
+
 export const parseWalletSlashCommand = (value) => {
   const match = /^\/\s*wallet(?:\s+([\s\S]*))?$/i.exec(String(value ?? "").trim());
   if (!match) return null;
@@ -78,6 +94,8 @@ export const parseDaoSlashCommand = (value) => {
 export function planMainWorkspacePrompt(value) {
   const prompt = String(value ?? "").trim();
   if (!prompt) return { action: "empty" };
+  const workspaceInspection = parseWorkspaceInspectionIntent(prompt);
+  if (workspaceInspection) return { action: "workspace-inspection", intent: workspaceInspection };
   const controlGoal = parseControlSlashCommand(prompt);
   if (controlGoal !== null) return { action: "control", goal: controlGoal };
   const memoryQuery = parseMemorySlashCommand(prompt);

--- a/browser-first/test/browser-diagnostics-host-service.test.mjs
+++ b/browser-first/test/browser-diagnostics-host-service.test.mjs
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 import { createBrowserDiagnosticsHostService } from "../host/browser-diagnostics-host-service.mjs";
 
@@ -27,6 +30,7 @@ test("browser diagnostics host service owns status, diagnostics, and download ro
   const routes = new Map(service.browserDiagnosticsRoutes.map((route) => [`${route.method} ${route.path}`, route]));
 
   assert.equal(typeof routes.get("GET /status")?.handler, "function");
+  assert.equal(typeof routes.get("GET /workspace/inspect")?.handler, "function");
   assert.equal(typeof routes.get("GET /browser/downloads")?.handler, "function");
   assert.equal(typeof routes.get("GET /browser/launch-diagnostics")?.handler, "function");
   assert.equal(typeof routes.get("POST /browser/downloads/action")?.handler, "function");
@@ -48,6 +52,53 @@ test("browser diagnostics host service aggregates system status without exposing
   assert.deepEqual(status.memory, { exists: true });
   assert.deepEqual(status.addons, [{ id: "living-archive" }]);
   assert.deepEqual(status.records, { goals: 2, delegations: 3 });
+});
+
+test("browser diagnostics host service inspects workspace stack metadata without delegated execution", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "resonantos-workspace-inspect-"));
+  const repoRoot = path.join(root, "repo");
+  const extensionRoot = path.join(repoRoot, "browser-first", "resonantos-side-panel-extension");
+  try {
+    await mkdir(path.join(repoRoot, "src-tauri"), { recursive: true });
+    await mkdir(path.join(repoRoot, "src"), { recursive: true });
+    await mkdir(extensionRoot, { recursive: true });
+    await writeFile(path.join(repoRoot, "package.json"), JSON.stringify({
+      name: "stack-test",
+      version: "2.0.0-alpha",
+      packageManager: "npm@10.0.0",
+      dependencies: { "@tauri-apps/api": "^2.0.0", react: "^19.0.0", vite: "^6.0.0" },
+      devDependencies: { typescript: "^5.0.0", vitest: "^4.0.0" }
+    }, null, 2));
+    await writeFile(path.join(repoRoot, "package-lock.json"), "{}\n");
+    await writeFile(path.join(repoRoot, "src", "App.tsx"), "export const App = () => null;\n");
+    await writeFile(path.join(repoRoot, "src", "main.ts"), "import './App';\n");
+    await writeFile(path.join(repoRoot, "src-tauri", "Cargo.toml"), "[package]\nname = \"stack-test\"\n[dependencies]\ntauri = \"2\"\n");
+    await writeFile(path.join(repoRoot, "src-tauri", "main.rs"), "fn main() {}\n");
+    await writeFile(path.join(extensionRoot, "manifest.json"), JSON.stringify({ manifest_version: 3, version: "0.1.0" }));
+
+    const service = createService({
+      repoRoot,
+      resonantExtension: extensionRoot,
+      redactPathForDiagnostics: (value) => String(value ?? "").replace(root, "~")
+    });
+    const report = await service.executeWorkspaceInspection();
+
+    assert.equal(report.project.name, "stack-test");
+    assert.ok(report.languages.some((entry) => entry.label === "TypeScript/React"));
+    assert.ok(report.languages.some((entry) => entry.label === "Rust"));
+    assert.ok(report.frameworks.some((entry) => entry.label === "React"));
+    assert.ok(report.frameworks.some((entry) => entry.label === "Vite"));
+    assert.ok(report.frameworks.some((entry) => entry.label === "Tauri"));
+    assert.ok(report.frameworks.some((entry) => entry.label === "Chrome Extension MV3"));
+    assert.ok(report.runtimes.some((entry) => entry.label === "Node.js"));
+    assert.ok(report.runtimes.some((entry) => entry.label === "Chromium extension runtime"));
+    assert.ok(report.packageManagers.some((entry) => entry.label === "npm"));
+    assert.ok(report.packageManagers.some((entry) => entry.label === "Cargo"));
+    assert.match(report.project.root, /^~\/repo$/);
+    assert.match(report.boundary, /Read-only metadata inspection/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });
 
 test("browser diagnostics host service fails fast when a dependency is missing", () => {

--- a/browser-first/test/browser-diagnostics-host-service.test.mjs
+++ b/browser-first/test/browser-diagnostics-host-service.test.mjs
@@ -94,7 +94,7 @@ test("browser diagnostics host service inspects workspace stack metadata without
     assert.ok(report.runtimes.some((entry) => entry.label === "Chromium extension runtime"));
     assert.ok(report.packageManagers.some((entry) => entry.label === "npm"));
     assert.ok(report.packageManagers.some((entry) => entry.label === "Cargo"));
-    assert.match(report.project.root, /^~\/repo$/);
+    assert.match(report.project.root.replace(/\\/g, "/"), /^~\/repo$/);
     assert.match(report.boundary, /Read-only metadata inspection/);
   } finally {
     await rm(root, { recursive: true, force: true });

--- a/browser-first/test/browser-first-contract.test.mjs
+++ b/browser-first/test/browser-first-contract.test.mjs
@@ -488,6 +488,8 @@ test("browser-first main workspace owns new-tab AI chat and hands browser tasks 
   assert.match(browserDiagnosticsHostService, /diagnostics-report-export/);
   assert.match(browserDiagnosticsHostService, /createBrowserDiagnosticsService/);
   assert.match(browserDiagnosticsService, /executeDiagnosticsReport/);
+  assert.match(browserDiagnosticsHostService, /\/workspace\/inspect/);
+  assert.match(browserDiagnosticsService, /executeWorkspaceInspection/);
   assert.match(browserDiagnosticsService, /browser-launch-diagnostics\.mjs/);
   assert.match(browserDiagnosticsHostService, /\/browser\/launch-diagnostics/);
   assert.match(browserDiagnosticsService, /executeBrowserLaunchDiagnostics/);

--- a/browser-first/test/main-workspace-action-controller.test.mjs
+++ b/browser-first/test/main-workspace-action-controller.test.mjs
@@ -47,6 +47,16 @@ function createHarness(overrides = {}) {
       if (route === "/augmentor/chat") {
         return { content: "assistant reply", usage: { tokens: 4 } };
       }
+      if (route === "/workspace/inspect") {
+        return {
+          project: { name: "resonantos-vnext", version: "0.1.0" },
+          languages: [{ label: "TypeScript", count: 12 }, { label: "Rust", count: 3 }],
+          frameworks: [{ label: "React", detail: "react dependency" }, { label: "Tauri", detail: "src-tauri Cargo metadata" }],
+          runtimes: [{ label: "Node.js", detail: "npm scripts" }, { label: "Chromium extension runtime", detail: "Manifest V3 side panel" }],
+          packageManagers: [{ label: "npm", detail: "package-lock.json" }, { label: "Cargo", detail: "Rust/Tauri metadata" }],
+          evidence: [{ label: "package.json", detail: "project scripts" }]
+        };
+      }
       if (route === "/addons/delegate") {
         return { id: "task-1", path: "Tasks/task-1.md", target: request.body.target };
       }
@@ -151,6 +161,26 @@ test("main workspace action controller routes explicit control slash commands in
     event[1].targetUrl === "https://disney.com/"
   ));
   assert.equal(harness.events.some((event) => event[0] === "bridge" && event[1] === "/augmentor/chat"), false);
+});
+
+test("main workspace action controller completes workspace self-inspection without delegation", async () => {
+  const harness = createHarness({
+    prompt: "/control inspect this workspace and summarize the languages, frameworks, runtimes, and package managers used"
+  });
+
+  await harness.controller.handleSubmit({ preventDefault() {} });
+
+  assert.ok(harness.events.some((event) => event[0] === "bridge" && event[1] === "/workspace/inspect"));
+  assert.equal(harness.events.some((event) => event[0] === "bridge" && event[1] === "/augmentor/chat"), false);
+  assert.equal(harness.events.some((event) => event[0] === "bridge" && event[1] === "/addons/delegate"), false);
+  assert.equal(harness.events.some((event) => event[0] === "runtime-message"), false);
+  const message = harness.events.find((event) => event[0] === "message" && event[1] === "system" && /Workspace inspection completed/.test(event[2]));
+  assert.ok(message);
+  assert.match(message[2], /TypeScript/);
+  assert.match(message[2], /React/);
+  assert.match(message[2], /Tauri/);
+  assert.match(message[2], /npm/);
+  assert.match(message[2], /No OpenCode\/Hermes delegation/);
 });
 
 test("main workspace action controller falls back when atomic browser handoff is unavailable", async () => {

--- a/browser-first/test/main-workspace-prompt-router.test.mjs
+++ b/browser-first/test/main-workspace-prompt-router.test.mjs
@@ -9,6 +9,7 @@ import {
   parseIntakeSlashCommand,
   parseMemorySlashCommand,
   parseOpenCodeSlashCommand,
+  parseWorkspaceInspectionIntent,
   parseWalletSlashCommand,
   planMainWorkspacePrompt
 } from "../resonantos-side-panel-extension/src/lib/main-workspace-prompt-router.js";
@@ -17,6 +18,10 @@ test("main workspace prompt router parses explicit workspace slash commands", ()
   assert.equal(parseMemorySlashCommand("/memory augmentatism"), "augmentatism");
   assert.equal(parseControlSlashCommand("/control go to disney.com"), "go to disney.com");
   assert.equal(parseControlSlashCommand("/control"), "");
+  assert.deepEqual(parseWorkspaceInspectionIntent("/control inspect this workspace and summarize languages"), {
+    query: "inspect this workspace and summarize languages",
+    source: "control-slash"
+  });
   assert.equal(parseMemorySlashCommand("/archive"), "");
   assert.equal(parseHermesSlashCommand("/hermes coordinate research"), "coordinate research");
   assert.equal(parseOpenCodeSlashCommand("/open code inspect tests"), "inspect tests");
@@ -130,6 +135,13 @@ test("main workspace prompt router preserves explicit command priority", () => {
     action: "control",
     goal: "go to disney.com"
   });
+  assert.deepEqual(planMainWorkspacePrompt("/control inspect this workspace and summarize the languages, frameworks, runtimes, and package managers used"), {
+    action: "workspace-inspection",
+    intent: {
+      query: "inspect this workspace and summarize the languages, frameworks, runtimes, and package managers used",
+      source: "control-slash"
+    }
+  });
 });
 
 test("main workspace prompt router separates browser control from normal chat", () => {
@@ -137,6 +149,8 @@ test("main workspace prompt router separates browser control from normal chat", 
   assert.equal(planMainWorkspacePrompt("can you navigate to manoloremiddi.com?").action, "control");
   assert.equal(planMainWorkspacePrompt("find latest AI news on the internet").action, "control");
   assert.equal(planMainWorkspacePrompt("hey what's the most inportant new in the world today?").action, "control");
+  assert.equal(planMainWorkspacePrompt("what is your technology stack?").action, "workspace-inspection");
+  assert.equal(planMainWorkspacePrompt("inspect this workspace and summarize the package managers").action, "workspace-inspection");
   assert.equal(planMainWorkspacePrompt("explain the strategy without delegating").action, "chat");
   assert.equal(planMainWorkspacePrompt("").action, "empty");
 });


### PR DESCRIPTION
## Summary
- Route workspace/self-inspection prompts before browser control, provider chat, or OpenCode delegation.
- Add a read-only /workspace/inspect host route that summarizes languages, frameworks, runtimes, package managers, and evidence from repo metadata.
- Add regressions for the exact failing command: /control inspect this workspace and summarize the languages, frameworks, runtimes, and package managers used.

## Failure Mode Fixed
The main Augmentor was creating an OpenCode packet for workspace self-inspection, then reporting a blocked runtime when OpenCode CLI was unavailable. Self-inspection should complete from host metadata without requiring OpenCode/Hermes or local shell execution.

## Validation
- node --test browser-first/test/main-workspace-prompt-router.test.mjs browser-first/test/main-workspace-action-controller.test.mjs browser-first/test/browser-diagnostics-host-service.test.mjs browser-first/test/browser-first-contract.test.mjs
- npm run test:browser-first
- npm test -- --run
- npm run build
- git diff --check