### PR TITLE
fix(settings): show provider-account save errors inside the dialog (#271)

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/lib/settings/providers-section.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/settings/providers-section.js
@@ -109,7 +109,7 @@ function providerAccountForm(provider = {}) {
   return form;
 }
 
-function openProviderAccountModal({ bridgeRequest, getBridgeRequest, statusNode, reload }) {
+export function openProviderAccountModal({ bridgeRequest, getBridgeRequest, statusNode, reload }) {
   const bridge = () => (typeof getBridgeRequest === "function" ? getBridgeRequest() : bridgeRequest);
   const overlay = document.createElement("div");
   overlay.className = "settings-provider-modal";
@@ -135,7 +135,15 @@ function openProviderAccountModal({ bridgeRequest, getBridgeRequest, statusNode,
   save.textContent = "Save account";
   actions.append(save);
   form.append(actions);
-  panel.append(heading, form);
+  // Status lives INSIDE the modal so save progress and — critically — save
+  // failures are shown to the user while the dialog is still open. Writing them
+  // to the settings page behind the modal (the old behavior) hid the error and
+  // left the dialog stuck with no signal (#271).
+  const modalStatus = document.createElement("p");
+  modalStatus.className = "settings-provider-modal-status";
+  modalStatus.setAttribute("role", "status");
+  modalStatus.setAttribute("aria-live", "polite");
+  panel.append(heading, form, modalStatus);
   overlay.append(panel);
   document.body.append(overlay);
   close.addEventListener("click", () => overlay.remove());
@@ -145,18 +153,21 @@ function openProviderAccountModal({ bridgeRequest, getBridgeRequest, statusNode,
   form.addEventListener("submit", async (event) => {
     event.preventDefault();
     save.disabled = true;
-    setStatus(statusNode, "Saving provider account...");
+    setStatus(modalStatus, "Saving provider account…");
     try {
       await bridge()("/providers/accounts", {
         method: "POST",
         capability: "provider-credential-write",
         body: providerAccountPayload(form),
       });
+      // Success: close the dialog, then surface confirmation on the settings page.
       overlay.remove();
       setStatus(statusNode, "Provider account saved.", "success");
       await reload();
     } catch (error) {
-      setStatus(statusNode, `Provider account save failed: ${safeErrorMessage(error)}`, "error");
+      // Failure: keep the dialog open and show the reason in the dialog so the
+      // user can correct the input and retry — do not write it behind the modal.
+      setStatus(modalStatus, `Save failed: ${safeErrorMessage(error)}`, "error");
     } finally {
       save.disabled = false;
     }

--- a/browser-first/resonantos-side-panel-extension/src/styles/main-workspace/settings.css
+++ b/browser-first/resonantos-side-panel-extension/src/styles/main-workspace/settings.css
@@ -1035,6 +1035,21 @@
   justify-content: flex-end;
 }
 
+.settings-provider-modal-status {
+  min-height: 1.3em;
+  margin: 10px 2px 0;
+  font-size: 0.82rem;
+  color: rgba(143, 159, 149, 0.82);
+}
+
+.settings-provider-modal-status[data-tone="success"] {
+  color: rgba(36, 209, 143, 0.92);
+}
+
+.settings-provider-modal-status[data-tone="error"] {
+  color: rgba(255, 124, 124, 0.9);
+}
+
 .settings-provider-modal-actions button {
   border: 0;
   background: var(--accent);

--- a/browser-first/test/providers-section-modal.test.mjs
+++ b/browser-first/test/providers-section-modal.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { JSDOM } from "jsdom";
+
+import { openProviderAccountModal } from "../resonantos-side-panel-extension/src/lib/settings/providers-section.js";
+
+// Regression coverage for #271: the Add-provider dialog used to write save
+// errors to the settings page *behind* the still-open modal, so the user saw no
+// signal and the dialog appeared stuck. Errors must now stay inside the dialog
+// (which stays open) and only a success closes it.
+
+function setupDom() {
+  const dom = new JSDOM("<!doctype html><main id=\"root\"></main>", { url: "https://resonantos.local/" });
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  globalThis.Event = dom.window.Event;
+  globalThis.FormData = dom.window.FormData;
+  return {
+    dom,
+    statusNode: dom.window.document.querySelector("#root"),
+    cleanup: () => {
+      delete globalThis.window;
+      delete globalThis.document;
+      delete globalThis.Event;
+      delete globalThis.FormData;
+    },
+  };
+}
+
+const flush = async () => {
+  for (let i = 0; i < 3; i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+};
+
+function submitModal() {
+  const form = document.querySelector(".settings-provider-account-form");
+  assert.ok(form, "modal form should be mounted");
+  form.dispatchEvent(new globalThis.Event("submit", { bubbles: true, cancelable: true }));
+}
+
+test("#271 provider save failure stays in the dialog and keeps it open", async () => {
+  const { statusNode, cleanup } = setupDom();
+  try {
+    openProviderAccountModal({
+      bridgeRequest: async () => {
+        throw new Error("Invalid API base URL");
+      },
+      statusNode,
+      reload: async () => {},
+    });
+    submitModal();
+    await flush();
+
+    // Dialog stays open so the user can fix the input and retry.
+    assert.ok(document.querySelector(".settings-provider-modal"), "modal must remain open on failure");
+
+    // The error is shown INSIDE the dialog, with error tone.
+    const modalStatus = document.querySelector(".settings-provider-modal-status");
+    assert.ok(modalStatus, "in-dialog status node must exist");
+    assert.match(modalStatus.textContent, /Save failed/);
+    assert.match(modalStatus.textContent, /Invalid API base URL/);
+    assert.equal(modalStatus.dataset.tone, "error");
+
+    // The settings page behind the modal is NOT where the error goes.
+    assert.doesNotMatch(statusNode.textContent ?? "", /failed/i);
+  } finally {
+    cleanup();
+  }
+});
+
+test("#271 provider save success closes the dialog and confirms on the settings page", async () => {
+  const { statusNode, cleanup } = setupDom();
+  let reloaded = false;
+  try {
+    openProviderAccountModal({
+      bridgeRequest: async () => ({ ok: true }),
+      statusNode,
+      reload: async () => {
+        reloaded = true;
+      },
+    });
+    submitModal();
+    await flush();
+
+    assert.equal(document.querySelector(".settings-provider-modal"), null, "modal must close on success");
+    assert.match(statusNode.textContent, /saved/i);
+    assert.equal(statusNode.dataset.tone, "success");
+    assert.ok(reloaded, "reload() should run after a successful save");
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
Fixes #271. The Add-provider dialog wrote save progress + errors to the settings page **behind** the still-open modal, so a failed save gave the user no in-dialog signal and the dialog looked stuck.

- `providers-section.js`: export `openProviderAccountModal`; add an in-dialog status line; route saving/error there (dialog stays open so the user can correct + retry), success to the page after the dialog closes
- `settings.css`: style `.settings-provider-modal-status` (error/success tones)
- test: JSDOM regression — error stays in the open dialog, success closes it

Gates: full browser-first suite **823/823**; the regression guard proven **non-vacuous** via `rig-mutate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)