### PR TITLE
docs: add contributor-handoff field to feature issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -72,6 +72,19 @@ body:
     validations:
       required: true
 
+  - type: textarea
+    id: handoff
+    attributes:
+      label: Contributor handoff (code entry-point)
+      description: |
+        So a contributor can start without chat-history archaeology. If you know the codebase, name the module a contributor would begin from and a focused test; a triager can fill this in later otherwise. Note that `npm run test:browser-first` runs the FULL suite and ignores path arguments — target a file with `node --test <path>` instead. Mark whether the work is in the browser-first Alpha runtime or deferred/native.
+      placeholder: |
+        - Entry-point: browser-first/resonantos-side-panel-extension/src/lib/<module>.js
+        - Focused test: node --test browser-first/test/<file>.test.mjs
+        - Runtime: browser-first Alpha (per AGENTS.md) | deferred | native-future
+    validations:
+      required: false
+
   - type: dropdown
     id: sensitive_actions
     attributes:


### PR DESCRIPTION
## Why

Part of a full Augmentor executability audit. A three-vendor panel (grok-4.5, gpt-5.6, gemini-3.1-pro) found two systemic gaps that this closes for **future** issues:

1. **No code entry-point.** Well-specified feature issues still stranded contributors because they named no module to start from. All three reviewers' top recommendation was a required 'contributor handoff' with an entry-point.
2. **Wrong targeted-test guidance.** `scripts/run-browser-first-extension-tests.mjs` `readdir`s the test folder and runs everything — it ignores path args. So "run targeted tests" via `npm run test:browser-first <file>` silently runs the full suite. The correct form is `node --test <path>`.

## Change

Adds an optional `handoff` textarea to `feature.yml` (optional so a community proposer isn't blocked; triagers fill it at triage per PROJECT_GOVERNANCE.md), with the corrected test guidance and an Alpha/deferred/native runtime marker baked into the description.

Companion to the acceptance-matrix sync (#265) and the backfill of handoff blocks onto the existing open Augmentor issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)