### PR TITLE
Fix delegation finalization failure handling

### DIFF
--- a/browser-first/host/addon-delegation-service.mjs
+++ b/browser-first/host/addon-delegation-service.mjs
@@ -485,6 +485,24 @@ export function createAddonDelegationService(dependencies) {
     return next;
   }
 
+  async function failDelegationAfterRunning(taskPath, error) {
+    const message = error instanceof Error ? error.message : String(error);
+    try {
+      const updated = await writeDelegationStatus(taskPath, "failed", {
+        failedAt: new Date().toISOString(),
+        failureReason: message.slice(0, 500),
+      });
+      return {
+        ...delegationSummaryFromMarkdown(taskPath, updated, await stat(taskPath)),
+        failureReason: message,
+        status: "failed",
+      };
+    } catch (statusError) {
+      const statusMessage = statusError instanceof Error ? statusError.message : String(statusError);
+      throw new Error(`Delegation failed, and failed-status recovery also failed: ${message}; recovery: ${statusMessage}`);
+    }
+  }
+
   function deterministicHermesResult(packet) {
     const mission = sectionFromMarkdown(packet, "Mission");
     const hasContext = Boolean(sectionFromMarkdown(packet, "Context Packet"));
@@ -646,39 +664,29 @@ export function createAddonDelegationService(dependencies) {
         status: "blocked",
       };
     }
-    let result;
     try {
-      result = adapter === "deterministic"
+      const result = adapter === "deterministic"
         ? deterministicHermesResult(packet)
         : await runHermesCliDelegation(command, packet, payload);
-    } catch (error) {
-      const failedAt = new Date().toISOString();
-      const updated = await writeDelegationStatus(taskPath, "failed", {
-        failedAt,
-        failureReason: error instanceof Error ? error.message.slice(0, 500) : String(error).slice(0, 500),
+      const artifactPath = await writeHermesResultArtifact(taskPath, packet, result);
+      let updated = await writeDelegationStatus(taskPath, "completed", {
+        completedAt: new Date().toISOString(),
+        resultArtifactPath: path.relative(userRoot(), artifactPath),
       });
+      updated = `${updated.trimEnd()}\n\n## Result\n${result.finalSummary}\n\n## Result Artifact\n${path.relative(userRoot(), artifactPath)}\n`;
+      await writeFile(taskPath, updated);
       return {
         ...delegationSummaryFromMarkdown(taskPath, updated, await stat(taskPath)),
-        failureReason: error instanceof Error ? error.message : String(error),
-        status: "failed",
+        adapter: result.adapter,
+        artifact: {
+          path: path.relative(userRoot(), artifactPath),
+          ...result,
+        },
+        status: "completed",
       };
+    } catch (error) {
+      return failDelegationAfterRunning(taskPath, error);
     }
-    const artifactPath = await writeHermesResultArtifact(taskPath, packet, result);
-    let updated = await writeDelegationStatus(taskPath, "completed", {
-      completedAt: new Date().toISOString(),
-      resultArtifactPath: path.relative(userRoot(), artifactPath),
-    });
-    updated = `${updated.trimEnd()}\n\n## Result\n${result.finalSummary}\n\n## Result Artifact\n${path.relative(userRoot(), artifactPath)}\n`;
-    await writeFile(taskPath, updated);
-    return {
-      ...delegationSummaryFromMarkdown(taskPath, updated, await stat(taskPath)),
-      adapter: result.adapter,
-      artifact: {
-        path: path.relative(userRoot(), artifactPath),
-        ...result,
-      },
-      status: "completed",
-    };
   }
 
   async function executeHermesDelegationStatus(payload = {}) {
@@ -1072,38 +1080,29 @@ export function createAddonDelegationService(dependencies) {
         status: "blocked",
       };
     }
-    let result;
     try {
-      result = adapter === "deterministic"
+      const result = adapter === "deterministic"
         ? deterministicOpenCodeResult(packet, payload)
         : await runOpenCodeCliDelegation(command, packet, payload);
-    } catch (error) {
-      const updated = await writeDelegationStatus(taskPath, "failed", {
-        failedAt: new Date().toISOString(),
-        failureReason: error instanceof Error ? error.message.slice(0, 500) : String(error).slice(0, 500),
+      const artifactPath = await writeOpenCodeResultArtifact(taskPath, packet, result);
+      let updated = await writeDelegationStatus(taskPath, "completed", {
+        completedAt: new Date().toISOString(),
+        resultArtifactPath: path.relative(userRoot(), artifactPath),
       });
+      updated = `${updated.trimEnd()}\n\n## Result\n${result.finalSummary}\n\n## Result Artifact\n${path.relative(userRoot(), artifactPath)}\n`;
+      await writeFile(taskPath, updated);
       return {
         ...delegationSummaryFromMarkdown(taskPath, updated, await stat(taskPath)),
-        failureReason: error instanceof Error ? error.message : String(error),
-        status: "failed",
+        adapter: result.adapter,
+        artifact: {
+          path: path.relative(userRoot(), artifactPath),
+          ...result,
+        },
+        status: "completed",
       };
+    } catch (error) {
+      return failDelegationAfterRunning(taskPath, error);
     }
-    const artifactPath = await writeOpenCodeResultArtifact(taskPath, packet, result);
-    let updated = await writeDelegationStatus(taskPath, "completed", {
-      completedAt: new Date().toISOString(),
-      resultArtifactPath: path.relative(userRoot(), artifactPath),
-    });
-    updated = `${updated.trimEnd()}\n\n## Result\n${result.finalSummary}\n\n## Result Artifact\n${path.relative(userRoot(), artifactPath)}\n`;
-    await writeFile(taskPath, updated);
-    return {
-      ...delegationSummaryFromMarkdown(taskPath, updated, await stat(taskPath)),
-      adapter: result.adapter,
-      artifact: {
-        path: path.relative(userRoot(), artifactPath),
-        ...result,
-      },
-      status: "completed",
-    };
   }
 
   async function executeOpenCodeDelegationStatus(payload = {}) {

--- a/browser-first/test/addon-delegation-service-error-handling.test.mjs
+++ b/browser-first/test/addon-delegation-service-error-handling.test.mjs
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { createAddonDelegationService } from "../host/addon-delegation-service.mjs";
+
+function safeFileSlug(value) {
+  return String(value ?? "item")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80) || "item";
+}
+
+function createService(root) {
+  let id = 0;
+  const browserFirstRoot = () => path.join(root, "BrowserFirst");
+  return createAddonDelegationService({
+    browserFirstRoot,
+    bridgePublicUrl: "http://127.0.0.1:47773",
+    dashboardTarget: () => ({ host: "127.0.0.1", port: 9119, url: "http://127.0.0.1:9119" }),
+    execFileStdout: async () => {
+      throw new Error("CLI execution should not run in deterministic tests.");
+    },
+    expandUserPath: (value) => path.resolve(root, String(value ?? "")),
+    firstExistingExecutable: () => null,
+    hermesCommand: () => null,
+    hermesHome: () => path.join(root, "HermesHome"),
+    listFilesRecursive: async () => [],
+    memoryRoot: () => path.join(root, "Memory"),
+    opencodeCommand: () => null,
+    opencodeRuntimeDiagnostics: () => ({ installed: false, command: null }),
+    redactPathForDiagnostics: (value) => String(value ?? "").replace(root, "<root>"),
+    repoRoot: root,
+    safeFileSlug,
+    socketOpen: async () => false,
+    uniqueRuntimeId: (prefix) => `${prefix}-test-${++id}`,
+    userRoot: () => root,
+  });
+}
+
+async function withTempService(fn) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "ros-delegation-errors-"));
+  try {
+    return await fn(createService(root), root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function blockArtifactRoot(root) {
+  const browserFirstRoot = path.join(root, "BrowserFirst");
+  await mkdir(browserFirstRoot, { recursive: true });
+  await writeFile(path.join(browserFirstRoot, "DelegationArtifacts"), "not a directory");
+}
+
+async function assertFinalizationFailureIsTerminal(target) {
+  await withTempService(async (service, root) => {
+    const created = await service.executeDelegationRecord({
+      target,
+      mission: `Exercise ${target} finalization failure handling.`,
+    });
+    await blockArtifactRoot(root);
+
+    const started = target === "hermes"
+      ? await service.executeHermesDelegationStart({ path: created.path, adapter: "deterministic" })
+      : await service.executeOpenCodeDelegationStart({ path: created.path, adapter: "deterministic" });
+
+    assert.equal(started.status, "failed");
+    assert.match(started.failureReason, /DelegationArtifacts|not a directory|ENOTDIR|EEXIST/i);
+
+    const taskPacket = await readFile(path.join(root, created.path), "utf8");
+    assert.match(taskPacket, /^- status:\s*failed$/mi);
+    assert.doesNotMatch(taskPacket, /^- status:\s*running$/mi);
+    assert.match(taskPacket, /^- failureReason:\s*.+$/mi);
+  });
+}
+
+test("Hermes delegation records failed status when artifact finalization fails", async () => {
+  await assertFinalizationFailureIsTerminal("hermes");
+});
+
+test("OpenCode delegation records failed status when artifact finalization fails", async () => {
+  await assertFinalizationFailureIsTerminal("opencode");
+});


### PR DESCRIPTION
**Summary**

Fixes delegation lifecycle error handling so Hermes and OpenCode tasks do not remain stuck in `running` when finalization fails after adapter execution succeeds.

**Changes**

- Wraps adapter execution, artifact creation, completed-status write, and final task-packet append in one guarded lifecycle path.
- Adds shared failed-status recovery for post-`running` delegation failures.
- Adds regression tests for Hermes and OpenCode artifact finalization failures.

**Validation**

- `node --test browser-first/test/addon-delegation-service-error-handling.test.mjs browser-first/test/delegation-bridge-inprocess-self-test.test.mjs browser-first/test/addon-delegation-host-service.test.mjs`
- `npm test -- --run`
- `npm run build`

**Note**

`npm run test:browser-first` was attempted but timed out in this environment and showed unrelated/adjacent failures in the Hermes Windows CLI fixture and TLS tests. The new regression tests and nearby delegation smoke tests pass.