### PR TITLE
Clarify OpenCode install path

### DIFF
--- a/browser-first/host/addon-delegation-service.mjs
+++ b/browser-first/host/addon-delegation-service.mjs
@@ -57,6 +57,7 @@ export function createAddonDelegationService(dependencies) {
     listFilesRecursive,
     memoryRoot,
     opencodeCommand,
+    opencodeRuntimeDiagnostics,
     redactPathForDiagnostics,
     repoRoot,
     safeFileSlug,
@@ -64,6 +65,29 @@ export function createAddonDelegationService(dependencies) {
     uniqueRuntimeId,
     userRoot,
   } = dependencies;
+
+  function currentOpenCodeRuntime() {
+    if (typeof opencodeRuntimeDiagnostics === "function") {
+      return opencodeRuntimeDiagnostics();
+    }
+    const command = opencodeCommand();
+    return {
+      installed: Boolean(command),
+      command,
+      commandRedacted: command ? redactPathForDiagnostics(command) : "",
+      installHint: "Install OpenCode with `curl -fsSL https://opencode.ai/install | bash` or `npm install -g opencode-ai`. If it is already installed outside PATH, set `OPENCODE_COMMAND=/absolute/path/to/opencode` and restart ResonantOS.",
+      installCommand: "curl -fsSL https://opencode.ai/install | bash",
+      alternativeInstallCommands: ["npm install -g opencode-ai", "brew install anomalyco/tap/opencode"],
+      configureCommand: "OPENCODE_COMMAND=/absolute/path/to/opencode",
+      searchedCommands: ["opencode", "opencode-ai"],
+      searchedPaths: [],
+      searchedPathCount: 0,
+      searchedPathOmitted: 0,
+      overrideConfigured: false,
+      overridePath: "",
+      overrideFound: false,
+    };
+  }
 
   // Reverse-proxy URL the extension can embed in an iframe without tripping
   // Chrome's mixed-content blocker. The proxy lives at the bridge origin
@@ -669,7 +693,8 @@ export function createAddonDelegationService(dependencies) {
 
   async function executeOpenCodeStatus(payload = {}) {
     const executionSettings = await readAddonExecutionSettings();
-    const command = opencodeCommand();
+    const runtime = currentOpenCodeRuntime();
+    const command = runtime.command;
     const taskRoot = path.join(delegationRoot(), "opencode");
     const tasks = await listFilesRecursive(taskRoot, (filePath) => filePath.endsWith(".md"), 200);
     const statusCounts = {};
@@ -680,13 +705,24 @@ export function createAddonDelegationService(dependencies) {
     }
     return {
       installed: Boolean(command),
-      command: command ? redactPathForDiagnostics(command) : "",
+      command: runtime.commandRedacted || (command ? redactPathForDiagnostics(command) : ""),
       mode: command && addonLocalCliExecutionEnabled("opencode", payload, executionSettings) ? "local-opencode-cli" : command ? "local-opencode-cli-disabled" : "packet-only",
       executionEnabled: addonLocalCliExecutionEnabled("opencode", payload, executionSettings),
       workspaceLaunch: "not-enabled-in-browser-first-v1",
       detail: command
         ? "OpenCode runtime was detected. ResonantOS can create governed coding packets and start execution only when explicit OpenCode execution is enabled."
-        : "OpenCode runtime was not detected. Install or configure OpenCode before enabling local coding execution.",
+        : "OpenCode runtime was not detected. Install OpenCode, or point ResonantOS at an existing binary with OPENCODE_COMMAND.",
+      installHint: runtime.installHint,
+      installCommand: runtime.installCommand,
+      alternativeInstallCommands: runtime.alternativeInstallCommands,
+      configureCommand: runtime.configureCommand,
+      searchedCommands: runtime.searchedCommands,
+      searchedPaths: runtime.searchedPaths,
+      searchedPathCount: runtime.searchedPathCount,
+      searchedPathOmitted: runtime.searchedPathOmitted,
+      overrideConfigured: runtime.overrideConfigured,
+      overridePath: runtime.overridePath,
+      overrideFound: runtime.overrideFound,
       taskCounts: statusCounts,
       delegationPackets: tasks.length,
       requiredGrants: ["filesystem", "shell", "providers", "ui-embedding"],
@@ -830,7 +866,8 @@ export function createAddonDelegationService(dependencies) {
       throw new Error(`OpenCode delegation is already ${currentStatus}.`);
     }
     const adapter = String(payload.adapter ?? process.env.RESONANTOS_OPENCODE_ADAPTER ?? "auto").trim().toLowerCase();
-    const command = opencodeCommand();
+    const runtime = currentOpenCodeRuntime();
+    const command = runtime.command;
     const executionSettings = await readAddonExecutionSettings();
     await writeDelegationStatus(taskPath, "running", {
       startedAt: new Date().toISOString(),
@@ -844,7 +881,18 @@ export function createAddonDelegationService(dependencies) {
       });
       return {
         ...delegationSummaryFromMarkdown(taskPath, updated, await stat(taskPath)),
-        blockedReason: "OpenCode CLI unavailable. Install or configure OpenCode, or run the deterministic adapter in tests.",
+        blockedReason: "OpenCode CLI unavailable.",
+        installHint: runtime.installHint,
+        installCommand: runtime.installCommand,
+        alternativeInstallCommands: runtime.alternativeInstallCommands,
+        configureCommand: runtime.configureCommand,
+        searchedCommands: runtime.searchedCommands,
+        searchedPaths: runtime.searchedPaths,
+        searchedPathCount: runtime.searchedPathCount,
+        searchedPathOmitted: runtime.searchedPathOmitted,
+        overrideConfigured: runtime.overrideConfigured,
+        overridePath: runtime.overridePath,
+        overrideFound: runtime.overrideFound,
         status: "blocked",
       };
     }

--- a/browser-first/host/opencode-runtime.mjs
+++ b/browser-first/host/opencode-runtime.mjs
@@ -1,0 +1,126 @@
+import { existsSync, statSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+import { redactPathForDiagnostics } from "./browser-first-host-utils.mjs";
+
+export const OPENCODE_INSTALL_COMMAND = "curl -fsSL https://opencode.ai/install | bash";
+export const OPENCODE_NPM_INSTALL_COMMAND = "npm install -g opencode-ai";
+export const OPENCODE_BREW_INSTALL_COMMAND = "brew install anomalyco/tap/opencode";
+export const OPENCODE_CONFIGURE_COMMAND = "OPENCODE_COMMAND=/absolute/path/to/opencode";
+export const OPENCODE_COMMAND_NAMES = ["opencode", "opencode-ai"];
+
+function unique(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function expandUserPath(value) {
+  const raw = String(value ?? "").trim();
+  if (!raw) return "";
+  if (raw === "~") return os.homedir();
+  if (raw.startsWith("~/")) return path.join(os.homedir(), raw.slice(2));
+  return path.resolve(raw);
+}
+
+function executableNames(commandName) {
+  return process.platform === "win32"
+    ? [`${commandName}.cmd`, `${commandName}.exe`, `${commandName}.bat`, commandName]
+    : [commandName];
+}
+
+function executableCandidatesFromPath(commandName, env = process.env) {
+  return String(env.PATH ?? "")
+    .split(path.delimiter)
+    .filter(Boolean)
+    .flatMap((entry) => executableNames(commandName).map((name) => path.join(entry, name)));
+}
+
+function commonOpenCodeBaseDirs(env = process.env) {
+  const home = os.homedir();
+  const dirs = [
+    path.join(home, ".local", "bin"),
+    path.join(home, ".npm-global", "bin"),
+    path.join(home, "node_modules", ".bin"),
+    path.join(home, ".bun", "bin"),
+    path.join(home, ".yarn", "bin"),
+    path.join(home, ".config", "yarn", "global", "node_modules", ".bin"),
+    path.join(home, ".local", "share", "pnpm"),
+    path.join(home, "Library", "pnpm"),
+  ];
+  if (process.platform === "darwin") {
+    dirs.push("/opt/homebrew/bin", "/usr/local/bin");
+  }
+  if (process.platform === "win32") {
+    if (env.APPDATA) dirs.push(path.join(env.APPDATA, "npm"));
+    dirs.push(path.join(home, "scoop", "shims"));
+  }
+  return unique(dirs);
+}
+
+function commonOpenCodeCandidates(env = process.env) {
+  const names = OPENCODE_COMMAND_NAMES.flatMap(executableNames);
+  const candidates = commonOpenCodeBaseDirs(env).flatMap((dir) => names.map((name) => path.join(dir, name)));
+  if (process.platform === "darwin") {
+    candidates.push("/Applications/OpenCode.app/Contents/MacOS/opencode-cli");
+    candidates.push("/Applications/OpenCode Desktop.app/Contents/MacOS/opencode-cli");
+  }
+  return candidates;
+}
+
+function fileExists(candidate) {
+  if (!candidate || !existsSync(candidate)) return false;
+  try {
+    return statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
+}
+
+export function opencodeInstallHint() {
+  return [
+    `Install OpenCode with \`${OPENCODE_INSTALL_COMMAND}\`.`,
+    `Node users can use \`${OPENCODE_NPM_INSTALL_COMMAND}\`; Homebrew users can use \`${OPENCODE_BREW_INSTALL_COMMAND}\`.`,
+    `If OpenCode is already installed outside PATH, set \`${OPENCODE_CONFIGURE_COMMAND}\` and restart ResonantOS.`
+  ].join(" ");
+}
+
+export function opencodeCandidatePaths(options = {}) {
+  const env = options.env ?? process.env;
+  const includeCommonCandidates = options.includeCommonCandidates !== false;
+  const overridePath = expandUserPath(env.OPENCODE_COMMAND);
+  return unique([
+    overridePath,
+    ...OPENCODE_COMMAND_NAMES.flatMap((commandName) => executableCandidatesFromPath(commandName, env)),
+    ...(includeCommonCandidates ? commonOpenCodeCandidates(env) : []),
+  ]);
+}
+
+export function opencodeRuntimeDiagnostics(options = {}) {
+  const env = options.env ?? process.env;
+  const displayLimit = Number.isInteger(options.displayLimit) && options.displayLimit > 0 ? options.displayLimit : 48;
+  const overridePath = expandUserPath(env.OPENCODE_COMMAND);
+  const candidates = opencodeCandidatePaths(options);
+  const command = candidates.find(fileExists) ?? null;
+  const searchedPaths = candidates.map(redactPathForDiagnostics).slice(0, displayLimit);
+  return {
+    installed: Boolean(command),
+    command,
+    commandRedacted: command ? redactPathForDiagnostics(command) : "",
+    installHint: opencodeInstallHint(),
+    installCommand: OPENCODE_INSTALL_COMMAND,
+    alternativeInstallCommands: [OPENCODE_NPM_INSTALL_COMMAND, OPENCODE_BREW_INSTALL_COMMAND],
+    configureCommand: OPENCODE_CONFIGURE_COMMAND,
+    searchedCommands: OPENCODE_COMMAND_NAMES,
+    searchedPaths,
+    searchedPathCount: candidates.length,
+    searchedPathOmitted: Math.max(0, candidates.length - searchedPaths.length),
+    overrideConfigured: Boolean(overridePath),
+    overridePath: overridePath ? redactPathForDiagnostics(overridePath) : "",
+    overrideFound: overridePath ? fileExists(overridePath) : false,
+  };
+}
+
+export function opencodeCommand(options = {}) {
+  return opencodeRuntimeDiagnostics(options).command;
+}

--- a/browser-first/host/run-browser-first.mjs
+++ b/browser-first/host/run-browser-first.mjs
@@ -14,7 +14,6 @@ import {
 import {
   countFiles,
   dashboardTarget,
-  executableCandidates,
   execFileStdout,
   expandUserPath,
   firstExistingExecutable,
@@ -38,6 +37,7 @@ import { createBrowserDiagnosticsHostService } from "./browser-diagnostics-host-
 import { createExtensionPrefsHostService } from "./extension-prefs-host-service.mjs";
 import { createMemoryHostService } from "./memory-host-service.mjs";
 import { createMemorySourceIntakeHostService } from "./memory-source-intake-host-service.mjs";
+import { opencodeCommand, opencodeRuntimeDiagnostics } from "./opencode-runtime.mjs";
 import {
   findChromiumExtension,
   removeCachedUnpackedExtension,
@@ -156,24 +156,6 @@ function hermesCommand(profileHome) {
   return candidates.find((candidate) => existsSync(candidate)) ?? firstExistingExecutable("hermes");
 }
 
-function opencodeCommand() {
-  if (process.env.OPENCODE_COMMAND && existsSync(process.env.OPENCODE_COMMAND)) {
-    return process.env.OPENCODE_COMMAND;
-  }
-  const home = os.homedir();
-  const candidates = [
-    ...executableCandidates("opencode"),
-    ...executableCandidates("opencode-ai"),
-    path.join(home, ".local", "bin", "opencode"),
-    path.join(home, ".npm-global", "bin", "opencode"),
-    path.join(home, "node_modules", ".bin", process.platform === "win32" ? "opencode.cmd" : "opencode"),
-    ...(process.platform === "darwin"
-      ? ["/Applications/OpenCode.app/Contents/MacOS/opencode-cli"]
-      : []),
-  ];
-  return candidates.find((candidate) => existsSync(candidate)) ?? null;
-}
-
 const {
   executeProviderStatus,
   extractAssistantContent,
@@ -235,6 +217,7 @@ const addonDelegationService = createAddonDelegationService({
   listFilesRecursive,
   memoryRoot,
   opencodeCommand,
+  opencodeRuntimeDiagnostics,
   redactPathForDiagnostics,
   repoRoot,
   safeFileSlug,

--- a/browser-first/resonantos-side-panel-extension/src/lib/main-workspace-opencode.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/main-workspace-opencode.js
@@ -14,6 +14,34 @@ function boundaryItem(text) {
   return item;
 }
 
+function openCodeRuntimeSetupText(status = {}) {
+  const lines = [];
+  if (status.installHint) {
+    lines.push(`Setup: ${status.installHint}`);
+  }
+  if (status.installCommand) {
+    lines.push(`Primary command: ${status.installCommand}`);
+  }
+  if (Array.isArray(status.alternativeInstallCommands) && status.alternativeInstallCommands.length) {
+    lines.push(`Alternatives: ${status.alternativeInstallCommands.join(" | ")}`);
+  }
+  if (status.configureCommand) {
+    lines.push(`Existing install override: ${status.configureCommand}`);
+  }
+  if (status.overrideConfigured && !status.overrideFound) {
+    lines.push(`Configured override was not found: ${status.overridePath || "OPENCODE_COMMAND"}`);
+  }
+  if (Array.isArray(status.searchedCommands) && status.searchedCommands.length) {
+    lines.push(`Command names checked: ${status.searchedCommands.join(", ")}`);
+  }
+  if (Array.isArray(status.searchedPaths) && status.searchedPaths.length) {
+    const suffix = status.searchedPathOmitted > 0 ? ` (+${status.searchedPathOmitted} more)` : "";
+    lines.push(`Searched paths${suffix}:`);
+    lines.push(...status.searchedPaths.slice(0, 12).map((candidate) => `- ${candidate}`));
+  }
+  return lines.join("\n");
+}
+
 export function renderOpenCodeWorkspace({ container, bridgeRequest, getBridgeRequest, initialMission = "" }) {
   // Resolve at call time. The module-level `bridgeRequest` may be
   // null at construction (rebind still in flight); the getter lets
@@ -83,17 +111,20 @@ export function renderOpenCodeWorkspace({ container, bridgeRequest, getBridgeReq
       const status = await bridge()("/opencode/status", { method: "GET" });
       const executionEnabled = status.executionEnabled !== false;
       statusBody.textContent = status.detail;
-      statusMeta.textContent = status.command || "OpenCode command not detected";
+      statusMeta.textContent = status.command || status.installCommand || "OpenCode command not detected";
       statusCard.dataset.ready = status.installed ? "true" : "false";
       if (!status.installed || !executionEnabled) {
         const guidance = statusCard.querySelector(".delegation-guidance") ?? document.createElement("pre");
         guidance.className = "delegation-guidance";
-        guidance.textContent = delegationGuidanceText({
-          blockedReason: status.blockedReason || status.detail,
-          executionEnabled,
-          runtimeAvailable: Boolean(status.installed),
-          target: "opencode"
-        });
+        guidance.textContent = [
+          delegationGuidanceText({
+            blockedReason: status.blockedReason || status.detail,
+            executionEnabled,
+            runtimeAvailable: Boolean(status.installed),
+            target: "opencode"
+          }),
+          !status.installed ? openCodeRuntimeSetupText(status) : ""
+        ].filter(Boolean).join("\n\n");
         statusCard.append(guidance);
       } else {
         statusCard.querySelector(".delegation-guidance")?.remove();
@@ -139,12 +170,15 @@ export function renderOpenCodeWorkspace({ container, bridgeRequest, getBridgeReq
       const lifecycle = started.status === "completed"
         ? `Completed · ${started.resultArtifactPath || "result artifact ready"}`
         : started.status === "blocked"
-          ? delegationGuidanceText({
-              blockedReason: started.blockedReason || "OpenCode runtime unavailable",
-              executionEnabled: false,
-              runtimeAvailable: false,
-              target: "opencode"
-            })
+          ? [
+              delegationGuidanceText({
+                blockedReason: started.blockedReason || "OpenCode runtime unavailable",
+                executionEnabled: false,
+                runtimeAvailable: false,
+                target: "opencode"
+              }),
+              openCodeRuntimeSetupText(started)
+            ].filter(Boolean).join("\n\n")
           : `Status ${started.status || "queued"}`;
       setStatus(taskStatus, `Delegation queued: ${result.id} · ${result.path}\n${lifecycle}`, started.status === "blocked" ? "warning" : "success");
       missionInput.value = "";

--- a/browser-first/test/main-workspace-opencode.test.mjs
+++ b/browser-first/test/main-workspace-opencode.test.mjs
@@ -86,7 +86,17 @@ test("opencode workspace can create an initial routed delegation", async () => {
   const bridgeRequest = async (route, options = {}) => {
     calls.push([route, options]);
     if (route === "/opencode/status") {
-      return { installed: false, command: "", detail: "OpenCode runtime was not detected." };
+      return {
+        installed: false,
+        command: "",
+        detail: "OpenCode runtime was not detected.",
+        installHint: "Install OpenCode with `curl -fsSL https://opencode.ai/install | bash`.",
+        installCommand: "curl -fsSL https://opencode.ai/install | bash",
+        alternativeInstallCommands: ["npm install -g opencode-ai"],
+        configureCommand: "OPENCODE_COMMAND=/absolute/path/to/opencode",
+        searchedCommands: ["opencode", "opencode-ai"],
+        searchedPaths: ["~/.local/bin/opencode", "/opt/homebrew/bin/opencode"],
+      };
     }
     if (route === "/addons/delegate") {
       return { id: "opencode-routed", path: "BrowserFirst/Delegations/opencode/opencode-routed.md" };
@@ -114,6 +124,11 @@ test("opencode workspace can create an initial routed delegation", async () => {
     assert.match(container.textContent, /opencode-routed/);
     assert.match(container.textContent, /Blocked: OpenCode runtime unavailable/);
     assert.match(container.textContent, /Next action: Install or start OpenCode/);
+    assert.match(container.textContent, /curl -fsSL https:\/\/opencode\.ai\/install \| bash/);
+    assert.match(container.textContent, /npm install -g opencode-ai/);
+    assert.match(container.textContent, /OPENCODE_COMMAND=\/absolute\/path\/to\/opencode/);
+    assert.match(container.textContent, /Command names checked: opencode, opencode-ai/);
+    assert.match(container.textContent, /~\/\.local\/bin\/opencode/);
     assert.match(container.textContent, /OpenCode is an add-on worker/);
   } finally {
     cleanup();

--- a/browser-first/test/opencode-runtime.test.mjs
+++ b/browser-first/test/opencode-runtime.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  OPENCODE_INSTALL_COMMAND,
+  OPENCODE_NPM_INSTALL_COMMAND,
+  opencodeCandidatePaths,
+  opencodeRuntimeDiagnostics,
+} from "../host/opencode-runtime.mjs";
+
+test("opencode diagnostics surface install and override guidance when runtime is missing", () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "resonantos-opencode-missing-"));
+  try {
+    const diagnostics = opencodeRuntimeDiagnostics({
+      env: {
+        PATH: tempDir,
+        OPENCODE_COMMAND: path.join(tempDir, "missing-opencode"),
+      },
+      includeCommonCandidates: false,
+    });
+
+    assert.equal(diagnostics.installed, false);
+    assert.equal(diagnostics.command, null);
+    assert.equal(diagnostics.overrideConfigured, true);
+    assert.equal(diagnostics.overrideFound, false);
+    assert.equal(diagnostics.installCommand, OPENCODE_INSTALL_COMMAND);
+    assert.ok(diagnostics.alternativeInstallCommands.includes(OPENCODE_NPM_INSTALL_COMMAND));
+    assert.match(diagnostics.configureCommand, /OPENCODE_COMMAND/);
+    assert.deepEqual(diagnostics.searchedCommands, ["opencode", "opencode-ai"]);
+    assert.ok(diagnostics.searchedPaths.some((candidate) => candidate.includes("missing-opencode")));
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("opencode diagnostics detect opencode from PATH before packet-only fallback", () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "resonantos-opencode-path-"));
+  const binaryName = process.platform === "win32" ? "opencode.cmd" : "opencode";
+  const fakeOpenCode = path.join(tempDir, binaryName);
+  try {
+    writeFileSync(fakeOpenCode, process.platform === "win32" ? "@echo off\r\n" : "#!/bin/sh\n");
+    chmodSync(fakeOpenCode, 0o755);
+
+    const diagnostics = opencodeRuntimeDiagnostics({
+      env: { PATH: tempDir },
+      includeCommonCandidates: false,
+    });
+
+    assert.equal(diagnostics.installed, true);
+    assert.equal(diagnostics.command, fakeOpenCode);
+    assert.equal(diagnostics.commandRedacted, fakeOpenCode.replace(os.homedir(), "~"));
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("opencode candidate paths include both official command names", () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "resonantos-opencode-candidates-"));
+  try {
+    const candidates = opencodeCandidatePaths({
+      env: { PATH: tempDir },
+      includeCommonCandidates: false,
+    });
+    assert.ok(candidates.some((candidate) => path.basename(candidate).startsWith("opencode")));
+    assert.ok(candidates.some((candidate) => path.basename(candidate).startsWith("opencode-ai")));
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/src/core/contracts.ts
+++ b/src/core/contracts.ts
@@ -2517,6 +2517,16 @@ export interface OpenCodeStatus {
   version?: string | null;
   binaryPath?: string | null;
   installHint: string;
+  installCommand?: string | null;
+  alternativeInstallCommands?: string[];
+  configureCommand?: string | null;
+  searchedCommands?: string[];
+  searchedPaths?: string[];
+  searchedPathCount?: number;
+  searchedPathOmitted?: number;
+  overrideConfigured?: boolean;
+  overridePath?: string | null;
+  overrideFound?: boolean;
   supportsWebUi: boolean;
   supportsServerApi: boolean;
 }

--- a/src/modules/opencode/OpenCodeWorkspace.tsx
+++ b/src/modules/opencode/OpenCodeWorkspace.tsx
@@ -32,6 +32,33 @@ const hasGrant = (installation: AddOnInstallation | undefined, capability: Capab
 const configuredWorkspacePath = (installation: AddOnInstallation | undefined): string =>
   typeof installation?.config?.workspacePath === "string" ? installation.config.workspacePath : "";
 
+const openCodeRuntimeGuidance = (status: OpenCodeStatus | null): string => {
+  const lines = [
+    status?.installHint || "Install OpenCode with `curl -fsSL https://opencode.ai/install | bash` or `npm install -g opencode-ai`.",
+  ];
+  if (status?.installCommand) {
+    lines.push(`Primary command: ${status.installCommand}`);
+  }
+  if (status?.alternativeInstallCommands?.length) {
+    lines.push(`Alternatives: ${status.alternativeInstallCommands.join(" | ")}`);
+  }
+  if (status?.configureCommand) {
+    lines.push(`Existing install override: ${status.configureCommand}`);
+  }
+  if (status?.overrideConfigured && !status.overrideFound) {
+    lines.push(`Configured override was not found: ${status.overridePath || "OPENCODE_COMMAND"}`);
+  }
+  if (status?.searchedCommands?.length) {
+    lines.push(`Command names checked: ${status.searchedCommands.join(", ")}`);
+  }
+  if (status?.searchedPaths?.length) {
+    const suffix = status.searchedPathOmitted ? ` (+${status.searchedPathOmitted} more)` : "";
+    lines.push(`Searched paths${suffix}:`);
+    lines.push(...status.searchedPaths.slice(0, 12).map((candidate) => `- ${candidate}`));
+  }
+  return lines.join("\n");
+};
+
 export function OpenCodeWorkspace({
   active,
   manifest,
@@ -256,7 +283,7 @@ export function OpenCodeWorkspace({
     }
 
     if (!nextStatus.installed) {
-      setError("OpenCode is not installed or not detectable. Install the OpenCode desktop app, then press Set up and launch again.");
+      setError(`OpenCode is not installed or not detectable.\n${openCodeRuntimeGuidance(nextStatus)}`);
       setBusyLabel("");
       return;
     }
@@ -337,6 +364,7 @@ export function OpenCodeWorkspace({
             <span className="eyebrow">Runtime</span>
             <strong>{status?.installed ? `OpenCode ${status.version ?? "detected"}` : "OpenCode not detected"}</strong>
             <p>{status?.binaryPath ?? status?.installHint ?? "Checking OpenCode runtime..."}</p>
+            {status && !status.installed ? <pre className="opencode-runtime-guidance">{openCodeRuntimeGuidance(status)}</pre> : null}
             <button type="button" className="button-secondary touch-action" onClick={() => void refreshStatus()} disabled={Boolean(busyLabel)}>
               Check OpenCode
             </button>

--- a/src/modules/opencode/opencode-workspace.css
+++ b/src/modules/opencode/opencode-workspace.css
@@ -162,6 +162,15 @@
 .opencode-error {
   border-color: rgba(248, 113, 113, 0.26);
   color: #fda4af;
+  white-space: pre-wrap;
+}
+
+.opencode-runtime-guidance {
+  margin: 0;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+  color: var(--warning);
+  font: 700 0.72rem/1.45 ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 .opencode-actions {


### PR DESCRIPTION
## Summary
- Add browser-first OpenCode runtime diagnostics for install commands, OPENCODE_COMMAND override, checked command names, and redacted searched paths.
- Surface those diagnostics in the OpenCode workspace runtime card and blocked delegation flow instead of the generic not-detected blocker.
- Extend the shared OpenCodeStatus contract and Tauri workspace UI to display the richer setup guidance when available.

## Verification
- node --test browser-first/test/opencode-runtime.test.mjs browser-first/test/main-workspace-opencode.test.mjs
- npm run test:browser-first
- npm test -- --run
- npm run build
- git diff --check