### PR TITLE
fix(#240): non-bypassable human-only public-submit handoff

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/content.js
+++ b/browser-first/resonantos-side-panel-extension/src/content.js
@@ -422,13 +422,19 @@ const ambiguousTargetResponse = (kind, target, candidates) => ({
   candidates
 });
 
+// #240: public-commit verbs. A control carrying one of these is treated as a
+// public submit even without a <form> (SPA buttons, links, type="button" that
+// wire up JS submit) — it is a human-only handoff, never auto-clicked.
+const PUBLIC_COMMIT_VERBS = /\b(submit|send|post|publish|save|share|buy|pay|confirm|connect|sign|reserve|book|order|checkout|apply|vote|subscribe|register|comment)\b/i;
 const isSubmitLikeElement = (element) => {
   const type = String(element.getAttribute("type") || "").toLowerCase();
   const role = String(element.getAttribute("role") || "").toLowerCase();
+  const tag = element.tagName ? element.tagName.toLowerCase() : "";
   const text = visibleText(element).toLowerCase();
   return type === "submit" ||
     (element instanceof HTMLButtonElement && (!type || type === "submit") && Boolean(element.closest("form"))) ||
-    (role === "button" && Boolean(element.closest("form")) && /\b(submit|send|post|publish|save|share|buy|pay|confirm|connect|sign)\b/i.test(text));
+    // formless / type="button" / link / role=button commits are still human-only
+    ((tag === "button" || tag === "a" || role === "button" || role === "link") && PUBLIC_COMMIT_VERBS.test(text));
 };
 
 const isHardRestrictedElement = (element, fallbackText = "") => {
@@ -453,13 +459,18 @@ const clickElement = (element, { userApproved = false, fallbackText = "" } = {})
       error: `Clicking "${visibleText(element) || fallbackText}" crosses a wallet/payment/login/credential boundary and must be completed by the human.`
     };
   }
-  if (isSubmitLikeElement(element) && !userApproved) {
-    pulseControlOverlay({ state: "blocked", label: "Approval required for public action", phase: "blocked", target: element });
+  // #240: submit-like is UNCONDITIONALLY human-only. Do not add a userApproved
+  // or any other bypass gate here — an in-panel approval must never turn a public
+  // submit into an agent-performed click. The human clicks it on the page.
+  if (isSubmitLikeElement(element)) {
+    element.scrollIntoView({ block: "center", inline: "center", behavior: "auto" });
+    pulseControlOverlay({ state: "blocked", label: "Human-only: click this yourself", phase: "handoff", target: element });
     return {
       ok: false,
       approvalRequired: true,
       deniedToAutomation: true,
-      error: `Clicking "${visibleText(element) || fallbackText}" looks like a submit/public action and requires human approval.`
+      humanHandoff: true,
+      error: `Clicking "${visibleText(element) || fallbackText}" is a public submit/commit action and must be performed by the human on the page.`
     };
   }
   element.scrollIntoView({ block: "center", inline: "center", behavior: "auto" });
@@ -676,6 +687,20 @@ const setNativeValue = (element, value) => {
   element.dispatchEvent(new Event("change", { bubbles: true }));
 };
 
+// #240: a field that is safe to submit on its own (a search box) must NOT submit
+// a form that also carries sensitive or public-commit fields. Only auto-submit a
+// form whose every data field classifies as a search query.
+const formIsSafeToAutoSubmit = (form) => {
+  if (!form) return true; // no enclosing form -> Enter only affects the field itself
+  const fields = form.querySelectorAll("input, textarea, select");
+  for (const candidate of fields) {
+    const candidateType = String(candidate.getAttribute("type") || "").toLowerCase();
+    if (["hidden", "submit", "button", "reset", "search"].includes(candidateType)) continue;
+    if (classifyEditableField(candidate).kind !== "search-query") return false;
+  }
+  return true;
+};
+
 const typeIntoPage = ({ text, field = "", ref = "", submit = false, userApproved = false } = {}) => {
   const value = String(text ?? "").trim();
   if (!value) {
@@ -710,6 +735,18 @@ const typeIntoPage = ({ text, field = "", ref = "", submit = false, userApproved
         deniedToAutomation: true,
         fieldSafety,
         error: "Submitting a non-search field requires human approval."
+      };
+    }
+    if (!formIsSafeToAutoSubmit(element.form)) {
+      element.scrollIntoView({ block: "center", inline: "center", behavior: "auto" });
+      pulseControlOverlay({ state: "blocked", label: "Human-only: submit this form yourself", phase: "handoff", target: element });
+      return {
+        ok: false,
+        approvalRequired: true,
+        deniedToAutomation: true,
+        humanHandoff: true,
+        fieldSafety,
+        error: "This search field is inside a form with sensitive or public-submit fields; the human must submit it on the page."
       };
     }
     element.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", code: "Enter", bubbles: true, cancelable: true }));

--- a/browser-first/resonantos-side-panel-extension/src/content.js
+++ b/browser-first/resonantos-side-panel-extension/src/content.js
@@ -430,11 +430,20 @@ const isSubmitLikeElement = (element) => {
   const type = String(element.getAttribute("type") || "").toLowerCase();
   const role = String(element.getAttribute("role") || "").toLowerCase();
   const tag = element.tagName ? element.tagName.toLowerCase() : "";
-  const text = visibleText(element).toLowerCase();
-  return type === "submit" ||
-    (element instanceof HTMLButtonElement && (!type || type === "submit") && Boolean(element.closest("form"))) ||
-    // formless / type="button" / link / role=button commits are still human-only
-    ((tag === "button" || tag === "a" || role === "button" || role === "link") && PUBLIC_COMMIT_VERBS.test(text));
+  const label = `${visibleText(element)} ${element.getAttribute("value") || ""}`.toLowerCase();
+  // Native form-submit controls are always human-only.
+  if (type === "submit" || type === "image") return true;
+  if (element instanceof HTMLButtonElement && (!type || type === "submit") && Boolean(element.closest("form"))) return true;
+  // A control that BEHAVES like a button (incl. input[type=button] and scripted
+  // <a onclick>/<div onclick>) AND carries a public-commit verb is human-only.
+  // Plain navigation links (<a href> without button semantics) stay clickable so
+  // safe reads like "Order History" or "How to apply" are not blocked.
+  const behavesLikeButton =
+    tag === "button" ||
+    role === "button" ||
+    (tag === "input" && ["button", "reset"].includes(type)) ||
+    (typeof element.hasAttribute === "function" && element.hasAttribute("onclick"));
+  return behavesLikeButton && PUBLIC_COMMIT_VERBS.test(label);
 };
 
 const isHardRestrictedElement = (element, fallbackText = "") => {
@@ -695,8 +704,15 @@ const formIsSafeToAutoSubmit = (form) => {
   const fields = form.querySelectorAll("input, textarea, select");
   for (const candidate of fields) {
     const candidateType = String(candidate.getAttribute("type") || "").toLowerCase();
-    if (["hidden", "submit", "button", "reset", "search"].includes(candidateType)) continue;
+    if (["hidden", "submit", "button", "image", "reset", "search"].includes(candidateType)) continue;
     if (classifyEditableField(candidate).kind !== "search-query") return false;
+  }
+  // A public-commit control anywhere in the form (e.g. "Place order", "Publish")
+  // makes the whole form human-only, even if every data field is a search box.
+  // A plain search submit ("Go"/"Search") carries no commit verb, so it stays safe.
+  for (const control of form.querySelectorAll("button, input[type=submit], input[type=image], input[type=button], [role=button]")) {
+    const controlLabel = `${visibleText(control)} ${control.getAttribute("value") || ""}`.toLowerCase();
+    if (PUBLIC_COMMIT_VERBS.test(controlLabel)) return false;
   }
   return true;
 };

--- a/browser-first/resonantos-side-panel-extension/src/lib/approval-policy.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/approval-policy.js
@@ -1,6 +1,8 @@
 const restrictedPlannerText = /\b(seed|private key|password|passphrase|wallet|phantom|sign|signature|approve|buy|sell|swap|stake|unstake|bridge|mint|claim|pay|payment|checkout|login|delete|remove|destroy|credential|2fa|otp|transfer)\b/i;
 const hardApprovalBoundaryText = /\b(seed|private key|password|passphrase|wallet|phantom|sign|signature|approve|buy|sell|swap|stake|unstake|bridge|mint|claim|pay|payment|checkout|login|delete|remove|destroy|credential|2fa|otp|transfer|card|cvc|cvv|iban|billing|autofill|personal contact|human-controlled autofill)\b/i;
-const publicSubmitBoundaryText = /\b(submit|publish|post|share|send|save|confirm)\b/i;
+// #240: keep aligned with content.js PUBLIC_COMMIT_VERBS so the runner classifies
+// the same controls the content script hands off (minus the hard-boundary verbs).
+const publicSubmitBoundaryText = /\b(submit|publish|post|share|send|save|confirm|reserve|book|order|apply|vote|subscribe|register|comment)\b/i;
 
 export function approvalBoundaryForStep(step, reason = "") {
   const stepHaystack = [

--- a/browser-first/resonantos-side-panel-extension/src/lib/approval-policy.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/approval-policy.js
@@ -2,7 +2,7 @@ const restrictedPlannerText = /\b(seed|private key|password|passphrase|wallet|ph
 const hardApprovalBoundaryText = /\b(seed|private key|password|passphrase|wallet|phantom|sign|signature|approve|buy|sell|swap|stake|unstake|bridge|mint|claim|pay|payment|checkout|login|delete|remove|destroy|credential|2fa|otp|transfer|card|cvc|cvv|iban|billing|autofill|personal contact|human-controlled autofill)\b/i;
 // #240: keep aligned with content.js PUBLIC_COMMIT_VERBS so the runner classifies
 // the same controls the content script hands off (minus the hard-boundary verbs).
-const publicSubmitBoundaryText = /\b(submit|publish|post|share|send|save|confirm|reserve|book|order|apply|vote|subscribe|register|comment)\b/i;
+const publicSubmitBoundaryText = /\b(submit|publish|post|share|send|save|confirm|connect|reserve|book|order|apply|vote|subscribe|register|comment)\b/i;
 
 export function approvalBoundaryForStep(step, reason = "") {
   const stepHaystack = [

--- a/browser-first/resonantos-side-panel-extension/src/lib/control-approval-actions.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/control-approval-actions.js
@@ -25,10 +25,14 @@ export function createControlApprovalActions({
 
     const approval = pendingApproval;
     const boundary = approvalBoundaryForStep(approval.step, approval.reason);
-    if (boundary === "hard") {
+    // #240: public-submit joins hard as non-approvable — an in-panel approval must
+    // never execute a public commit. The human performs it on the page, then resumes.
+    if (boundary === "hard" || boundary === "public-submit") {
       await addMessage(
         "system",
-        `Cannot automate this action: ${controlStepLabel(approval.step)}.\nWallet, payment, login, credential, signing, and transfer actions are human-only.`
+        boundary === "public-submit"
+          ? `Cannot automate this action: ${controlStepLabel(approval.step)}.\nPublic submit and commit actions (send, publish, post, reserve, order, apply, confirm) are human-only — click it yourself on the page, then resume.`
+          : `Cannot automate this action: ${controlStepLabel(approval.step)}.\nWallet, payment, login, credential, signing, and transfer actions are human-only.`
       );
       return;
     }

--- a/browser-first/test/agent-control-public-submit.test.mjs
+++ b/browser-first/test/agent-control-public-submit.test.mjs
@@ -61,9 +61,16 @@ const PAGE = `<!doctype html>
     <input name="q" aria-label="Query" placeholder="Query">
     <button type="submit">Go</button>
   </form>
+  <form id="commitform">
+    <input name="ordersearch" aria-label="Order search" placeholder="Order search">
+    <button type="submit">Place order</button>
+  </form>
   <button id="publishit">Publish now</button>
   <button id="safe">Safe Details</button>
   <button id="sign" type="submit">Sign transaction</button>
+  <div id="divpublish" onclick="window.__divClicked = true">Publish article</div>
+  <a id="navlink" href="#orders">Order History</a>
+  <a id="linkbtn" role="button" onclick="window.__linkClicked = true">Reserve seat</a>
   <div id="status">idle</div>`;
 
 test("#240: approved click of a public submit button is denied and does not submit", async () => {
@@ -113,8 +120,39 @@ test("#240: a hard-boundary control (Sign) is denied by the hard check, ahead of
   assert.equal(win.__submitted, false);
 });
 
+test("#240: typing+submit is denied when the form holds a public-commit button (no sensitive field)", async () => {
+  const { win, send } = await loadContentScript(PAGE);
+  win.eval(`document.querySelector("#commitform").addEventListener("submit", (e) => { e.preventDefault(); window.__orderSubmitted = true; });`);
+  const res = send({ type: "type_text", field: "Order search", text: "widget", submit: true, userApproved: true });
+  assert.equal(res.ok, false, "a form with a 'Place order' button must not be auto-submitted via a search field");
+  assert.equal(res.deniedToAutomation, true);
+  assert.notEqual(win.__orderSubmitted, true);
+});
+
+test("#240: an onclick commit control (div) is denied", async () => {
+  const { win, send } = await loadContentScript(PAGE);
+  const res = send({ type: "click_text", text: "Publish article", userApproved: true });
+  assert.equal(res.ok, false);
+  assert.equal(res.deniedToAutomation, true, "a scripted <div onclick>Publish must be human-only");
+  assert.notEqual(win.__divClicked, true);
+});
+
+test("#240: an <a role=button onclick> commit is denied", async () => {
+  const { win, send } = await loadContentScript(PAGE);
+  const res = send({ type: "click_text", text: "Reserve seat", userApproved: true });
+  assert.equal(res.ok, false);
+  assert.equal(res.deniedToAutomation, true);
+  assert.notEqual(win.__linkClicked, true);
+});
+
+test("#240 non-breaking: a plain navigation link with a commit-word is still clickable", async () => {
+  const { send } = await loadContentScript(PAGE);
+  const res = send({ type: "click_text", text: "Order History" });
+  assert.equal(res.ok, true, "a plain <a href> nav link (no button semantics) must not be blocked by #240");
+});
+
 test("#240: the runner boundary classifier agrees with the widened commit verbs", () => {
-  for (const verb of ["submit", "publish", "post", "send", "reserve", "order", "apply", "confirm"]) {
+  for (const verb of ["submit", "publish", "post", "send", "reserve", "order", "apply", "confirm", "connect", "subscribe", "vote"]) {
     assert.equal(approvalBoundaryForStep({ type: "click", text: `${verb} it` }), "public-submit", `${verb} → public-submit`);
   }
   // hard verbs still win over public-submit

--- a/browser-first/test/agent-control-public-submit.test.mjs
+++ b/browser-first/test/agent-control-public-submit.test.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { JSDOM } from "jsdom";
+import { approvalBoundaryForStep } from "../resonantos-side-panel-extension/src/lib/approval-policy.js";
+
+// #240: public-submit is a non-bypassable human-only handoff. These tests prove
+// the enforcement layer (content.js) refuses to auto-perform a public submit even
+// with userApproved:true, and closes the search-field-in-public-form requestSubmit
+// hole — the two bypasses a design red-team found surviving the naive one-liner.
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+const ext = (...p) => path.join(repoRoot, "browser-first", "resonantos-side-panel-extension", "src", ...p);
+const scripts = [
+  ext("lib", "control-overlay.js"),
+  ext("lib", "content-field-safety.js"),
+  ext("lib", "content-inline-actions.js"),
+  ext("lib", "content-control-refs.js"),
+  ext("content.js"),
+];
+
+async function loadContentScript(html) {
+  const dom = new JSDOM(html, { runScripts: "outside-only", url: "https://shop.test/checkout" });
+  const win = dom.window;
+  let listener = null;
+  win.chrome = {
+    runtime: {
+      onMessage: { addListener(cb) { listener = cb; } },
+      sendMessage: () => Promise.resolve(),
+    },
+    storage: { onChanged: { addListener() {} } },
+  };
+  win.HTMLElement.prototype.scrollIntoView = function scrollIntoView() {};
+  for (const scriptPath of scripts) win.eval(await readFile(scriptPath, "utf8"));
+  assert.equal(typeof listener, "function", "content.js should register a message listener");
+  // jsdom runs "outside-only", so page scripts are inert — wire up observable state here.
+  win.eval(`
+    window.__submitted = false;
+    window.__searchSubmitted = false;
+    window.__safeClicked = false;
+    document.querySelector("#public").addEventListener("submit", (e) => { e.preventDefault(); window.__submitted = true; });
+    document.querySelector("#searchonly").addEventListener("submit", (e) => { e.preventDefault(); window.__searchSubmitted = true; });
+    document.querySelector("#safe").addEventListener("click", () => { window.__safeClicked = true; });
+  `);
+  const send = (message) => {
+    let response = null;
+    listener({ channel: "resonantos.browser_first.content", ...message }, {}, (payload) => { response = payload; });
+    return response;
+  };
+  return { win, send };
+}
+
+const PAGE = `<!doctype html>
+  <form id="public">
+    <input name="search" aria-label="Search field" placeholder="Search field">
+    <input type="password" name="password" aria-label="Password">
+    <button id="submit" type="submit">Submit public form</button>
+  </form>
+  <form id="searchonly" role="search">
+    <input name="q" aria-label="Query" placeholder="Query">
+    <button type="submit">Go</button>
+  </form>
+  <button id="publishit">Publish now</button>
+  <button id="safe">Safe Details</button>
+  <button id="sign" type="submit">Sign transaction</button>
+  <div id="status">idle</div>`;
+
+test("#240: approved click of a public submit button is denied and does not submit", async () => {
+  const { win, send } = await loadContentScript(PAGE);
+  const res = send({ type: "click_text", text: "Submit public form", userApproved: true });
+  assert.equal(res.ok, false, "must not click a public submit");
+  assert.equal(res.deniedToAutomation, true);
+  assert.equal(res.humanHandoff, true);
+  assert.equal(win.__submitted, false, "the public form must NOT have been submitted");
+});
+
+test("#240: approved click of a formless commit button (Publish) is denied", async () => {
+  const { send } = await loadContentScript(PAGE);
+  const res = send({ type: "click_text", text: "Publish now", userApproved: true });
+  assert.equal(res.ok, false);
+  assert.equal(res.deniedToAutomation, true, "formless Publish must be human-only even with approval");
+});
+
+test("#240: typing+submit on a search field inside a public form is denied (requestSubmit hole)", async () => {
+  const { win, send } = await loadContentScript(PAGE);
+  const res = send({ type: "type_text", field: "Search field", text: "hello", submit: true, userApproved: true });
+  assert.equal(res.ok, false, "must not submit a form that also carries a password field");
+  assert.equal(res.deniedToAutomation, true);
+  assert.equal(win.__submitted, false, "the public form must NOT have been submitted via requestSubmit");
+});
+
+test("#240 non-breaking: typing+submit on a search-only form still works", async () => {
+  const { send } = await loadContentScript(PAGE);
+  const res = send({ type: "type_text", field: "Query", text: "cats", submit: true });
+  assert.equal(res.ok, true, "a search-only form remains auto-submittable");
+  assert.equal(res.submitted, true);
+});
+
+test("#240 non-breaking: a benign non-submit button is still clickable", async () => {
+  const { win, send } = await loadContentScript(PAGE);
+  const res = send({ type: "click_text", text: "Safe Details" });
+  assert.equal(res.ok, true, "safe reads/clicks must not be blocked by #240");
+  assert.equal(win.__safeClicked, true);
+});
+
+test("#240: a hard-boundary control (Sign) is denied by the hard check, ahead of submit", async () => {
+  const { win, send } = await loadContentScript(PAGE);
+  const res = send({ type: "click_text", text: "Sign transaction", userApproved: true });
+  assert.equal(res.ok, false);
+  assert.equal(res.deniedToAutomation, true);
+  assert.match(res.error, /wallet\/payment\/login\/credential/, "hard boundary error, checked before submit-like");
+  assert.equal(win.__submitted, false);
+});
+
+test("#240: the runner boundary classifier agrees with the widened commit verbs", () => {
+  for (const verb of ["submit", "publish", "post", "send", "reserve", "order", "apply", "confirm"]) {
+    assert.equal(approvalBoundaryForStep({ type: "click", text: `${verb} it` }), "public-submit", `${verb} → public-submit`);
+  }
+  // hard verbs still win over public-submit
+  assert.equal(approvalBoundaryForStep({ type: "click", text: "pay now" }), "hard");
+  // a plain safe action stays safe
+  assert.equal(approvalBoundaryForStep({ type: "click", text: "open details" }), "safe");
+});

--- a/browser-first/test/control-approval-actions.test.mjs
+++ b/browser-first/test/control-approval-actions.test.mjs
@@ -65,6 +65,18 @@ test("control approval actions block hard-boundary automation", async () => {
   assert.match(harness.events.find((event) => event[0] === "message")?.[2], /human-only/);
 });
 
+test("#240: control approval actions block public-submit automation", async () => {
+  const harness = createHarness({
+    approvalBoundaryForStep: () => "public-submit",
+    pendingApproval: { reason: "public submit", step: { type: "click", text: "Submit public form" } },
+  });
+
+  await harness.actions.approvePendingControlStep();
+
+  assert.equal(harness.events.some((event) => event[0] === "approve"), false, "public-submit must not reach the runner approve path");
+  assert.match(harness.events.find((event) => event[0] === "message")?.[2], /human-only/);
+});
+
 test("control approval actions trust only safe task classes before approving", async () => {
   const harness = createHarness();
 


### PR DESCRIPTION
Closes the public-submit bypass identified in the 2026-07-17 due-diligence review: an in-panel "Approve once" set `userApproved:true`, which let the extension programmatically click a public **Submit** button (the agent submitted, not the human).

## The fix (4 parts, rig-certified)
- **content.js `clickElement`** — submit-like is now **unconditionally** human-only; dropped the `userApproved` bypass. Scrolls to + highlights the control and returns a `humanHandoff`.
- **content.js `typeIntoPage`** — gate `requestSubmit()` on the whole **form** being safe (no sensitive fields *and* no public-commit button), closing the search-field-in-public-form hole.
- **content.js `isSubmitLikeElement`** — widened to catch `input[type=button]` and scripted `<a onclick>`/`<div onclick>` commits, while **not** blocking plain `<a href>` navigation links.
- **approval-policy / control-approval-actions** — `public-submit` joins `hard` as a non-approvable boundary, so "Approve once" can't loop into a denied re-exec.

## Review (Resonant-Rig v2)
Design was certified by a 3-vendor panel **before** code; the diff was then re-certified by a second panel whose **live adversarial probe** (grok-4.5) found two holes the first pass missed — a form-commit-button submit and an `input[type=button]`/`onclick` under-match — plus a nav-link over-match (gemini). All three are now closed and covered by tests. Every disagreement was adjudicated against the code.

## Verification
- New suite `agent-control-public-submit.test.mjs` — 11 cases covering all three bypasses + non-breaking paths; **mutation-proven** non-vacuous (each guard reverted → matching test fails).
- Full `npm run test:browser-first` — **704/704**.

## ⚠️ Not merge-ready alone
Deterministic tests are necessary but **not sufficient** for a browser-safety change. This needs **live-browser proof via #267** (the restored Agent-Control harness) before close. Enforcement lives in the content script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)