### PR TITLE
fix(#206): readable provider/model dropdowns on Chrome/Windows 11

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/styles/main-workspace/base-rail.css
+++ b/browser-first/resonantos-side-panel-extension/src/styles/main-workspace/base-rail.css
@@ -73,6 +73,17 @@ textarea {
   font: inherit;
 }
 
+/* The native <option> popup is rendered by the OS/browser and does not inherit
+   a select's translucent background. Without an explicit opaque background the
+   list renders the app's light text on a white default on Chrome/Windows 11,
+   making every dropdown unreadable (#206). Pin an opaque dark surface + light
+   text for readable contrast. */
+select option,
+select optgroup {
+  background-color: var(--bg, #0b120e);
+  color: var(--text, #eef7f0);
+}
+
 button {
   cursor: pointer;
 }

--- a/browser-first/resonantos-side-panel-extension/src/styles/side-panel/base-layout.css
+++ b/browser-first/resonantos-side-panel-extension/src/styles/side-panel/base-layout.css
@@ -29,6 +29,15 @@ textarea {
   font: inherit;
 }
 
+/* Native <option> popups don't inherit a select's translucent background, so
+   without an explicit opaque surface the list renders light text on a white
+   default on Chrome/Windows 11 (#206). Pin an opaque dark surface + light text. */
+select option,
+select optgroup {
+  background-color: var(--bg, #0b120e);
+  color: var(--text, #eef7f0);
+}
+
 button {
   cursor: pointer;
 }


### PR DESCRIPTION
Closes #206.

## Problem
On Chrome / Windows 11 the provider-template dropdown and the chat model-router dropdown were very hard to read (see issue screenshots). Native `<option>` popups are rendered by the OS and do **not** inherit a `<select>`'s translucent background — and the app had **no `option` styling anywhere** — so the open list rendered the app's light text on a white OS default.

## Fix
Add an opaque dark `option`/`optgroup` background + light text in both base stylesheets (`main-workspace/base-rail.css`, `side-panel/base-layout.css`), using the existing theme variables `var(--bg)` (#050807) and `var(--text)` (#eef7f0) — ~19:1 contrast (WCAG AAA). Scoped to `select option` so it covers every dropdown in the app, not just the two reported.

## Verification
Contrast is mathematically ~19:1; the rule is scoped correctly and applied in both surfaces. This is the standard remedy for the Windows-Chrome native-option rendering issue; final visual confirmation is best done on the reporter's Windows 11 Chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)