### PR TITLE
fix(agent-control): explain restricted pages instead of a generic no-target error

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/lib/control-target-classification.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/control-target-classification.js
@@ -1,0 +1,66 @@
+// Single source of truth for which browser tabs Agent Control can operate — and,
+// when it can't, a specific, human-facing reason.
+//
+// Chrome forbids extensions from injecting content scripts into its own pages
+// (chrome://, chrome-extension://, the Web Store, DevTools, view-source, about:,
+// other Chromium internal schemes). Agent Control reads and clicks a page through
+// an injected content script, so it can only operate normal http(s) websites.
+// This is a hard platform limit, not a ResonantOS choice — so when the only
+// available tab is a restricted page (e.g. chrome://settings), the right behavior
+// is to explain clearly, not to fail with a generic "no target" message.
+
+const GENERIC_NO_TARGET =
+  "Agent Control needs a normal web page target. Open or select a website first, " +
+  "or ask Augmentor to navigate to a site before operating the browser.";
+
+// Prefix → friendly label for the restricted schemes a normal browser exposes.
+const RESTRICTED_SCHEME_LABELS = [
+  ["chrome://", "a Chrome page"],
+  ["chrome-untrusted://", "a Chrome page"],
+  ["chrome-extension://", "an extension page"],
+  ["devtools://", "a DevTools page"],
+  ["view-source:", "a view-source page"],
+  ["about:", "a browser page"],
+  ["edge://", "a browser page"],
+  ["brave://", "a browser page"],
+];
+
+// The controllability predicate: a tab is operable only when it is an http(s)
+// page. Used everywhere a tab is considered as an Agent Control target so the
+// rule lives in exactly one place.
+export function isControllableTabUrl(url) {
+  return typeof url === "string" && /^https?:\/\//i.test(url);
+}
+
+function shortTarget(url) {
+  const value = String(url).trim();
+  return value.length > 64 ? `${value.slice(0, 61)}…` : value;
+}
+
+// Classify a candidate target URL into { controllable, reason, label, guidance }.
+// `guidance` is the message to show the human when a control command can't run:
+//   - "ok"          → controllable http(s) page (no guidance needed)
+//   - "empty"       → no open page / about:blank → the generic "open a site" ask
+//   - "restricted"  → a browser-internal page Chrome won't let us script, named
+//                     specifically, with what Agent Control can do instead
+export function classifyControlTarget(url) {
+  if (isControllableTabUrl(url)) {
+    return { controllable: true, reason: "ok", label: "", guidance: "" };
+  }
+  const value = typeof url === "string" ? url.trim() : "";
+  if (!value || /^about:blank$/i.test(value)) {
+    return { controllable: false, reason: "empty", label: "no open web page", guidance: GENERIC_NO_TARGET };
+  }
+  const lower = value.toLowerCase();
+  const match = RESTRICTED_SCHEME_LABELS.find(([prefix]) => lower.startsWith(prefix));
+  const label = match ? match[1] : "a page it can't operate";
+  return {
+    controllable: false,
+    reason: "restricted",
+    label,
+    guidance:
+      `Agent Control can't operate ${label} (${shortTarget(value)}) — Chrome blocks extensions ` +
+      "from reading or clicking its own pages. Open a normal website, or tell me to navigate to " +
+      "one, and I'll operate that. To change a Chrome setting, ask me and I'll walk you through the steps.",
+  };
+}

--- a/browser-first/resonantos-side-panel-extension/src/lib/side-panel-control-command-controller.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/side-panel-control-command-controller.js
@@ -1,4 +1,5 @@
 import { inferControlNavigationTarget } from "./browser-command-parser.js";
+import { classifyControlTarget } from "./control-target-classification.js";
 
 const TERMINAL_CONTROL_RUN_STATUSES = new Set(["completed", "blocked", "denied", "cancelled", "failed"]);
 
@@ -10,6 +11,7 @@ export function createSidePanelControlCommandController({
   createBrowserJob = async () => null,
   getBrowserJobScheduler = () => null,
   getCurrentControlRun = () => null,
+  getRawActiveTab = async () => null,
   currentReadableControlTab = activeTab,
   ensureControlTabForUrl = async () => null,
   permissionForUrl = async () => "ask-before-action",
@@ -62,7 +64,11 @@ export function createSidePanelControlCommandController({
 
     const tab = await currentReadableControlTab();
     if (!tab?.url) {
-      throw new Error("Agent Control needs a normal web page target. Open or select a webpage first, or ask Augmentor to navigate to a site before operating the browser.");
+      // No http(s) tab is available to operate. Name the actual active page
+      // (e.g. chrome://settings) and explain Chrome's platform limit instead of a
+      // generic dead-end, so the human knows why and what to do next.
+      const rawActive = await getRawActiveTab().catch(() => null);
+      throw new Error(classifyControlTarget(rawActive?.url).guidance);
     }
     return {
       kind: "current-page",

--- a/browser-first/resonantos-side-panel-extension/src/main-workspace.js
+++ b/browser-first/resonantos-side-panel-extension/src/main-workspace.js
@@ -1,5 +1,6 @@
 import { createBrowserPageActions } from "./lib/browser-page-actions.js";
 import { normalizeBrowserUrl } from "./lib/browser-command-parser.js";
+import { isControllableTabUrl } from "./lib/control-target-classification.js";
 import { createBridgeClient, createRawBridgeFetch, detectLoopbackBridge, initCapabilityTokens, isUnauthorizedBridgeError, resolveBridgeConfig } from "./lib/bridge-client.js";
 import { createPrefsSync } from "./lib/prefs-sync.js";
 import { createChatSessionStore } from "./lib/chat-session-store.js";
@@ -290,7 +291,7 @@ const taskConsentStore = createTaskConsentStore({
   taskConsentStorageKey: STORAGE_KEYS.taskConsents
 });
 
-const isReadableBrowserTab = (tab) => typeof tab?.url === "string" && /^https?:\/\//i.test(tab.url);
+const isReadableBrowserTab = (tab) => isControllableTabUrl(tab?.url);
 const setMainActivity = (_phase, label, detail = "") => {
   updateConnectionLine(detail ? `${label}: ${detail}` : label);
 };

--- a/browser-first/resonantos-side-panel-extension/src/side-panel.js
+++ b/browser-first/resonantos-side-panel-extension/src/side-panel.js
@@ -40,6 +40,7 @@ import { createSidePanelBrowserJobController } from "./lib/side-panel-browser-jo
 import { createSidePanelChatHydration } from "./lib/side-panel-chat-hydration.js";
 import { createSidePanelCommandRouter } from "./lib/side-panel-command-router.js";
 import { createSidePanelControlCommandController } from "./lib/side-panel-control-command-controller.js";
+import { isControllableTabUrl } from "./lib/control-target-classification.js";
 import { createSidePanelControlPreflightController } from "./lib/side-panel-control-preflight-controller.js";
 import {
   getSidePanelElements,
@@ -287,7 +288,7 @@ const browserJobStore = createBrowserJobStore({
   storageKeys: STORAGE_KEYS
 });
 
-const isReadableBrowserTab = (tab) => typeof tab?.url === "string" && /^https?:\/\//i.test(tab.url);
+const isReadableBrowserTab = (tab) => isControllableTabUrl(tab?.url);
 const sidePanelUi = createSidePanelUiController({
   activityDetail,
   activityLabel,
@@ -932,6 +933,7 @@ const controlCommandController = createSidePanelControlCommandController({
   ensureControlTabForUrl,
   getBrowserJobScheduler: () => browserJobScheduler,
   getCurrentControlRun: () => currentControlRun,
+  getRawActiveTab: async () => (await chrome.tabs.query({ active: true, currentWindow: true }).catch(() => []))[0] ?? null,
   permissionForUrl,
   persistContextDockExpanded,
   renderControlMonitor: () => renderControlMonitor(),

--- a/browser-first/test/control-target-classification.test.mjs
+++ b/browser-first/test/control-target-classification.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  classifyControlTarget,
+  isControllableTabUrl,
+} from "../resonantos-side-panel-extension/src/lib/control-target-classification.js";
+
+test("isControllableTabUrl accepts only http(s) pages", () => {
+  assert.equal(isControllableTabUrl("https://example.com"), true);
+  assert.equal(isControllableTabUrl("http://example.com/page"), true);
+  assert.equal(isControllableTabUrl("chrome://settings"), false);
+  assert.equal(isControllableTabUrl("chrome-extension://abc/main.html"), false);
+  assert.equal(isControllableTabUrl("about:blank"), false);
+  assert.equal(isControllableTabUrl(""), false);
+  assert.equal(isControllableTabUrl(undefined), false);
+});
+
+test("classifyControlTarget marks a normal website controllable", () => {
+  const result = classifyControlTarget("https://fifa.com/news");
+  assert.equal(result.controllable, true);
+  assert.equal(result.reason, "ok");
+  assert.equal(result.guidance, "");
+});
+
+test("classifyControlTarget names the restricted Chrome page and explains why", () => {
+  const result = classifyControlTarget("chrome://settings");
+  assert.equal(result.controllable, false);
+  assert.equal(result.reason, "restricted");
+  assert.equal(result.label, "a Chrome page");
+  // The message must name the page and explain the platform limit — not a generic ask.
+  assert.match(result.guidance, /chrome:\/\/settings/);
+  assert.match(result.guidance, /Chrome blocks extensions/);
+});
+
+test("classifyControlTarget labels other restricted schemes", () => {
+  assert.equal(classifyControlTarget("chrome-extension://abc/x.html").label, "an extension page");
+  assert.equal(classifyControlTarget("view-source:https://x.com").label, "a view-source page");
+  assert.equal(classifyControlTarget("about:preferences").label, "a browser page");
+});
+
+test("classifyControlTarget falls back to the generic ask for no open page", () => {
+  for (const empty of [undefined, "", "about:blank"]) {
+    const result = classifyControlTarget(empty);
+    assert.equal(result.controllable, false);
+    assert.equal(result.reason, "empty");
+    assert.match(result.guidance, /needs a normal web page target/);
+  }
+});

--- a/browser-first/test/side-panel-control-command-controller.test.mjs
+++ b/browser-first/test/side-panel-control-command-controller.test.mjs
@@ -50,6 +50,7 @@ function createHarness({
       }
     }),
     getCurrentControlRun: () => currentRun,
+    getRawActiveTab: async () => activeTab,
     permissionForUrl: async () => permissionMode,
     persistContextDockExpanded: async () => events.push(["persist-dock"]),
     renderControlMonitor: () => events.push(["render-control"]),
@@ -158,7 +159,24 @@ test("control command controller refuses current-page jobs when only ResonantOS 
 
   assert.equal(result, null);
   assert.ok(harness.events.some((event) => event[0] === "status" && event[1] === "Control target unavailable"));
-  assert.ok(harness.events.some((event) => event[0] === "message" && /normal web page target/.test(event[2])));
+  // The message names the restricted page and explains why, not a generic ask.
+  assert.ok(harness.events.some((event) => event[0] === "message" && /can't operate an extension page/.test(event[2])));
+  assert.equal(harness.events.some((event) => event[0] === "create-job"), false);
+});
+
+test("control command controller explains chrome:// pages can't be operated (#chrome-internal)", async () => {
+  const harness = createHarness({
+    activeTab: { id: 9, url: "chrome://settings" },
+    currentReadableControlTab: null
+  });
+
+  const result = await harness.controller.runControlCommand("click the On startup option");
+
+  assert.equal(result, null);
+  const message = harness.events.find((event) => event[0] === "message")?.[2] ?? "";
+  assert.match(message, /can't operate a Chrome page/);
+  assert.match(message, /chrome:\/\/settings/);
+  assert.match(message, /Chrome blocks extensions/);
   assert.equal(harness.events.some((event) => event[0] === "create-job"), false);
 });
 


### PR DESCRIPTION
## Why it failed
On a Chrome-internal page (`chrome://settings`, an extension page, `view-source:`, `about:`, DevTools) with no normal web tab open, Agent Control threw a generic *\"needs a normal web page target\"* error. Root cause: the controllable predicate is `http(s)`-only ([`side-panel.js:290`](https://github.com/ResonantOS/2.0.0-alpha/blob/dev/browser-first/resonantos-side-panel-extension/src/side-panel.js)), and **Chrome forbids extensions from scripting its own pages** — so `currentReadableControlTab()` returns null and the command dead-ends without saying why. Controlling `chrome://` is a hard platform limit, not a bug.

## Full-scope fix (handling + messaging, since control of chrome:// is impossible)
- **`control-target-classification.js`** — single source of truth for the `http(s)` controllability rule (`isControllableTabUrl`) + a classifier that names the restricted page and gives actionable guidance
- **controller** — when no readable tab exists, classify the *raw* active tab (new `getRawActiveTab` dep, since `activeTab` is readable-filtered) and surface the specific reason
- **dedupe** the duplicated `isReadableBrowserTab` predicate in `side-panel.js` + `main-workspace.js` onto the shared helper
- **tests** — classifier unit tests + controller cases for `chrome://` and extension pages; restricted-page message proven **non-vacuous** via `rig-mutate`

## Gates
full browser-first **829/829**, vitest **312/312**, `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)