### PR TITLE
ci: skip Project 2 sync gracefully when PROJECT_SYNC_TOKEN is absent

### DIFF
--- a/.github/workflows/project-issue-sync.yml
+++ b/.github/workflows/project-issue-sync.yml
@@ -44,17 +44,16 @@ jobs:
           HAS_PROJECT_SYNC_TOKEN: ${{ secrets.PROJECT_SYNC_TOKEN != '' }}
         run: |
           if [ "$HAS_PROJECT_SYNC_TOKEN" != "true" ]; then
-            echo "::warning::PROJECT_SYNC_TOKEN is not configured. Organization Project 2 synchronization cannot run."
+            # Project 2 synchronization is optional infrastructure: when the
+            # PROJECT_SYNC_TOKEN secret is not configured, warn and skip the sync
+            # steps rather than failing the job. A hard failure here surfaced a
+            # red check on every PR/commit even though nothing in the change was
+            # wrong. Configure the org secret to enable the sync.
+            echo "::warning::PROJECT_SYNC_TOKEN is not configured. Skipping Project 2 synchronization."
             echo "configured=false" >> "$GITHUB_OUTPUT"
           else
             echo "configured=true" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Require Project token
-        if: steps.project-token.outputs.configured != 'true'
-        run: |
-          echo "::error::PROJECT_SYNC_TOKEN is required for repository-owned Project 2 synchronization."
-          exit 1
 
       - name: Capture Project 2 scope snapshot
         if: steps.project-token.outputs.configured == 'true'

--- a/scripts/browser-first-release-scope-audit.test.mjs
+++ b/scripts/browser-first-release-scope-audit.test.mjs
@@ -120,7 +120,8 @@ test("project sync executes pull-request events only from trusted base code", as
   const workflow = parse(workflowText);
   const job = workflow.jobs.sync;
   const checkout = job.steps.find((step) => step.name === "Checkout");
-  const requireToken = job.steps.find((step) => step.name === "Require Project token");
+  const captureSnapshot = job.steps.find((step) => step.name === "Capture Project 2 scope snapshot");
+  const syncStep = job.steps.find((step) => step.name === "Sync project and labels");
 
   assert.equal(workflow.on.pull_request, undefined);
   assert.ok(workflow.on.pull_request_target);
@@ -134,8 +135,11 @@ test("project sync executes pull-request events only from trusted base code", as
   assert.equal(workflow.permissions.contents, "read");
   assert.equal(workflow.permissions.issues, undefined);
   assert.equal(workflow.permissions["pull-requests"], undefined);
-  assert.equal(requireToken.if, "steps.project-token.outputs.configured != 'true'");
-  assert.match(requireToken.run, /exit 1/);
+  // Token gating: the actual Project sync steps run only when the token is
+  // configured. A missing token skips them gracefully rather than failing the
+  // workflow on every unrelated PR/commit (#260).
+  assert.equal(captureSnapshot.if, "steps.project-token.outputs.configured == 'true'");
+  assert.equal(syncStep.if, "steps.project-token.outputs.configured == 'true'");
 });
 
 test("committed mode preserves added and deleted branch paths in a clean worktree", async () => {


### PR DESCRIPTION
## Problem
The `project-issue-sync` workflow hard-failed (`exit 1`) whenever the optional `PROJECT_SYNC_TOKEN` org secret wasn't configured — which is the current state — so **every PR and commit showed a permanent red check** unrelated to the change under review.

## Fix
Remove the `Require Project token` hard-fail step. The three sync steps (snapshot, roadmap-verify, sync) already gate on `steps.project-token.outputs.configured == 'true'`, so with the token absent the job now **warns and skips** (green); with the token present it runs the sync normally. No behavior change when the secret is configured.

To actually enable the sync, a repo admin sets the `PROJECT_SYNC_TOKEN` secret (Settings → Secrets and variables → Actions) — this PR just stops the missing-secret state from failing unrelated checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)