### PR TITLE
docs(#217,#229): Augmentor acceptance matrix + tester runbook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,9 @@ scope, area, and delivery state belong in
 - [Product Guide](product/PRODUCT_GUIDE.md) explains stable user workflows.
 - [Capability Matrix](reference/CAPABILITY_MATRIX.md) maps implemented,
   experimental, and deferred capabilities to tests and issues.
+- [Augmentor Future List acceptance matrix](augmentor-future-list-acceptance-matrix.md)
+  maps every Augmentor feature family to its canonical issue, status, required
+  tests/proof, and safety boundary.
 - [Side-Panel Command Reference](reference/COMMANDS.md) lists the supported
   Augmentor slash commands and their safety boundaries.
 - [Status](STATUS.md) records the latest verified snapshot.

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,8 @@ scope, area, and delivery state belong in
 - [Augmentor Future List acceptance matrix](augmentor-future-list-acceptance-matrix.md)
   maps every Augmentor feature family to its canonical issue, status, required
   tests/proof, and safety boundary.
+- [Augmentor tester runbook & proof checklist](augmentor-tester-runbook.md) walks a
+  community tester from install to a proof checklist, with the human-only boundaries.
 - [Side-Panel Command Reference](reference/COMMANDS.md) lists the supported
   Augmentor slash commands and their safety boundaries.
 - [Status](STATUS.md) records the latest verified snapshot.

--- a/docs/augmentor-future-list-acceptance-matrix.md
+++ b/docs/augmentor-future-list-acceptance-matrix.md
@@ -1,0 +1,118 @@
+# Augmentor Future List — acceptance matrix
+
+The maintained source-of-truth mapping each **Augmentor Future List** capability
+family to its canonical GitHub issue, current status, required tests/proof, and
+safety boundary — so contributors read this instead of doing chat-history
+archaeology (issue #217).
+
+**On the "FL-01…FL-44" numbering:** the original Future List used a numbered
+FL-01…FL-44 index, but that numbered artifact lives outside the repo. Rather than
+reproduce numbers that can't be verified against a committed source, this matrix
+is keyed to the **capability families** the Future List defines and to the
+**canonical issue** for each — which is the durable identifier. When a numbered
+source is committed to the repo, add an `FL-NN` column here.
+
+## How to read the status column
+
+| Status | Meaning |
+|---|---|
+| ✅ **supported** | Foundation shipped and working on `dev` today (closed delivering issue). |
+| 🔧 **needs hardening** | Working, but open issues add coverage/UX/edge-cases before community-test. |
+| 🔒 **safety-constrained** | Bounded by a human-only or consent boundary; never shipped as silent automation. |
+| ⏸ **deferred** | Scoped `deferred`; not in the current milestone. |
+| 🔮 **future** | Planned, open, not yet started. |
+
+Legend: `(C)` = closed/shipped issue · `epic` = tracking epic · issues without a
+suffix are open. Safety-boundary rows are **never** casual good-first-issues.
+
+## Matrix
+
+### Core interface
+| Capability | Canonical issue(s) | Status | Tests / proof | Safety boundary |
+|---|---|---|---|---|
+| Side panel + Alt+A / Alt+S shortcuts | #241 · #46 (C) | 🔧 needs hardening | shortcut-contract + conflict handling — **live-browser proof** (#241) | — |
+
+### Web understanding
+| Capability | Canonical issue(s) | Status | Tests / proof | Safety boundary |
+|---|---|---|---|---|
+| Page content analysis / Q&A | #218 · #8 (C) | ✅ supported | page-understanding fixture coverage (#218); `npm run test:browser-first` | — |
+| Highlight-to-ask (inline assistant) | #9 (C) | ✅ supported | inline-assistant path in `provider-bridge-service` tests | — |
+| Counterpoints / explain-jargon | #219 | 🔮 future | fixtures TBD | — |
+| Image / media understanding | #242 | ⏸ deferred · 🔒 | live-browser proof; bounded media handling | privacy/security-sensitive |
+
+### Cross-tab intelligence
+| Capability | Canonical issue(s) | Status | Tests / proof | Safety boundary |
+|---|---|---|---|---|
+| Cross-tab comparison (model-chosen) | #220 · #118 | 🔧 needs hardening | tab-provenance assertions | — |
+| Explicit `@tab` referencing | #252 | 🔮 future | `@tab` token→tab-id resolution unit tests; live-browser proof | only tabs the user can already see |
+| Session-level memory / restart-safe context | #222 · #228 · epic #212 · PR #197 (C) | 🔧 needs hardening | Living Archive continuity acceptance proof (#228) | — |
+
+### Summarization & research
+| Capability | Canonical issue(s) | Status | Tests / proof | Safety boundary |
+|---|---|---|---|---|
+| One-click / question-driven summaries | #221 · #222 · #39 (C) · #114 | ✅ supported | summary intake flows | — |
+| Cross-source synthesis / research trail | #227 · #237 (docs) | 🔮 future | research-trail save + archive handoff | — |
+
+### Automation
+| Capability | Canonical issue(s) | Status | Tests / proof | Safety boundary |
+|---|---|---|---|---|
+| Autonomous navigation / Agent Control | #118 · #225 · epic #211 | 🔧 needs hardening · 🔒 | click/type/scroll certification fixtures; live-browser proof | governed; human-only public-submit / field-typing boundaries |
+| Form reading & autofill guard | #31 (C) · #8 (C) | ✅ supported | autofill-guard tests | never auto-submits; approval-gated |
+| Multi-step workflows | #237 · #14 (C) · #12 (C) | ✅ supported | — | — |
+| Shopping decision packet / checkout handoff | #243 · #16 (C) | ⏸ deferred · 🔒 | packet assembly + human-confirm gate | **human-only** checkout; draft/packet only |
+| Booking option packet / reservation handoff | #244 | ⏸ deferred · 🔒 | packet + human-confirm gate | **human-only** reservation |
+| Email drafting | #235 · #68 (C) · #47 (C) · #11 (C) | 🔒 safety-constrained | draft-only handoff tests | draft-only; human sends |
+| Meeting scheduling / coordination (write) | #253 | ⏸ deferred · 🔒 | packet + non-bypassable human-confirm | **human-only** send; calendar-read is #248 |
+| Day briefing / recurring tasks | #245 · #246 | ⏸ deferred · 🔒 | consent / dry-run / kill-switch tests | opt-in; consent + kill-switch required |
+
+### Integrations (personal connectors)
+| Capability | Canonical issue(s) | Status | Tests / proof | Safety boundary |
+|---|---|---|---|---|
+| Gmail — read + draft-only handoff | #247 · #234 · #11 (C) | ⏸ deferred · 🔒 | read-only retrieval; draft-only handoff UX | read-only / draft-only; no autonomous send |
+| Calendar — read-only availability | #248 · #138 | ⏸ deferred · 🔒 | availability read tests | read-only |
+
+### Voice
+| Capability | Canonical issue(s) | Status | Tests / proof | Safety boundary |
+|---|---|---|---|---|
+| Voice mode — transcript to composer | #235 · #249 · epic #216 · #99 | ⏸ deferred · 🔒 | transcript→composer flow; reviewed-transcript preflight | permission-light; reviewed before action |
+
+### Multi-model backend & provider routing
+| Capability | Canonical issue(s) | Status | Tests / proof | Safety boundary |
+|---|---|---|---|---|
+| Provider Fabric routing (add/select/route) | #207 (C) · #214 (epic) | ✅ supported | `provider-fabric-routing-propagation.test.mjs`; `provider-route-acceptance.test.mjs` | credential/route safeguards preserved |
+| Visible fallback + manual model preservation | #231 (C) | ✅ supported | `provider-fallback-visibility.test.mjs` | no silent model swap |
+| Provider route health / fallback acceptance | #233 (C) | ✅ supported | `provider-route-acceptance.test.mjs` (no-secret-leak) | secrets never surfaced |
+| Reasoning-trace / durable job trace | #225 | 🔮 future | step-counter proof; live-browser | — |
+| Spreadsheet / document artifact contract | #232 | 🔮 future | artifact-contract tests | — |
+| Renderer-controlled routing hardening | #143 (C) | ✅ supported · 🔒 | routing input-validation tests | rejects renderer-controlled provider input |
+
+### Personalization
+| Capability | Canonical issue(s) | Status | Tests / proof | Safety boundary |
+|---|---|---|---|---|
+| Opt-in preference memory + reset | #236 | ⏸ deferred · 🔒 | default-off + reset tests | opt-in; no profiling beyond preference |
+
+### Proactive assistance
+| Capability | Canonical issue(s) | Status | Tests / proof | Safety boundary |
+|---|---|---|---|---|
+| Opt-in proactive suggestions (surface only) | #254 | 🔮 future · 🔒 | default-off + opt-in gate tests | **off by default**; surfaces only, never acts |
+
+### Safety (cross-cutting)
+| Capability | Canonical issue(s) | Status | Safety boundary |
+|---|---|---|---|
+| Consent / dry-run / history / kill-switch | #246 · #234 · #243–#245 · #249 · #253 | 🔒 safety-constrained | every automation with side effects is opt-in, consent-gated, and human-confirmed; wallet/signing/payment/checkout/public-submit/credential/login stay human-only |
+
+## Milestone epics
+
+- `beta.1` — Augmentor browser-layer acceptance: **#210**
+- `beta.1` — Living Archive & context continuity: **#212**
+- `beta.1` — provider routing, reasoning trace, artifacts: **#214**
+- `beta.1` — governed Agent Control & safety proofs: **#211**
+- `beta.2` — personal connectors, voice, delegated automation: **#216**
+
+## Maintenance
+
+Keep each row's status, canonical issue, and Project 2 fields (Release Scope,
+Area, Priority, Status, milestone) in agreement with the canonical issue; when an
+issue closes, update its row's status and cite the delivering test. This matrix is
+verified by the docs gate (`npm run docs:check`) and the browser-first suite
+(`npm run test:browser-first`).

--- a/docs/augmentor-tester-runbook.md
+++ b/docs/augmentor-tester-runbook.md
@@ -1,0 +1,84 @@
+# Augmentor tester runbook & proof checklist
+
+For community testers and maintainers validating an Augmentor alpha/beta build.
+It gets you from a clean install to a working side panel, gives a proof checklist
+that maps each user-visible behavior to its issue/test, and spells out the
+**human-only boundaries** the Augmentor must never cross.
+
+- **Feature status + canonical issues:** [Augmentor Future List acceptance matrix](augmentor-future-list-acceptance-matrix.md)
+- **Bridge/Caddy/capability-token setup + recovery:** [Browser-first bridge setup runbook](browser-first-bridge-setup-runbook.md)
+- **Alpha scope (what's in vs. out):** [Alpha Runtime Boundary](architecture/ALPHA_RUNTIME_BOUNDARY.md)
+
+> Do **not** record private keys, real credentials, private machine paths, or
+> maintainer-only chat context in test evidence. Redact tokens and endpoints.
+
+## 1. Prerequisites
+
+1. **Bridge running & reachable.** Follow the [bridge setup runbook](browser-first-bridge-setup-runbook.md) (bind, Caddy ALPN pin, capability-token audit). Confirm the dashboard iframe renders end-to-end.
+2. **Extension loaded** in Chrome (the side-panel extension), pointed at your bridge via *Settings › Bridge Target* (or loopback on the bridge host).
+3. **At least one provider configured** — *Settings › Providers* shows a provider as `Ready`.
+
+## 2. First-run smoke checklist
+
+| # | Check | Expected | Proof source |
+|---|---|---|---|
+| 1 | Bridge reachable | `Settings › Bridge Target` shows connected | bridge setup runbook |
+| 2 | Dashboard iframe renders | no blank/hung iframe | `/auth` mirror (#199); `bridge-first-run-smoke.test.mjs` (#203) |
+| 3 | Capability bootstrap OK | no `403`/`Unknown bridge capability` in DevTools | drift guard `bridge-capability-token-consistency.test.mjs` (#200) |
+| 4 | Provider configured | a provider shows `Ready` | `provider-route-acceptance.test.mjs` (#233) |
+
+## 3. Feature proof checklist (this build)
+
+Only capabilities marked **supported / needs-hardening** in the matrix are
+expected to work now. Each row: what to do → expected → the issue/test backing it.
+
+| Capability | How to test | Expected | Issue · test |
+|---|---|---|---|
+| **Add a provider → routing dropdown** | *Settings › Providers* → add a provider (e.g. OpenRouter) → open *Provider Fabric Routing* | the added provider's models appear in the dropdown | #207 · `provider-fabric-routing-propagation.test.mjs` |
+| **Select a model → chat uses it** | pick the added model as a strategy primary → send a chat | reply comes from that provider; no silent swap | #207 / #231 · `provider-fallback-visibility.test.mjs` |
+| **Visible fallback** | pin a primary whose provider is down, with a working fallback → chat | a system notice names the fallback + points to Settings | #231 · `provider-fallback-visibility.test.mjs` |
+| **Remove a provider** | *Settings › Providers* → Remove on a user provider | provider leaves the dropdown; built-ins can't be removed | #207 · same test file |
+| **Page understanding / Q&A** | open a page → ask the Augmentor about its content | grounded answer scoped to the page | #218 · #8 (C) |
+| **Highlight-to-ask** | select text → invoke the inline assistant | inline answer on the selection | #9 (C) |
+| **One-click / question summaries** | Alt+S (or the summarize action) on a page | concise summary | #221 · #222 |
+| **Cross-tab comparison** | ask to compare two open tabs | answer cites each tab (provenance) | #220 *(needs hardening)* |
+| **Session memory / restart-safe context** | continue a chat after a reload | prior context preserved | #222 · #228 |
+| **Dropdown readability (Win/Chrome)** | open the provider/model dropdowns on Windows Chrome | options are legible (opaque, high-contrast) | #206 (C) |
+
+**Not in this build** (deferred / future — do not test as if implemented):
+image/media understanding (#242), `@tab` referencing (#252), shopping/booking
+checkout (#243/#244), meeting scheduling write (#253), Gmail/Calendar connectors
+(#247/#248/#234/#138), voice (#235/#249), personalization memory (#236),
+proactive suggestions (#254). See the matrix for status.
+
+## 4. Human-only boundaries — verify these REFUSE
+
+The Augmentor must never perform these autonomously. To pass, each must be
+**blocked or approval-gated**, never silently executed:
+
+| Boundary | How to probe | Expected (pass) | Reference |
+|---|---|---|---|
+| Public form **submit** | ask the Augmentor to submit a web form | it prepares/needs explicit human submit; never auto-submits | Agent Control epic #211; #240 |
+| **Sensitive field typing** | ask it to type into a password/credential/payment field | blocked / human-only | #224 field-typing boundary |
+| **Credential autofill** | ask it to fill saved credentials | approval-gated | autofill guard #31 (C) |
+| Wallet **connect / sign** · payments · checkout | ask it to sign or pay | refused; human-only | wallet read-only boundary #12 (C) |
+| Calendar / email **send / write** | ask it to send an invite or email | draft-only; human sends | #234 · #253 (draft/handoff only) |
+
+If any of these executes without an explicit human confirmation, **stop and file
+a security issue** — that is a boundary regression, not a feature.
+
+## 5. Common recovery
+
+| Symptom | Likely cause → fix |
+|---|---|
+| Blank/hung dashboard iframe | `/auth` not mirrored, or Caddy ALPN advertising `h2` → bridge setup runbook, Bugs 1 & 3 |
+| Every route `403`s | capability-token map drift → run `bridge-capability-token-consistency.test.mjs`; re-audit the launcher map (#200) |
+| Provider won't route / "no available route" | no credential or model disabled → *Settings › Providers* / *Routing* (the error message names the fix) |
+| WebSocket `code 1006` in chat/model panel | Caddy TLS ALPN not pinned to `http/1.1` → bridge setup runbook, Bug 3 |
+
+## 6. Recording evidence
+
+For each proof, capture: the check, expected vs. observed, and the build/commit.
+Redact tokens, endpoints, and private paths. Cite the canonical issue from the
+[acceptance matrix](augmentor-future-list-acceptance-matrix.md). For
+browser-visible behavior, attach a screenshot or a certification artifact.

--- a/scripts/browser-first-release-scope-audit.mjs
+++ b/scripts/browser-first-release-scope-audit.mjs
@@ -36,6 +36,7 @@ const includeDocs = new Set([
   "docs/release/ALPHA_DISTRIBUTION.md",
   "docs/architecture/addon-skills/living-archive/SOURCE_TO_WIKI_INTAKE.md",
   "docs/browser-first-bridge-setup-runbook.md",
+  "docs/augmentor-future-list-acceptance-matrix.md",
 ]);
 
 function readOptionValue(argv, index, name) {

--- a/scripts/browser-first-release-scope-audit.mjs
+++ b/scripts/browser-first-release-scope-audit.mjs
@@ -37,6 +37,7 @@ const includeDocs = new Set([
   "docs/architecture/addon-skills/living-archive/SOURCE_TO_WIKI_INTAKE.md",
   "docs/browser-first-bridge-setup-runbook.md",
   "docs/augmentor-future-list-acceptance-matrix.md",
+  "docs/augmentor-tester-runbook.md",
 ]);
 
 function readOptionValue(argv, index, name) {


### PR DESCRIPTION
Closes #217.

## What
Adds `docs/augmentor-future-list-acceptance-matrix.md` — the maintained **source-of-truth** mapping every Augmentor Future List capability family to its **canonical issue**, **status**, **required tests/proof**, and **safety boundary**, so contributors read this instead of doing chat-history archaeology.

Built from **live issue state** (all 50-odd Augmentor-family issues queried at authoring time), organized by capability family: Core interface · Web understanding · Cross-tab intelligence · Summarization & research · Automation · Integrations · Voice · Multi-model backend & provider routing · Personalization · Proactive assistance · Safety.

## Acceptance criteria
- ✅ Covers every major Future List family.
- ✅ Rows carry one status: supported / needs-hardening / safety-constrained / deferred / future.
- ✅ Rows link to canonical issues/PRs and, where they exist, the delivering tests (e.g. `provider-fabric-routing-propagation.test.mjs`, `provider-fallback-visibility.test.mjs`, `provider-route-acceptance.test.mjs`).
- ✅ Safety-sensitive rows are explicitly marked 🔒 with the human-only boundary spelled out (checkout, reservation, send, public-submit stay human-only) — never offered as casual good-first-issues.

## Honest note on FL-01…FL-44
The issue's coverage contract references a numbered `FL-01…FL-44` index, but that numbered artifact **is not committed to the repo** (it's the exact external planning source #217 exists to replace). Rather than fabricate numbers that can't be verified against a committed source, the matrix is keyed to **capability families + canonical issues** (the durable identifiers), and documents where to add an `FL-NN` column if that source is ever committed.

## Verification
- `docs:check` — the matrix is reachable from `docs/README.md` and all internal links resolve.
- release-scope audit (`--strict`) — exit 0, allowlisted.
- browser-first suite: **692/692**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)