### PR TITLE
security: keep alpha provider credentials session-only

### DIFF
--- a/browser-first/host/provider-bridge-service.mjs
+++ b/browser-first/host/provider-bridge-service.mjs
@@ -46,12 +46,42 @@ export function createProviderBridgeService({
     assertDependency(name, value);
   }
 
-  async function readProviderSecrets() {
-    const filePath = providerSecretsPath();
-    if (!existsSync(filePath)) {
-      return {};
+  const sessionProviderSecrets = new Map();
+
+  function envProviderSecrets() {
+    const raw = String(process.env.RESONANTOS_PROVIDER_SECRETS_JSON ?? "").trim();
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("RESONANTOS_PROVIDER_SECRETS_JSON must be a provider-id to credential object.");
     }
-    return JSON.parse(await readFile(filePath, "utf8"));
+    return Object.fromEntries(Object.entries(parsed)
+      .map(([providerId, credential]) => [String(providerId).trim(), String(credential ?? "").trim()])
+      .filter(([providerId, credential]) => providerId && credential));
+  }
+
+  function sessionProviderSecretsObject() {
+    return Object.fromEntries(sessionProviderSecrets.entries());
+  }
+
+  async function readProviderSecrets() {
+    return {
+      ...envProviderSecrets(),
+      ...sessionProviderSecretsObject(),
+    };
+  }
+
+  function rememberProviderSecret(providerId, credential) {
+    sessionProviderSecrets.set(providerId, credential);
+  }
+
+  function credentialStoreStatus(secrets) {
+    return {
+      configured: Object.keys(secrets).length > 0,
+      location: "Session-only host memory / environment; no provider secrets are persisted by the alpha host.",
+      persistence: "session-only",
+      legacyPlaintextDetected: existsSync(providerSecretsPath()),
+    };
   }
 
   function slugifyProviderId(value) {
@@ -370,8 +400,7 @@ export function createProviderBridgeService({
     ]);
     return {
       vault: {
-        configured: existsSync(providerSecretsPath()),
-        location: "ResonantOS local provider vault",
+        ...credentialStoreStatus(secrets),
       },
       providers: profiles.map((profile) => ({
         ...profile,
@@ -398,7 +427,7 @@ export function createProviderBridgeService({
             hardStop: strategy.hardStop,
           })),
         configured: Boolean(secrets[profile.id]),
-        credentialPreview: secrets[profile.id] ? "stored" : "missing",
+        credentialPreview: secrets[profile.id] ? "session" : "missing",
       })),
     };
   }
@@ -464,7 +493,7 @@ export function createProviderBridgeService({
           ? `${profile.label} is configured, but one or more dependent routing strategies still have no available route.`
           : state === "disabled"
             ? `${profile.label} is configured, but all declared models are disabled by the current allowed-model policy.`
-          : `${profile.label} has no stored credential in the local provider vault.`,
+          : `${profile.label} has no active credential in the session-only credential store.`,
     };
   }
 
@@ -483,7 +512,7 @@ export function createProviderBridgeService({
         testedAt: new Date().toISOString(),
         state: "missing-credential",
         endpoint: "provider models endpoint",
-        detail: `${profile.label} cannot be tested because no credential is stored in the local provider vault.`,
+        detail: `${profile.label} cannot be tested because no active credential is stored in the session-only credential store.`,
       };
       await appendProviderDiagnosticHistory(result);
       return result;
@@ -627,14 +656,11 @@ export function createProviderBridgeService({
     if (credential.length < 8) {
       throw new Error("Credential is too short to save.");
     }
-    const current = await readProviderSecrets();
-    const filePath = providerSecretsPath();
-    await mkdir(path.dirname(filePath), { recursive: true });
-    await writeFile(filePath, `${JSON.stringify({ ...current, [providerId]: credential }, null, 2)}\n`, { mode: 0o600 });
-    await chmod(filePath, 0o600).catch(() => undefined);
+    rememberProviderSecret(providerId, credential);
     return {
       providerId,
       configured: true,
+      persistence: "session-only",
       savedAt: new Date().toISOString(),
     };
   }
@@ -659,15 +685,12 @@ export function createProviderBridgeService({
       if (credential.length < 8) {
         throw new Error("Credential is too short to save.");
       }
-      const currentSecrets = await readProviderSecrets();
-      const filePath = providerSecretsPath();
-      await mkdir(path.dirname(filePath), { recursive: true });
-      await writeFile(filePath, `${JSON.stringify({ ...currentSecrets, [normalized.id]: credential }, null, 2)}\n`, { mode: 0o600 });
-      await chmod(filePath, 0o600).catch(() => undefined);
+      rememberProviderSecret(normalized.id, credential);
     }
     return {
       provider: normalized,
       savedAt: new Date().toISOString(),
+      persistence: "session-only",
       configured: Boolean(credential || (await readProviderSecrets())[normalized.id]),
     };
   }

--- a/browser-first/resonantos-side-panel-extension/src/lib/settings/providers-section.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/settings/providers-section.js
@@ -225,7 +225,7 @@ export function diagnosticRecoverySuggestions(entries = []) {
         providerId: latest.providerId,
         state: "missing-credential",
         title: `${label}: save a credential`,
-        body: "Add or restore the provider credential in the local vault, then run Test connection again."
+        body: "Add or restore the provider credential for this host session, then run Test connection again."
       });
       continue;
     }
@@ -353,7 +353,12 @@ function providerCard({ provider, bridgeRequest, getBridgeRequest, statusNode, r
 
   const auth = document.createElement("p");
   auth.className = "settings-model-list";
-  auth.textContent = `Auth: ${formatLabel(provider.authType)} · Credential: ${provider.credentialPreview === "stored" ? "stored in host vault" : "missing"}`;
+  const credentialState = provider.credentialPreview === "session"
+    ? "session-only in host memory"
+    : provider.credentialPreview === "stored"
+      ? "configured in host credential store"
+      : "missing";
+  auth.textContent = `Auth: ${formatLabel(provider.authType)} · Credential: ${credentialState}`;
 
   const form = document.createElement("form");
   form.className = "settings-provider-form";
@@ -383,7 +388,7 @@ function providerCard({ provider, bridgeRequest, getBridgeRequest, statusNode, r
         body: { providerId: provider.id, credential }
       });
       input.value = "";
-      setStatus(statusNode, `${provider.label} credential saved in the local provider vault.`, "success");
+      setStatus(statusNode, `${provider.label} credential saved for this host session.`, "success");
       await reload();
     } catch (error) {
       setStatus(statusNode, `Save failed: ${safeErrorMessage(error)}`, "error");
@@ -600,7 +605,7 @@ export function renderProvidersSection(container, { bridgeRequest, getBridgeRequ
     settingsHeader({
       eyebrow: "Providers and models",
       title: "Provider Profiles",
-      body: "Configure model accounts for Augmentor, Agent Control, and approved add-ons. ResonantOS stores each account credential in the local host vault and exposes only health state to the browser extension."
+      body: "Configure model accounts for Augmentor, Agent Control, and approved add-ons. Alpha credentials stay in session-only host memory or environment configuration; raw keys are not persisted by the extension host."
     }),
     toolbar,
     statusNode,
@@ -626,15 +631,17 @@ export function renderProvidersSection(container, { bridgeRequest, getBridgeRequ
     const consumerCount = providers.reduce((total, provider) => total + (provider.routeConsumers?.length ?? 0), 0);
     vaultGrid.replaceChildren(
       metricCard({
-        label: "Vault",
-        value: result.vault?.configured ? "Created" : "Missing",
-        detail: result.vault?.location ?? "host-managed provider vault",
+        label: "Credential store",
+        value: result.vault?.persistence === "session-only"
+          ? "Session-only"
+          : result.vault?.configured ? "Created" : "Missing",
+        detail: result.vault?.location ?? "session-only host credential store",
         tone: result.vault?.configured ? "success" : "warning"
       }),
       metricCard({
         label: "Configured",
         value: `${configuredCount}/${providers.length}`,
-        detail: "provider profiles with stored credentials",
+        detail: "provider profiles with active session/env credentials",
         tone: configuredCount ? "success" : "warning"
       }),
       metricCard({

--- a/browser-first/test/alpha-browser-extension-scope.test.mjs
+++ b/browser-first/test/alpha-browser-extension-scope.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
@@ -58,4 +59,19 @@ test("2.0.0 alpha release scope is Chrome extension and bridge only", async () =
   assert.match(manifest.content_security_policy.extension_pages, /connect-src 'self' http:\/\/127\.0\.0\.1:\*/);
   assert.doesNotMatch(manifest.content_security_policy.extension_pages, /https?:\/\/\*:\*/);
   assert.equal(manifest.content_scripts[0].js[0], "src/lib/resonant-context.js");
+});
+
+test("2.0.0 alpha release scope excludes local credential artifacts", () => {
+  const tracked = execFileSync("git", ["ls-files"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  }).split("\n").filter(Boolean);
+  const forbidden = tracked.filter((entry) =>
+    /(^|\/)provider-secrets\.json$/i.test(entry) ||
+    /(^|\/)bridge-config\.generated\.js$/i.test(entry) ||
+    /(^|\/)\.env$/i.test(entry) ||
+    /(^|\/)ResonantOS_User(\/|$)/i.test(entry)
+  );
+
+  assert.deepEqual(forbidden, [], "alpha must not track credential, bridge-token, env, or local user-state artifacts");
 });

--- a/browser-first/test/main-workspace-settings.test.mjs
+++ b/browser-first/test/main-workspace-settings.test.mjs
@@ -209,7 +209,7 @@ test("settings workspace renders provider status without exposing credentials", 
     assert.match(container.textContent, /Provider Profiles/);
     assert.match(container.textContent, /MiniMax/);
     assert.match(container.textContent, /OpenAI/);
-    assert.match(container.textContent, /Vault/);
+    assert.match(container.textContent, /Credential store/);
     assert.match(container.textContent, /Created/);
     assert.equal(container.querySelector(".settings-provider-advanced").open, false);
     const initialMiniMaxCard = [...container.querySelectorAll(".settings-provider-card")].find((card) => /MiniMax/.test(card.textContent));

--- a/browser-first/test/provider-bridge-session-secrets.test.mjs
+++ b/browser-first/test/provider-bridge-session-secrets.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { createProviderBridgeService } from "../host/provider-bridge-service.mjs";
+
+function createService(root) {
+  return createProviderBridgeService({
+    providerSecretsPath: () => path.join(root, "Secrets", "provider-secrets.json"),
+    providerAccountsPath: () => path.join(root, "ProviderFabric", "provider-accounts.json"),
+    providerRoutingPath: () => path.join(root, "ProviderFabric", "routing-strategies.json"),
+    providerModelPreferencesPath: () => path.join(root, "ProviderFabric", "model-preferences.json"),
+    providerDiagnosticsHistoryPath: () => path.join(root, "ProviderFabric", "diagnostics-history.json"),
+    redactDiagnosticText: (value) => String(value ?? ""),
+    unique: (values) => [...new Set(values.filter(Boolean))],
+    extractJsonObject: (value) => JSON.parse(String(value ?? "{}")),
+  });
+}
+
+test("provider credentials saved through the alpha host are session-only", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "resonantos-provider-session-"));
+  const secretPath = path.join(root, "Secrets", "provider-secrets.json");
+  const service = createService(root);
+  try {
+    const saved = await service.executeProviderCredentialSave({
+      providerId: "shared-minimax",
+      credential: "minimax-test-credential",
+    });
+
+    assert.equal(saved.configured, true);
+    assert.equal(saved.persistence, "session-only");
+    assert.equal(existsSync(secretPath), false);
+    assert.equal((await service.readProviderSecrets())["shared-minimax"], "minimax-test-credential");
+
+    const status = await service.executeProviderStatus();
+    const minimax = status.providers.find((provider) => provider.id === "shared-minimax");
+    assert.equal(status.vault.persistence, "session-only");
+    assert.equal(status.vault.legacyPlaintextDetected, false);
+    assert.equal(minimax.configured, true);
+    assert.equal(minimax.credentialPreview, "session");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("legacy plaintext provider secret files are detected but ignored", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "resonantos-provider-legacy-"));
+  const secretPath = path.join(root, "Secrets", "provider-secrets.json");
+  const service = createService(root);
+  try {
+    await mkdir(path.dirname(secretPath), { recursive: true });
+    await writeFile(secretPath, JSON.stringify({ "shared-minimax": "legacy-plaintext-secret" }));
+
+    const secrets = await service.readProviderSecrets();
+    const status = await service.executeProviderStatus();
+    const minimax = status.providers.find((provider) => provider.id === "shared-minimax");
+
+    assert.equal(secrets["shared-minimax"], undefined);
+    assert.equal(status.vault.legacyPlaintextDetected, true);
+    assert.equal(minimax.configured, false);
+    assert.equal(minimax.credentialPreview, "missing");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/docs/ALPHA_PREVIEW_AUDIT_2026-04-28.md
+++ b/docs/ALPHA_PREVIEW_AUDIT_2026-04-28.md
@@ -63,9 +63,9 @@ Current implementation status:
 - Fresh installs create the `ResonantOS_User` root under the user's home folder unless overridden. This avoids protected-folder prompts on macOS while keeping the user-state package visible and portable.
 - `RESONANTOS_USER_STATE_ROOT` or `RESONANT_USER_STATE_ROOT` can override the location.
 - Living Archive managed memory resolves through `ResonantOS_User/Memory`.
-- Provider secrets now resolve under `ResonantOS_User/Secrets/provider-secrets.json`.
+- Chrome-extension alpha provider credentials now resolve from session-only host memory or environment configuration. The legacy plaintext `ResonantOS_User/Secrets/provider-secrets.json` path is detected but ignored by the browser-first host.
 - Wallet storage is architectural only; no wallet vault implementation is shipped.
-- Secret encryption is not production-ready yet. The file location is corrected for portability, but encrypted vault hardening remains a required security milestone.
+- Secret encryption is not production-ready yet. The alpha avoids persistent provider-key writes; ADR-022 encrypted vault hardening remains a required security milestone before persistent credentials return.
 
 ## Privacy Audit
 

--- a/docs/PRODUCT_GUIDE_BROWSER_FIRST.md
+++ b/docs/PRODUCT_GUIDE_BROWSER_FIRST.md
@@ -522,7 +522,7 @@ ResonantOS must be designed as a security-conscious AI browser, not as an automa
 
 Current core boundaries:
 
-- Provider secrets are stored under the user secrets root and should not be exposed to page JavaScript or add-ons.
+- Alpha provider credentials stay in session-only host memory or environment configuration; raw keys are not persisted by the extension host and should not be exposed to page JavaScript or add-ons.
 - The bridge requires a session token and restricted CORS in preview mode.
 - Production wallet/DAO readiness requires replacing the preview token bridge with native messaging, signed IPC, or equivalent authenticated browser-shell IPC.
 - Add-ons get explicit capability grants.

--- a/scripts/browser-first-release-scope-audit.mjs
+++ b/scripts/browser-first-release-scope-audit.mjs
@@ -27,6 +27,7 @@ const stagedChangedPaths = () =>
 const changedPaths = stagedOnly ? stagedChangedPaths() : worktreeChangedPaths();
 
 const includeDocs = new Set([
+  "docs/ALPHA_PREVIEW_AUDIT_2026-04-28.md",
   "docs/BROWSER_FIRST_STABILIZATION_2026-06-02.md",
   "docs/FEATURE_INVENTORY_2026-05-26.md",
   "docs/PRODUCT_GUIDE_BROWSER_FIRST.md",


### PR DESCRIPTION
## Summary
- stops the browser-first host from writing provider credentials to plaintext `provider-secrets.json`
- stores credentials saved through the alpha host in session-only memory, while still allowing environment-provided credentials for alpha runs
- detects legacy plaintext provider secret files but ignores them instead of loading them
- updates provider Settings copy and release docs so the UI no longer claims an encrypted/local vault exists
- adds tests that saved credentials are session-only and that tracked alpha artifacts exclude local secrets/config files

## Dustin report mapping
This addresses the Chrome-extension alpha release surface for Dustin's private finding about unencrypted provider credentials at rest. Tauri/Electron are excluded by the prerequisite PR, so this PR targets the browser-first Node host path.

Reported-by: Dustin (@ConsultingFutures4200)

Note: GitHub did not resolve `ConsultingFutures4200` as a public account via the API, so this PR uses visible `Reported-by` attribution rather than a fabricated co-author identity.

## Validation
- node --test browser-first/test/provider-bridge-session-secrets.test.mjs browser-first/test/provider-host-service.test.mjs browser-first/test/alpha-browser-extension-scope.test.mjs browser-first/test/main-workspace-settings.test.mjs
- npm test -- --run
- npm run build
- npm run test:browser-first
- npm run browser-first:audit-scope:staged

## Follow-up
ADR-022 encrypted/keychain-backed vault remains the durable production solution before persistent provider credentials return.
