### PR TITLE
Fix blank screen on fresh boot: preserve host-owned state across runtime-state broadcast

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "ResonantOS vNext desktop shell foundation"
 authors = ["Resonant Alpha"]
 edition = "2021"
+default-run = "resonantos_vnext"
 
 [lib]
 name = "resonantos_vnext_lib"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -426,12 +426,19 @@ export function App() {
       if (cancelled) {
         return;
       }
-      currentReadyStateRef.current = nextState;
-      setLoadState((current) =>
-        current.phase === "ready"
-          ? { ...current, state: nextState }
-          : current,
-      );
+      // The host broadcasts a security-filtered state: fields it owns exclusively
+      // (installations, providerProfiles, securityPolicy, trustTier, ...) are
+      // stripped before the `runtime-state-updated` payload is emitted. Merge the
+      // incoming safe fields onto our existing full state instead of replacing it,
+      // so those host-owned fields are preserved rather than dropped to undefined.
+      setLoadState((current) => {
+        if (current.phase !== "ready") {
+          return current;
+        }
+        const mergedState = { ...current.state, ...nextState };
+        currentReadyStateRef.current = mergedState;
+        return { ...current, state: mergedState };
+      });
     }).then((cleanup) => {
       if (cancelled) {
         cleanup();


### PR DESCRIPTION
## What

Fixes the blank-screen-on-fresh-boot crash and the `cargo run` build failure.

Closes #192

## Why

On a fresh boot (no persisted runtime state), the shell renders a blank screen and `<App>` crashes:

```
TypeError: undefined is not an object (evaluating 'state.installations[selectedManifest.id]')
    at selectors.ts:183
```

The Rust host emits a **security-filtered** `runtime-state-updated` event — `save_runtime_state` strips host-owned fields (`installations`, `providerProfiles`, `securityPolicy`, `trustTier`) before persisting and broadcasting (`src-tauri/src/lib.rs:226-242`). The `App.tsx` subscription wholesale-replaced its in-memory state with that partial payload, so `state.installations` became `undefined` and `buildShellViewModel` crashed at `src/modules/shell/selectors.ts:183`.

## Changes

- **`src/App.tsx`** — the `runtime-state-updated` subscription now **merges** the security-filtered broadcast onto the existing full state (`{ ...current.state, ...nextState }`) instead of replacing it, preserving host-owned fields the broadcast intentionally omits. `currentReadyStateRef` is updated to the merged state so subsequent edits don't lose those fields either.
- **`src-tauri/Cargo.toml`** — added `default-run = "resonantos_vnext"`. The crate gained a second binary (`src/bin/electron_core_ipc.rs`), so `cargo run` (invoked by `tauri dev`) could no longer pick a default and failed with exit code 101.

## Testing

- `npm run tauri:dev` now builds and launches cleanly (previously exited 101).
- App boots past the previously-blank screen; `state.installations` is preserved across the host's `runtime-state-updated` broadcast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
