### PR TITLE
fix(host): detect uv-venv Hermes and npm-global OpenCode runtimes

### DIFF
--- a/browser-first/host/hermes-runtime.mjs
+++ b/browser-first/host/hermes-runtime.mjs
@@ -282,6 +282,7 @@ export function hermesPythonRuntimeDiagnostics(command, options = {}) {
       return unavailablePythonRuntime(rejections);
     }
 
+    const pathApi = platform === "win32" ? path.win32 : path.posix;
     const canonicalInstallationRoot = realpath(adapter.agentRoot);
     const canonicalPythonPath = realpath(adapter.pythonPath);
     const canonicalRunAgentPath = realpath(adapter.runAgentPath);
@@ -289,7 +290,21 @@ export function hermesPythonRuntimeDiagnostics(command, options = {}) {
       rejections.push({ path: adapter.agentRoot, reason: "canonical installation root escapes fixed allowlisted roots" });
       return unavailablePythonRuntime(rejections);
     }
-    if (!pathInside(canonicalPythonPath, canonicalInstallationRoot, platform)) {
+    // A virtualenv legitimately symlinks its python launcher to a base
+    // interpreter in a Python store (uv/pyenv/system), so realpath(python) can
+    // resolve OUTSIDE the Hermes root. Accept the interpreter when its resolved
+    // path stays inside the root (copied venv) OR it is a genuine venv rooted
+    // INSIDE the trusted installation root — proven by a pyvenv.cfg whose
+    // canonical path is also inside the root. The trust anchor still holds:
+    // creating such a venv needs write access to the Hermes install itself,
+    // which already implies control of run_agent.py. A bare malicious symlink
+    // (no pyvenv.cfg inside the root) is still rejected.
+    const venvConfigPath = pathApi.join(pathApi.dirname(pathApi.dirname(adapter.pythonPath)), "pyvenv.cfg");
+    let rootedVenv = false;
+    if (exists(venvConfigPath) && stat(venvConfigPath).isFile()) {
+      rootedVenv = pathInside(realpath(venvConfigPath), canonicalInstallationRoot, platform);
+    }
+    if (!pathInside(canonicalPythonPath, canonicalInstallationRoot, platform) && !rootedVenv) {
       rejections.push({ path: adapter.pythonPath, reason: "canonical path escapes fixed allowlisted Hermes installation root" });
       return unavailablePythonRuntime(rejections);
     }
@@ -298,14 +313,18 @@ export function hermesPythonRuntimeDiagnostics(command, options = {}) {
       return unavailablePythonRuntime(rejections);
     }
 
+    // Spawn the venv LAUNCHER (inside the trusted root), not the resolved base
+    // interpreter, so the venv's site-packages activate. For a copied venv the
+    // two are identical; for a symlinked venv only the launcher activates it.
+    const launchPythonPath = adapter.pythonPath;
     return {
       installed: true,
       agentRoot: canonicalInstallationRoot,
-      pythonPath: canonicalPythonPath,
+      pythonPath: launchPythonPath,
       runAgentPath: canonicalRunAgentPath,
       resolution: {
         base: selectedCandidate.base,
-        path: canonicalPythonPath,
+        path: launchPythonPath,
         canonical_path: canonicalPythonPath,
         validated_by: "hermesPythonRuntimeDiagnostics",
         source: selectedCandidate.source,

--- a/browser-first/host/opencode-runtime.mjs
+++ b/browser-first/host/opencode-runtime.mjs
@@ -37,7 +37,15 @@ function trustedCandidates({ homeDir, platform }) {
     ? OPENCODE_COMMAND_NAMES.map((name) => `${name}.exe`)
     : OPENCODE_COMMAND_NAMES;
   const candidates = [];
-  const appendRoot = (root, base, source, canonicalRoots) => {
+  const appendRoot = (root, base, source, extraRoots = []) => {
+    // A bin root's sibling `lib/node_modules` is where `npm install -g` with that
+    // prefix puts the package; the bin entry is just a symlink into it. Trust
+    // that sibling at the same level as the bin root, or a perfectly valid
+    // npm-global OpenCode (e.g. ~/.local/bin/opencode -> ~/.local/lib/node_modules/
+    // opencode-ai/bin/opencode) is rejected as "canonical path escapes fixed
+    // allowlisted roots".
+    const npmGlobalRoot = pathApi.join(pathApi.dirname(root), "lib", "node_modules");
+    const canonicalRoots = [root, npmGlobalRoot, ...extraRoots];
     for (const name of names) candidates.push(candidate(root, name, base, source, pathApi, canonicalRoots));
   };
   if (platform === "win32") {
@@ -48,9 +56,9 @@ function trustedCandidates({ homeDir, platform }) {
     appendRoot(pathApi.join(homeDir, ".opencode", "bin"), "install-prefix", "fixed-user-install-root");
     appendRoot(pathApi.join(homeDir, ".local", "bin"), "install-prefix", "fixed-user-install-root");
     if (platform === "darwin") {
-      appendRoot("/opt/homebrew/bin", "system-bin", "fixed-system-root", ["/opt/homebrew/bin", "/opt/homebrew/Cellar"]);
+      appendRoot("/opt/homebrew/bin", "system-bin", "fixed-system-root", ["/opt/homebrew/Cellar"]);
     }
-    appendRoot("/usr/local/bin", "system-bin", "fixed-system-root", ["/usr/local/bin", "/usr/local/Cellar"]);
+    appendRoot("/usr/local/bin", "system-bin", "fixed-system-root", ["/usr/local/Cellar"]);
     appendRoot("/usr/bin", "system-bin", "fixed-system-root");
     appendRoot("/bin", "system-bin", "fixed-system-root");
     if (platform === "darwin") {

--- a/browser-first/test/hermes-runtime.test.mjs
+++ b/browser-first/test/hermes-runtime.test.mjs
@@ -161,3 +161,58 @@ test("Hermes Python adapter rejects canonical escapes and non-executable candida
   assert.equal(nonRegular.installed, false);
   assert.ok(nonRegular.rejections.some(({ reason }) => /not a regular file/i.test(reason)));
 });
+
+test("Hermes Python adapter accepts a genuine venv whose interpreter symlinks to a Python store", () => {
+  const homeDir = "/home/reviewer";
+  const agentRoot = `${homeDir}/.hermes/hermes-agent`;
+  const command = `${agentRoot}/venv/bin/hermes`;
+  const pythonPath = `${agentRoot}/venv/bin/python`;
+  const runAgentPath = `${agentRoot}/run_agent.py`;
+  const pyvenvCfg = `${agentRoot}/venv/pyvenv.cfg`;
+  const uvBasePython = "/home/reviewer/.local/share/uv/python/cpython-3.11/bin/python3.11";
+  const files = new Set([command, pythonPath, runAgentPath, pyvenvCfg]);
+
+  const diagnostics = hermesRuntime.hermesPythonRuntimeDiagnostics(command, {
+    env: { HERMES_COMMAND: command },
+    homeDir,
+    platform: "linux",
+    exists: (candidate) => files.has(candidate),
+    // The venv launcher symlinks OUT to the uv store; the pyvenv.cfg stays in root.
+    realpath: (candidate) => (candidate === pythonPath ? uvBasePython : candidate),
+    stat: () => executableStat,
+  });
+
+  assert.equal(diagnostics.installed, true);
+  // Must spawn the launcher (activates the venv), not the resolved base interpreter.
+  assert.equal(diagnostics.pythonPath, pythonPath);
+  assert.equal(diagnostics.resolution.path, pythonPath);
+  assert.equal(diagnostics.resolution.canonical_path, uvBasePython);
+});
+
+test("Hermes Python adapter still rejects an escaping interpreter when the venv marker is outside the trusted root", () => {
+  const homeDir = "/home/reviewer";
+  const agentRoot = `${homeDir}/.hermes/hermes-agent`;
+  const command = `${agentRoot}/venv/bin/hermes`;
+  const pythonPath = `${agentRoot}/venv/bin/python`;
+  const runAgentPath = `${agentRoot}/run_agent.py`;
+  const pyvenvCfg = `${agentRoot}/venv/pyvenv.cfg`;
+  const files = new Set([command, pythonPath, runAgentPath, pyvenvCfg]);
+
+  const diagnostics = hermesRuntime.hermesPythonRuntimeDiagnostics(command, {
+    env: { HERMES_COMMAND: command },
+    homeDir,
+    platform: "linux",
+    exists: (candidate) => files.has(candidate),
+    // Both the interpreter AND the venv marker canonicalize outside the root:
+    // a bare symlink dressed up as a venv must not be trusted.
+    realpath: (candidate) => {
+      if (candidate === pythonPath) return "/tmp/attacker/python";
+      if (candidate === pyvenvCfg) return "/tmp/attacker/pyvenv.cfg";
+      return candidate;
+    },
+    stat: () => executableStat,
+  });
+
+  assert.equal(diagnostics.installed, false);
+  assert.ok(diagnostics.rejections.some(({ reason }) => /canonical path escapes/i.test(reason)));
+});

--- a/browser-first/test/opencode-runtime.test.mjs
+++ b/browser-first/test/opencode-runtime.test.mjs
@@ -112,3 +112,22 @@ test("opencode diagnostics reject canonical escapes from trusted candidates", ()
   assert.equal(diagnostics.command, null);
   assert.ok(diagnostics.rejections.some(({ reason }) => /canonical path escapes/i.test(reason)));
 });
+
+test("opencode diagnostics accept an npm-global symlink into the bin root's lib/node_modules", () => {
+  // `npm install -g --prefix ~/.local opencode-ai` symlinks ~/.local/bin/opencode
+  // to ~/.local/lib/node_modules/opencode-ai/bin/opencode — a legitimate install.
+  const link = "/home/reviewer/.local/bin/opencode";
+  const target = "/home/reviewer/.local/lib/node_modules/opencode-ai/bin/opencode";
+  const diagnostics = opencodeRuntimeDiagnostics({
+    env: {},
+    homeDir: "/home/reviewer",
+    platform: "linux",
+    exists: (candidate) => candidate === link,
+    realpath: (candidate) => (candidate === link ? target : candidate),
+    stat: () => ({ isFile: () => true, mode: 0o755 }),
+  });
+
+  assert.equal(diagnostics.installed, true);
+  assert.equal(diagnostics.command, target);
+  assert.equal(diagnostics.resolution?.source, "fixed-user-install-root");
+});


### PR DESCRIPTION
Two small, independent host-side runtime-detection fixes, split out of the larger Augmentor UX branch (#270) so they can land in `dev` on their own — they touch only `host/` files and carry their own tests.

## Fixes
- **OpenCode not detected when installed via `npm install -g`.** A prefix install (`~/.local/bin/opencode` → `~/.local/lib/node_modules/opencode-ai/bin/opencode`) was rejected as *"canonical path escapes fixed allowlisted roots"* because the detector only trusted the `bin` root. Now each bin root's sibling `lib/node_modules` is trusted (same install prefix, same trust level). Attacker escapes to unrelated roots are still rejected.
- **Hermes runtime rejected uv-created venv interpreters.** The venv allowlist now accepts a genuine venv proven by an in-root `pyvenv.cfg` (spawning the launcher, not the resolved base).

## Safety
Both keep the hard-boundary rejections intact; the existing "escape" tests are unchanged and still pass.

## Tests
`node --test test/hermes-runtime.test.mjs test/opencode-runtime.test.mjs` — 13 passing. Each new accept-case was mutation-proven non-vacuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)