### PR TITLE
docs: add local development package discipline

### DIFF
--- a/disciplines/DISCIPLINES.md
+++ b/disciplines/DISCIPLINES.md
@@ -1,0 +1,30 @@
+# ResonantOS Discipline Catalog
+
+Status: active-pattern
+Owner: ResonantOS maintainers
+
+This catalog formalizes recurring ResonantOS operating practices that should be
+checked locally before they are generalized into Arcanum framework guidance.
+
+## Catalog
+
+| ID | Discipline | Status | Steward | Evidence | Next hardening move |
+| --- | --- | --- | --- | --- | --- |
+| `development-package-promotion-gate` | Development package promotion gate | active-pattern | ResonantOS maintainers / Arcanum issue loop users | [Development package promotion gate](cards/development-package-promotion-gate.md) | Keep `development/` packages out of product PRs by default; use staged scope audit plus local catalog validation before framework promotion. |
+
+## Status Meanings
+
+| Status | Meaning |
+| --- | --- |
+| `candidate` | Useful practice exists, but local authority and validation are still being proven. |
+| `active-pattern` | Practice is already used by active ResonantOS workflows, but the rule may still need stronger automation. |
+| `implemented` | Working repository support exists, but may still need discipline-level hardening. |
+| `canonical` | Accepted local authority with deterministic validation or release governance support. |
+| `deprecated` | Superseded or withdrawn. |
+
+## Growth Rule
+
+Promote a local discipline only when the next route names its owner, evidence,
+validation surface, and mutation boundary. A local ResonantOS discipline can
+recommend an Arcanum promotion, but it does not make framework guidance
+canonical by itself.

--- a/disciplines/README.md
+++ b/disciplines/README.md
@@ -1,0 +1,37 @@
+# ResonantOS Disciplines
+
+This folder holds repository-local operating disciplines for ResonantOS.
+
+Local disciplines are the first landing place for recurring project practices
+that affect this repository's pull requests, release surface, validation, or
+contributor workflow. Promote a practice to Arcanum only after the local rule is
+clear, useful, and broadly reusable beyond ResonantOS.
+
+## Catalog
+
+Start with [DISCIPLINES.md](DISCIPLINES.md). Each row points to a discipline
+card under [cards/](cards/).
+
+## Local-First Rule
+
+When a run discovers a new discipline from ResonantOS evidence:
+
+1. Add or update the local ResonantOS discipline first.
+2. Validate the local catalog.
+3. Apply the rule to active ResonantOS pull requests.
+4. Promote a generalized Arcanum discipline only when the practice is
+   product-neutral and useful outside this repository.
+
+## Validation
+
+Run:
+
+```bash
+npm run discipline:validate
+```
+
+For pull request staging, also run:
+
+```bash
+npm run browser-first:audit-scope:staged
+```

--- a/disciplines/cards/development-package-promotion-gate.md
+++ b/disciplines/cards/development-package-promotion-gate.md
@@ -1,0 +1,49 @@
+# Development Package Promotion Gate
+
+Status: active-pattern
+Steward: ResonantOS maintainers / Arcanum issue loop users
+
+## Purpose
+
+Keep raw development and run packages out of ResonantOS product pull requests
+unless a repository guideline explicitly promotes a distilled artifact as
+source, release documentation, review evidence, or durable validation evidence.
+
+## Boundary
+
+This discipline governs ResonantOS commit and pull request surfaces. It does
+not forbid source, tests, contributor docs, architecture docs, review reports,
+release-scope docs, or curated evidence that the repository already treats as
+durable. It also does not own Arcanum's framework-level discipline catalog; if a
+practice should be reusable beyond ResonantOS, promote a product-neutral version
+to Arcanum after the local rule is in place.
+
+## Evidence
+
+- [VLAD PR guide](../../docs/VLAD-PR-GUIDE.md) - explicitly excludes `development/`, refinement runs, and research packages from the product PR scope.
+- [Browser-first stabilization release rules](../../docs/BROWSER_FIRST_STABILIZATION_2026-06-02.md) - excludes generated memory, runtime logs, private vault contents, credentials, and mixed release-scope artifacts.
+- [Agent instructions](../../AGENTS.md) - requires the smallest safe write set, deterministic validation, and explicit reporting of the mutation boundary.
+- [Local-first routing reflection](../reflections/2026-06-22-local-first-discipline-routing.md) - records the correction that local ResonantOS discipline should precede framework promotion.
+
+## Validation
+
+- Mode: mixed
+- Check: `npm run discipline:validate` plus `npm run browser-first:audit-scope:staged` before publishing PRs that touch governance or release-scope files.
+- Latest result: pass (2026-06-22 local catalog validation and staged scope audit).
+
+## Quality Bar
+
+A ResonantOS pull request satisfies this discipline when:
+
+- raw `development/`, refinement, invoke, task-session, runtime, observability, research, or scratch package paths are absent unless explicitly promoted;
+- the PR contains only the source, tests, docs, scripts, or curated evidence needed for the actual change;
+- any non-committed run evidence is summarized in the PR body or issue comment instead of bundled as raw process output;
+- the final changed-file set matches the stated dependency map and affected-only hypothesis;
+- local discipline validation runs before any Arcanum/framework promotion claim.
+
+## Promotion Guardrail
+
+This discipline can recommend an Arcanum discipline, validator, release-scope
+rule, or issue-loop contract update, but it cannot promote raw development
+packages or framework guidance by itself. Framework promotion must keep this
+local-first rule visible.

--- a/disciplines/reflections/2026-06-22-local-first-discipline-routing.md
+++ b/disciplines/reflections/2026-06-22-local-first-discipline-routing.md
@@ -1,0 +1,60 @@
+# Local-First Discipline Routing Reflection
+
+## Workflow Reflect Result
+
+- Scope: discipline-governance and github-project-issue-loop
+- Signals analyzed: 7
+- Thresholds triggered: severe-gap
+- Patterns found: 2
+- Proposals generated: 3 high-priority
+- Report: disciplines/reflections/2026-06-22-local-first-discipline-routing.md
+- Reflection state: unchanged
+- Recommended next action: targeted update
+
+## Context
+
+During the GitHub issue-loop cleanup on 2026-06-22, five open ResonantOS pull
+requests were corrected to remove raw `development/` issue-loop packages from
+their committed surfaces. A framework-level Arcanum discipline was then opened
+before a local ResonantOS discipline existed. The user corrected that route:
+the discipline should be created inside ResonantOS first, and only then
+generalized to Arcanum when appropriate.
+
+## Signals
+
+- User correction: local ResonantOS discipline should precede Arcanum promotion.
+- PR #185 cleanup: removed unpromoted issue-loop development package.
+- PR #186 cleanup: removed unpromoted issue-loop development package.
+- PR #187 cleanup: removed unpromoted issue-loop development package.
+- PR #188 cleanup: removed unpromoted issue-loop development package.
+- PR #189 cleanup: removed unpromoted issue-loop development package.
+- Arcanum PR #5 opened with a generalized discipline before local catalog state existed.
+
+## Patterns Found
+
+1. ResonantOS already had scattered local guidance for product PR scope, but no
+   local discipline catalog to make the rule explicit.
+2. Discipline-governance's target-local output rule can be misapplied when the
+   runtime skill itself comes from Arcanum and the consuming repository lacks a
+   local discipline surface.
+
+## Proposed Iterations
+
+1. Create a ResonantOS local discipline catalog and card for the development
+   package promotion gate.
+2. Add local validation so the discipline can be checked before PR publication.
+3. Update Arcanum's generalized discipline and discipline-governance behavior to
+   say consuming repositories should be checked or given a local discipline
+   surface before framework promotion.
+
+## Rejected Changes
+
+- Do not commit raw issue-loop run packages as evidence for this reflection.
+  The durable evidence is the local card, PR cleanup, and validation result.
+- Do not move all ResonantOS discipline ownership into Arcanum. Arcanum can hold
+  the reusable pattern, but ResonantOS owns its local PR scope.
+
+## Decision
+
+Targeted update. Add the local ResonantOS discipline first, then amend the
+Arcanum promotion to preserve local-first routing.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "engineer:prompt": "node scripts/engineer-runner.mjs prompt",
     "engineer:verify": "node scripts/engineer-runner.mjs verify",
     "test:engineer-runner": "node --test scripts/engineer-runner.test.mjs",
+    "discipline:validate": "node scripts/validate-discipline-catalog.mjs",
     "browser-first:audit-scope": "node scripts/browser-first-release-scope-audit.mjs",
     "browser-first:audit-scope:staged": "node scripts/browser-first-release-scope-audit.mjs --staged --strict"
   },

--- a/scripts/browser-first-release-scope-audit.mjs
+++ b/scripts/browser-first-release-scope-audit.mjs
@@ -44,6 +44,18 @@ function classify(path) {
       reason: "Chrome extension, Node bridge host, or browser-first tests/docs",
     };
   }
+  if (path.startsWith("development/")) {
+    return {
+      bucket: "defer",
+      reason: "Arcanum or local run package; keep out of product PRs unless explicitly promoted",
+    };
+  }
+  if (path.startsWith("disciplines/")) {
+    return {
+      bucket: "include",
+      reason: "local ResonantOS governance discipline",
+    };
+  }
   if (includeDocs.has(path)) {
     return {
       bucket: "include",

--- a/scripts/validate-discipline-catalog.mjs
+++ b/scripts/validate-discipline-catalog.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const catalogPath = path.join(root, "disciplines", "DISCIPLINES.md");
+const validStatuses = new Set(["candidate", "active-pattern", "implemented", "canonical", "deprecated"]);
+const requiredSections = ["## Purpose", "## Boundary", "## Evidence", "## Validation", "## Quality Bar", "## Promotion Guardrail"];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function splitRow(line) {
+  return line.trim().replace(/^\|/, "").replace(/\|$/, "").split("|").map((cell) => cell.trim());
+}
+
+function extractLinks(markdown) {
+  return [...markdown.matchAll(/\[[^\]]+\]\(([^)]+)\)/g)].map((match) => match[1]);
+}
+
+function resolveLocalLink(fromFile, link) {
+  const target = link.split("#", 1)[0];
+  return path.resolve(path.dirname(fromFile), target);
+}
+
+const failures = [];
+
+if (!existsSync(catalogPath)) {
+  fail("missing disciplines/DISCIPLINES.md");
+} else {
+  const catalog = readFileSync(catalogPath, "utf8");
+  const lines = catalog.split(/\r?\n/);
+  const headerIndex = lines.findIndex((line) => line.startsWith("| ID | Discipline |"));
+
+  if (headerIndex === -1) {
+    fail("catalog table header not found");
+  } else {
+    const header = splitRow(lines[headerIndex]);
+    const expected = ["ID", "Discipline", "Status", "Steward", "Evidence", "Next hardening move"];
+    if (header.join("\0") !== expected.join("\0")) {
+      fail(`catalog columns must be: ${expected.join(", ")}`);
+    }
+
+    const seenIds = new Set();
+    for (const line of lines.slice(headerIndex + 2)) {
+      if (!line.startsWith("|")) break;
+      const cells = splitRow(line);
+      if (cells.length !== expected.length) {
+        fail(`row has wrong column count: ${line}`);
+        continue;
+      }
+
+      const id = cells[0].replace(/`/g, "");
+      const status = cells[2];
+      const evidence = cells[4];
+
+      if (!/^[a-z][a-z0-9-]*$/.test(id)) {
+        fail(`invalid discipline id: ${id}`);
+      }
+      if (seenIds.has(id)) {
+        fail(`duplicate discipline id: ${id}`);
+      }
+      seenIds.add(id);
+      if (!validStatuses.has(status)) {
+        fail(`${id}: invalid status: ${status}`);
+      }
+
+      const links = extractLinks(evidence);
+      if (links.length === 0) {
+        fail(`${id}: evidence cell must include a local Markdown link`);
+      }
+      for (const link of links) {
+        if (/^[a-z]+:\/\//i.test(link)) {
+          fail(`${id}: evidence link must be local: ${link}`);
+          continue;
+        }
+        const target = resolveLocalLink(catalogPath, link);
+        if (!existsSync(target)) {
+          fail(`${id}: missing evidence target: ${link}`);
+          continue;
+        }
+
+        const card = readFileSync(target, "utf8");
+        for (const section of requiredSections) {
+          if (!card.includes(section)) {
+            fail(`${id}: card missing ${section}`);
+          }
+        }
+      }
+    }
+
+    if (seenIds.size === 0) {
+      fail("catalog table has no rows");
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Discipline catalog validation failed");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log("Discipline catalog validation passed");


### PR DESCRIPTION
## Summary
- add a local ResonantOS `disciplines/` catalog and development package promotion gate
- record the workflow reflection that local ResonantOS discipline should precede Arcanum/framework promotion
- add `npm run discipline:validate` and teach the staged release-scope audit to allow local discipline files while explicitly deferring `development/` run packages

## Validation
- `npm run discipline:validate`
- `npm run browser-first:audit-scope`
- `npm run browser-first:audit-scope:staged`
- `git diff --check`

## Notes
This is the local-first correction for the issue-loop cleanup: raw Arcanum/refine/invoke/task-session packages stay out of product PRs unless explicitly promoted, and reusable framework guidance can be promoted to Arcanum after the local discipline exists.

Framework follow-up: https://github.com/cyberAlchemyAI/Arcanum/pull/5