### PR TITLE
fix(#199,#203): mirror /auth + any-host bridge CSP + first-run smoke test

### DIFF
--- a/browser-first/host/bridge-server.mjs
+++ b/browser-first/host/bridge-server.mjs
@@ -111,8 +111,9 @@ function dashboardProxyPathPrefix() {
 // request path against each entry's `bridge` prefix (longest match wins),
 // strips it, and prefixes the upstream prefix to get the final upstream
 // path. See createDashboardProxyHandler for the full set of rules.
-const DASHBOARD_PROXY_MIRROR_PATHS = Object.freeze([
+export const DASHBOARD_PROXY_MIRROR_PATHS = Object.freeze([
   Object.freeze({ bridge: "/hermes-dashboard", upstream: "" }),
+  Object.freeze({ bridge: "/auth", upstream: "/auth" }),
   Object.freeze({ bridge: "/api", upstream: "/api" }),
   Object.freeze({ bridge: "/assets", upstream: "/assets" }),
   Object.freeze({ bridge: "/fonts-terminal", upstream: "/fonts-terminal" }),
@@ -1013,7 +1014,7 @@ function isAuthorizedCapabilityBootstrapRequest(request, capabilityBootstrapToke
   return constantTimeEqual(request.headers[bridgeCapabilityBootstrapHeader], capabilityBootstrapToken);
 }
 
-function scopedCapabilityTokenPayload(requestedCapabilities, bridgeCapabilityTokens) {
+export function scopedCapabilityTokenPayload(requestedCapabilities, bridgeCapabilityTokens) {
   const requested = Array.isArray(requestedCapabilities)
     ? requestedCapabilities
     : String(requestedCapabilities ?? "")

--- a/browser-first/resonantos-side-panel-extension/manifest.json
+++ b/browser-first/resonantos-side-panel-extension/manifest.json
@@ -8,7 +8,7 @@
   "permissions": ["activeTab", "clipboardRead", "clipboardWrite", "history", "scripting", "sidePanel", "storage", "tabs", "webNavigation"],
   "host_permissions": ["http://*/*", "https://*/*"],
   "content_security_policy": {
-    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; connect-src 'self' http://127.0.0.1:* http://localhost:* https://127.0.0.1:* https://localhost:*; img-src 'self' data: blob: http://127.0.0.1:* http://localhost:* https://127.0.0.1:* https://localhost:*; style-src 'self' 'unsafe-inline'; frame-src http://127.0.0.1:* http://localhost:* https://127.0.0.1:* https://localhost:*;"
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; connect-src 'self' http://127.0.0.1:* http://localhost:* https://127.0.0.1:* https://localhost:* http://*:* https://*:*; img-src 'self' data: blob: http://127.0.0.1:* http://localhost:* https://127.0.0.1:* https://localhost:* http://*:* https://*:*; style-src 'self' 'unsafe-inline'; frame-src http://127.0.0.1:* http://localhost:* https://127.0.0.1:* https://localhost:* http://*:* https://*:*;"
   },
   "background": {
     "service_worker": "src/background.js",

--- a/browser-first/test/alpha-browser-extension-scope.test.mjs
+++ b/browser-first/test/alpha-browser-extension-scope.test.mjs
@@ -57,7 +57,21 @@ test("2.0.0 alpha release scope is Chrome extension and bridge only", async () =
   assert.equal(manifest.side_panel.default_path, "src/side-panel.html");
   assert.equal(manifest.permissions.includes("audioCapture"), false);
   assert.match(manifest.content_security_policy.extension_pages, /connect-src 'self' http:\/\/127\.0\.0\.1:\*/);
-  assert.doesNotMatch(manifest.content_security_policy.extension_pages, /https?:\/\/\*:\*/);
+  // The extension connects to a user-configured bridge that can live on any
+  // LAN/Tailscale host, so connect-src/img-src/frame-src permit any host — CSP
+  // has no CIDR syntax to scope it to private ranges (#199). Code execution
+  // stays locked down: script-src must remain 'self' and never gain an
+  // any-host source, so the broadening only affects data/connection sources.
+  assert.doesNotMatch(
+    manifest.content_security_policy.extension_pages,
+    /script-src[^;]*https?:\/\/\*/,
+    "script-src must never allow an any-host source",
+  );
+  assert.match(
+    manifest.content_security_policy.extension_pages,
+    /connect-src[^;]*https?:\/\/\*:\*/,
+    "connect-src must permit the user's bridge host (remote LAN/Tailscale deployments)",
+  );
   assert.equal(manifest.content_scripts[0].js[0], "src/lib/resonant-context.js");
   assert.deepEqual(
     manifest.content_scripts[0].js.slice(0, 3),

--- a/browser-first/test/bridge-first-run-smoke.test.mjs
+++ b/browser-first/test/bridge-first-run-smoke.test.mjs
@@ -1,0 +1,79 @@
+// #203 first-run smoke test. A first-time browser-first bridge deployment hits
+// several independent bug classes in sequence; each leaves the dashboard iframe
+// dead. This exercises the in-repo-testable classes end-to-end so they fail CI
+// instead of a deployment. (The network-layer classes — Caddy HTTP/2 ALPN #201,
+// WS auth, upstream Hermes auth — require a live host and are covered by the
+// setup runbook, not this suite.)
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createBridgeToken,
+  scopedCapabilityTokenPayload,
+  DASHBOARD_PROXY_MIRROR_PATHS,
+  evaluateBridgeRequestForSelfTest,
+} from "../host/bridge-server.mjs";
+import { buildBridgeCapabilityTokens } from "../host/bridge-capability-tokens.mjs";
+import {
+  RUNTIME_CAPABILITY_ALLOWLIST,
+  capabilityForBridgeRoute,
+} from "../resonantos-side-panel-extension/src/lib/bridge-client.js";
+
+// Class #4 — capability-token bootstrap. On first load the extension POSTs its
+// full RUNTIME_CAPABILITY_ALLOWLIST to /api/capability-tokens; the launcher must
+// mint a token for each or the bootstrap 500s ("Unknown bridge capability
+// requested") and every capability-scoped route then 403s (#200/#204).
+test("bootstrap mints a token for every capability the extension requests (#203, class #4)", () => {
+  const mintMap = buildBridgeCapabilityTokens({ mint: createBridgeToken });
+  const payload = scopedCapabilityTokenPayload([...RUNTIME_CAPABILITY_ALLOWLIST], mintMap);
+  for (const capability of RUNTIME_CAPABILITY_ALLOWLIST) {
+    assert.ok(payload[capability], `bootstrap returned no token for "${capability}"`);
+  }
+  assert.equal(Object.keys(payload).length, RUNTIME_CAPABILITY_ALLOWLIST.length);
+});
+
+test("bootstrap rejects a capability the launcher cannot mint (the #200 failure mode)", () => {
+  const mintMap = buildBridgeCapabilityTokens({ mint: createBridgeToken });
+  assert.throws(
+    () => scopedCapabilityTokenPayload(["not-a-real-capability"], mintMap),
+    /Unknown bridge capability requested/,
+  );
+});
+
+test("a minted capability token authorizes its route end-to-end (#203)", async () => {
+  const bridgeToken = "smoke-bridge-token";
+  const mintMap = buildBridgeCapabilityTokens({ mint: () => "minted-credential-token" });
+  const capability = capabilityForBridgeRoute("/providers/credentials", "POST"); // provider-credential-write
+  const bootstrap = scopedCapabilityTokenPayload([capability], mintMap);
+  const routes = [{
+    method: "POST",
+    path: "/providers/credentials",
+    requiredCapability: capability,
+    handler: async () => ({ saved: true }),
+  }];
+
+  const authorized = await evaluateBridgeRequestForSelfTest({
+    method: "POST",
+    url: "/providers/credentials",
+    headers: {
+      "X-ResonantOS-Bridge-Token": bridgeToken,
+      "X-ResonantOS-Bridge-Capability-Token": bootstrap[capability],
+    },
+    body: {},
+    bridgeToken,
+    bridgeCapabilityTokens: mintMap,
+    routes,
+  });
+  assert.equal(authorized.status, 200);
+  assert.equal(authorized.payload.saved, true);
+});
+
+// Class #1 — the Hermes SPA redirects unauthenticated first loads to
+// /auth/login. If the dashboard proxy does not mirror /auth, the redirect lands
+// on the bridge's 404 catch-all and the iframe hangs silently (PR #199).
+test("dashboard proxy mirrors /auth so the Hermes login redirect resolves (#203, class #1)", () => {
+  assert.ok(
+    DASHBOARD_PROXY_MIRROR_PATHS.some((entry) => entry.bridge === "/auth"),
+    "dashboard proxy must mirror /auth or the Hermes /auth/login redirect 404s",
+  );
+});


### PR DESCRIPTION
Closes #203. Supersedes #199 (with attribution). Part of the #199 bridge first-time-setup epic.

## What & why
Writing the #203 smoke test surfaced that the `/auth` mirror fix from #199 **never landed on `dev`** (its `#203` note that it "landed 2026-06-30" was wrong), so bug class #1 was still live. This PR lands #199's two fixes on top of current `dev` and adds the smoke test that guards them.

### #199 — `/auth` proxy mirror
The Hermes dashboard SPA redirects unauthenticated first loads to `/auth/login`. The bridge dashboard proxy did not mirror `/auth`, so the redirect hit the 404 catch-all and the iframe hung silently. Added `/auth` to `DASHBOARD_PROXY_MIRROR_PATHS`.

### #199 — any-host bridge CSP
The extension connects to a **user-configured** bridge that can live on any LAN/Tailscale host, but the manifest CSP only allowed localhost — remote deployments couldn't reach their bridge. Broadened `connect-src`/`img-src`/`frame-src` to any host (CSP has no CIDR syntax to scope to private ranges).

**Security posture:** `script-src` stays `'self'` — code execution never gains an any-host source. The alpha-scope guardrail (`alpha-browser-extension-scope.test.mjs`) was updated to enforce exactly that (script-src locked) while permitting the connection broadening. This is why #199's original Build failed — the old guardrail forbade *any* any-host source; the new one keeps the meaningful invariant.

### #203 — first-run smoke test
`bridge-first-run-smoke.test.mjs` exercises the in-repo first-run bug classes so they fail CI instead of a deployment:
- capability-token bootstrap mints a token for the **full** extension allowlist (class #4 / #200);
- rejects an unmintable capability (the #200 failure mode);
- a minted token authorizes its route end-to-end;
- the dashboard proxy mirrors `/auth` (class #1).

Network-layer classes (Caddy HTTP/2 ALPN #201, WS auth, upstream Hermes auth) need a live host and are covered by the setup runbook (#202), not this suite.

## Tests
browser-first suite **680/680**.

## Attribution
Original diagnosis and the `/auth` + CSP fix by @Trilobyte17 (#199); rebased onto current `dev`, guardrail reconciled, and smoke test added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)