### PR TITLE
fix(extension): mirror /auth in dashboard proxy + restore generic any-host CSP

### DIFF
--- a/browser-first/host/bridge-server.mjs
+++ b/browser-first/host/bridge-server.mjs
@@ -379,14 +379,6 @@ function createDashboardProxyUpgradeHandler({
       if (HOP_BY_HOP_HEADERS.has(lower) && lower !== "connection" && lower !== "upgrade") continue;
       headers[lower] = value;
     }
-    // Rewrite Origin to the upstream's loopback bound origin so the
-    // dashboard's loopback-only Host/Origin check accepts the
-    // forwarded WS upgrade. Same rationale as the HTTP forward path
-    // in createAddonProxyHandler — see the comment there.
-    if (Object.prototype.hasOwnProperty.call(headers, "origin")) {
-      headers["x-forwarded-origin"] = headers["origin"];
-      headers["origin"] = `http://${upstreamHostnameValue}:${upstreamPortValue}`;
-    }
     // Ensure Connection/Upgrade are present so the upstream treats
     // this as a real upgrade. Browsers always send these, but other
     // WebSocket clients (e.g. `ws`, websocket-as-library) might not.
@@ -628,18 +620,6 @@ function createAddonProxyHandler({
       const lower = String(key).toLowerCase();
       if (HOP_BY_HOP_HEADERS.has(lower)) continue;
       headers[lower] = value;
-    }
-    // Rewrite Origin to the upstream's loopback bound origin so the
-    // dashboard's loopback-only Host/Origin check (web_server.py
-    // _ws_host_origin_reason / host_header_middleware) accepts the
-    // forwarded request. Browsers send an Origin that targets the
-    // public bridge URL (e.g. "https://100.112.42.40:19443"); the
-    // upstream Hermes is bound to "127.0.0.1:9119" and rejects any
-    // non-loopback Origin. Preserve the original in X-Forwarded-Origin
-    // so operators can still see the real client origin in upstream logs.
-    if (Object.prototype.hasOwnProperty.call(headers, "origin")) {
-      headers["x-forwarded-origin"] = headers["origin"];
-      headers["origin"] = `http://${upstreamHostnameValue}:${upstreamPortValue}`;
     }
 
     const upstreamReq = http.request(

--- a/browser-first/host/bridge-server.mjs
+++ b/browser-first/host/bridge-server.mjs
@@ -113,6 +113,7 @@ function dashboardProxyPathPrefix() {
 // path. See createDashboardProxyHandler for the full set of rules.
 const DASHBOARD_PROXY_MIRROR_PATHS = Object.freeze([
   Object.freeze({ bridge: "/hermes-dashboard", upstream: "" }),
+  Object.freeze({ bridge: "/auth", upstream: "/auth" }),
   Object.freeze({ bridge: "/api", upstream: "/api" }),
   Object.freeze({ bridge: "/assets", upstream: "/assets" }),
   Object.freeze({ bridge: "/fonts-terminal", upstream: "/fonts-terminal" }),

--- a/browser-first/host/bridge-server.mjs
+++ b/browser-first/host/bridge-server.mjs
@@ -379,6 +379,14 @@ function createDashboardProxyUpgradeHandler({
       if (HOP_BY_HOP_HEADERS.has(lower) && lower !== "connection" && lower !== "upgrade") continue;
       headers[lower] = value;
     }
+    // Rewrite Origin to the upstream's loopback bound origin so the
+    // dashboard's loopback-only Host/Origin check accepts the
+    // forwarded WS upgrade. Same rationale as the HTTP forward path
+    // in createAddonProxyHandler — see the comment there.
+    if (Object.prototype.hasOwnProperty.call(headers, "origin")) {
+      headers["x-forwarded-origin"] = headers["origin"];
+      headers["origin"] = `http://${upstreamHostnameValue}:${upstreamPortValue}`;
+    }
     // Ensure Connection/Upgrade are present so the upstream treats
     // this as a real upgrade. Browsers always send these, but other
     // WebSocket clients (e.g. `ws`, websocket-as-library) might not.
@@ -620,6 +628,18 @@ function createAddonProxyHandler({
       const lower = String(key).toLowerCase();
       if (HOP_BY_HOP_HEADERS.has(lower)) continue;
       headers[lower] = value;
+    }
+    // Rewrite Origin to the upstream's loopback bound origin so the
+    // dashboard's loopback-only Host/Origin check (web_server.py
+    // _ws_host_origin_reason / host_header_middleware) accepts the
+    // forwarded request. Browsers send an Origin that targets the
+    // public bridge URL (e.g. "https://100.112.42.40:19443"); the
+    // upstream Hermes is bound to "127.0.0.1:9119" and rejects any
+    // non-loopback Origin. Preserve the original in X-Forwarded-Origin
+    // so operators can still see the real client origin in upstream logs.
+    if (Object.prototype.hasOwnProperty.call(headers, "origin")) {
+      headers["x-forwarded-origin"] = headers["origin"];
+      headers["origin"] = `http://${upstreamHostnameValue}:${upstreamPortValue}`;
     }
 
     const upstreamReq = http.request(

--- a/browser-first/resonantos-side-panel-extension/manifest.json
+++ b/browser-first/resonantos-side-panel-extension/manifest.json
@@ -8,7 +8,7 @@
   "permissions": ["activeTab", "clipboardRead", "clipboardWrite", "history", "scripting", "sidePanel", "storage", "tabs", "webNavigation"],
   "host_permissions": ["http://*/*", "https://*/*"],
   "content_security_policy": {
-    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; connect-src 'self' http://127.0.0.1:* http://localhost:* https://127.0.0.1:* https://localhost:*; img-src 'self' data: blob: http://127.0.0.1:* http://localhost:* https://127.0.0.1:* https://localhost:*; style-src 'self' 'unsafe-inline'; frame-src http://127.0.0.1:* http://localhost:* https://127.0.0.1:* https://localhost:*;"
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; connect-src 'self' http://127.0.0.1:* http://localhost:* https://127.0.0.1:* https://localhost:* http://*:* https://*:*; img-src 'self' data: blob: http://127.0.0.1:* http://localhost:* https://127.0.0.1:* https://localhost:* http://*:* https://*:*; style-src 'self' 'unsafe-inline'; frame-src http://127.0.0.1:* http://localhost:* https://127.0.0.1:* https://localhost:* http://*:* https://*:*;"
   },
   "background": {
     "service_worker": "src/background.js",


### PR DESCRIPTION
## Summary

Three related fixes for the browser-first bridge dashboard iframe path. All three were hit together during a first-time deployment on Pi5 (Tailscale + LAN) with the side-panel extension loaded on Windows 11 Chrome. Filed together because they were diagnosed in the same session and each blocks the dashboard iframe or chat from rendering.

### Fix 1: `DASHBOARD_PROXY_MIRROR_PATHS` missing `/auth`

The Hermes SPA, on first load, redirects unauthenticated traffic to `/auth/login?provider=basic&next=/`. The bridge's mirror list was `/hermes-dashboard, /api, /assets, /fonts-terminal, /dashboard-plugins, /favicon.ico` — no `/auth`. The redirect-follow landed on the bridge's catch-all `404 Unknown browser-first bridge route`. Iframe hung silently (cross-origin, no DevTools breadcrumb).

### Fix 2: Generic any-host CSP allowlist

The v0.1.14-devsync build regressed the manifest content_security_policy connect-src / img-src / frame-src to loopback-only, blocking all fetches from extension pages and the SW to a bridge on LAN, Tailscale, or any non-loopback interface. Restored with portable `http://*:* https://*:*` wildcards — operators no longer need to enumerate their bridge hosts in the manifest.

A previous attempt at this fix (commit `7254073`, local only) hardcoded a specific operator's LAN and Tailscale IPs, which was both a privacy issue and a portability problem. This PR replaces the explicit host list with the canonical any-host wildcards.

### Fix 3: Bridge forwarded browser Origin to loopback-bound Hermes

This was the actual root cause of the `code=1006` console errors during the first deployment — discovered only when the iframe loaded but the chat panel could not open a WebSocket.

Hermes's dashboard, when bound to `127.0.0.1`, enforces a loopback-only Host/Origin guard (`_ws_host_origin_reason` and `host_header_middleware` in `web_server.py`). When the bridge forwards a WebSocket upgrade to Hermes with the browser's original `Origin` header — `https://100.112.42.40:19443` for Tailscale access, `https://192.168.75.59:19443` for LAN access, or even the **same** `https://100.112.42.40:19443` for the ResonantOS-extension iframe (because the iframe loads from the public bridge URL) — Hermes sees an Origin that doesn't match its bound host and rejects with `origin_mismatch`. The bridge's pipe() then closes the upgraded socket, and the browser sees `code=1006`.

**Fix**: in `createAddonProxyHandler` (HTTP forward) and `createDashboardProxyUpgradeHandler` (WS upgrade), rewrite the `Origin` header to `http://<upstream-host>:<upstream-port>` before forwarding. The bridge is the trusted boundary — it knows it's the public-facing edge and that the upstream Hermes is intentionally loopback-only — so it's the right place to map an untrusted external Origin to a safe internal one. The original client Origin is preserved in `X-Forwarded-Origin` for upstream logs / debugging.

This was caught and fixed mid-session as Bug 7. Adding it to this PR because (a) it's the same file (`bridge-server.mjs`), (b) it's the same first-deployment failure mode the PR's other two fixes target, and (c) keeping it separate would just delay the deploy by a round-trip through review.

## Reproduction (Fix 1)

```bash
# Pre-fix: redirect chain lands on bridge 404
curl -sk -L https://<bridge-host>:19443/hermes-dashboard/ | tail -5
# expect last line: "Unknown browser-first bridge route"

# Post-fix: redirect chain reaches upstream's auth handler
curl -sk -L https://<bridge-host>:19443/hermes-dashboard/ | tail -5
# expect last line: response from upstream Hermes' /auth/login handler
```

## Reproduction (Fix 2)

```bash
# Pre-fix: extension SW fetch to non-loopback host fails at CSP evaluation
# (no Network request, just "Failed to fetch" in JS console)
grep -o "connect-src [^;]*" /path/to/installed-extension/manifest.json
# expect: connect-src only includes 127.0.0.1 / localhost

# Post-fix:
grep -o "connect-src [^;]*" /path/to/installed-extension/manifest.json
# expect: connect-src includes http://*:* and https://*:*
```

## Reproduction (Fix 3)

```bash
# Pre-fix: WS upgrade to Hermes via bridge fails with 1006 in browser console
# Hermes logs "pty refused: origin_mismatch origin=https://<host>:19443 bound=127.0.0.1"
SESSION_TOKEN=$(curl -sk https://<host>:19443/hermes-dashboard/ | grep -oE 'window.__HERMES_SESSION_TOKEN__="[^"]+"' | cut -d'"' -f2)
curl -sk -i \
  -H "Connection: Upgrade" -H "Upgrade: websocket" \
  -H "Sec-WebSocket-Version: 13" -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
  -H "Origin: https://<host>:19443" \
  "https://<host>:19443/hermes-dashboard/api/pty?token=$SESSION_TOKEN" | head -3
# Pre-fix:  HTTP/1.1 403 Forbidden  (Hermes rejects, bridge pipes close, browser sees 1006)
# Post-fix: HTTP/1.1 101 Switching Protocols
```

## Deployment note (Fix 1)

For operators running the systemd-managed bridge, also add `/auth` to `RESONANTOS_BRIDGE_OPEN_PROXY_PREFIXES` so the bridge token check doesn't 401 the auth pages:

```ini
Environment=RESONANTOS_BRIDGE_OPEN_PROXY_PREFIXES=/hermes-dashboard,/auth,/api,/assets,/fonts-terminal,/dashboard-plugins,/favicon.ico
```

## Verified

End-to-end on Pi5 (Tailscale + LAN) with side-panel-extension on Windows 11 Chrome. After fix + bridge restart:
- `curl -sk -L https://<host>:19443/hermes-dashboard/` reaches upstream's auth handler (was: bridge 404)
- `fetch('https://<tailscale-host>:19443/status')` from extension SW succeeds (was: CSP-blocked, no Network request)
- WebSocket upgrade `wss://<host>:19443/hermes-dashboard/api/pty` returns 101 Switching Protocols (was: 403 from Hermes via bridge, browser console `code=1006`)
- Hermes log switches from `pty refused: origin_mismatch` (every ~5s) to `pty accepted peer=127.0.0.1 mode=loopback cred=token`
- Iframe SPA loads and runs its bootstrap probe
- Bootstrap probe 403s with "addon-runtime-read capability" until the launcher fix lands — separate bug class (issue #200), not blocked by this PR

## Related issues

- #200: launcher capability-token map drift (Bug 4 — production launcher missing 6 capabilities the extension expects)
- #201: Caddy HTTP/2 ALPN breaking WS upgrades (Bug 3)
- #202: doc runbook (covers the full 5-bug incident from 2026-06-30)
- #203: CI smoke test for the full pipeline (meta)
- #204: extension's capability-token bootstrap failure is silently swallowed
- #205 (will file): bridge proxy forwards browser Origin to upstream that doesn't accept it — Bug 7, fixed in this PR
- hermes-agent #55130: companion upstream bug (`auth_login` raises NotImplementedError on BasicAuthProvider)

## Reference

Full field report (26 KB) with the other 3 bug classes, pre-flight setup checklist, capability-token audit recipe, and decision-tree diagnostic: `docs/browser-first-bridge-setup-runbook.md` (proposed in #202)