### PR TITLE
fix(#200,#204): unify bridge capability-token map + surface bootstrap failures

### DIFF
--- a/browser-first/host/bridge-capability-tokens.mjs
+++ b/browser-first/host/bridge-capability-tokens.mjs
@@ -1,0 +1,70 @@
+// Canonical source of the browser-first bridge capability set.
+//
+// Every capability-scoped bridge route declares a `requiredCapability`; the
+// launcher mints one token per capability and the extension requests exactly
+// these (its RUNTIME_CAPABILITY_ALLOWLIST, derived from BRIDGE_ROUTE_CAPABILITIES
+// in resonantos-side-panel-extension/src/lib/bridge-client.js).
+//
+// Historically each launcher entry point (`run-bridge-minimal.mjs` and the
+// production `resonantos-bridge-full.mjs`) carried its own hand-maintained
+// `bridgeCapabilityTokens` object literal. Those drifted: when the extension
+// gained a new capability, a launcher that was not updated failed to mint the
+// token, `POST /api/capability-tokens` 500'd with `Unknown bridge capability
+// requested: <name>`, and the dashboard iframe died with no breadcrumb (#200).
+//
+// Both launchers now derive their mint map from BRIDGE_CAPABILITY_TOKEN_SPECS
+// here, so there is a single place to add a capability, and
+// bridge-capability-token-consistency.test.mjs locks this list to the
+// extension's allowlist so any future drift fails CI instead of production.
+//
+// The `arg`/`env` names are an external deployment contract (operators pass
+// --<arg> or set the env var to pin a stable token) — do not rename them.
+
+export const BRIDGE_CAPABILITY_TOKEN_SPECS = Object.freeze([
+  { capability: "provider-credential-write", arg: "provider-credential-token", env: "RESONANTOS_BROWSER_FIRST_PROVIDER_CREDENTIAL_TOKEN" },
+  { capability: "provider-routing-write", arg: "provider-routing-token", env: "RESONANTOS_BROWSER_FIRST_PROVIDER_ROUTING_TOKEN" },
+  { capability: "provider-diagnostics-read", arg: "provider-diagnostics-token", env: "RESONANTOS_BROWSER_FIRST_PROVIDER_DIAGNOSTICS_TOKEN" },
+  { capability: "provider-model-invoke", arg: "provider-model-invoke-token", env: "RESONANTOS_BROWSER_FIRST_PROVIDER_MODEL_INVOKE_TOKEN" },
+  { capability: "agent-control-plan", arg: "agent-control-plan-token", env: "RESONANTOS_BROWSER_FIRST_AGENT_CONTROL_PLAN_TOKEN" },
+  { capability: "memory-settings-write", arg: "memory-settings-token", env: "RESONANTOS_BROWSER_FIRST_MEMORY_SETTINGS_TOKEN" },
+  { capability: "memory-source-browse", arg: "memory-source-browse-token", env: "RESONANTOS_BROWSER_FIRST_MEMORY_SOURCE_BROWSE_TOKEN" },
+  { capability: "memory-source-scan", arg: "memory-source-scan-token", env: "RESONANTOS_BROWSER_FIRST_MEMORY_SOURCE_SCAN_TOKEN" },
+  { capability: "memory-source-manage", arg: "memory-source-manage-token", env: "RESONANTOS_BROWSER_FIRST_MEMORY_SOURCE_MANAGE_TOKEN" },
+  { capability: "memory-source-move", arg: "memory-source-move-token", env: "RESONANTOS_BROWSER_FIRST_MEMORY_SOURCE_MOVE_TOKEN" },
+  { capability: "memory-source-review", arg: "memory-source-review-token", env: "RESONANTOS_BROWSER_FIRST_MEMORY_SOURCE_REVIEW_TOKEN" },
+  { capability: "memory-source-intake", arg: "memory-source-intake-token", env: "RESONANTOS_BROWSER_FIRST_MEMORY_SOURCE_INTAKE_TOKEN" },
+  { capability: "memory-source-file-intake", arg: "memory-source-file-intake-token", env: "RESONANTOS_BROWSER_FIRST_MEMORY_SOURCE_FILE_INTAKE_TOKEN" },
+  { capability: "archive-read", arg: "archive-read-token", env: "RESONANTOS_BROWSER_FIRST_ARCHIVE_READ_TOKEN" },
+  { capability: "archive-write", arg: "archive-write-token", env: "RESONANTOS_BROWSER_FIRST_ARCHIVE_WRITE_TOKEN" },
+  { capability: "diagnostics-report-export", arg: "diagnostics-report-token", env: "RESONANTOS_BROWSER_FIRST_DIAGNOSTICS_REPORT_TOKEN" },
+  { capability: "browser-download-action", arg: "browser-download-action-token", env: "RESONANTOS_BROWSER_FIRST_BROWSER_DOWNLOAD_ACTION_TOKEN" },
+  { capability: "addon-execution-settings-write", arg: "addon-execution-settings-token", env: "RESONANTOS_BROWSER_FIRST_ADDON_EXECUTION_SETTINGS_TOKEN" },
+  { capability: "addon-runtime-read", arg: "addon-runtime-read-token", env: "RESONANTOS_BROWSER_FIRST_ADDON_RUNTIME_READ_TOKEN" },
+  { capability: "addon-runtime-control", arg: "addon-runtime-control-token", env: "RESONANTOS_BROWSER_FIRST_ADDON_RUNTIME_CONTROL_TOKEN" },
+  { capability: "addon-record-read", arg: "addon-record-read-token", env: "RESONANTOS_BROWSER_FIRST_ADDON_RECORD_READ_TOKEN" },
+  { capability: "addon-record-write", arg: "addon-record-write-token", env: "RESONANTOS_BROWSER_FIRST_ADDON_RECORD_WRITE_TOKEN" },
+  { capability: "extension-prefs-write", arg: "extension-prefs-write-token", env: "RESONANTOS_BROWSER_FIRST_EXTENSION_PREFS_WRITE_TOKEN" },
+]);
+
+// The canonical capability names, in declaration order.
+export const BRIDGE_CAPABILITIES = Object.freeze(
+  BRIDGE_CAPABILITY_TOKEN_SPECS.map((spec) => spec.capability),
+);
+
+// Build the launcher's capability→token mint map. For each capability the token
+// is taken from an explicit CLI arg, then a pinned env var, then a freshly
+// minted token — matching the prior per-entry precedence. `args` is any object
+// with a `.get(name)` method (the launcher's parsed argv); `mint` produces a
+// fresh token when neither override is present.
+export function buildBridgeCapabilityTokens({ args, env = process.env, mint } = {}) {
+  if (typeof mint !== "function") {
+    throw new Error("buildBridgeCapabilityTokens requires a mint() function.");
+  }
+  const argGet = typeof args?.get === "function" ? (name) => args.get(name) : () => undefined;
+  return Object.fromEntries(
+    BRIDGE_CAPABILITY_TOKEN_SPECS.map(({ capability, arg, env: envName }) => [
+      capability,
+      argGet(arg) ?? env?.[envName] ?? mint(),
+    ]),
+  );
+}

--- a/browser-first/host/run-bridge-minimal.mjs
+++ b/browser-first/host/run-bridge-minimal.mjs
@@ -30,6 +30,7 @@ import {
 } from "./browser-first-host-utils.mjs";
 import { runBrowserFirstSelfTest } from "./browser-first-self-test-service.mjs";
 import { createAgentControlHostService } from "./agent-control-host-service.mjs";
+import { buildBridgeCapabilityTokens } from "./bridge-capability-tokens.mjs";
 import { createAddonDelegationHostService } from "./addon-delegation-host-service.mjs";
 import { createAddonDelegationService } from "./addon-delegation-service.mjs";
 import { createArchiveReviewHostService } from "./archive-review-host-service.mjs";
@@ -347,77 +348,7 @@ const bridgeToken = args.get("bridge-token") ?? process.env.RESONANTOS_BROWSER_F
 const capabilityBootstrapToken = args.get("capability-bootstrap-token") ??
   process.env.RESONANTOS_BROWSER_FIRST_CAPABILITY_BOOTSTRAP_TOKEN ??
   createBridgeToken();
-const bridgeCapabilityTokens = {
-  "provider-credential-write": args.get("provider-credential-token") ??
-    process.env.RESONANTOS_BROWSER_FIRST_PROVIDER_CREDENTIAL_TOKEN ??
-    createBridgeToken(),
-  "provider-routing-write": args.get("provider-routing-token") ??
-    process.env.RESONANTOS_BROWSER_FIRST_PROVIDER_ROUTING_TOKEN ??
-    createBridgeToken(),
-  "provider-diagnostics-read": args.get("provider-diagnostics-token") ??
-    process.env.RESONANTOS_BROWSER_FIRST_PROVIDER_DIAGNOSTICS_TOKEN ??
-    createBridgeToken(),
-  "provider-model-invoke": args.get("provider-model-invoke-token") ??
-    process.env.RESONANTOS_BROWSER_FIRST_PROVIDER_MODEL_INVOKE_TOKEN ??
-    createBridgeToken(),
-  "agent-control-plan": args.get("agent-control-plan-token") ??
-    process.env.RESONANTOS_BROWSER_FIRST_AGENT_CONTROL_PLAN_TOKEN ??
-    createBridgeToken(),
-  "memory-settings-write": args.get("memory-settings-token") ??
-    process.env.RESONANTOS_BROWSER_FIRST_MEMORY_SETTINGS_TOKEN ??
-    createBridgeToken(),
-  "memory-source-browse": args.get("memory-source-browse-token") ??
-    process.env.RESONANTOS_BROWSER_FIRST_MEMORY_SOURCE_BROWSE_TOKEN ??
-    createBridgeToken(),
-  "memory-source-scan": args.get("memory-source-scan-token") ??
-    process.env.RESONANTOS_BROWSER_FIRST_MEMORY_SOURCE_SCAN_TOKEN ??
-    createBridgeToken(),
-  "memory-source-manage": args.get("memory-source-manage-token") ??
-    process.env.RESONANTOS_BROWSER_FIRST_MEMORY_SOURCE_MANAGE_TOKEN ??
-    createBridgeToken(),
-  "memory-source-move": args.get("memory-source-move-token") ??
-    process.env.RESONANTOS_BROWSER_FIRST_MEMORY_SOURCE_MOVE_TOKEN ??
-    createBridgeToken(),
-  "memory-source-review": args.get("memory-source-review-token") ??
-    process.env.RESONANTOS_BROWSER_FIRST_MEMORY_SOURCE_REVIEW_TOKEN ??
-    createBridgeToken(),
-  "memory-source-intake": args.get("memory-source-intake-token") ??
-    process.env.RESONANTOS_BROWSER_FIRST_MEMORY_SOURCE_INTAKE_TOKEN ??
-    createBridgeToken(),
-  "memory-source-file-intake": args.get("memory-source-file-intake-token") ??
-    process.env.RESONANTOS_BROWSER_FIRST_MEMORY_SOURCE_FILE_INTAKE_TOKEN ??
-    createBridgeToken(),
-  "archive-read": args.get("archive-read-token") ??
-    process.env.RESONANTOS_BROWSER_FIRST_ARCHIVE_READ_TOKEN ??
-    createBridgeToken(),
-  "archive-write": args.get("archive-write-token") ??
-    process.env.RESONANTOS_BROWSER_FIRST_ARCHIVE_WRITE_TOKEN ??
-    createBridgeToken(),
-  "diagnostics-report-export": args.get("diagnostics-report-token") ??
-    process.env.RESONANTOS_BROWSER_FIRST_DIAGNOSTICS_REPORT_TOKEN ??
-    createBridgeToken(),
-  "browser-download-action": args.get("browser-download-action-token") ??
-    process.env.RESONANTOS_BROWSER_FIRST_BROWSER_DOWNLOAD_ACTION_TOKEN ??
-    createBridgeToken(),
-  "addon-execution-settings-write": args.get("addon-execution-settings-token") ??
-    process.env.RESONANTOS_BROWSER_FIRST_ADDON_EXECUTION_SETTINGS_TOKEN ??
-    createBridgeToken(),
-  "addon-runtime-read": args.get("addon-runtime-read-token") ??
-    process.env.RESONANTOS_BROWSER_FIRST_ADDON_RUNTIME_READ_TOKEN ??
-    createBridgeToken(),
-  "addon-runtime-control": args.get("addon-runtime-control-token") ??
-    process.env.RESONANTOS_BROWSER_FIRST_ADDON_RUNTIME_CONTROL_TOKEN ??
-    createBridgeToken(),
-  "addon-record-read": args.get("addon-record-read-token") ??
-    process.env.RESONANTOS_BROWSER_FIRST_ADDON_RECORD_READ_TOKEN ??
-    createBridgeToken(),
-  "addon-record-write": args.get("addon-record-write-token") ??
-    process.env.RESONANTOS_BROWSER_FIRST_ADDON_RECORD_WRITE_TOKEN ??
-    createBridgeToken(),
-  "extension-prefs-write": args.get("extension-prefs-write-token") ??
-    process.env.RESONANTOS_BROWSER_FIRST_EXTENSION_PREFS_WRITE_TOKEN ??
-    createBridgeToken(),
-};
+const bridgeCapabilityTokens = buildBridgeCapabilityTokens({ args, mint: createBridgeToken });
 
 async function invokeBridgeRouteForSelfTest({ method = "POST", routePath, body = {}, capabilityToken = "" } = {}) {
   const route = bridgeRoutes.find((entry) => entry.method === method && entry.path === routePath);

--- a/browser-first/resonantos-side-panel-extension/src/background.js
+++ b/browser-first/resonantos-side-panel-extension/src/background.js
@@ -90,7 +90,17 @@ function rebindAndHydrate({ refreshGenerated = false } = {}) {
       bridgeRequest = createBridgeClient(cfg);
       rawFetch = createRawBridgeFetch(cfg);
       return initCapabilityTokens(cfg)
-        .catch(() => undefined)
+        .catch((error) => {
+          // Surface capability-token bootstrap failures so operators get a
+          // DevTools breadcrumb. A 500 here — commonly the bridge launcher's
+          // mint map missing a requested capability (#200) — otherwise leaves
+          // every capability-scoped route silently 403ing with no clue why.
+          console.error(
+            "[resonantos] capability-token bootstrap failed; capability-scoped bridge routes will be rejected until this is resolved.",
+            error,
+          );
+          return undefined;
+        })
         .then(() => ({ cfg, bridgeRequest, rawFetch }));
     })
     .then(({ cfg, bridgeRequest: req, rawFetch: raw }) => {

--- a/browser-first/test/bridge-capability-token-consistency.test.mjs
+++ b/browser-first/test/bridge-capability-token-consistency.test.mjs
@@ -1,0 +1,45 @@
+// #200 drift guard: the browser-first bridge launcher mints one capability token
+// per entry in BRIDGE_CAPABILITY_TOKEN_SPECS; the extension requests exactly the
+// capabilities in RUNTIME_CAPABILITY_ALLOWLIST. If these ever diverge, first-time
+// bootstrap 500s with `Unknown bridge capability requested: <name>` in production.
+// This test locks them together so drift fails CI instead of a deployment.
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { BRIDGE_CAPABILITIES, buildBridgeCapabilityTokens } from "../host/bridge-capability-tokens.mjs";
+import { RUNTIME_CAPABILITY_ALLOWLIST } from "../resonantos-side-panel-extension/src/lib/bridge-client.js";
+
+test("launcher capability set exactly matches the extension allowlist (#200)", () => {
+  const missingInLauncher = RUNTIME_CAPABILITY_ALLOWLIST.filter((cap) => !BRIDGE_CAPABILITIES.includes(cap));
+  const orphanInLauncher = BRIDGE_CAPABILITIES.filter((cap) => !RUNTIME_CAPABILITY_ALLOWLIST.includes(cap));
+  assert.deepEqual(
+    missingInLauncher, [],
+    `Extension requests capabilities the launcher cannot mint (bootstrap would 500): ${missingInLauncher.join(", ")}`,
+  );
+  assert.deepEqual(
+    orphanInLauncher, [],
+    `Launcher mints capabilities the extension never requests (dead entries): ${orphanInLauncher.join(", ")}`,
+  );
+  assert.deepEqual([...BRIDGE_CAPABILITIES].sort(), [...RUNTIME_CAPABILITY_ALLOWLIST].sort());
+});
+
+test("buildBridgeCapabilityTokens mints a token for every capability", () => {
+  const map = buildBridgeCapabilityTokens({ mint: () => "tok" });
+  assert.equal(Object.keys(map).length, BRIDGE_CAPABILITIES.length);
+  for (const cap of BRIDGE_CAPABILITIES) {
+    assert.ok(map[cap], `no token minted for ${cap}`);
+  }
+});
+
+test("buildBridgeCapabilityTokens honors arg > env > mint precedence", () => {
+  const args = new Map([["provider-credential-token", "from-arg"]]);
+  const env = { RESONANTOS_BROWSER_FIRST_PROVIDER_ROUTING_TOKEN: "from-env" };
+  const map = buildBridgeCapabilityTokens({ args, env, mint: () => "minted" });
+  assert.equal(map["provider-credential-write"], "from-arg", "CLI arg should win");
+  assert.equal(map["provider-routing-write"], "from-env", "env var should win over mint");
+  assert.equal(map["archive-read"], "minted", "mint is the fallback");
+});
+
+test("buildBridgeCapabilityTokens requires a mint function", () => {
+  assert.throws(() => buildBridgeCapabilityTokens({}), /requires a mint/);
+});


### PR DESCRIPTION
Closes #200. Closes #204. Part of the #199 bridge first-time-setup epic.

## #200 — capability-token map drift
The dev launcher (`run-bridge-minimal.mjs`) and the production launcher (`resonantos-bridge-full.mjs`, external to the repo) each carried their own hand-maintained `bridgeCapabilityTokens` literal. When the extension's `RUNTIME_CAPABILITY_ALLOWLIST` grew, an un-updated launcher failed to mint the new token and `POST /api/capability-tokens` 500'd with `Unknown bridge capability requested: <name>`, killing the dashboard iframe.

**Fix:** a single canonical source — `browser-first/host/bridge-capability-tokens.mjs` (`BRIDGE_CAPABILITY_TOKEN_SPECS` + `buildBridgeCapabilityTokens`). The launcher now derives its mint map from it; the production launcher can import the same module, eliminating the drift at its source. A **drift-guard test** locks the canonical capability list to the extension's allowlist, so any future divergence fails CI instead of a deployment. The CLI-arg / env-var override names are preserved (external deployment contract).

## #204 — silent bootstrap failure
`background.js#rebindAndHydrate` swallowed `initCapabilityTokens()` failures with `.catch(() => undefined)`, so a bootstrap 500 left every capability-scoped route 403ing with no DevTools breadcrumb. Now logs the failure with guidance (`console.error`).

## Tests
- New `bridge-capability-token-consistency.test.mjs` (4 cases): drift equality, per-capability minting, arg>env>mint precedence, mint-required guard.
- browser-first suite: **676/676**.

## Verification note
The capability-map unification and drift guard are fully verified in-repo. The `#204` breadcrumb is a service-worker `console.error` (not unit-tested — the SW isn't imported by the node suite); verified by inspection. Full first-time-setup end-to-end (against a live Pi5 + Caddy) is tracked by #203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)