### PR TITLE
ci: make Project 2 sync best-effort (stop failure-email flood)

### DIFF
--- a/.github/workflows/project-issue-sync.yml
+++ b/.github/workflows/project-issue-sync.yml
@@ -56,17 +56,29 @@ jobs:
           fi
 
       - name: Capture Project 2 scope snapshot
+        id: snapshot
         if: steps.project-token.outputs.configured == 'true'
         env:
           GH_TOKEN: ${{ secrets.PROJECT_SYNC_TOKEN }}
-        run: gh project item-list 2 --owner ResonantOS --format json --limit 500 > "$RUNNER_TEMP/project-2.json"
+        run: |
+          # Best-effort: an auth/scope problem — e.g. PROJECT_SYNC_TOKEN missing
+          # the 'project' + 'read:org' scope, which surfaces as "unknown owner
+          # type" — must warn and skip the sync, not fail the job and email the
+          # maintainer on every push/schedule/issue trigger. A *working* token
+          # still runs the roadmap/sync checks below, which may legitimately fail.
+          if gh project item-list 2 --owner ResonantOS --format json --limit 500 > "$RUNNER_TEMP/project-2.json" 2>"$RUNNER_TEMP/project-2.err"; then
+            echo "snapshot-ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Project 2 sync skipped — could not read the org project: $(tr '\n' ' ' < "$RUNNER_TEMP/project-2.err"). PROJECT_SYNC_TOKEN likely needs 'project' + 'read:org' scope for the ResonantOS org."
+            echo "snapshot-ok=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Verify roadmap scope against Project 2
-        if: steps.project-token.outputs.configured == 'true'
+        if: steps.snapshot.outputs.snapshot-ok == 'true'
         run: npm run project:check-roadmap -- --project-json "$RUNNER_TEMP/project-2.json"
 
       - name: Sync project and labels
-        if: steps.project-token.outputs.configured == 'true'
+        if: steps.snapshot.outputs.snapshot-ok == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.PROJECT_SYNC_TOKEN }}
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}

--- a/scripts/browser-first-release-scope-audit.test.mjs
+++ b/scripts/browser-first-release-scope-audit.test.mjs
@@ -135,11 +135,12 @@ test("project sync executes pull-request events only from trusted base code", as
   assert.equal(workflow.permissions.contents, "read");
   assert.equal(workflow.permissions.issues, undefined);
   assert.equal(workflow.permissions["pull-requests"], undefined);
-  // Token gating: the actual Project sync steps run only when the token is
-  // configured. A missing token skips them gracefully rather than failing the
-  // workflow on every unrelated PR/commit (#260).
+  // Token gating: the snapshot step runs only when the token is configured, and
+  // the sync steps run only when the snapshot succeeded (snapshot-ok) — so the
+  // sync is transitively gated on a working token. A missing/underscoped token
+  // warns and skips rather than failing the workflow on every trigger (#260).
   assert.equal(captureSnapshot.if, "steps.project-token.outputs.configured == 'true'");
-  assert.equal(syncStep.if, "steps.project-token.outputs.configured == 'true'");
+  assert.equal(syncStep.if, "steps.snapshot.outputs.snapshot-ok == 'true'");
 });
 
 test("committed mode preserves added and deleted branch paths in a clean worktree", async () => {


### PR DESCRIPTION
## Problem
After `PROJECT_SYNC_TOKEN` was configured, the `project-issue-sync` workflow **ran** the sync and failed in ~13s with `unknown owner type` from `gh project item-list 2 --owner ResonantOS`. That means the token lacks the scope to read the org Project (`project` + `read:org`). Because the workflow triggers on push-to-dev, a 6-hourly schedule, every issue event, and `pull_request_target`, each failed run emailed the maintainer — a flood.

## Fix (this PR — stops the flood regardless of the token)
Make the snapshot step **best-effort**: on an auth/scope failure it emits a `::warning::` naming the likely cause and sets `snapshot-ok=false`; the roadmap-verify and sync steps now gate on `snapshot-ok`, so a broken/underscoped token **warns and skips** instead of failing the job. A *working* token still runs the roadmap/sync checks, which may legitimately fail on real drift. The workflow-security test's sync-gating assertion is updated to match (the sync remains transitively token-gated: `snapshot-ok` requires `configured`).

## The real fix (repo admin)
To make the sync actually **run**, `PROJECT_SYNC_TOKEN` needs `project` + `read:org` scope on the `ResonantOS` org (a classic PAT with those scopes, or a fine-grained PAT with org **Projects: Read and write**). This PR only ensures a misconfigured token can't spam failure emails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)