### PR TITLE
test: add co-located controller/selector tests per issue #126

### DIFF
--- a/src/core/defaults.ts
+++ b/src/core/defaults.ts
@@ -903,7 +903,7 @@ export const buildDefaultState = (manifests: AddOnManifest[]): ResonantShellStat
     manifests.map((manifest) => [manifest.id, createDefaultInstallation(manifest, "bundled")]),
   );
 
-  return {
+  const raw: ResonantShellState = {
     strategistIdentity: {
       id: "strategist.identity",
       defaultName: "Augmentor",
@@ -965,4 +965,6 @@ export const buildDefaultState = (manifests: AddOnManifest[]): ResonantShellStat
     },
     distributionModel: "curated-plus-sideload",
   };
+
+  return structuredClone(raw) as ResonantShellState;
 };

--- a/src/modules/addons/controller.test.ts
+++ b/src/modules/addons/controller.test.ts
@@ -1,7 +1,40 @@
-import { describe, expect, it } from "vitest";
-import type { AddOnManifest, CapabilityGrant } from "../../core/contracts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  AddOnHookDefinition,
+  AddOnInstallation,
+  AddOnManifest,
+  AddOnScriptDefinition,
+  CapabilityGrant,
+  InstallationStatus,
+  LogicianExecutionArtifact,
+  ResonantShellState,
+} from "../../core/contracts";
 import { buildDefaultState } from "../../core/defaults";
-import { grantAddonCapabilities } from "./controller";
+
+const runtimeMocks = vi.hoisted(() => ({
+  applyProviderCredentialStatuses: vi.fn((s: unknown) => s),
+  hydrateState: vi.fn(),
+  loadProviderCredentialStatuses: vi.fn(),
+  sideloadManifest: vi.fn(),
+}));
+
+vi.mock("../../core/runtime", () => runtimeMocks);
+
+const logicianMocks = vi.hoisted(() => ({
+  executeLogicianHook: vi.fn(),
+  executeLogicianScript: vi.fn(),
+}));
+
+vi.mock("../../core/logician", () => logicianMocks);
+import {
+  executeSideloadManifest,
+  grantAddonCapabilities,
+  runAddonLogicianHook,
+  runAddonLogicianScript,
+  toggleAddonCapabilityGrant,
+  toggleAddonInstallation,
+  updateAddonConfig,
+} from "./controller";
 
 const capability = (name: CapabilityGrant["capability"]): CapabilityGrant => ({
   capability: name,
@@ -47,6 +80,162 @@ const createHermesManifest = (): AddOnManifest => ({
   },
 });
 
+const createMinimalManifest = (id: string, name: string): AddOnManifest => ({
+  id,
+  name,
+  version: "0.1.0",
+  author: "test",
+  category: "tool",
+  description: `${name} manifest`,
+  runtimeType: "ui-module",
+  surfaces: [],
+  requestedCapabilities: [],
+  providerRequirements: { sharedProfiles: [], supportsPrivateCredentials: false },
+  archiveIntegration: { readScopes: [], intakeWriteScopes: [], canRequestIngest: false, canWriteKnowledgePages: false },
+  health: { strategy: "none" },
+  installHooks: {},
+  compatibility: { shellVersion: "^0.1.0", platforms: ["macOS"] },
+});
+
+const createMinimalInstallation = (addonId: string, installed: boolean, enabled: boolean, status: InstallationStatus): AddOnInstallation => ({
+  addonId,
+  source: "bundled",
+  provenanceTier: "curated-signed",
+  verificationState: "verified",
+  installed,
+  enabled,
+  status,
+  grantedCapabilities: [],
+  recommendedGrantPresetIds: [],
+  privateProviderProfileIds: [],
+  notes: [],
+});
+
+describe("toggleAddonInstallation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("installs a previously uninstalled addon", () => {
+    const manifest = createMinimalManifest("addon.test", "Test Addon");
+    let state = buildDefaultState([manifest]);
+    state.installations["addon.test"] = createMinimalInstallation("addon.test", false, false, "available");
+
+    toggleAddonInstallation(manifest, (updater) => {
+      state = updater(state);
+    });
+
+    expect(state.installations["addon.test"].installed).toBe(true);
+    expect(state.installations["addon.test"].enabled).toBe(true);
+    expect(state.installations["addon.test"].status).toBe("enabled");
+  });
+
+  it("disables an enabled addon", () => {
+    const manifest = createMinimalManifest("addon.test", "Test Addon");
+    let state = buildDefaultState([manifest]);
+    state.installations["addon.test"] = createMinimalInstallation("addon.test", true, true, "enabled");
+
+    toggleAddonInstallation(manifest, (updater) => {
+      state = updater(state);
+    });
+
+    expect(state.installations["addon.test"].enabled).toBe(false);
+    expect(state.installations["addon.test"].status).toBe("disabled");
+  });
+
+  it("re-enables a disabled addon", () => {
+    const manifest = createMinimalManifest("addon.test", "Test Addon");
+    let state = buildDefaultState([manifest]);
+    state.installations["addon.test"] = createMinimalInstallation("addon.test", true, false, "disabled");
+
+    toggleAddonInstallation(manifest, (updater) => {
+      state = updater(state);
+    });
+
+    expect(state.installations["addon.test"].enabled).toBe(true);
+    expect(state.installations["addon.test"].status).toBe("enabled");
+  });
+
+  it("toggles the hermes channel when toggling hermes addon", () => {
+    const manifest = createHermesManifest();
+    let state = buildDefaultState([manifest]);
+    state.channels.find((c) => c.id === "desktop-hermes")!.enabled = true;
+    state.installations["addon.hermes"] = {
+      ...state.installations["addon.hermes"],
+      installed: true,
+      enabled: true,
+      status: "enabled",
+    };
+
+    toggleAddonInstallation(manifest, (updater) => {
+      state = updater(state);
+    });
+
+    expect(state.channels.find((c) => c.id === "desktop-hermes")?.enabled).toBe(false);
+  });
+
+  it("silently returns when installation is missing from state", () => {
+    const manifest = createMinimalManifest("addon.missing", "Missing");
+    let state = buildDefaultState([]);
+
+    toggleAddonInstallation(manifest, (updater) => {
+      state = updater(state);
+    });
+
+    expect(state.installations["addon.missing"]).toBeUndefined();
+  });
+});
+
+describe("toggleAddonCapabilityGrant", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("toggles a capability grant from false to true", () => {
+    const manifest = createMinimalManifest("addon.test", "Test Addon");
+    let state = buildDefaultState([manifest]);
+    state.installations["addon.test"] = {
+      ...createMinimalInstallation("addon.test", true, true, "enabled"),
+      grantedCapabilities: [
+        { capability: "network", granted: false, scope: "shared", revocationBehavior: "hard-stop" },
+      ],
+    };
+
+    toggleAddonCapabilityGrant("addon.test", "network", (updater) => {
+      state = updater(state);
+    });
+
+    expect(state.installations["addon.test"].grantedCapabilities[0].granted).toBe(true);
+  });
+
+  it("toggles a capability grant from true to false", () => {
+    const manifest = createMinimalManifest("addon.test", "Test Addon");
+    let state = buildDefaultState([manifest]);
+    state.installations["addon.test"] = {
+      ...createMinimalInstallation("addon.test", true, true, "enabled"),
+      grantedCapabilities: [
+        { capability: "network", granted: true, scope: "shared", revocationBehavior: "hard-stop" },
+      ],
+    };
+
+    toggleAddonCapabilityGrant("addon.test", "network", (updater) => {
+      state = updater(state);
+    });
+
+    expect(state.installations["addon.test"].grantedCapabilities[0].granted).toBe(false);
+  });
+
+  it("silently returns when the addon installation is missing", () => {
+    let state = buildDefaultState([]);
+
+    toggleAddonCapabilityGrant("addon.nonexistent", "network", (updater) => {
+      state = updater(state);
+    });
+
+    expect(state.installations["addon.nonexistent"]).toBeUndefined();
+  });
+});
+
 describe("grantAddonCapabilities", () => {
   it("only grants the requested Hermes workspace capabilities", () => {
     const hermesManifest = createHermesManifest();
@@ -64,5 +253,294 @@ describe("grantAddonCapabilities", () => {
 
     expect(granted).toEqual(new Set(["shell", "ui-embedding"]));
     expect(state.channels.find((channel) => channel.id === "desktop-hermes")?.enabled).toBe(true);
+  });
+
+  it("merges missing requested capabilities into existing grants", () => {
+    const hermesManifest = createHermesManifest();
+    let state = buildDefaultState([hermesManifest]);
+    state.installations["addon.hermes"].grantedCapabilities = [];
+
+    grantAddonCapabilities("addon.hermes", ["shell"], hermesManifest.requestedCapabilities, (updater) => {
+      state = updater(state);
+    });
+
+    expect(state.installations["addon.hermes"].grantedCapabilities.length).toBeGreaterThanOrEqual(
+      hermesManifest.requestedCapabilities.length,
+    );
+    expect(state.installations["addon.hermes"].grantedCapabilities.find((g) => g.capability === "shell")?.granted).toBe(true);
+  });
+});
+
+describe("updateAddonConfig", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("merges config into an existing installation", () => {
+    const manifest = createMinimalManifest("addon.test", "Test Addon");
+    let state = buildDefaultState([manifest]);
+
+    updateAddonConfig("addon.test", { apiKey: "sk-123" }, (updater) => {
+      state = updater(state);
+    });
+
+    expect(state.installations["addon.test"].config).toEqual({ apiKey: "sk-123" });
+  });
+
+  it("merges additional keys into existing config", () => {
+    const manifest = createMinimalManifest("addon.test", "Test Addon");
+    let state = buildDefaultState([manifest]);
+    state.installations["addon.test"].config = { existingKey: "value" };
+
+    updateAddonConfig("addon.test", { newKey: "newValue" }, (updater) => {
+      state = updater(state);
+    });
+
+    expect(state.installations["addon.test"].config).toEqual({
+      existingKey: "value",
+      newKey: "newValue",
+    });
+  });
+
+  it("silently returns when installation is missing", () => {
+    let state = buildDefaultState([]);
+
+    updateAddonConfig("addon.missing", { key: "val" }, (updater) => {
+      state = updater(state);
+    });
+
+    expect(state.installations["addon.missing"]).toBeUndefined();
+  });
+});
+
+describe("runAddonLogicianScript", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("executes a logician script and appends the verification artifact", async () => {
+    const manifest = createMinimalManifest("addon.test", "Test Addon");
+    const installation = createMinimalInstallation("addon.test", true, true, "enabled");
+    const script: AddOnScriptDefinition = {
+      id: "script-test",
+      name: "Test Script",
+      description: "A test script",
+      commandRef: "scripts/test.sh",
+      runPolicy: "on-demand",
+      deterministic: true,
+      requiredCapabilities: [],
+      producesArtifacts: [],
+      requiresHumanApproval: false,
+    };
+    const artifact: LogicianExecutionArtifact = {
+      id: "artifact-1",
+      addonId: "addon.test",
+      kind: "script",
+      targetId: "script-test",
+      label: "Test Script",
+      commandRef: "scripts/test.sh",
+      status: "passed",
+      summary: "Script passed",
+      detail: "",
+      requiredCapabilities: [],
+      missingCapabilities: [],
+      producedArtifacts: [],
+      startedAt: "2026-07-20T00:00:00.000Z",
+      completedAt: "2026-07-20T00:00:01.000Z",
+      durationMs: 1000,
+      evidence: {},
+    };
+    logicianMocks.executeLogicianScript.mockResolvedValue(artifact);
+    let state = buildDefaultState([manifest]);
+    state.installations["addon.test"] = {
+      ...state.installations["addon.test"],
+      installed: true,
+      enabled: true,
+      status: "enabled",
+    };
+
+    const result = await runAddonLogicianScript(manifest, installation, script, (updater) => {
+      state = updater(state);
+    });
+
+    expect(logicianMocks.executeLogicianScript).toHaveBeenCalledWith(
+      expect.objectContaining({ manifest, installation, script, humanInitiated: true }),
+    );
+    expect(result).toEqual(artifact);
+    expect(state.installations["addon.test"].status).toBe("enabled");
+  });
+
+  it("sets installation status to degraded when script fails", async () => {
+    const manifest = createMinimalManifest("addon.test", "Test Addon");
+    const installation = createMinimalInstallation("addon.test", true, true, "enabled");
+    const script: AddOnScriptDefinition = {
+      id: "script-fail",
+      name: "Fail Script",
+      description: "A failing script",
+      commandRef: "scripts/fail.sh",
+      runPolicy: "on-demand",
+      deterministic: true,
+      requiredCapabilities: [],
+      producesArtifacts: [],
+      requiresHumanApproval: false,
+    };
+    const artifact: LogicianExecutionArtifact = {
+      id: "artifact-fail",
+      addonId: "addon.test",
+      kind: "script",
+      targetId: "script-fail",
+      label: "Fail Script",
+      commandRef: "scripts/fail.sh",
+      status: "failed",
+      summary: "Script failed",
+      detail: "exit code 1",
+      requiredCapabilities: [],
+      missingCapabilities: [],
+      producedArtifacts: [],
+      startedAt: "2026-07-20T00:00:00.000Z",
+      completedAt: "2026-07-20T00:00:01.000Z",
+      durationMs: 500,
+      evidence: {},
+    };
+    logicianMocks.executeLogicianScript.mockResolvedValue(artifact);
+    let state = buildDefaultState([manifest]);
+    state.installations["addon.test"] = {
+      ...state.installations["addon.test"],
+      installed: true,
+      enabled: true,
+      status: "enabled",
+    };
+
+    await runAddonLogicianScript(manifest, installation, script, (updater) => {
+      state = updater(state);
+    });
+
+    expect(state.installations["addon.test"].status).toBe("degraded");
+  });
+});
+
+describe("runAddonLogicianHook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("executes a logician hook and appends the verification artifact", async () => {
+    const manifest = createMinimalManifest("addon.test", "Test Addon");
+    const installation = createMinimalInstallation("addon.test", true, true, "enabled");
+    const hook: AddOnHookDefinition = {
+      id: "hook-test",
+      event: "after-install",
+      handlerRef: "hooks/after-install.sh",
+      requiredCapabilities: [],
+      failurePolicy: "warn",
+    };
+    const artifact: LogicianExecutionArtifact = {
+      id: "artifact-hook",
+      addonId: "addon.test",
+      kind: "hook",
+      targetId: "hook-test",
+      label: "Test Hook",
+      commandRef: "hooks/post-install.sh",
+      status: "passed",
+      summary: "Hook passed",
+      detail: "",
+      requiredCapabilities: [],
+      missingCapabilities: [],
+      producedArtifacts: [],
+      startedAt: "2026-07-20T00:00:00.000Z",
+      completedAt: "2026-07-20T00:00:01.000Z",
+      durationMs: 200,
+      evidence: {},
+    };
+    logicianMocks.executeLogicianHook.mockResolvedValue(artifact);
+    let state = buildDefaultState([manifest]);
+
+    const result = await runAddonLogicianHook(manifest, installation, hook, (updater) => {
+      state = updater(state);
+    });
+
+    expect(logicianMocks.executeLogicianHook).toHaveBeenCalledWith(
+      expect.objectContaining({ manifest, installation, hook, humanInitiated: true }),
+    );
+    expect(result).toEqual(artifact);
+  });
+});
+
+describe("executeSideloadManifest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns early when sideload path is empty", async () => {
+    const setReadyState = vi.fn();
+    const setSelectedAddonId = vi.fn();
+    const setSideloadPath = vi.fn();
+    const setErrorState = vi.fn();
+
+    await executeSideloadManifest({
+      sideloadPath: "",
+      bundled: [],
+      sideloaded: [],
+      setReadyState,
+      setSelectedAddonId,
+      setSideloadPath,
+      setErrorState,
+      errorMessageOf: (_e, fallback) => fallback,
+    });
+
+    expect(runtimeMocks.sideloadManifest).not.toHaveBeenCalled();
+    expect(setReadyState).not.toHaveBeenCalled();
+    expect(setSideloadPath).not.toHaveBeenCalled();
+  });
+
+  it("sideloads a manifest, hydrates state, and calls setters", async () => {
+    const manifest = createMinimalManifest("addon.sideloaded", "Sideloaded");
+    runtimeMocks.sideloadManifest.mockResolvedValue(manifest);
+    runtimeMocks.hydrateState.mockResolvedValue(buildDefaultState([manifest]));
+    runtimeMocks.loadProviderCredentialStatuses.mockResolvedValue([]);
+
+    const setReadyState = vi.fn();
+    const setSelectedAddonId = vi.fn();
+    const setSideloadPath = vi.fn();
+    const setErrorState = vi.fn();
+
+    await executeSideloadManifest({
+      sideloadPath: "/path/to/addon.json",
+      bundled: [],
+      sideloaded: [],
+      setReadyState,
+      setSelectedAddonId,
+      setSideloadPath,
+      setErrorState,
+      errorMessageOf: (_e, fallback) => fallback,
+    });
+
+    expect(runtimeMocks.sideloadManifest).toHaveBeenCalledWith("/path/to/addon.json");
+    expect(runtimeMocks.hydrateState).toHaveBeenCalled();
+    expect(runtimeMocks.loadProviderCredentialStatuses).toHaveBeenCalled();
+    expect(runtimeMocks.applyProviderCredentialStatuses).toHaveBeenCalled();
+    expect(setReadyState).toHaveBeenCalled();
+    expect(setSelectedAddonId).toHaveBeenCalledWith("addon.sideloaded");
+    expect(setSideloadPath).toHaveBeenCalledWith("");
+    expect(setErrorState).not.toHaveBeenCalled();
+  });
+
+  it("calls setErrorState on failure", async () => {
+    runtimeMocks.sideloadManifest.mockRejectedValue(new Error("invalid manifest"));
+
+    const setErrorState = vi.fn();
+
+    await executeSideloadManifest({
+      sideloadPath: "/path/to/bad.json",
+      bundled: [],
+      sideloaded: [],
+      setReadyState: vi.fn(),
+      setSelectedAddonId: vi.fn(),
+      setSideloadPath: vi.fn(),
+      setErrorState,
+      errorMessageOf: (_e, fallback) => fallback,
+    });
+
+    expect(setErrorState).toHaveBeenCalledWith("Failed to sideload manifest.");
   });
 });

--- a/src/modules/archive/controller.test.ts
+++ b/src/modules/archive/controller.test.ts
@@ -1,0 +1,1365 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildDefaultState } from "../../core/defaults";
+import type {
+  ArchiveIngestProbeResult,
+  ArchiveSearchSourceHit,
+  ArchiveSourceWatchRecord,
+  ProviderDiagnosticReport,
+} from "../../core/contracts";
+
+const runtimeMocks = vi.hoisted(() => ({
+  requestProviderDiagnostics: vi.fn(),
+  requestArchiveImportedLibraries: vi.fn(),
+  requestArchiveSourceFolderScan: vi.fn(),
+  requestArchiveLibraryImport: vi.fn(),
+  requestArchiveLibraryPreflight: vi.fn(),
+  requestArchiveAiMemoryBuildJobs: vi.fn(),
+  requestArchiveIngestProbe: vi.fn(),
+  requestArchiveLibraryFolderSelection: vi.fn(),
+  requestArchiveLibraryClassificationReview: vi.fn(),
+  requestArchiveLibraryReorganisationPlan: vi.fn(),
+  requestArchiveQueueImportedLibraryIngest: vi.fn(),
+  requestArchiveReviewQueue: vi.fn(),
+  requestArchiveReviewArtifacts: vi.fn(),
+  requestArchiveBackgroundCycle: vi.fn(),
+  requestArchiveLint: vi.fn(),
+  requestArchiveSemanticLint: vi.fn(),
+  requestArchiveAiMemoryBuildJob: vi.fn(),
+}));
+
+vi.mock("../../core/runtime", () => runtimeMocks);
+
+const memoryProviderMock = vi.hoisted(() => ({
+  status: vi.fn(),
+  search: vi.fn(),
+  read: vi.fn(),
+  reviewQueue: vi.fn(),
+  reviewArtifacts: vi.fn(),
+  ingestRequest: vi.fn(),
+  processIngestRequest: vi.fn(),
+  decideReview: vi.fn(),
+  promoteReviewArtifact: vi.fn(),
+  maintenanceCycle: vi.fn(),
+  lint: vi.fn(),
+  semanticLint: vi.fn(),
+  backgroundCycle: vi.fn(),
+}));
+
+vi.mock("../../core/memory-provider", () => ({
+  livingArchiveMemoryProvider: () => memoryProviderMock,
+  resolveMemoryProviderBroker: vi.fn(),
+}));
+
+const resolveArchiveIngestRouteMock = vi.fn();
+const routedProviderLabelMock = vi.fn();
+const resolveRoutineRouteMock = vi.fn();
+vi.mock("../../core/provider-service", () => ({
+  resolveArchiveIngestRoute: (...args: unknown[]) => resolveArchiveIngestRouteMock(...args),
+  resolveRoutineRoute: (...args: unknown[]) => resolveRoutineRouteMock(...args),
+  routedProviderLabel: (...args: unknown[]) => routedProviderLabelMock(...args),
+}));
+
+const applyProviderDiagnosticsMock = vi.fn((state: unknown, _reports: unknown) => state);
+const providerCredentialReadyMock = vi.fn().mockReturnValue(true);
+vi.mock("../../core/policies", () => ({
+  applyProviderDiagnostics: applyProviderDiagnosticsMock,
+}));
+vi.mock("../../core/provider-credentials", () => ({
+  providerCredentialReady: providerCredentialReadyMock,
+}));
+
+const errorMessageOf = (_error: unknown, fallback: string) => fallback;
+
+const createRouteMock = (overrides = {}) => ({
+  provider: { id: "provider-test", providerType: "openai", label: "Test Provider", credentialStatus: "configured" },
+  runtimeNode: { id: "node-test", kind: "cloud", endpoint: "https://api.test.com" },
+  model: "gpt-4o",
+  decision: {
+    authTier: "supported",
+    resolutionReason: "viable-route-found",
+  },
+  ...overrides,
+});
+
+describe("loadArchiveImportedLibraries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads imported libraries from runtime and sets them", async () => {
+    const libraries = [{ id: "lib-1", name: "Test Lib" }];
+    runtimeMocks.requestArchiveImportedLibraries.mockResolvedValue(libraries);
+    const setArchiveImportedLibraries = vi.fn();
+
+    const { loadArchiveImportedLibraries } = await import("./controller");
+    await loadArchiveImportedLibraries({
+      setChatNotice: vi.fn(),
+      setArchiveSourceScanBusy: vi.fn(),
+      setArchiveImportedLibraries,
+      errorMessageOf,
+    });
+
+    expect(setArchiveImportedLibraries).toHaveBeenCalledWith(libraries);
+  });
+});
+
+describe("scanArchiveSourceFolders", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("scans source folders and sets the result", async () => {
+    const result = { filesSeen: 10, newFiles: 3, changedFiles: 1 };
+    runtimeMocks.requestArchiveSourceFolderScan.mockResolvedValue(result);
+    const setArchiveSourceScanResult = vi.fn();
+    const setChatNotice = vi.fn();
+
+    const { scanArchiveSourceFolders } = await import("./controller");
+    await scanArchiveSourceFolders({
+      rootPath: "/path/to/source",
+      setChatNotice,
+      setArchiveSourceScanBusy: vi.fn(),
+      setArchiveSourceScanResult,
+      errorMessageOf,
+    });
+
+    expect(setArchiveSourceScanResult).toHaveBeenCalledWith(result);
+    expect(setChatNotice).toHaveBeenCalledWith(expect.stringContaining("Scanned 10 source file"));
+  });
+});
+
+describe("loadArchiveRuntimeStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads runtime status from the memory provider", async () => {
+    const status = { status: "ready", version: "1.0" };
+    memoryProviderMock.status.mockResolvedValue(status);
+    const setArchiveStatus = vi.fn();
+
+    const { loadArchiveRuntimeStatus } = await import("./controller");
+    await loadArchiveRuntimeStatus({
+      setChatNotice: vi.fn(),
+      setArchiveStatusBusy: vi.fn(),
+      setArchiveStatus,
+      errorMessageOf,
+    });
+
+    expect(setArchiveStatus).toHaveBeenCalledWith(status);
+  });
+});
+
+describe("queueArchiveSourceForIngest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("queues a source and refreshes the queue", async () => {
+    const queue = [{ id: "req-1" }];
+    const artifacts = [{ id: "art-1" }];
+    memoryProviderMock.ingestRequest.mockResolvedValue(undefined);
+    memoryProviderMock.reviewQueue.mockResolvedValue(queue);
+    memoryProviderMock.reviewArtifacts.mockResolvedValue(artifacts);
+    const setArchiveQueue = vi.fn();
+    const setArchiveReviewArtifacts = vi.fn();
+    const setChatNotice = vi.fn();
+
+    const { queueArchiveSourceForIngest } = await import("./controller");
+    await queueArchiveSourceForIngest({
+      source: { sourceId: "src-1", rawPath: "/path/to/doc", title: "My Doc", sourceType: "pdf", processed: false },
+      setChatNotice,
+      setArchiveQueueBusy: vi.fn(),
+      setArchiveQueue,
+      setArchiveReviewArtifacts,
+      errorMessageOf,
+    });
+
+    expect(memoryProviderMock.ingestRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ sourcePath: "/path/to/doc" }),
+    );
+    expect(setArchiveQueue).toHaveBeenCalledWith(queue);
+    expect(setChatNotice).toHaveBeenCalledWith(expect.stringContaining("Queued My Doc"));
+  });
+});
+
+describe("promoteApprovedArchiveReviewArtifacts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("skips when no artifacts are promotable", async () => {
+    const setChatNotice = vi.fn();
+
+    const { promoteApprovedArchiveReviewArtifacts } = await import("./controller");
+    await promoteApprovedArchiveReviewArtifacts({
+      artifacts: [],
+      actorId: "strategist.core",
+      setChatNotice,
+      setArchiveQueueBusy: vi.fn(),
+      setArchiveReviewArtifacts: vi.fn(),
+      setArchivePromotionResult: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(setChatNotice).toHaveBeenCalledWith(
+      "No approved, unpromoted archive review artifacts are ready for trusted wiki promotion.",
+    );
+  });
+});
+
+describe("executeArchiveIngestProbe", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    providerCredentialReadyMock.mockReset();
+    providerCredentialReadyMock.mockReturnValue(true);
+  });
+
+  it("resolves route, probes ingest, and sets the probe result", async () => {
+    const state = buildDefaultState([]);
+    const reports: ProviderDiagnosticReport[] = [];
+    runtimeMocks.requestProviderDiagnostics.mockResolvedValue(reports);
+    resolveArchiveIngestRouteMock.mockReturnValue(createRouteMock());
+    routedProviderLabelMock.mockReturnValue("Test Provider via Cloud");
+    const probeResult = {
+      sourceLabel: "Probe source",
+      summary: "Probe succeeded",
+      checkedAt: new Date().toISOString(),
+    } as ArchiveIngestProbeResult;
+    runtimeMocks.requestArchiveIngestProbe.mockResolvedValue(probeResult);
+
+    const snapshot = { state, bundled: [], sideloaded: [] };
+    const setArchiveProbeResult = vi.fn();
+
+    const { executeArchiveIngestProbe } = await import("./controller");
+    await executeArchiveIngestProbe({
+      snapshot,
+      commitReadyState: vi.fn(),
+      setProviderDiagnostics: vi.fn(),
+      setChatNotice: vi.fn(),
+      setArchiveProbeBusy: vi.fn(),
+      setArchiveProbeResult,
+      errorMessageOf,
+    });
+
+    expect(runtimeMocks.requestArchiveIngestProbe).toHaveBeenCalled();
+    expect(setArchiveProbeResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        probe: probeResult,
+        routeLabel: "Test Provider via Cloud",
+        model: "gpt-4o",
+      }),
+    );
+  });
+
+  it("reports failure when no viable route is found", async () => {
+    const state = buildDefaultState([]);
+    runtimeMocks.requestProviderDiagnostics.mockResolvedValue([]);
+    resolveArchiveIngestRouteMock.mockReturnValue(
+      createRouteMock({ provider: undefined, runtimeNode: undefined, model: undefined }),
+    );
+
+    const snapshot = { state, bundled: [], sideloaded: [] };
+    const setChatNotice = vi.fn();
+
+    const { executeArchiveIngestProbe } = await import("./controller");
+    await executeArchiveIngestProbe({
+      snapshot,
+      commitReadyState: vi.fn(),
+      setProviderDiagnostics: vi.fn(),
+      setChatNotice,
+      setArchiveProbeBusy: vi.fn(),
+      setArchiveProbeResult: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(setChatNotice).toHaveBeenCalledWith("Archive ingest probe failed.");
+  });
+
+  it("reports failure when provider credential is not ready", async () => {
+    const state = buildDefaultState([]);
+    runtimeMocks.requestProviderDiagnostics.mockResolvedValue([]);
+    resolveArchiveIngestRouteMock.mockReturnValue(createRouteMock());
+    providerCredentialReadyMock.mockReturnValue(false);
+
+    const snapshot = { state, bundled: [], sideloaded: [] };
+    const setChatNotice = vi.fn();
+
+    const { executeArchiveIngestProbe } = await import("./controller");
+    await executeArchiveIngestProbe({
+      snapshot,
+      commitReadyState: vi.fn(),
+      setProviderDiagnostics: vi.fn(),
+      setChatNotice,
+      setArchiveProbeBusy: vi.fn(),
+      setArchiveProbeResult: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(setChatNotice).toHaveBeenCalledWith("Archive ingest probe failed.");
+  });
+});
+
+describe("executeArchiveSearch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("searches the memory provider and sets the result", async () => {
+    const result = { hits: [{ path: "/doc.md", score: 0.95 }], totalHits: 1 };
+    memoryProviderMock.search.mockResolvedValue(result);
+    const setArchiveSearchResult = vi.fn();
+
+    const { executeArchiveSearch } = await import("./controller");
+    await executeArchiveSearch({
+      query: "test query",
+      setChatNotice: vi.fn(),
+      setArchiveSearchBusy: vi.fn(),
+      setArchiveSearchResult,
+      errorMessageOf,
+    });
+
+    expect(memoryProviderMock.search).toHaveBeenCalledWith("test query");
+    expect(setArchiveSearchResult).toHaveBeenCalledWith(result);
+  });
+
+  it("reports error on search failure", async () => {
+    memoryProviderMock.search.mockRejectedValue(new Error("search error"));
+    const setChatNotice = vi.fn();
+
+    const { executeArchiveSearch } = await import("./controller");
+    await executeArchiveSearch({
+      query: "fail",
+      setChatNotice,
+      setArchiveSearchBusy: vi.fn(),
+      setArchiveSearchResult: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(setChatNotice).toHaveBeenCalledWith("Living Archive search failed.");
+  });
+});
+
+describe("loadArchiveDocument", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reads a document from the memory provider", async () => {
+    const doc = { path: "/doc.md", content: "# Hello", metadata: {} };
+    memoryProviderMock.read.mockResolvedValue(doc);
+    const setArchiveDocument = vi.fn();
+
+    const { loadArchiveDocument } = await import("./controller");
+    await loadArchiveDocument({
+      path: "/doc.md",
+      setChatNotice: vi.fn(),
+      setArchiveDocumentBusy: vi.fn(),
+      setArchiveDocument,
+      errorMessageOf,
+    });
+
+    expect(memoryProviderMock.read).toHaveBeenCalledWith("/doc.md");
+    expect(setArchiveDocument).toHaveBeenCalledWith(doc);
+  });
+
+  it("reports error on read failure", async () => {
+    memoryProviderMock.read.mockRejectedValue(new Error("read error"));
+    const setChatNotice = vi.fn();
+
+    const { loadArchiveDocument } = await import("./controller");
+    await loadArchiveDocument({
+      path: "/doc.md",
+      setChatNotice,
+      setArchiveDocumentBusy: vi.fn(),
+      setArchiveDocument: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(setChatNotice).toHaveBeenCalledWith("Failed to read archive document.");
+  });
+});
+
+describe("loadArchiveReviewQueue", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads the review queue and artifacts from the memory provider", async () => {
+    const queue = [{ id: "req-1", sourcePath: "/doc.md" }];
+    const artifacts = [{ id: "art-1", artifactFile: "/art.md" }];
+    memoryProviderMock.reviewQueue.mockResolvedValue(queue);
+    memoryProviderMock.reviewArtifacts.mockResolvedValue(artifacts);
+    const setArchiveQueue = vi.fn();
+    const setArchiveReviewArtifacts = vi.fn();
+
+    const { loadArchiveReviewQueue } = await import("./controller");
+    await loadArchiveReviewQueue({
+      setChatNotice: vi.fn(),
+      setArchiveQueueBusy: vi.fn(),
+      setArchiveQueue,
+      setArchiveReviewArtifacts,
+      errorMessageOf,
+    });
+
+    expect(memoryProviderMock.reviewQueue).toHaveBeenCalled();
+    expect(memoryProviderMock.reviewArtifacts).toHaveBeenCalled();
+    expect(setArchiveQueue).toHaveBeenCalledWith(queue);
+    expect(setArchiveReviewArtifacts).toHaveBeenCalledWith(artifacts);
+  });
+
+  it("reports error when loading review queue fails", async () => {
+    memoryProviderMock.reviewQueue.mockRejectedValue(new Error("queue error"));
+    const setChatNotice = vi.fn();
+
+    const { loadArchiveReviewQueue } = await import("./controller");
+    await loadArchiveReviewQueue({
+      setChatNotice,
+      setArchiveQueueBusy: vi.fn(),
+      setArchiveQueue: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(setChatNotice).toHaveBeenCalledWith("Failed to load archive review queue.");
+  });
+});
+
+describe("loadArchiveAiMemoryBuildJobs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads AI memory build jobs from runtime", async () => {
+    const jobs = [{ id: "job-1", status: "completed" }];
+    runtimeMocks.requestArchiveAiMemoryBuildJobs.mockResolvedValue(jobs);
+    const setArchiveAiMemoryBuildJobs = vi.fn();
+
+    const { loadArchiveAiMemoryBuildJobs } = await import("./controller");
+    await loadArchiveAiMemoryBuildJobs({
+      setChatNotice: vi.fn(),
+      setArchiveQueueBusy: vi.fn(),
+      setArchiveAiMemoryBuildJobs,
+      errorMessageOf,
+    });
+
+    expect(runtimeMocks.requestArchiveAiMemoryBuildJobs).toHaveBeenCalled();
+    expect(setArchiveAiMemoryBuildJobs).toHaveBeenCalledWith(jobs);
+  });
+
+  it("reports error on failure", async () => {
+    runtimeMocks.requestArchiveAiMemoryBuildJobs.mockRejectedValue(new Error("build error"));
+    const setChatNotice = vi.fn();
+
+    const { loadArchiveAiMemoryBuildJobs } = await import("./controller");
+    await loadArchiveAiMemoryBuildJobs({
+      setChatNotice,
+      setArchiveQueueBusy: vi.fn(),
+      setArchiveAiMemoryBuildJobs: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(setChatNotice).toHaveBeenCalledWith("Failed to load AI Memory build jobs.");
+  });
+});
+
+describe("queueWatchedArchiveSourceForIngest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("queues a watched source and refreshes the queue", async () => {
+    const queue = [{ id: "req-1" }];
+    const artifacts = [{ id: "art-1" }];
+    memoryProviderMock.ingestRequest.mockResolvedValue(undefined);
+    memoryProviderMock.reviewQueue.mockResolvedValue(queue);
+    memoryProviderMock.reviewArtifacts.mockResolvedValue(artifacts);
+    const setArchiveQueue = vi.fn();
+    const setArchiveReviewArtifacts = vi.fn();
+    const setChatNotice = vi.fn();
+    const source: ArchiveSourceWatchRecord = {
+      path: "/watched/file.md",
+      absolutePath: "/watched/file.md",
+      title: "Watched File",
+      sourceType: "markdown",
+      status: "new",
+      hash: "abc123",
+      rootRole: "documents",
+      sizeBytes: 1024,
+      modifiedAt: "2026-07-20T00:00:00.000Z",
+      indexedInDb: false,
+    };
+
+    const { queueWatchedArchiveSourceForIngest } = await import("./controller");
+    await queueWatchedArchiveSourceForIngest({
+      source,
+      setChatNotice,
+      setArchiveQueueBusy: vi.fn(),
+      setArchiveQueue,
+      setArchiveReviewArtifacts,
+      errorMessageOf,
+    });
+
+    expect(memoryProviderMock.ingestRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ sourcePath: "/watched/file.md" }),
+    );
+    expect(setArchiveQueue).toHaveBeenCalledWith(queue);
+    expect(setChatNotice).toHaveBeenCalledWith(expect.stringContaining("Queued Watched File"));
+  });
+
+  it("reports error on failure", async () => {
+    memoryProviderMock.ingestRequest.mockRejectedValue(new Error("queue error"));
+    const setChatNotice = vi.fn();
+
+    const { queueWatchedArchiveSourceForIngest } = await import("./controller");
+    await queueWatchedArchiveSourceForIngest({
+      source: { path: "/f.md", absolutePath: "/f.md", title: "F", sourceType: "markdown", status: "new", hash: "", rootRole: "", sizeBytes: 0, modifiedAt: "2026-07-20T00:00:00.000Z", indexedInDb: false },
+      setChatNotice,
+      setArchiveQueueBusy: vi.fn(),
+      setArchiveQueue: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(setChatNotice).toHaveBeenCalledWith("Failed to queue scanned source for archive review.");
+  });
+});
+
+describe("importArchiveLibrary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("imports a library and sets the result", async () => {
+    const result = { libraryName: "Test Lib", filesImported: 10 };
+    runtimeMocks.requestArchiveLibraryImport.mockResolvedValue(result);
+    const setArchiveLibraryImportResult = vi.fn();
+
+    const { importArchiveLibrary } = await import("./controller");
+    await importArchiveLibrary({
+      sourcePath: "/path/lib",
+      domain: "mixed-library",
+      importMode: "copy",
+      setChatNotice: vi.fn(),
+      setArchiveSourceScanBusy: vi.fn(),
+      setArchiveLibraryImportResult,
+      errorMessageOf,
+    });
+
+    expect(runtimeMocks.requestArchiveLibraryImport).toHaveBeenCalledWith(
+      expect.objectContaining({ sourcePath: "/path/lib" }),
+    );
+    expect(setArchiveLibraryImportResult).toHaveBeenCalledWith(result);
+  });
+
+  it("refreshes imported libraries when callback is provided", async () => {
+    const result = { libraryName: "Test Lib", filesImported: 5 };
+    runtimeMocks.requestArchiveLibraryImport.mockResolvedValue(result);
+    const libraries = [{ id: "lib-1", name: "Test Lib" }];
+    runtimeMocks.requestArchiveImportedLibraries.mockResolvedValue(libraries);
+    const setArchiveImportedLibraries = vi.fn();
+
+    const { importArchiveLibrary } = await import("./controller");
+    await importArchiveLibrary({
+      sourcePath: "/path/lib",
+      domain: "mixed-library",
+      importMode: "copy",
+      setChatNotice: vi.fn(),
+      setArchiveSourceScanBusy: vi.fn(),
+      setArchiveLibraryImportResult: vi.fn(),
+      setArchiveImportedLibraries,
+      errorMessageOf,
+    });
+
+    expect(runtimeMocks.requestArchiveImportedLibraries).toHaveBeenCalled();
+    expect(setArchiveImportedLibraries).toHaveBeenCalledWith(libraries);
+  });
+
+  it("reports error on failure", async () => {
+    runtimeMocks.requestArchiveLibraryImport.mockRejectedValue(new Error("import error"));
+    const setChatNotice = vi.fn();
+
+    const { importArchiveLibrary } = await import("./controller");
+    await importArchiveLibrary({
+      sourcePath: "/path/lib",
+      domain: "mixed-library",
+      importMode: "copy",
+      setChatNotice,
+      setArchiveSourceScanBusy: vi.fn(),
+      setArchiveLibraryImportResult: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(setChatNotice).toHaveBeenCalledWith("Failed to import library into Living Archive.");
+  });
+});
+
+describe("preflightArchiveLibrary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("runs a preflight check and sets the result", async () => {
+    const result = { supportedFiles: 10, skippedFiles: 2 };
+    runtimeMocks.requestArchiveLibraryPreflight.mockResolvedValue(result);
+    const setArchiveLibraryPreflightResult = vi.fn();
+
+    const { preflightArchiveLibrary } = await import("./controller");
+    await preflightArchiveLibrary({
+      sourcePath: "/path/lib",
+      setChatNotice: vi.fn(),
+      setArchiveSourceScanBusy: vi.fn(),
+      setArchiveLibraryPreflightResult,
+      errorMessageOf,
+    });
+
+    expect(runtimeMocks.requestArchiveLibraryPreflight).toHaveBeenCalledWith("/path/lib");
+    expect(setArchiveLibraryPreflightResult).toHaveBeenCalledWith(result);
+  });
+
+  it("reports error on failure", async () => {
+    runtimeMocks.requestArchiveLibraryPreflight.mockRejectedValue(new Error("preflight error"));
+    const setChatNotice = vi.fn();
+
+    const { preflightArchiveLibrary } = await import("./controller");
+    await preflightArchiveLibrary({
+      sourcePath: "/path/lib",
+      setChatNotice,
+      setArchiveSourceScanBusy: vi.fn(),
+      setArchiveLibraryPreflightResult: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(setChatNotice).toHaveBeenCalledWith("Failed to preflight Living Archive library import.");
+  });
+});
+
+describe("loadArchiveLibraryClassificationReview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads the classification review", async () => {
+    const review = { entries: [{ path: "/doc.md", classification: "note" }] };
+    runtimeMocks.requestArchiveLibraryClassificationReview.mockResolvedValue(review);
+    const setArchiveClassificationReview = vi.fn();
+
+    const { loadArchiveLibraryClassificationReview } = await import("./controller");
+    await loadArchiveLibraryClassificationReview({
+      classificationManifestPath: "/manifest.json",
+      setChatNotice: vi.fn(),
+      setArchiveSourceScanBusy: vi.fn(),
+      setArchiveClassificationReview,
+      errorMessageOf,
+    });
+
+    expect(runtimeMocks.requestArchiveLibraryClassificationReview).toHaveBeenCalledWith("/manifest.json");
+    expect(setArchiveClassificationReview).toHaveBeenCalledWith(review);
+  });
+
+  it("reports error on failure", async () => {
+    runtimeMocks.requestArchiveLibraryClassificationReview.mockRejectedValue(new Error("review error"));
+    const setChatNotice = vi.fn();
+
+    const { loadArchiveLibraryClassificationReview } = await import("./controller");
+    await loadArchiveLibraryClassificationReview({
+      classificationManifestPath: "/manifest.json",
+      setChatNotice,
+      setArchiveSourceScanBusy: vi.fn(),
+      setArchiveClassificationReview: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(setChatNotice).toHaveBeenCalledWith("Failed to open Living Archive classification review.");
+  });
+});
+
+describe("generateArchiveLibraryReorganisationPlan", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("generates a reorganisation plan", async () => {
+    const plan = { libraryName: "Test Lib", operations: [] };
+    runtimeMocks.requestArchiveLibraryReorganisationPlan.mockResolvedValue(plan);
+    const setArchiveReorganisationPlan = vi.fn();
+
+    const { generateArchiveLibraryReorganisationPlan } = await import("./controller");
+    await generateArchiveLibraryReorganisationPlan({
+      classificationManifestPath: "/manifest.json",
+      setChatNotice: vi.fn(),
+      setArchiveSourceScanBusy: vi.fn(),
+      setArchiveReorganisationPlan,
+      errorMessageOf,
+    });
+
+    expect(runtimeMocks.requestArchiveLibraryReorganisationPlan).toHaveBeenCalledWith("/manifest.json", "strategist.core");
+    expect(setArchiveReorganisationPlan).toHaveBeenCalledWith(plan);
+  });
+
+  it("reports error on failure", async () => {
+    runtimeMocks.requestArchiveLibraryReorganisationPlan.mockRejectedValue(new Error("plan error"));
+    const setChatNotice = vi.fn();
+
+    const { generateArchiveLibraryReorganisationPlan } = await import("./controller");
+    await generateArchiveLibraryReorganisationPlan({
+      classificationManifestPath: "/manifest.json",
+      setChatNotice,
+      setArchiveSourceScanBusy: vi.fn(),
+      setArchiveReorganisationPlan: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(setChatNotice).toHaveBeenCalledWith("Failed to generate Living Archive reorganisation plan.");
+  });
+});
+
+describe("queueImportedLibraryForIngest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("queues an imported library and refreshes the queue", async () => {
+    const result = { libraryName: "Test Lib", queued: 5, skippedUnsupported: 1, skippedExistingQueue: 0 };
+    runtimeMocks.requestArchiveQueueImportedLibraryIngest.mockResolvedValue(result);
+    const queue = [{ id: "req-1" }];
+    const artifacts = [{ id: "art-1" }];
+    runtimeMocks.requestArchiveReviewQueue.mockResolvedValue(queue);
+    runtimeMocks.requestArchiveReviewArtifacts.mockResolvedValue(artifacts);
+    const setArchiveQueue = vi.fn();
+    const setArchiveReviewArtifacts = vi.fn();
+
+    const { queueImportedLibraryForIngest } = await import("./controller");
+    await queueImportedLibraryForIngest({
+      manifestPath: "/manifest.json",
+      setChatNotice: vi.fn(),
+      setArchiveQueueBusy: vi.fn(),
+      setArchiveQueue,
+      setArchiveReviewArtifacts,
+      errorMessageOf,
+    });
+
+    expect(runtimeMocks.requestArchiveQueueImportedLibraryIngest).toHaveBeenCalledWith(
+      expect.objectContaining({ manifestPath: "/manifest.json" }),
+    );
+    expect(runtimeMocks.requestArchiveReviewQueue).toHaveBeenCalled();
+    expect(setArchiveQueue).toHaveBeenCalledWith(queue);
+  });
+
+  it("reports error on failure", async () => {
+    runtimeMocks.requestArchiveQueueImportedLibraryIngest.mockRejectedValue(new Error("queue error"));
+    const setChatNotice = vi.fn();
+
+    const { queueImportedLibraryForIngest } = await import("./controller");
+    await queueImportedLibraryForIngest({
+      manifestPath: "/manifest.json",
+      setChatNotice,
+      setArchiveQueueBusy: vi.fn(),
+      setArchiveQueue: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(setChatNotice).toHaveBeenCalledWith("Failed to queue imported library for AI Memory review.");
+  });
+});
+
+describe("pickArchiveLibraryFolder", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the selected folder path", async () => {
+    runtimeMocks.requestArchiveLibraryFolderSelection.mockResolvedValue("/selected/folder");
+    const { pickArchiveLibraryFolder } = await import("./controller");
+    const result = await pickArchiveLibraryFolder({
+      setChatNotice: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(runtimeMocks.requestArchiveLibraryFolderSelection).toHaveBeenCalled();
+    expect(result).toBe("/selected/folder");
+  });
+
+  it("returns null on error", async () => {
+    runtimeMocks.requestArchiveLibraryFolderSelection.mockRejectedValue(new Error("picker error"));
+    const setChatNotice = vi.fn();
+
+    const { pickArchiveLibraryFolder } = await import("./controller");
+    const result = await pickArchiveLibraryFolder({
+      setChatNotice,
+      errorMessageOf,
+    });
+
+    expect(result).toBeNull();
+    expect(setChatNotice).toHaveBeenCalledWith("Failed to open folder picker.");
+  });
+});
+
+describe("decideArchiveReviewArtifact", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("records a review decision and refreshes artifacts", async () => {
+    const decisionResult = { status: "approved", artifactFile: "/art.md" };
+    memoryProviderMock.decideReview.mockResolvedValue(decisionResult);
+    const artifacts = [{ id: "art-1" }];
+    memoryProviderMock.reviewArtifacts.mockResolvedValue(artifacts);
+    const setArchiveReviewArtifacts = vi.fn();
+    const setArchiveReviewDecisionResult = vi.fn();
+
+    const { decideArchiveReviewArtifact } = await import("./controller");
+    await decideArchiveReviewArtifact({
+      artifactFile: "/art.md",
+      action: "approve",
+      actorId: "strategist.core",
+      setChatNotice: vi.fn(),
+      setArchiveQueueBusy: vi.fn(),
+      setArchiveReviewArtifacts,
+      setArchiveReviewDecisionResult,
+      errorMessageOf,
+    });
+
+    expect(memoryProviderMock.decideReview).toHaveBeenCalledWith(
+      expect.objectContaining({ artifactFile: "/art.md", action: "approve" }),
+    );
+    expect(setArchiveReviewDecisionResult).toHaveBeenCalledWith(decisionResult);
+  });
+
+  it("reports error on failure", async () => {
+    memoryProviderMock.decideReview.mockRejectedValue(new Error("decision error"));
+    const setChatNotice = vi.fn();
+
+    const { decideArchiveReviewArtifact } = await import("./controller");
+    await decideArchiveReviewArtifact({
+      artifactFile: "/art.md",
+      action: "approve",
+      actorId: "strategist.core",
+      setChatNotice,
+      setArchiveQueueBusy: vi.fn(),
+      setArchiveReviewArtifacts: vi.fn(),
+      setArchiveReviewDecisionResult: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(setChatNotice).toHaveBeenCalledWith("Failed to record archive review decision.");
+  });
+});
+
+describe("promoteArchiveReviewArtifact", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("promotes an artifact and refreshes the list", async () => {
+    const promotionResult = { pagesWritten: [{ path: "/wiki/page.md" }], skippedPages: [] };
+    memoryProviderMock.promoteReviewArtifact.mockResolvedValue(promotionResult);
+    const artifacts = [{ id: "art-1" }];
+    memoryProviderMock.reviewArtifacts.mockResolvedValue(artifacts);
+    const setArchivePromotionResult = vi.fn();
+
+    const { promoteArchiveReviewArtifact } = await import("./controller");
+    await promoteArchiveReviewArtifact({
+      artifactFile: "/art.md",
+      actorId: "strategist.core",
+      setChatNotice: vi.fn(),
+      setArchiveQueueBusy: vi.fn(),
+      setArchiveReviewArtifacts: vi.fn(),
+      setArchivePromotionResult,
+      errorMessageOf,
+    });
+
+    expect(memoryProviderMock.promoteReviewArtifact).toHaveBeenCalledWith(
+      expect.objectContaining({ artifactFile: "/art.md" }),
+    );
+    expect(setArchivePromotionResult).toHaveBeenCalledWith(promotionResult);
+  });
+
+  it("reports error on failure", async () => {
+    memoryProviderMock.promoteReviewArtifact.mockRejectedValue(new Error("promotion error"));
+    const setChatNotice = vi.fn();
+
+    const { promoteArchiveReviewArtifact } = await import("./controller");
+    await promoteArchiveReviewArtifact({
+      artifactFile: "/art.md",
+      actorId: "strategist.core",
+      setChatNotice,
+      setArchiveQueueBusy: vi.fn(),
+      setArchiveReviewArtifacts: vi.fn(),
+      setArchivePromotionResult: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(setChatNotice).toHaveBeenCalledWith("Failed to promote archive review artifact.");
+  });
+});
+
+describe("runArchiveLint", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("runs lint on the memory provider", async () => {
+    const result = { findings: [{ severity: "info", message: "ok" }] };
+    memoryProviderMock.lint.mockResolvedValue(result);
+    const setArchiveLintResult = vi.fn();
+
+    const { runArchiveLint } = await import("./controller");
+    await runArchiveLint({
+      setChatNotice: vi.fn(),
+      setArchiveQueueBusy: vi.fn(),
+      setArchiveLintResult,
+      errorMessageOf,
+    });
+
+    expect(memoryProviderMock.lint).toHaveBeenCalled();
+    expect(setArchiveLintResult).toHaveBeenCalledWith(result);
+  });
+
+  it("falls back to runtime lint when provider has no lint method", async () => {
+    const savedLint = memoryProviderMock.lint;
+    delete (memoryProviderMock as Record<string, unknown>).lint;
+    try {
+      const result = { findings: [{ severity: "warn", message: "warning" }] };
+      runtimeMocks.requestArchiveLint.mockResolvedValue(result);
+      const setArchiveLintResult = vi.fn();
+
+      const { runArchiveLint } = await import("./controller");
+      await runArchiveLint({
+        setChatNotice: vi.fn(),
+        setArchiveQueueBusy: vi.fn(),
+        setArchiveLintResult,
+        errorMessageOf,
+      });
+
+      expect(runtimeMocks.requestArchiveLint).toHaveBeenCalled();
+      expect(setArchiveLintResult).toHaveBeenCalledWith(result);
+    } finally {
+      memoryProviderMock.lint = savedLint;
+    }
+  });
+
+  it("reports error on failure", async () => {
+    memoryProviderMock.lint.mockRejectedValue(new Error("lint error"));
+    const setChatNotice = vi.fn();
+
+    const { runArchiveLint } = await import("./controller");
+    await runArchiveLint({
+      setChatNotice,
+      setArchiveQueueBusy: vi.fn(),
+      setArchiveLintResult: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(setChatNotice).toHaveBeenCalledWith("Failed to run Living Archive lint.");
+  });
+});
+
+describe("processArchiveQueuedRequest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    providerCredentialReadyMock.mockReturnValue(true);
+    resolveRoutineRouteMock.mockReturnValue(createRouteMock());
+  });
+
+  it("resolves route, processes the ingest request, and refreshes state", async () => {
+    const state = buildDefaultState([]);
+    const reports: ProviderDiagnosticReport[] = [];
+    runtimeMocks.requestProviderDiagnostics.mockResolvedValue(reports);
+    resolveArchiveIngestRouteMock.mockReturnValue(createRouteMock());
+    const processResult = { status: "completed", pagesWritten: 2 };
+    memoryProviderMock.processIngestRequest.mockResolvedValue(processResult);
+    memoryProviderMock.reviewQueue.mockResolvedValue([]);
+    memoryProviderMock.reviewArtifacts.mockResolvedValue([]);
+
+    const snapshot = { state, bundled: [], sideloaded: [] };
+    const setArchiveProcessResult = vi.fn();
+
+    const { processArchiveQueuedRequest } = await import("./controller");
+    await processArchiveQueuedRequest({
+      snapshot,
+      requestFile: "/requests/req-1.json",
+      commitReadyState: vi.fn(),
+      setProviderDiagnostics: vi.fn(),
+      setChatNotice: vi.fn(),
+      setArchiveQueueBusy: vi.fn(),
+      setArchiveQueue: vi.fn(),
+      setArchiveProcessResult,
+      setArchiveReviewArtifacts: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(runtimeMocks.requestProviderDiagnostics).toHaveBeenCalled();
+    expect(resolveArchiveIngestRouteMock).toHaveBeenCalled();
+    expect(memoryProviderMock.processIngestRequest).toHaveBeenCalled();
+    expect(setArchiveProcessResult).toHaveBeenCalledWith(processResult);
+  });
+
+  it("reports failure when no viable route is found", async () => {
+    const state = buildDefaultState([]);
+    runtimeMocks.requestProviderDiagnostics.mockResolvedValue([]);
+    resolveArchiveIngestRouteMock.mockReturnValue(
+      createRouteMock({ provider: undefined, runtimeNode: undefined, model: undefined }),
+    );
+    const setChatNotice = vi.fn();
+
+    const snapshot = { state, bundled: [], sideloaded: [] };
+
+    const { processArchiveQueuedRequest } = await import("./controller");
+    await processArchiveQueuedRequest({
+      snapshot,
+      requestFile: "/requests/req-1.json",
+      commitReadyState: vi.fn(),
+      setProviderDiagnostics: vi.fn(),
+      setChatNotice,
+      setArchiveQueueBusy: vi.fn(),
+      setArchiveQueue: vi.fn(),
+      setArchiveProcessResult: vi.fn(),
+      setArchiveReviewArtifacts: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(setChatNotice).toHaveBeenCalledWith("Failed to process archive ingest request.");
+  });
+});
+
+describe("runArchiveMaintenanceCycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    providerCredentialReadyMock.mockReturnValue(true);
+    resolveRoutineRouteMock.mockReturnValue(createRouteMock());
+  });
+
+  it("runs a maintenance cycle through the memory provider", async () => {
+    const state = buildDefaultState([]);
+    runtimeMocks.requestProviderDiagnostics.mockResolvedValue([]);
+    resolveArchiveIngestRouteMock.mockReturnValue(createRouteMock());
+    const maintenanceResult = {
+      processed: [{ status: "completed" }],
+      promoted: [{ pagesWritten: [{ path: "/wiki/p.md" }] }],
+    };
+    memoryProviderMock.maintenanceCycle.mockResolvedValue(maintenanceResult);
+    memoryProviderMock.reviewQueue.mockResolvedValue([]);
+    memoryProviderMock.reviewArtifacts.mockResolvedValue([]);
+
+    const snapshot = { state, bundled: [], sideloaded: [] };
+    const setArchiveMaintenanceResult = vi.fn();
+
+    const { runArchiveMaintenanceCycle } = await import("./controller");
+    await runArchiveMaintenanceCycle({
+      snapshot,
+      commitReadyState: vi.fn(),
+      setProviderDiagnostics: vi.fn(),
+      setChatNotice: vi.fn(),
+      setArchiveQueueBusy: vi.fn(),
+      setArchiveQueue: vi.fn(),
+      setArchiveReviewArtifacts: vi.fn(),
+      setArchiveProcessResult: vi.fn(),
+      setArchivePromotionResult: vi.fn(),
+      setArchiveMaintenanceResult,
+      errorMessageOf,
+    });
+
+    expect(memoryProviderMock.maintenanceCycle).toHaveBeenCalled();
+    expect(setArchiveMaintenanceResult).toHaveBeenCalledWith(maintenanceResult);
+  });
+
+  it("throws when memory provider has no maintenanceCycle", async () => {
+    const state = buildDefaultState([]);
+    memoryProviderMock.maintenanceCycle.mockReturnValue(undefined);
+    runtimeMocks.requestProviderDiagnostics.mockResolvedValue([]);
+
+    const snapshot = { state, bundled: [], sideloaded: [] };
+    const setChatNotice = vi.fn();
+
+    const { runArchiveMaintenanceCycle } = await import("./controller");
+    await runArchiveMaintenanceCycle({
+      snapshot,
+      commitReadyState: vi.fn(),
+      setProviderDiagnostics: vi.fn(),
+      setChatNotice,
+      setArchiveQueueBusy: vi.fn(),
+      setArchiveQueue: vi.fn(),
+      setArchiveReviewArtifacts: vi.fn(),
+      setArchiveProcessResult: vi.fn(),
+      setArchivePromotionResult: vi.fn(),
+      setArchiveMaintenanceResult: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(setChatNotice).toHaveBeenCalledWith("Failed to run Living Archive maintenance.");
+  });
+});
+
+describe("runArchiveSemanticLint", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    providerCredentialReadyMock.mockReturnValue(true);
+    resolveRoutineRouteMock.mockReturnValue(createRouteMock());
+  });
+
+  it("runs semantic lint through the memory provider", async () => {
+    const state = buildDefaultState([]);
+    runtimeMocks.requestProviderDiagnostics.mockResolvedValue([]);
+    resolveArchiveIngestRouteMock.mockReturnValue(createRouteMock());
+    const result = { findings: [{ message: "inconsistency" }], candidatesReviewed: 5 };
+    memoryProviderMock.semanticLint.mockResolvedValue(result);
+    const setArchiveSemanticLintResult = vi.fn();
+
+    const snapshot = { state, bundled: [], sideloaded: [] };
+
+    const { runArchiveSemanticLint } = await import("./controller");
+    await runArchiveSemanticLint({
+      snapshot,
+      commitReadyState: vi.fn(),
+      setProviderDiagnostics: vi.fn(),
+      setChatNotice: vi.fn(),
+      setArchiveQueueBusy: vi.fn(),
+      setArchiveSemanticLintResult,
+      errorMessageOf,
+    });
+
+    expect(memoryProviderMock.semanticLint).toHaveBeenCalled();
+    expect(setArchiveSemanticLintResult).toHaveBeenCalledWith(result);
+  });
+
+  it("falls back to runtime semantic lint when provider has no method", async () => {
+    const saved = memoryProviderMock.semanticLint;
+    delete (memoryProviderMock as Record<string, unknown>).semanticLint;
+    try {
+      const state = buildDefaultState([]);
+      runtimeMocks.requestProviderDiagnostics.mockResolvedValue([]);
+      resolveArchiveIngestRouteMock.mockReturnValue(createRouteMock());
+      const result = { findings: [{ message: "ok" }], candidatesReviewed: 0 };
+      runtimeMocks.requestArchiveSemanticLint.mockResolvedValue(result);
+      const setArchiveSemanticLintResult = vi.fn();
+
+      const snapshot = { state, bundled: [], sideloaded: [] };
+
+      const { runArchiveSemanticLint } = await import("./controller");
+      await runArchiveSemanticLint({
+        snapshot,
+        commitReadyState: vi.fn(),
+        setProviderDiagnostics: vi.fn(),
+        setChatNotice: vi.fn(),
+        setArchiveQueueBusy: vi.fn(),
+        setArchiveSemanticLintResult,
+        errorMessageOf,
+      });
+
+      expect(runtimeMocks.requestArchiveSemanticLint).toHaveBeenCalled();
+      expect(setArchiveSemanticLintResult).toHaveBeenCalledWith(result);
+    } finally {
+      memoryProviderMock.semanticLint = saved;
+    }
+  });
+
+  it("reports error on failure", async () => {
+    const state = buildDefaultState([]);
+    runtimeMocks.requestProviderDiagnostics.mockResolvedValue([]);
+    resolveArchiveIngestRouteMock.mockReturnValue(createRouteMock());
+    memoryProviderMock.semanticLint.mockRejectedValue(new Error("lint error"));
+    const setChatNotice = vi.fn();
+
+    const snapshot = { state, bundled: [], sideloaded: [] };
+
+    const { runArchiveSemanticLint } = await import("./controller");
+    await runArchiveSemanticLint({
+      snapshot,
+      commitReadyState: vi.fn(),
+      setProviderDiagnostics: vi.fn(),
+      setChatNotice,
+      setArchiveQueueBusy: vi.fn(),
+      setArchiveSemanticLintResult: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(setChatNotice).toHaveBeenCalledWith("Failed to run Living Archive semantic lint.");
+  });
+});
+
+describe("runArchiveAiMemoryBuildJob", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    providerCredentialReadyMock.mockReturnValue(true);
+    resolveRoutineRouteMock.mockReturnValue(createRouteMock());
+  });
+
+  it("runs an AI memory build job", async () => {
+    const state = buildDefaultState([]);
+    runtimeMocks.requestProviderDiagnostics.mockResolvedValue([]);
+    resolveArchiveIngestRouteMock.mockReturnValue(createRouteMock());
+    const buildResult = {
+      status: "completed",
+      recordsSeen: 10,
+      queuedThisRun: 3,
+      processedThisRun: 3,
+      promotedThisRun: 1,
+      queueRemaining: 0,
+      maintenance: { processed: [{ status: "completed" }], promoted: [{ pagesWritten: [] }] },
+    };
+    runtimeMocks.requestArchiveAiMemoryBuildJob.mockResolvedValue(buildResult);
+    runtimeMocks.requestArchiveReviewQueue.mockResolvedValue([]);
+    runtimeMocks.requestArchiveReviewArtifacts.mockResolvedValue([]);
+    runtimeMocks.requestArchiveAiMemoryBuildJobs.mockResolvedValue([]);
+
+    const snapshot = { state, bundled: [], sideloaded: [] };
+    const setArchiveAiMemoryBuildResult = vi.fn();
+
+    const { runArchiveAiMemoryBuildJob } = await import("./controller");
+    await runArchiveAiMemoryBuildJob({
+      snapshot,
+      manifestPath: "/manifest.json",
+      commitReadyState: vi.fn(),
+      setProviderDiagnostics: vi.fn(),
+      setChatNotice: vi.fn(),
+      setArchiveQueueBusy: vi.fn(),
+      setArchiveQueue: vi.fn(),
+      setArchiveReviewArtifacts: vi.fn(),
+      setArchiveProcessResult: vi.fn(),
+      setArchivePromotionResult: vi.fn(),
+      setArchiveMaintenanceResult: vi.fn(),
+      setArchiveAiMemoryBuildResult,
+      setArchiveAiMemoryBuildJobs: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(runtimeMocks.requestArchiveAiMemoryBuildJob).toHaveBeenCalled();
+    expect(setArchiveAiMemoryBuildResult).toHaveBeenCalledWith(buildResult);
+  });
+
+  it("reports error on failure", async () => {
+    const state = buildDefaultState([]);
+    runtimeMocks.requestProviderDiagnostics.mockResolvedValue([]);
+    resolveArchiveIngestRouteMock.mockReturnValue(createRouteMock());
+    runtimeMocks.requestArchiveAiMemoryBuildJob.mockRejectedValue(new Error("build error"));
+    const setChatNotice = vi.fn();
+
+    const snapshot = { state, bundled: [], sideloaded: [] };
+
+    const { runArchiveAiMemoryBuildJob } = await import("./controller");
+    await runArchiveAiMemoryBuildJob({
+      snapshot,
+      manifestPath: "/manifest.json",
+      commitReadyState: vi.fn(),
+      setProviderDiagnostics: vi.fn(),
+      setChatNotice,
+      setArchiveQueueBusy: vi.fn(),
+      setArchiveQueue: vi.fn(),
+      setArchiveReviewArtifacts: vi.fn(),
+      setArchiveProcessResult: vi.fn(),
+      setArchivePromotionResult: vi.fn(),
+      setArchiveMaintenanceResult: vi.fn(),
+      setArchiveAiMemoryBuildResult: vi.fn(),
+      setArchiveAiMemoryBuildJobs: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(setChatNotice).toHaveBeenCalledWith("Failed to run the AI Memory build job.");
+  });
+});
+
+describe("runArchiveBackgroundCycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    providerCredentialReadyMock.mockReturnValue(true);
+    resolveRoutineRouteMock.mockReturnValue(createRouteMock());
+  });
+
+  it("runs a background cycle through the memory provider", async () => {
+    const state = buildDefaultState([]);
+    runtimeMocks.requestProviderDiagnostics.mockResolvedValue([]);
+    resolveArchiveIngestRouteMock.mockReturnValue(createRouteMock());
+    const bgResult = {
+      scan: { newFiles: 2, changedFiles: 1, filesSeen: 10 },
+      queuedRequestFiles: ["/req-1.json"],
+      maintenance: { processed: [{ status: "completed" }], promoted: [{ pagesWritten: [] }] },
+    };
+    memoryProviderMock.backgroundCycle.mockResolvedValue(bgResult);
+    memoryProviderMock.reviewQueue.mockResolvedValue([]);
+    memoryProviderMock.reviewArtifacts.mockResolvedValue([]);
+
+    const snapshot = { state, bundled: [], sideloaded: [] };
+
+    const { runArchiveBackgroundCycle } = await import("./controller");
+    await runArchiveBackgroundCycle({
+      snapshot,
+      commitReadyState: vi.fn(),
+      setProviderDiagnostics: vi.fn(),
+      setChatNotice: vi.fn(),
+      setArchiveQueueBusy: vi.fn(),
+      setArchiveQueue: vi.fn(),
+      setArchiveReviewArtifacts: vi.fn(),
+      setArchiveProcessResult: vi.fn(),
+      setArchivePromotionResult: vi.fn(),
+      setArchiveMaintenanceResult: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(memoryProviderMock.backgroundCycle).toHaveBeenCalled();
+  });
+
+  it("falls back to runtime background cycle when provider has no method", async () => {
+    const saved = memoryProviderMock.backgroundCycle;
+    delete (memoryProviderMock as Record<string, unknown>).backgroundCycle;
+    try {
+      const state = buildDefaultState([]);
+      runtimeMocks.requestProviderDiagnostics.mockResolvedValue([]);
+      resolveArchiveIngestRouteMock.mockReturnValue(createRouteMock());
+      const bgResult = {
+        scan: { newFiles: 1, changedFiles: 0, filesSeen: 5 },
+        queuedRequestFiles: [],
+        maintenance: { processed: [], promoted: [] },
+      };
+      runtimeMocks.requestArchiveBackgroundCycle.mockResolvedValue(bgResult);
+      memoryProviderMock.reviewQueue.mockResolvedValue([]);
+      memoryProviderMock.reviewArtifacts.mockResolvedValue([]);
+
+      const snapshot = { state, bundled: [], sideloaded: [] };
+
+      const { runArchiveBackgroundCycle } = await import("./controller");
+      await runArchiveBackgroundCycle({
+        snapshot,
+        commitReadyState: vi.fn(),
+        setProviderDiagnostics: vi.fn(),
+        setChatNotice: vi.fn(),
+        setArchiveQueueBusy: vi.fn(),
+        setArchiveQueue: vi.fn(),
+        setArchiveReviewArtifacts: vi.fn(),
+        setArchiveProcessResult: vi.fn(),
+        setArchivePromotionResult: vi.fn(),
+        setArchiveMaintenanceResult: vi.fn(),
+        errorMessageOf,
+      });
+
+      expect(runtimeMocks.requestArchiveBackgroundCycle).toHaveBeenCalled();
+    } finally {
+      memoryProviderMock.backgroundCycle = saved;
+    }
+  });
+
+  it("reports error on failure", async () => {
+    const state = buildDefaultState([]);
+    runtimeMocks.requestProviderDiagnostics.mockResolvedValue([]);
+    resolveArchiveIngestRouteMock.mockReturnValue(createRouteMock());
+    memoryProviderMock.backgroundCycle.mockRejectedValue(new Error("bg error"));
+    const setChatNotice = vi.fn();
+
+    const snapshot = { state, bundled: [], sideloaded: [] };
+
+    const { runArchiveBackgroundCycle } = await import("./controller");
+    await runArchiveBackgroundCycle({
+      snapshot,
+      commitReadyState: vi.fn(),
+      setProviderDiagnostics: vi.fn(),
+      setChatNotice,
+      setArchiveQueueBusy: vi.fn(),
+      setArchiveQueue: vi.fn(),
+      setArchiveReviewArtifacts: vi.fn(),
+      setArchiveProcessResult: vi.fn(),
+      setArchivePromotionResult: vi.fn(),
+      setArchiveMaintenanceResult: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(setChatNotice).toHaveBeenCalledWith("Failed to run Living Archive background cycle.");
+  });
+});

--- a/src/modules/recovery/controller.test.ts
+++ b/src/modules/recovery/controller.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildDefaultState } from "../../core/defaults";
+import type { RecoveryRouteCandidate } from "../../core/contracts";
+
+const createEngineerThreadMock = vi.fn((state) => state);
+
+vi.mock("../../core/chat", () => ({
+  createEngineerThread: createEngineerThreadMock,
+}));
+
+const noop = vi.fn();
+
+describe("setRecoveryMode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("enables recovery mode, reconfigures the engineer agent, and logs entry", async () => {
+    let state = buildDefaultState([]);
+    const updateRuntimeState = (updater: (current: typeof state) => typeof state) => {
+      state = updater(state);
+    };
+
+    const setChatNotice = vi.fn();
+    const setAgentActivityLabel = vi.fn();
+    const setSelectedChatModel = vi.fn();
+
+    const { setRecoveryMode } = await import("./controller");
+    setRecoveryMode(true, updateRuntimeState, setChatNotice, setAgentActivityLabel, setSelectedChatModel);
+
+    expect(state.recoverySession.active).toBe(true);
+    expect(state.recoverySession.lastNormalThreadId).toBe(state.uiPreferences.activeChatThreadId);
+    expect(state.recoverySession.changeLog.some((entry) => entry.includes("Entered recovery mode"))).toBe(true);
+    expect(state.recoverySession.checklist[0].status).toBe("active");
+    expect(state.agents.find((a) => a.id === state.recoverySession.engineerAgentId)?.providerProfileId).toBe("shared-local");
+    expect(createEngineerThreadMock).toHaveBeenCalled();
+    expect(setChatNotice).toHaveBeenCalledWith(expect.stringContaining("Recovery mode active"));
+    expect(setAgentActivityLabel).toHaveBeenCalledWith(expect.stringContaining("Awaiting recovery start"));
+    expect(setSelectedChatModel).toHaveBeenCalledWith("");
+  });
+
+  it("disables recovery mode, restores the last normal thread, and logs exit", async () => {
+    let state = buildDefaultState([]);
+    state.recoverySession.active = true;
+    state.recoverySession.lastNormalThreadId = "thread-previous";
+    const updateRuntimeState = (updater: (current: typeof state) => typeof state) => {
+      state = updater(state);
+    };
+
+    const { setRecoveryMode } = await import("./controller");
+    setRecoveryMode(false, updateRuntimeState, noop, noop, noop);
+
+    expect(state.recoverySession.active).toBe(false);
+    expect(state.uiPreferences.activeChatThreadId).toBe("thread-previous");
+    expect(state.recoverySession.changeLog.some((entry) => entry.includes("Exited recovery mode"))).toBe(true);
+  });
+});
+
+describe("promoteRecoveryRoute", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("promotes the engineer agent to the candidate route and updates the checklist", async () => {
+    let state = buildDefaultState([]);
+    state.recoverySession.active = true;
+    const updateRuntimeState = (updater: (current: typeof state) => typeof state) => {
+      state = updater(state);
+    };
+
+    const candidate: RecoveryRouteCandidate = {
+      id: "candidate-1",
+      providerId: "provider-openai",
+      providerLabel: "OpenAI",
+      runtimeNodeId: "node-openai",
+      runtimeNodeLabel: "OpenAI Cloud",
+      runtimeKind: "cloud",
+      model: "gpt-4o",
+      credentialConfigured: true,
+      reachable: true,
+      promotable: true,
+      recommended: true,
+      reason: "Primary cloud route is healthy",
+    };
+
+    const { promoteRecoveryRoute } = await import("./controller");
+    promoteRecoveryRoute(candidate, updateRuntimeState, noop, noop, noop);
+
+    const engineer = state.agents.find((a) => a.id === state.recoverySession.engineerAgentId);
+    expect(engineer?.providerProfileId).toBe("provider-openai");
+    expect(engineer?.fallbackProviderProfileId).toBe("shared-local");
+    expect(state.recoverySession.changeLog.some((entry) => entry.includes("promote_route"))).toBe(true);
+    expect(state.recoverySession.checklist.find((s) => s.id === "better-brain")?.status).toBe("complete");
+    expect(state.recoverySession.checklist.find((s) => s.id === "promote")?.status).toBe("complete");
+  });
+
+  it("activates deep-diagnosis when promote is complete and deep-diagnosis is pending", async () => {
+    let state = buildDefaultState([]);
+    state.recoverySession.active = true;
+    const deepStep = state.recoverySession.checklist.find((s) => s.id === "deep-diagnosis");
+    if (deepStep) deepStep.status = "pending";
+
+    const updateRuntimeState = (updater: (current: typeof state) => typeof state) => {
+      state = updater(state);
+    };
+
+    const candidate: RecoveryRouteCandidate = {
+      id: "candidate-2",
+      providerId: "provider-local",
+      providerLabel: "Local",
+      runtimeNodeId: "node-local",
+      runtimeNodeLabel: "Local Runtime",
+      runtimeKind: "local",
+      model: "gemma-4-26b",
+      credentialConfigured: true,
+      reachable: true,
+      promotable: true,
+      recommended: true,
+      reason: "Local recovery route",
+    };
+
+    const { promoteRecoveryRoute } = await import("./controller");
+    promoteRecoveryRoute(candidate, updateRuntimeState, noop, noop, noop);
+
+    expect(state.recoverySession.checklist.find((s) => s.id === "deep-diagnosis")?.status).toBe("active");
+  });
+});

--- a/src/modules/settings/controller.test.ts
+++ b/src/modules/settings/controller.test.ts
@@ -1,0 +1,658 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildDefaultState } from "../../core/defaults";
+import type { ResonantShellState } from "../../core/contracts";
+
+const runtimeMocks = vi.hoisted(() => ({
+  requestProviderDiagnostics: vi.fn(),
+  saveProviderSecret: vi.fn(),
+  requestProviderSmokeTest: vi.fn(),
+  requestLivingArchiveMemoryServiceStatus: vi.fn(),
+  requestLivingArchiveMemoryServiceStart: vi.fn(),
+  requestLivingArchiveMemoryServiceStop: vi.fn(),
+  requestProviderSetupProbe: vi.fn(),
+}));
+
+vi.mock("../../core/runtime", () => runtimeMocks);
+
+const findProviderTemplateMock = vi.fn();
+vi.mock("./provider-templates", () => ({
+  findProviderTemplate: (...args: unknown[]) => findProviderTemplateMock(...args),
+}));
+
+const updateWorkloadStrategyMock = vi.fn();
+const routeFromOptionKeyMock = vi.fn();
+vi.mock("../../core/model-strategy", () => ({
+  updateWorkloadStrategy: (...args: unknown[]) => updateWorkloadStrategyMock(...args),
+  routeFromOptionKey: (...args: unknown[]) => routeFromOptionKeyMock(...args),
+}));
+
+const applyProviderDiagnosticsMock = vi.fn((state, _reports) => state);
+vi.mock("../../core/policies", () => ({
+  applyProviderDiagnostics: applyProviderDiagnosticsMock,
+}));
+
+const errorMessageOf = (_error: unknown, fallback: string) => fallback;
+
+describe("updateProviderProfile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("updates the primary model of a provider", async () => {
+    let state = buildDefaultState([]);
+    const updateRuntimeState = (updater: (current: ResonantShellState) => ResonantShellState) => {
+      state = updater(state);
+    };
+
+    const { updateProviderProfile } = await import("./controller");
+    const profileId = state.providers[0].id;
+    updateProviderProfile(profileId, "primaryModel", "gpt-5", updateRuntimeState);
+
+    expect(state.providers.find((p) => p.id === profileId)?.primaryModel).toBe("gpt-5");
+  });
+
+  it("updates the status of a provider", async () => {
+    let state = buildDefaultState([]);
+    const updateRuntimeState = (updater: (current: ResonantShellState) => ResonantShellState) => {
+      state = updater(state);
+    };
+
+    const { updateProviderProfile } = await import("./controller");
+    const profileId = state.providers[0].id;
+    updateProviderProfile(profileId, "status", "error", updateRuntimeState);
+
+    expect(state.providers.find((p) => p.id === profileId)?.status).toBe("error");
+  });
+});
+
+describe("updateModelWorkloadStrategyRoute", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls routeFromOptionKey and updateWorkloadStrategy when a route is found", async () => {
+    const route = { providerProfileId: "provider-test", model: "gpt-4o" };
+    routeFromOptionKeyMock.mockReturnValue(route);
+
+    let state = buildDefaultState([]);
+    const updateRuntimeState = (updater: (current: ResonantShellState) => ResonantShellState) => {
+      state = updater(state);
+    };
+
+    const { updateModelWorkloadStrategyRoute } = await import("./controller");
+    updateModelWorkloadStrategyRoute("strategy-test", "option-key", updateRuntimeState);
+
+    expect(routeFromOptionKeyMock).toHaveBeenCalledWith(expect.anything(), "option-key");
+    expect(updateWorkloadStrategyMock).toHaveBeenCalled();
+  });
+
+  it("does nothing when routeFromOptionKey returns undefined", async () => {
+    routeFromOptionKeyMock.mockReturnValue(undefined);
+
+    const { updateModelWorkloadStrategyRoute } = await import("./controller");
+    updateModelWorkloadStrategyRoute("strategy-test", "invalid-key", vi.fn());
+
+    expect(updateWorkloadStrategyMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("executeRefreshProviderDiagnostics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("probes diagnostics and commits state", async () => {
+    const reports = [{ providerId: "p1", providerLabel: "Provider 1" }];
+    runtimeMocks.requestProviderDiagnostics.mockResolvedValue(reports);
+    applyProviderDiagnosticsMock.mockImplementation((state) => state);
+
+    const snapshot = {
+      state: buildDefaultState([]),
+      bundled: [],
+      sideloaded: [],
+    };
+    const commitReadyState = vi.fn();
+    const setProviderDiagnosticsBusy = vi.fn();
+    const setActiveProviderProbeId = vi.fn();
+    const setProviderDiagnostics = vi.fn();
+    const setSettingsNotice = vi.fn();
+
+    const { executeRefreshProviderDiagnostics } = await import("./controller");
+    await executeRefreshProviderDiagnostics({
+      snapshot,
+      commitReadyState,
+      updateRuntimeState: vi.fn(),
+      setProviderDiagnosticsBusy,
+      setActiveProviderProbeId,
+      setProviderDiagnostics,
+      setSettingsNotice,
+      errorMessageOf,
+    });
+
+    expect(runtimeMocks.requestProviderDiagnostics).toHaveBeenCalled();
+    expect(applyProviderDiagnosticsMock).toHaveBeenCalled();
+    expect(commitReadyState).toHaveBeenCalled();
+    expect(setProviderDiagnosticsBusy).toHaveBeenCalledWith(false);
+  });
+
+  it("handles errors gracefully", async () => {
+    runtimeMocks.requestProviderDiagnostics.mockRejectedValue(new Error("network failure"));
+
+    const snapshot = { state: buildDefaultState([]), bundled: [], sideloaded: [] };
+    const setSettingsNotice = vi.fn();
+
+    const { executeRefreshProviderDiagnostics } = await import("./controller");
+    await executeRefreshProviderDiagnostics({
+      snapshot,
+      commitReadyState: vi.fn(),
+      updateRuntimeState: vi.fn(),
+      setProviderDiagnosticsBusy: vi.fn(),
+      setActiveProviderProbeId: vi.fn(),
+      setProviderDiagnostics: vi.fn(),
+      setSettingsNotice,
+      errorMessageOf,
+    });
+
+    expect(setSettingsNotice).toHaveBeenCalledWith("Failed to probe provider diagnostics.");
+  });
+});
+
+describe("executeProviderSmokeTest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("runs a smoke test for an existing provider", async () => {
+    const state = buildDefaultState([]);
+    const providerId = state.providers[0].id;
+    runtimeMocks.requestProviderSmokeTest.mockResolvedValue({ summary: "All good" });
+
+    const snapshot = { state, bundled: [], sideloaded: [] };
+    const setProviderSmokeResults = vi.fn();
+
+    const { executeProviderSmokeTest } = await import("./controller");
+    await executeProviderSmokeTest({
+      snapshot,
+      providerId,
+      setProviderSmokeBusyId: vi.fn(),
+      setProviderSmokeResults,
+      setSettingsNotice: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(runtimeMocks.requestProviderSmokeTest).toHaveBeenCalled();
+    expect(setProviderSmokeResults).toHaveBeenCalled();
+  });
+
+  it("shows a notice when the provider is not found", async () => {
+    const state = buildDefaultState([]);
+    const snapshot = { state, bundled: [], sideloaded: [] };
+    const setSettingsNotice = vi.fn();
+
+    const { executeProviderSmokeTest } = await import("./controller");
+    await executeProviderSmokeTest({
+      snapshot,
+      providerId: "nonexistent",
+      setProviderSmokeBusyId: vi.fn(),
+      setProviderSmokeResults: vi.fn(),
+      setSettingsNotice,
+      errorMessageOf,
+    });
+
+    expect(setSettingsNotice).toHaveBeenCalledWith("Provider nonexistent was not found.");
+    expect(runtimeMocks.requestProviderSmokeTest).not.toHaveBeenCalled();
+  });
+});
+
+describe("executeRefreshMemoryServiceStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches and sets the memory service status", async () => {
+    const status = { status: "running", statusDetail: "Service is running" };
+    runtimeMocks.requestLivingArchiveMemoryServiceStatus.mockResolvedValue(status);
+    const setMemoryServiceStatus = vi.fn();
+    const setSettingsNotice = vi.fn();
+
+    const { executeRefreshMemoryServiceStatus } = await import("./controller");
+    await executeRefreshMemoryServiceStatus({
+      setMemoryServiceBusy: vi.fn(),
+      setMemoryServiceStatus,
+      setSettingsNotice,
+      errorMessageOf,
+    });
+
+    expect(setMemoryServiceStatus).toHaveBeenCalledWith(status);
+    expect(setSettingsNotice).toHaveBeenCalledWith("Service is running");
+  });
+});
+
+describe("executeSaveProviderSecret", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("saves a non-empty secret and sets credential status to configured", async () => {
+    const state = buildDefaultState([]);
+    const profileId = state.providers[0].id;
+    runtimeMocks.saveProviderSecret.mockResolvedValue(undefined);
+    runtimeMocks.requestProviderDiagnostics.mockResolvedValue([]);
+    applyProviderDiagnosticsMock.mockImplementation((s) => s);
+
+    const snapshot = { state, bundled: [], sideloaded: [] };
+    const commitReadyState = vi.fn();
+    const updateRuntimeState = vi.fn((updater) => {
+      updater(snapshot.state);
+    });
+    const setProviderDrafts = vi.fn();
+    const setSettingsNotice = vi.fn();
+
+    const { executeSaveProviderSecret } = await import("./controller");
+    await executeSaveProviderSecret({
+      snapshot,
+      profileId,
+      secret: "sk-abc123",
+      commitReadyState,
+      updateRuntimeState,
+      setProviderDrafts,
+      setSettingsNotice,
+      setProviderDiagnosticsBusy: vi.fn(),
+      setActiveProviderProbeId: vi.fn(),
+      setProviderDiagnostics: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(runtimeMocks.saveProviderSecret).toHaveBeenCalledWith(profileId, "sk-abc123");
+    expect(commitReadyState).toHaveBeenCalled();
+    expect(setProviderDrafts).toHaveBeenCalled();
+    expect(setSettingsNotice).toHaveBeenCalledWith("Provider secret saved.");
+  });
+
+  it("saves an empty secret and sets credential status to missing", async () => {
+    const state = buildDefaultState([]);
+    const profileId = state.providers[0].id;
+    runtimeMocks.saveProviderSecret.mockResolvedValue(undefined);
+    runtimeMocks.requestProviderDiagnostics.mockResolvedValue([]);
+    applyProviderDiagnosticsMock.mockImplementation((s) => s);
+
+    const snapshot = { state, bundled: [], sideloaded: [] };
+    const setSettingsNotice = vi.fn();
+
+    const { executeSaveProviderSecret } = await import("./controller");
+    await executeSaveProviderSecret({
+      snapshot,
+      profileId,
+      secret: "",
+      commitReadyState: vi.fn(),
+      updateRuntimeState: vi.fn(),
+      setProviderDrafts: vi.fn(),
+      setSettingsNotice,
+      setProviderDiagnosticsBusy: vi.fn(),
+      setActiveProviderProbeId: vi.fn(),
+      setProviderDiagnostics: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(setSettingsNotice).toHaveBeenCalledWith("Provider secret cleared.");
+  });
+
+  it("reports error on failure", async () => {
+    runtimeMocks.saveProviderSecret.mockRejectedValue(new Error("save error"));
+
+    const snapshot = { state: buildDefaultState([]), bundled: [], sideloaded: [] };
+    const setSettingsNotice = vi.fn();
+
+    const { executeSaveProviderSecret } = await import("./controller");
+    await executeSaveProviderSecret({
+      snapshot,
+      profileId: "provider-test",
+      secret: "sk-abc",
+      commitReadyState: vi.fn(),
+      updateRuntimeState: vi.fn(),
+      setProviderDrafts: vi.fn(),
+      setSettingsNotice,
+      setProviderDiagnosticsBusy: vi.fn(),
+      setActiveProviderProbeId: vi.fn(),
+      setProviderDiagnostics: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(setSettingsNotice).toHaveBeenCalledWith("Failed to save provider secret.");
+  });
+});
+
+describe("updateModelWorkloadStrategy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("delegates to updateWorkloadStrategy via the state updater", async () => {
+    const state = buildDefaultState([]);
+    let captured: unknown;
+
+    const updateRuntimeState = (updater: (current: ResonantShellState) => ResonantShellState) => {
+      captured = updater(state);
+    };
+
+    const { updateModelWorkloadStrategy } = await import("./controller");
+    updateModelWorkloadStrategy("strategy-test", { primaryRoute: { providerProfileId: "p1", model: "gpt-4o" } }, updateRuntimeState);
+
+    expect(updateWorkloadStrategyMock).toHaveBeenCalledWith(
+      state,
+      "strategy-test",
+      expect.objectContaining({ primaryRoute: { providerProfileId: "p1", model: "gpt-4o" } }),
+    );
+  });
+});
+
+describe("executeStartMemoryService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts the memory service and refreshes status", async () => {
+    const startResult = {
+      sessionId: "session-1",
+      endpoint: "http://localhost:9090",
+      alreadyRunning: false,
+    };
+    const status = { status: "running", statusDetail: "Service started" };
+    runtimeMocks.requestLivingArchiveMemoryServiceStart.mockResolvedValue(startResult);
+    runtimeMocks.requestLivingArchiveMemoryServiceStatus.mockResolvedValue(status);
+
+    const { executeStartMemoryService } = await import("./controller");
+    await executeStartMemoryService({
+      setMemoryServiceBusy: vi.fn(),
+      setMemoryServiceStatus: vi.fn(),
+      setMemoryServiceLastResult: vi.fn(),
+      setSettingsNotice: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(runtimeMocks.requestLivingArchiveMemoryServiceStart).toHaveBeenCalled();
+  });
+
+  it("shows already-running notice when service was already started", async () => {
+    const startResult = {
+      sessionId: "session-1",
+      endpoint: "http://localhost:9090",
+      alreadyRunning: true,
+    };
+    runtimeMocks.requestLivingArchiveMemoryServiceStart.mockResolvedValue(startResult);
+    runtimeMocks.requestLivingArchiveMemoryServiceStatus.mockResolvedValue({});
+
+    const setSettingsNotice = vi.fn();
+
+    const { executeStartMemoryService } = await import("./controller");
+    await executeStartMemoryService({
+      setMemoryServiceBusy: vi.fn(),
+      setMemoryServiceStatus: vi.fn(),
+      setMemoryServiceLastResult: vi.fn(),
+      setSettingsNotice,
+      errorMessageOf,
+    });
+
+    expect(setSettingsNotice).toHaveBeenCalledWith(expect.stringContaining("already running"));
+  });
+
+  it("reports error on failure", async () => {
+    runtimeMocks.requestLivingArchiveMemoryServiceStart.mockRejectedValue(new Error("start error"));
+    const setSettingsNotice = vi.fn();
+
+    const { executeStartMemoryService } = await import("./controller");
+    await executeStartMemoryService({
+      setMemoryServiceBusy: vi.fn(),
+      setMemoryServiceStatus: vi.fn(),
+      setMemoryServiceLastResult: vi.fn(),
+      setSettingsNotice,
+      errorMessageOf,
+    });
+
+    expect(setSettingsNotice).toHaveBeenCalledWith("Failed to start Living Archive memory service.");
+  });
+});
+
+describe("executeStopMemoryService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("stops the memory service and refreshes status", async () => {
+    const stopResult = { sessionId: "session-1", endpoint: "http://localhost:9090" };
+    runtimeMocks.requestLivingArchiveMemoryServiceStop.mockResolvedValue(stopResult);
+    runtimeMocks.requestLivingArchiveMemoryServiceStatus.mockResolvedValue({});
+
+    const { executeStopMemoryService } = await import("./controller");
+    await executeStopMemoryService({
+      setMemoryServiceBusy: vi.fn(),
+      setMemoryServiceStatus: vi.fn(),
+      setMemoryServiceLastResult: vi.fn(),
+      setSettingsNotice: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(runtimeMocks.requestLivingArchiveMemoryServiceStop).toHaveBeenCalled();
+  });
+
+  it("reports error on failure", async () => {
+    runtimeMocks.requestLivingArchiveMemoryServiceStop.mockRejectedValue(new Error("stop error"));
+    const setSettingsNotice = vi.fn();
+
+    const { executeStopMemoryService } = await import("./controller");
+    await executeStopMemoryService({
+      setMemoryServiceBusy: vi.fn(),
+      setMemoryServiceStatus: vi.fn(),
+      setMemoryServiceLastResult: vi.fn(),
+      setSettingsNotice,
+      errorMessageOf,
+    });
+
+    expect(setSettingsNotice).toHaveBeenCalledWith("Failed to stop Living Archive memory service.");
+  });
+});
+
+describe("executeCreateProviderProfile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns early when template is not found", async () => {
+    findProviderTemplateMock.mockReturnValue(undefined);
+    const setSettingsNotice = vi.fn();
+
+    const { executeCreateProviderProfile } = await import("./controller");
+    await executeCreateProviderProfile({
+      templateId: "nonexistent",
+      label: "Test",
+      updateRuntimeState: vi.fn(),
+      setSettingsNotice,
+      errorMessageOf,
+    });
+
+    expect(setSettingsNotice).toHaveBeenCalledWith("Provider template nonexistent was not found.");
+  });
+
+  it("returns early when template requires a base URL but none is provided", async () => {
+    findProviderTemplateMock.mockReturnValue({
+      id: "openai",
+      label: "OpenAI",
+      providerType: "openai",
+      requiresBaseUrl: true,
+      defaultApiBaseUrl: "",
+      requiresSecret: true,
+      authMethod: "api-key",
+      authTier: "supported",
+      allowedModels: ["gpt-4o"],
+      primaryModel: "gpt-4o",
+      fallbackModel: "gpt-4o-mini",
+      modelContext: [],
+      consumerScopes: ["chat"],
+      initialStatus: "missing",
+      credentialStatus: "missing",
+      runtimeKind: "cloud",
+      runtimeLocality: "remote",
+      initialRuntimeHealthState: "unavailable",
+      deployableOnDemand: false,
+      executionState: "stopped",
+      note: "Requires API key",
+    });
+    const setSettingsNotice = vi.fn();
+
+    const { executeCreateProviderProfile } = await import("./controller");
+    await executeCreateProviderProfile({
+      templateId: "openai",
+      label: "My OpenAI",
+      updateRuntimeState: vi.fn(),
+      setSettingsNotice,
+      errorMessageOf,
+    });
+
+    expect(setSettingsNotice).toHaveBeenCalledWith(expect.stringContaining("API base URL"));
+  });
+
+  it("returns early when template requires a secret but none is provided", async () => {
+    findProviderTemplateMock.mockReturnValue({
+      id: "openai",
+      label: "OpenAI",
+      providerType: "openai",
+      requiresBaseUrl: true,
+      defaultApiBaseUrl: "https://api.openai.com",
+      requiresSecret: true,
+      authMethod: "api-key",
+      authTier: "supported",
+      allowedModels: ["gpt-4o"],
+      primaryModel: "gpt-4o",
+      fallbackModel: "gpt-4o-mini",
+      modelContext: [],
+      consumerScopes: ["chat"],
+      initialStatus: "missing",
+      credentialStatus: "missing",
+      runtimeKind: "cloud",
+      runtimeLocality: "remote",
+      initialRuntimeHealthState: "unavailable",
+      deployableOnDemand: false,
+      executionState: "stopped",
+      note: "Requires API key",
+    });
+    const setSettingsNotice = vi.fn();
+
+    const { executeCreateProviderProfile } = await import("./controller");
+    await executeCreateProviderProfile({
+      templateId: "openai",
+      label: "My OpenAI",
+      apiBaseUrl: "https://api.openai.com",
+      updateRuntimeState: vi.fn(),
+      setSettingsNotice,
+      errorMessageOf,
+    });
+
+    expect(setSettingsNotice).toHaveBeenCalledWith(expect.stringContaining("credential"));
+  });
+
+  it("creates a provider profile, runs setup probe, and updates state", async () => {
+    findProviderTemplateMock.mockReturnValue({
+      id: "ollama",
+      label: "Ollama",
+      providerType: "openai-compatible",
+      requiresBaseUrl: false,
+      defaultApiBaseUrl: "http://localhost:11434",
+      requiresSecret: false,
+      authMethod: "local-runtime",
+      authTier: "supported",
+      allowedModels: ["gemma-4-26b"],
+      primaryModel: "gemma-4-26b",
+      fallbackModel: "gemma-4-9b",
+      modelContext: [],
+      consumerScopes: ["chat"],
+      initialStatus: "ready",
+      credentialStatus: "configured",
+      runtimeKind: "local",
+      runtimeLocality: "device",
+      initialRuntimeHealthState: "ready",
+      deployableOnDemand: true,
+      executionState: "started",
+      note: "Local engine running",
+    });
+    const setupProbeResult = {
+      discoveredModels: ["gemma-4-26b", "gemma-4-9b"],
+      recommendedPrimaryModel: "gemma-4-26b",
+      recommendedFallbackModel: "gemma-4-9b",
+      endpoint: "http://localhost:11434",
+      summary: "Probe succeeded",
+      setupState: "routable-now",
+      source: "openai-compatible-models",
+      detail: "All good",
+    };
+    runtimeMocks.requestProviderSetupProbe.mockResolvedValue(setupProbeResult);
+
+    const updateRuntimeState = vi.fn();
+    const setSettingsNotice = vi.fn();
+
+    const { executeCreateProviderProfile } = await import("./controller");
+    await executeCreateProviderProfile({
+      templateId: "ollama",
+      label: "Local Ollama",
+      updateRuntimeState,
+      setSettingsNotice,
+      errorMessageOf,
+    });
+
+    expect(runtimeMocks.requestProviderSetupProbe).toHaveBeenCalled();
+    expect(updateRuntimeState).toHaveBeenCalled();
+    expect(setSettingsNotice).toHaveBeenCalledWith(expect.stringContaining("was added"));
+  });
+});
+
+describe("executeSetupProviderProfile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports error when provider is not found", async () => {
+    const snapshot = { state: buildDefaultState([]), bundled: [], sideloaded: [] };
+    const setSettingsNotice = vi.fn();
+
+    const { executeSetupProviderProfile } = await import("./controller");
+    await executeSetupProviderProfile({
+      snapshot,
+      profileId: "nonexistent",
+      updateRuntimeState: vi.fn(),
+      setSettingsNotice,
+      errorMessageOf,
+    });
+
+    expect(setSettingsNotice).toHaveBeenCalledWith(expect.stringContaining("missing"));
+  });
+
+  it("re-runs the setup probe and updates provider and runtime node", async () => {
+    const state = buildDefaultState([]);
+    const provider = state.providers[0];
+    const runtimeNode = state.runtimeNodes.find((n) => n.providerProfileId === provider.id);
+    const snapshot = { state, bundled: [], sideloaded: [] };
+    const setupProbeResult = {
+      discoveredModels: ["gpt-4o", "gpt-4o-mini"],
+      recommendedPrimaryModel: "gpt-4o",
+      recommendedFallbackModel: "gpt-4o-mini",
+      endpoint: "https://api.openai.com",
+      summary: "Re-probe succeeded",
+      setupState: "routable-now",
+      source: "openai-compatible-models",
+      detail: "All healthy",
+    };
+    runtimeMocks.requestProviderSetupProbe.mockResolvedValue(setupProbeResult);
+    const updateRuntimeState = vi.fn();
+
+    const { executeSetupProviderProfile } = await import("./controller");
+    await executeSetupProviderProfile({
+      snapshot,
+      profileId: provider.id,
+      updateRuntimeState,
+      setSettingsNotice: vi.fn(),
+      errorMessageOf,
+    });
+
+    expect(runtimeMocks.requestProviderSetupProbe).toHaveBeenCalled();
+    expect(updateRuntimeState).toHaveBeenCalled();
+  });
+});

--- a/src/modules/shell/controller.test.ts
+++ b/src/modules/shell/controller.test.ts
@@ -1,6 +1,7 @@
 // Intent citation: docs/architecture/ADR-002-modular-codebase.md
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AddOnManifest } from "../../core/contracts";
 import { buildDefaultState } from "../../core/defaults";
 
 const runtimeMocks = vi.hoisted(() => ({
@@ -32,5 +33,92 @@ describe("shell boot controller", () => {
     const booted = await loadInitialShellState();
 
     expect(booted.state.uiPreferences.activeSection).toBe("archive");
+  });
+
+  it("loads recovery runtime snapshot with status and candidates", async () => {
+    const state = buildDefaultState([]);
+    const status = { recoveryModelRunning: true, modelVersion: "0.1.0" };
+    const candidates = [{ providerId: "shared-local", providerLabel: "Local", runtimeNodeLabel: "Local Runtime", model: "gemma-4-26b" }];
+    runtimeMocks.requestLocalRuntimeStatus.mockResolvedValue(status);
+    runtimeMocks.requestRecoveryRouteCandidates.mockResolvedValue(candidates);
+
+    const { loadRecoveryRuntimeSnapshot } = await import("./controller");
+    const result = await loadRecoveryRuntimeSnapshot(state);
+
+    expect(result.status).toEqual(status);
+    expect(result.candidates).toEqual(candidates);
+    expect(runtimeMocks.requestLocalRuntimeStatus).toHaveBeenCalledWith(
+      state.providers.find((p) => p.id === "shared-local")?.primaryModel ?? "batiai/gemma4-e2b:q4",
+    );
+    expect(runtimeMocks.requestRecoveryRouteCandidates).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies first-run recommended addons by enabling selected manifests", async () => {
+    const manifests: AddOnManifest[] = [
+      {
+        id: "addon.augmentor-chat",
+        name: "Augmentor Chat",
+        version: "0.1.0",
+        author: "test",
+        category: "agent",
+        description: "Chat UI",
+        runtimeType: "agent-addon",
+        surfaces: [],
+        requestedCapabilities: [],
+        systemSlots: [{ id: "chat-interface", recommended: true }],
+        providerRequirements: { sharedProfiles: [], supportsPrivateCredentials: false },
+        archiveIntegration: { readScopes: [], intakeWriteScopes: [], canRequestIngest: false, canWriteKnowledgePages: false },
+        health: { strategy: "none" },
+        installHooks: {},
+        compatibility: { shellVersion: "^0.1.0", platforms: ["macOS"] },
+      },
+    ];
+    const state = buildDefaultState(manifests);
+
+    const { applyFirstRunRecommendedAddOns } = await import("./controller");
+    const result = applyFirstRunRecommendedAddOns(state, manifests, ["addon.augmentor-chat"]);
+
+    expect(result.uiPreferences.recommendedAddOnsReviewed).toBe(true);
+    const installation = result.installations["addon.augmentor-chat"];
+    expect(installation.installed).toBe(true);
+    expect(installation.enabled).toBe(true);
+    expect(installation.status).toBe("enabled");
+  });
+
+  it("skips non-recommended addons during first-run setup", async () => {
+    const state = buildDefaultState([]);
+    const manifests: AddOnManifest[] = [
+      {
+        id: "custom-addon",
+        name: "Custom",
+        version: "0.1.0",
+        author: "test",
+        category: "tool",
+        description: "Custom Addon",
+        runtimeType: "ui-module",
+        surfaces: [],
+        requestedCapabilities: [],
+        providerRequirements: { sharedProfiles: [], supportsPrivateCredentials: false },
+        archiveIntegration: { readScopes: [], intakeWriteScopes: [], canRequestIngest: false, canWriteKnowledgePages: false },
+        health: { strategy: "none" },
+        installHooks: {},
+        compatibility: { shellVersion: "^0.1.0", platforms: ["macOS"] },
+      },
+    ];
+
+    const { applyFirstRunRecommendedAddOns } = await import("./controller");
+    const result = applyFirstRunRecommendedAddOns(state, manifests, ["custom-addon"]);
+
+    expect(result.uiPreferences.recommendedAddOnsReviewed).toBe(true);
+    expect(result.installations["custom-addon"]?.installed).toBeFalsy();
+  });
+
+  it("marks recommended addons as reviewed", async () => {
+    const state = buildDefaultState([]);
+    const { markFirstRunRecommendedAddOnsReviewed } = await import("./controller");
+    const result = markFirstRunRecommendedAddOnsReviewed(state);
+
+    expect(result.uiPreferences.recommendedAddOnsReviewed).toBe(true);
+    expect(result).not.toBe(state);
   });
 });

--- a/src/modules/shell/controller.test.ts
+++ b/src/modules/shell/controller.test.ts
@@ -65,7 +65,7 @@ describe("shell boot controller", () => {
         runtimeType: "agent-addon",
         surfaces: [],
         requestedCapabilities: [],
-        systemSlots: [{ id: "chat-interface", recommended: true }],
+        systemSlots: [{ id: "chat-interface", role: "default-provider", replaceable: true, recommended: true }],
         providerRequirements: { sharedProfiles: [], supportsPrivateCredentials: false },
         archiveIntegration: { readScopes: [], intakeWriteScopes: [], canRequestIngest: false, canWriteKnowledgePages: false },
         health: { strategy: "none" },
@@ -86,7 +86,6 @@ describe("shell boot controller", () => {
   });
 
   it("skips non-recommended addons during first-run setup", async () => {
-    const state = buildDefaultState([]);
     const manifests: AddOnManifest[] = [
       {
         id: "custom-addon",
@@ -105,12 +104,13 @@ describe("shell boot controller", () => {
         compatibility: { shellVersion: "^0.1.0", platforms: ["macOS"] },
       },
     ];
+    const state = buildDefaultState(manifests);
 
     const { applyFirstRunRecommendedAddOns } = await import("./controller");
     const result = applyFirstRunRecommendedAddOns(state, manifests, ["custom-addon"]);
 
     expect(result.uiPreferences.recommendedAddOnsReviewed).toBe(true);
-    expect(result.installations["custom-addon"]?.installed).toBeFalsy();
+    expect(result.installations["custom-addon"]?.installed).toBe(false);
   });
 
   it("marks recommended addons as reviewed", async () => {

--- a/src/modules/shell/selectors.test.ts
+++ b/src/modules/shell/selectors.test.ts
@@ -1,7 +1,181 @@
 import { describe, expect, it } from "vitest";
-import type { ConversationThread } from "../../core/contracts";
+import type { AddOnManifest, ChannelDefinition, ConversationThread } from "../../core/contracts";
 import { buildDefaultState } from "../../core/defaults";
-import { buildShellViewModel, resolveSelectableChatModelsForSelection } from "./selectors";
+import {
+  buildShellViewModel,
+  channelAllowedByOwningAddon,
+  resolveActiveProviderForSelection,
+  resolveSelectableChatModelsForSelection,
+} from "./selectors";
+
+describe("resolveActiveProviderForSelection", () => {
+  it("returns undefined when state is null", () => {
+    expect(resolveActiveProviderForSelection(null, "")).toBeUndefined();
+  });
+
+  it("returns shared-local provider for Hermes agent thread", () => {
+    const state = buildDefaultState([]);
+    const hermesThread = state.conversationThreads.find((t) => t.owningAgentId === "hermes.agent");
+    if (!hermesThread) return;
+
+    const provider = resolveActiveProviderForSelection(state, "", hermesThread.id);
+    expect(provider?.id).toBe("shared-local");
+  });
+});
+
+describe("channelAllowedByOwningAddon", () => {
+  it("returns true when the channel has no owning addon", () => {
+    const state = buildDefaultState([]);
+    const channel: ChannelDefinition = {
+      id: "desktop-main",
+      type: "desktop",
+      label: "Main",
+      owningAgentId: "strategist.core",
+      strategistIdentityId: "strategist.identity",
+      enabled: true,
+      sessionMode: "shared-identity",
+      workspaceId: "ws-main",
+      metadata: {},
+    };
+    expect(channelAllowedByOwningAddon(state, channel)).toBe(true);
+  });
+
+  it("returns false when the owning addon is disabled", () => {
+    const state = buildDefaultState([]);
+    state.installations["addon.companion"] = {
+      addonId: "addon.companion",
+      source: "bundled",
+      provenanceTier: "curated-signed",
+      verificationState: "verified",
+      installed: true,
+      enabled: false,
+      status: "disabled",
+      grantedCapabilities: [],
+      recommendedGrantPresetIds: [],
+      privateProviderProfileIds: [],
+      notes: [],
+    };
+    const channel: ChannelDefinition = {
+      id: "desktop-companion",
+      type: "desktop",
+      label: "Companion",
+      owningAgentId: "addon.companion",
+      strategistIdentityId: "strategist.identity",
+      enabled: true,
+      sessionMode: "isolated-session",
+      workspaceId: "ws-companion",
+      metadata: { addonId: "addon.companion" },
+    };
+    expect(channelAllowedByOwningAddon(state, channel)).toBe(false);
+  });
+});
+
+describe("buildShellViewModel", () => {
+  it("filters manifests by search query", () => {
+    const state = buildDefaultState([]);
+    const bundled: AddOnManifest[] = [
+      {
+        id: "addon.alpha",
+        name: "Alpha Addon",
+        version: "0.1.0",
+        author: "test",
+        category: "tool",
+        description: "UI tools",
+        runtimeType: "ui-module",
+        surfaces: [],
+        requestedCapabilities: [],
+        providerRequirements: { sharedProfiles: [], supportsPrivateCredentials: false },
+        archiveIntegration: { readScopes: [], intakeWriteScopes: [], canRequestIngest: false, canWriteKnowledgePages: false },
+        health: { strategy: "none" },
+        installHooks: {},
+        compatibility: { shellVersion: "^0.1.0", platforms: ["macOS"] },
+      },
+      {
+        id: "addon.beta",
+        name: "Beta Service",
+        version: "0.1.0",
+        author: "test",
+        category: "agent",
+        description: "Background agent service",
+        runtimeType: "local-service",
+        surfaces: [],
+        requestedCapabilities: [],
+        providerRequirements: { sharedProfiles: [], supportsPrivateCredentials: false },
+        archiveIntegration: { readScopes: [], intakeWriteScopes: [], canRequestIngest: false, canWriteKnowledgePages: false },
+        health: { strategy: "none" },
+        installHooks: {},
+        compatibility: { shellVersion: "^0.1.0", platforms: ["macOS"] },
+      },
+    ];
+
+    const withMatch = buildShellViewModel({
+      state,
+      bundled,
+      sideloaded: [],
+      deferredSearch: "alpha",
+      selectedAddonId: "",
+      composer: "",
+      attachments: [],
+      selectedChatModel: "",
+    });
+    expect(withMatch.filteredManifests).toHaveLength(1);
+    expect(withMatch.filteredManifests[0].id).toBe("addon.alpha");
+  });
+
+  it("returns all manifests when search is empty", () => {
+    const state = buildDefaultState([]);
+    const bundled: AddOnManifest[] = [
+      {
+        id: "addon.one",
+        name: "One",
+        version: "0.1.0",
+        author: "test",
+        category: "agent",
+        description: "",
+        runtimeType: "agent-addon",
+        surfaces: [],
+        requestedCapabilities: [],
+        providerRequirements: { sharedProfiles: [], supportsPrivateCredentials: false },
+        archiveIntegration: { readScopes: [], intakeWriteScopes: [], canRequestIngest: false, canWriteKnowledgePages: false },
+        health: { strategy: "none" },
+        installHooks: {},
+        compatibility: { shellVersion: "^0.1.0", platforms: ["macOS"] },
+      },
+    ];
+
+    const vm = buildShellViewModel({
+      state,
+      bundled,
+      sideloaded: [],
+      deferredSearch: "",
+      selectedAddonId: "",
+      composer: "",
+      attachments: [],
+      selectedChatModel: "",
+    });
+    expect(vm.filteredManifests).toHaveLength(1);
+    expect(vm.allManifests).toHaveLength(1);
+  });
+
+  it("reports recovery mode active", () => {
+    const state = buildDefaultState([]);
+    state.recoverySession.active = true;
+
+    const vm = buildShellViewModel({
+      state,
+      bundled: [],
+      sideloaded: [],
+      deferredSearch: "",
+      selectedAddonId: "",
+      composer: "",
+      attachments: [],
+      selectedChatModel: "",
+    });
+
+    expect(vm.recoveryModeActive).toBe(true);
+    expect(vm.strategistRecoveryActive).toBe(true);
+  });
+});
 
 describe("Hermes chat model selection", () => {
   it("uses Hermes' configured local model instead of the generic agent route", () => {

--- a/src/modules/strategist/controller.test.ts
+++ b/src/modules/strategist/controller.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildDefaultState } from "../../core/defaults";
+import type { ResonantShellState } from "../../core/contracts";
+
+const createStrategistThreadMock = vi.fn((state, _input) => state);
+
+vi.mock("../../core/chat", () => ({
+  createStrategistThread: createStrategistThreadMock,
+}));
+
+describe("renameStrategistIdentity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sets the custom name and updates the strategist agent display name", async () => {
+    let state = buildDefaultState([]);
+    const updateRuntimeState = (updater: (current: ResonantShellState) => ResonantShellState) => {
+      state = updater(state);
+    };
+
+    const { renameStrategistIdentity } = await import("./controller");
+    renameStrategistIdentity("Athena", updateRuntimeState);
+
+    expect(state.strategistIdentity.customName).toBe("Athena");
+    expect(state.agents.find((a) => a.id === "strategist.core")?.displayName).toBe("Athena");
+  });
+
+  it("resets to default display name when given an empty string", async () => {
+    let state = buildDefaultState([]);
+    state.strategistIdentity.customName = "Athena";
+    const agent = state.agents.find((a) => a.id === "strategist.core");
+    if (agent) agent.displayName = "Athena";
+    const updateRuntimeState = (updater: (current: ResonantShellState) => ResonantShellState) => {
+      state = updater(state);
+    };
+
+    const { renameStrategistIdentity } = await import("./controller");
+    renameStrategistIdentity("", updateRuntimeState);
+
+    expect(state.strategistIdentity.customName).toBeUndefined();
+    expect(state.agents.find((a) => a.id === "strategist.core")?.displayName).toBe(state.strategistIdentity.defaultName);
+  });
+});
+
+describe("activateChatThread", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sets the active chat thread and resets composer, notice, and attachments", async () => {
+    let state = buildDefaultState([]);
+    const updateRuntimeState = (updater: (current: ResonantShellState) => ResonantShellState) => {
+      state = updater(state);
+    };
+    const setComposer = vi.fn();
+    const setChatNotice = vi.fn();
+    const setAttachments = vi.fn();
+
+    const { activateChatThread } = await import("./controller");
+    activateChatThread("thread-test", updateRuntimeState, setComposer, setChatNotice, setAttachments);
+
+    expect(state.uiPreferences.activeChatThreadId).toBe("thread-test");
+    expect(setComposer).toHaveBeenCalledWith("");
+    expect(setChatNotice).toHaveBeenCalledWith(null);
+    expect(setAttachments).toHaveBeenCalledWith([]);
+  });
+});
+
+describe("createNewStrategistChat", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a new strategist thread via createStrategistThread", async () => {
+    let state = buildDefaultState([]);
+    const updateRuntimeState = (updater: (current: ResonantShellState) => ResonantShellState) => {
+      state = updater(state);
+    };
+    const activeChannel = state.channels.find((c) => c.id === "desktop-main") ?? null;
+
+    const { createNewStrategistChat } = await import("./controller");
+    createNewStrategistChat({
+      state,
+      activeChannel,
+      updateRuntimeState,
+      setComposer: vi.fn(),
+      setAttachments: vi.fn(),
+      setChatNotice: vi.fn(),
+    });
+
+    expect(createStrategistThreadMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ channelId: "desktop-main" }),
+    );
+  });
+
+  it("returns early when recovery mode is active", async () => {
+    const state = buildDefaultState([]);
+    state.recoverySession.active = true;
+
+    const { createNewStrategistChat } = await import("./controller");
+    createNewStrategistChat({
+      state,
+      activeChannel: null,
+      updateRuntimeState: vi.fn(),
+      setComposer: vi.fn(),
+      setAttachments: vi.fn(),
+      setChatNotice: vi.fn(),
+    });
+
+    expect(createStrategistThreadMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("toggleStrategistChannel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("toggles a channel from enabled to disabled", async () => {
+    let state = buildDefaultState([]);
+    const channel = state.channels.find((c) => c.id === "desktop-main")!;
+    channel.enabled = true;
+    const updateRuntimeState = (updater: (current: ResonantShellState) => ResonantShellState) => {
+      state = updater(state);
+    };
+
+    const { toggleStrategistChannel } = await import("./controller");
+    toggleStrategistChannel("desktop-main", updateRuntimeState);
+
+    expect(channel.enabled).toBe(false);
+  });
+
+  it("toggles a channel from disabled to enabled", async () => {
+    let state = buildDefaultState([]);
+    const channel = state.channels.find((c) => c.id === "desktop-main")!;
+    channel.enabled = false;
+    const updateRuntimeState = (updater: (current: ResonantShellState) => ResonantShellState) => {
+      state = updater(state);
+    };
+
+    const { toggleStrategistChannel } = await import("./controller");
+    toggleStrategistChannel("desktop-main", updateRuntimeState);
+
+    expect(channel.enabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Scope

Adds co-located `controller.test.ts` (and `selectors.test.ts` for shell) test files for the `addons`, `archive`, `recovery`, `settings`, `shell`, and `strategist` modules, closing the last remaining gap from issue #126 (the `chat` module already had `controller.test.ts` coverage before this branch).

Also fixes two latent bugs surfaced while writing the shell boot tests:
- A `systemSlots` fixture in the first-run addon test was missing required `role`/`replaceable` fields, which broke `tsc` (and thus `npm run build`) even though `vitest run` passed, since test files are in tsconfig's typecheck scope.
- The sibling "skips non-recommended addons" test built its default state from an empty manifest list, so the asserted installation key never existed regardless of whether the skip logic worked. Now seeds from the same manifests and asserts the exact value.

Adds a defensive `structuredClone` in `buildDefaultState` (`src/core/defaults.ts`) so the returned default state isn't a shared mutable reference.

Out of scope: the `chat` module (already covered prior to this branch). No other production behavior changes.

Linked issue: Closes #126

Project 2 release scope: community-test
Project 2 area: extension

## Modules And Ownership

- Affected modules: `src/modules/addons/`, `src/modules/archive/`, `src/modules/recovery/`, `src/modules/settings/`, `src/modules/shell/`, `src/modules/strategist/`, `src/core/defaults.ts`
- Ownership or boundary review: Each module already has a named owner in `docs/architecture/MODULE-OWNERSHIP.md`. This PR only adds test files inside each module's existing boundary — no module was added, no ownership moved, and no module started importing another module's controller.

## Safety And Privacy

- Safety/privacy impact: None. Test-only additions plus a non-behavioral defensive copy in default-state construction; no new data flows, credentials, permissions, or personal data touched.
- Required human handoff or approval boundary: None.
- Secret-handling impact: None.

## Validation

| Command | Result |
| --- | --- |
| `npx tsc --noEmit` | Pass — no errors |
| `npx vitest run` | Pass — 41 test files, 426 tests passed |

Live-browser proof: Not required — test-only change plus a non-behavioral defensive copy; no UI or user-visible behavior changed.

## Documentation

Documentation impact: None. No module was added and no ownership moved, so `docs/architecture/MODULE-OWNERSHIP.md` does not need an update.

## Checklist

- [x] The branch targets `dev` and does not include unrelated work.
- [x] The linked issue and Project 2 fields reflect the intended release scope.
- [x] I reviewed module ownership and called out every cross-module boundary change.
- [x] I assessed security, privacy, secrets, and required human-only actions.
- [x] I added or updated tests for behavior changes.
- [x] I recorded every relevant command and its actual result above.
- [x] I attached redacted live-browser proof when the change requires it.
- [x] I updated current documentation or explained why no documentation changed.
- [x] This pull request contains no credentials, tokens, private user data, browser profiles, or unredacted sensitive logs.
