### PR TITLE
fix(test): settle the public-submit job before classifying and release its page lock

### DIFF
--- a/browser-first/test/agent-control-live.mjs
+++ b/browser-first/test/agent-control-live.mjs
@@ -625,8 +625,25 @@ async function verifyPublicSubmitBoundary(panel, page) {
   }
   const blockedState = (await evaluate(page, `({ submitted: window.__submitted, status: document.querySelector("#status").textContent })`)).result.value;
   assert(!blockedState.submitted, `Public-submit boundary executed the action: ${JSON.stringify(blockedState)}`);
-  const approvalJobs = outcome.publicJobs.filter((job) => job.status === "approval" && job.pendingApproval);
-  const hasExecutableApproval = outcome.buttons.includes("Approve once");
+  // The human-only refusal message renders before the job finishes settling, so
+  // `outcome` can be sampled while the job is still queued/running. Classifying
+  // from that snapshot both misses a late "approval" job (a false pass on the
+  // human-only property) and leaves it holding the tab page lock, which starves
+  // every later scenario. Re-read the job store once the job has settled.
+  const settledPublicJobs = await waitForPageCondition(panel, `(async () => {
+    const jobs = (await chrome.storage.local.get("augmentorBrowserJobs")).augmentorBrowserJobs ?? [];
+    const publicJobs = jobs.filter((job) => /Submit public form/i.test(job.goal ?? "")
+      || /Submit public form/i.test(job.pendingApproval?.step?.text ?? ""));
+    if (!publicJobs.length) return false;
+    const settled = publicJobs.every((job) => !["queued", "running"].includes(job.status));
+    if (!settled) return false;
+    const buttons = [...document.querySelectorAll("button")]
+      .filter((button) => /click "Submit public form"/i.test(button.title || ""))
+      .map((button) => button.textContent.trim());
+    return { publicJobs, buttons };
+  })()`, "public-submit job settle");
+  const approvalJobs = settledPublicJobs.publicJobs.filter((job) => job.status === "approval" && job.pendingApproval);
+  const hasExecutableApproval = settledPublicJobs.buttons.includes("Approve once");
   const humanHandoff = outcome.humanSignal && approvalJobs.length === 0 && !hasExecutableApproval;
   const decision = decidePublicSubmitScenario({ mode: publicSubmitContract, humanHandoff });
   certificationReport.record("post-approval-public-submit", decision.status, decision.reason);


### PR DESCRIPTION
## Summary

The `agent-control-live` certification has failed on every run since #268 merged: 21 consecutive failures, with the last success on 2026-07-18 (run on the #267 branch, before #268 landed on `dev`). This restores it.

Fixes the failure reported at `browser-first/test/agent-control-live.mjs` "iframe context read", and re-enables the ~15 assertions that sit after it and had not executed on `dev` since.

## Root cause

`verifyPublicSubmitBoundary` exits as soon as the human-only refusal *message* renders:

```js
if (!publicJobs.length && !humanSignal) return false;
```

That happens before the job settles. Two consequences:

1. **Page-lock starvation (the visible failure).** The job then reaches `approval` status, which is in `LOCK_HOLDING_JOB_STATUSES`, and holds the tab page lock. Because classification had already scored `approvalJobs` as empty, the `humanHandoff` branch ran and skipped the existing deny cleanup. Every later scenario's job queued behind that lock forever, so the iframe read never ran and its `waitForPanelText` timed out.

   Confirmed from the job store at the failing assertion:

   ```json
   { "goal": "click \"Submit public form\"", "status": "approval",
     "pageLock": { "siteKey": "127.0.0.1", "tabId": 1872933921 },
     "pendingApprovalText": "Submit public form" },
   { "goal": "book a call now", "status": "queued" }
   ```

2. **A possible false pass on the #240 property (the more serious one).** An `approval` job arriving after the snapshot was scored as "no approval job exists", giving `humanHandoff = true`, which `decidePublicSubmitScenario` reports as **passed**: "#240 human-only public-submit handoff is active and no executable approval is exposed." The certification could therefore have certified #240 as satisfied while an approval-status job with a live `pendingApproval` existed.

   After this change the same revision correctly reports `gated` — "#240 human-only public-submit handoff is not present in this revision" — which matches reality: an executable "Approve once" control is still exposed for public submit. See #240.

## Change

Re-read the job store and the approval buttons once no public-submit job is `queued`/`running`, and classify from that settled state instead of the transient snapshot. 19 lines, one file.

**No assertion is relaxed.** The safety property is still asserted directly and unconditionally: `assert(!blockedState.submitted, ...)` — the public submit must not execute. This changes *when* state is read, not what is required.

## How this was verified

Three hypotheses were tested against CI before any fix was written; the first two were refuted by instrumented runs rather than argument:

| Hypothesis | Verdict |
| --- | --- |
| Dock popout hides panel text from `innerText` (#79299ec) | Refuted — probe returned `textContentHasNeedle: false`; the text is never rendered |
| Command parsing/routing regression (#92c6053) | Refuted — the job is created correctly, it simply never runs |
| Page-lock starvation from a parked `approval` job | Confirmed by the job-store dump above |

All diagnostic instrumentation was reverted before this commit; the branch carries the fix only.

## Checks run

- `npm run test:browser-first` — 829 passed, 0 failed
- `node scripts/security-pipeline/run-check.mjs` — exit 0 (the single `off-list-approved` openssl finding is pre-existing and carries an approval marker)
- `agent-control-live.yml` on this branch — **passed-with-gates**: 54 passed, 0 failed, 1 gated, 1 excluded
  - gated: `post-approval-public-submit` — #240 not present in this revision
  - excluded: `provider-inline-assistant-flow` — separate certification lane

Runs: [29895288043](https://github.com/ResonantOS/2.0.0-alpha/actions/runs/29895288043) (fix), [29895510046](https://github.com/ResonantOS/2.0.0-alpha/actions/runs/29895510046) (re-verified after removing an unused defensive branch).

## Notes

- A first draft added a third branch to handle "refusal rendered, no executable approval, but an approval job exists". The certification report showed it never fired, so it was removed — unexercised defensive code in a harness can silently *gate* a novel state that should fail loudly.
- The live harness still cannot be reproduced locally: it fails early with `Side panel did not finish binding listeners` / `hasInput: false`, i.e. it never attaches to the real side-panel document outside CI. That is separate from this fix and worth its own issue under #267's "restore" intent — a safety gate nobody can run locally is hard to maintain.

Refs #267. Evidence for #240.

_Authored with AI assistance (Claude); all diagnosis was verified against CI runs and the checks listed above._
