### PR TITLE
[codex] Preserve browser chat context across tabs

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/lib/browser-page-actions.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/browser-page-actions.js
@@ -26,6 +26,7 @@ export function createBrowserPageActions(deps) {
     setActivity,
     setContextMeter,
     setControlledTabId,
+    getLastSnapshot = () => null,
     setLastSnapshot,
     setStatus,
     siteKeyForUrl,
@@ -224,6 +225,41 @@ export function createBrowserPageActions(deps) {
     return sendContentActionToFrames(tab.id, message);
   }
 
+  function sameContextTab(snapshot, tab) {
+    if (!snapshot || !tab?.id) return false;
+    const snapshotTabId = Number(snapshot.tabId ?? snapshot.tab?.id);
+    if (Number.isFinite(snapshotTabId) && snapshotTabId !== tab.id) return false;
+    if (Number.isFinite(snapshotTabId)) return true;
+    return Boolean(snapshot.url && tab.url && snapshot.url === tab.url);
+  }
+
+  async function hydrateCachedTabSnapshot(tab) {
+    if (!tab?.id) {
+      setLastSnapshot(null);
+      setContextMeter(null);
+      return null;
+    }
+    const currentSnapshot = getLastSnapshot();
+    if (sameContextTab(currentSnapshot, tab)) {
+      setContextMeter(currentSnapshot);
+      return currentSnapshot;
+    }
+    const response = await chrome.runtime?.sendMessage?.({
+      channel: "resonantos.browser_first",
+      type: "active_tab_context",
+      tabId: tab.id
+    }).catch(() => null);
+    const snapshot = response?.snapshot ?? null;
+    if (sameContextTab(snapshot, tab)) {
+      setLastSnapshot(snapshot);
+      setContextMeter(snapshot);
+      return snapshot;
+    }
+    setLastSnapshot(null);
+    setContextMeter(null);
+    return null;
+  }
+
   const setPageControlOverlay = async (active, label = "", phase = "") => sendContentAction({
     type: "control_overlay",
     active,
@@ -317,6 +353,7 @@ export function createBrowserPageActions(deps) {
     const label = tab?.title || tab?.url || "No page context";
     deps.setReadButtonTitle(`Attach/read current page: ${label}`);
     await renderSitePermissionPanel(tab);
+    await hydrateCachedTabSnapshot(tab);
     setStatus("Ready");
     return tab;
   }

--- a/browser-first/resonantos-side-panel-extension/src/lib/main-workspace-action-controller.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/main-workspace-action-controller.js
@@ -9,6 +9,10 @@ import {
 import { delegationTargetLabel, startDelegationLifecycle } from "./delegation-lifecycle.js";
 import { buildDelegationStatusMessage } from "./delegation-status.js";
 import { buildHermesRuntimeStatusMessage } from "./addon-runtime-status.js";
+import {
+  pageContextForSnapshot,
+  runtimeContextForAttachments
+} from "./chat-turn-controller.js";
 import { runReviewableCapture } from "./main-workspace-review-handoff.js";
 import {
   mainWorkspaceRequestMessage,
@@ -69,6 +73,7 @@ export function createMainWorkspaceActionController({
   composerController,
   composerNotice,
   getBusy,
+  getLastSnapshot = () => null,
   getModel,
   getPersonalizationSettings,
   getThinkingDepth,
@@ -118,6 +123,9 @@ export function createMainWorkspaceActionController({
     activeChatAbortController = new AbortController();
     updateConnectionLine("Thinking");
     try {
+      const attachments = typeof chatSessionStore.getAttachments === "function"
+        ? chatSessionStore.getAttachments()
+        : [];
       const response = await bridge()("/augmentor/chat", {
         method: "POST",
         signal: activeChatAbortController.signal,
@@ -127,6 +135,8 @@ export function createMainWorkspaceActionController({
           workload: "augmentor-chat",
           thinkingDepth: getThinkingDepth(),
           systemPrompt: getPersonalizationSettings()?.augmentor?.systemPrompt ?? "",
+          pageContext: pageContextForSnapshot(getLastSnapshot()),
+          runtimeContext: runtimeContextForAttachments(attachments),
           messages: providerMessagesFromHistory(chatSessionStore.getMessages())
         }
       });

--- a/browser-first/resonantos-side-panel-extension/src/lib/side-panel-chat-hydration.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/side-panel-chat-hydration.js
@@ -22,7 +22,6 @@ export function createSidePanelChatHydration(dependencies) {
       const settings = await storage?.get?.([storageKeys.contextDockExpanded]).catch(() => ({}));
       setContextDockExpanded(Boolean(settings?.[storageKeys.contextDockExpanded]));
       await hydrateControlPreflight();
-      await chatSessionStore.ensureFreshSession();
       renderMessages();
       renderAttachments();
       updateConnectionLine();

--- a/browser-first/resonantos-side-panel-extension/src/main-workspace.js
+++ b/browser-first/resonantos-side-panel-extension/src/main-workspace.js
@@ -327,6 +327,7 @@ const mainWorkspaceActions = createMainWorkspaceActionController({
   composerController,
   composerNotice,
   getBusy: () => busy,
+  getLastSnapshot: () => lastSnapshot,
   getModel: () => modelSelect.value,
   getPersonalizationSettings: () => personalizationSettings,
   getThinkingDepth: () => thinkingDepthSelect.value,

--- a/browser-first/test/browser-page-actions.test.mjs
+++ b/browser-first/test/browser-page-actions.test.mjs
@@ -30,6 +30,12 @@ function createHarness(overrides = {}) {
         return { id: tabId, ...payload };
       }
     },
+    runtime: overrides.activeTabContext ? {
+      sendMessage: async (message) => {
+        events.push(["runtime.sendMessage", message]);
+        return overrides.activeTabContext(message);
+      }
+    } : undefined,
     scripting: overrides.scripting ?? {
       executeScript: async (payload) => events.push(["inject", payload])
     },
@@ -160,6 +166,72 @@ test("browser page actions merge frame snapshots when reading the active page", 
   assert.match(result.snapshot.text, /child text/);
   assert.equal(result.snapshot.frames.length, 2);
   assert.equal(harness.getLastSnapshot().title, "Top");
+});
+
+test("browser page actions hydrates cached active-tab context from background snapshot store", async () => {
+  const harness = createHarness({
+    activeTabContext: () => ({
+      ok: true,
+      snapshot: {
+        tabId: 1,
+        title: "Cached Active Tab",
+        url: "https://example.test/",
+        text: "cached page context"
+      }
+    })
+  });
+
+  await harness.actions.readActivePage({ announce: false });
+
+  assert.ok(harness.events.some((event) => event[0] === "runtime.sendMessage" && event[1].type === "active_tab_context"));
+  assert.ok(harness.events.some((event) => event[0] === "snapshot" && event[1] === "Cached Active Tab"));
+  assert.ok(harness.events.some((event) => event[0] === "context" && event[1] === "Cached Active Tab"));
+});
+
+test("browser page actions clears stale page context when active tab changes", async () => {
+  const harness = createHarness({
+    lastSnapshot: {
+      tabId: 9,
+      title: "Old Tab",
+      url: "https://old.example/",
+      text: "stale"
+    },
+    activeTabContext: () => ({
+      ok: true,
+      snapshot: {
+        tabId: 9,
+        title: "Old Tab",
+        url: "https://old.example/",
+        text: "stale"
+      }
+    })
+  });
+
+  await harness.actions.readActivePage({ announce: false });
+
+  assert.ok(harness.events.some((event) => event[0] === "snapshot" && event[1] === null));
+  assert.ok(harness.events.some((event) => event[0] === "context" && event[1] === null));
+});
+
+test("browser page actions rejects cached tab context without tab identity or URL", async () => {
+  const harness = createHarness({
+    lastSnapshot: {
+      title: "Malformed Cached Snapshot",
+      text: "no tab or URL identity"
+    },
+    activeTabContext: () => ({
+      ok: true,
+      snapshot: {
+        title: "Malformed Cached Snapshot",
+        text: "no tab or URL identity"
+      }
+    })
+  });
+
+  await harness.actions.readActivePage({ announce: false });
+
+  assert.ok(harness.events.some((event) => event[0] === "snapshot" && event[1] === null));
+  assert.ok(harness.events.some((event) => event[0] === "context" && event[1] === null));
 });
 
 test("browser page actions inject content script after missing receiver failure", async () => {

--- a/browser-first/test/main-workspace-action-controller.test.mjs
+++ b/browser-first/test/main-workspace-action-controller.test.mjs
@@ -13,6 +13,7 @@ function createHarness(overrides = {}) {
     { role: "user", content: "previous question" },
     { role: "assistant", content: "previous answer" }
   ];
+  const attachments = overrides.attachments ?? [];
   const browserPageActions = {
     detectWalletState: async () => {
       events.push(["wallet-status"]);
@@ -76,6 +77,7 @@ function createHarness(overrides = {}) {
       addMessage: async (role, content, options = {}) => {
         events.push(["store-message", role, content, options]);
       },
+      getAttachments: () => attachments,
       getMessages: () => messages
     },
     chromeApi: {
@@ -100,6 +102,7 @@ function createHarness(overrides = {}) {
     },
     composerNotice: {},
     getBusy: () => busy,
+    getLastSnapshot: () => overrides.lastSnapshot ?? null,
     getModel: () => "MiniMax 2.7",
     getPersonalizationSettings: () => ({ augmentor: { systemPrompt: "custom prompt" } }),
     getThinkingDepth: () => "high",
@@ -136,6 +139,31 @@ test("main workspace action controller runs provider chat with current model, de
   assert.equal(harness.commandInput.value, "");
   assert.ok(harness.events.some((event) => event[0] === "message" && event[1] === "assistant" && event[2] === "assistant reply"));
   assert.deepEqual(harness.events.at(-1), ["busy", false]);
+});
+
+test("main workspace action controller forwards current page and attachment context to provider chat", async () => {
+  const harness = createHarness({
+    prompt: "what matters on this page?",
+    lastSnapshot: {
+      title: "ResonantOS Docs",
+      url: "https://example.test/docs",
+      text: "Visible documentation text",
+      links: [{ text: "Install", href: "https://example.test/install" }]
+    },
+    attachments: [{
+      name: "notes.md",
+      type: "text/markdown",
+      content: "Local note context"
+    }]
+  });
+
+  await harness.controller.handleSubmit({ preventDefault() {} });
+
+  const chatCall = harness.events.find((event) => event[0] === "bridge" && event[1] === "/augmentor/chat");
+  assert.match(chatCall[2].pageContext, /ResonantOS Docs/);
+  assert.match(chatCall[2].pageContext, /Visible documentation text/);
+  assert.match(chatCall[2].runtimeContext, /notes\.md/);
+  assert.match(chatCall[2].runtimeContext, /Local note context/);
 });
 
 test("main workspace action controller replaces raw model fetch failures with bridge setup guidance", async () => {

--- a/browser-first/test/side-panel-chat-hydration.test.mjs
+++ b/browser-first/test/side-panel-chat-hydration.test.mjs
@@ -8,7 +8,7 @@ test("side panel chat hydration owns startup ordering and state handoff", async 
   const hydration = createSidePanelChatHydration({
     chatSessionStore: {
       hydrate: async () => events.push("session-hydrate"),
-      ensureFreshSession: async () => events.push("ensure-fresh-session")
+      ensureFreshSession: async () => events.push("unexpected-ensure-fresh-session")
     },
     hydrateControlPreflight: async () => events.push("hydrate-control-preflight"),
     hydrateProviderModelOptions: async () => events.push("hydrate-provider-options"),
@@ -43,7 +43,6 @@ test("side panel chat hydration owns startup ordering and state handoff", async 
     ["storage-get", ["augmentorContextDockExpanded"]],
     ["context-expanded", true],
     "hydrate-control-preflight",
-    "ensure-fresh-session",
     "render-messages",
     "render-attachments",
     "update-connection-line",
@@ -56,7 +55,7 @@ test("side panel chat hydration safely treats missing context dock state as coll
   const hydration = createSidePanelChatHydration({
     chatSessionStore: {
       hydrate: async () => undefined,
-      ensureFreshSession: async () => undefined
+      ensureFreshSession: async () => events.push("unexpected-ensure-fresh-session")
     },
     hydrateControlPreflight: async () => undefined,
     hydrateProviderModelOptions: async () => undefined,


### PR DESCRIPTION
## Summary

- Preserve the current side-panel chat session during hydration instead of forcing a fresh session on startup.
- Forward main-workspace chat page context and composer attachment context through the same provider chat contract used by the side panel.
- Hydrate main-workspace page context from the background active-tab snapshot store, and clear stale or malformed tab context when the active tab changes.

## Why

The current browser-first experience can lose continuity when Augmentor is used across multiple tabs or surfaces. The side panel was starting a fresh session during hydration, while main chat did not forward the active page or attachment context to the provider request. This PR isolates that continuity fix without including the separate Blackboard experiment currently present in the primary local checkout.

## Validation

- `node --test browser-first/test/side-panel-chat-hydration.test.mjs browser-first/test/main-workspace-action-controller.test.mjs browser-first/test/chat-turn-controller.test.mjs browser-first/test/browser-page-actions.test.mjs browser-first/test/tab-context-controller.test.mjs` — 44 passed
- `npm run test:browser-first` — 624 passed
- `npm test -- --run` — 312 passed
- `npm run build` — passed, with existing large chunk warning
- `npm run pre-release:scan` — passed
- `npm run browser-first:audit-scope` — passed, 7 changed paths, 0 deferred, 0 manual review
- `git diff --check` — passed
