### PR TITLE
fix(#226): halt Agent Control runs immediately on stop/cancel and show recovery state

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/lib/agent-control-runner.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/agent-control-runner.js
@@ -391,6 +391,7 @@ export function createAgentControlRunner(deps) {
     executeControlStep,
     finishControlRun,
     getActiveJobId,
+    getActiveJobStatus = () => null,
     getCurrentControlRun,
     getLastSnapshot,
     renderControlMonitor,
@@ -408,9 +409,47 @@ export function createAgentControlRunner(deps) {
     updateControlStep
   } = deps;
 
+  function stoppedJobStatus() {
+    const status = getActiveJobStatus();
+    return ["cancelled", "paused"].includes(status) ? status : null;
+  }
+
+  async function stopRun(status, { goal = "", results = [] } = {}) {
+    finishControlRun(status);
+    setPendingApproval(null);
+    renderControlMonitor();
+    setStatus(status === "paused" ? "Paused" : "Cancelled");
+    setActivity(status === "paused" ? "paused" : "failed", status === "paused" ? "Control paused" : "Control stopped", goal);
+    await addMessage(
+      "system",
+      [
+        `Agent Control Mode ${status === "paused" ? "paused" : "stopped by human"}.`,
+        `Goal: ${goal}`,
+        "No further browser actions ran after stop. Pending approval and page control are cleared.",
+        "Review the page state, then continue the job or start a new task when ready."
+      ].join("\n")
+    );
+    await updateBrowserJob(getActiveJobId(), { status });
+    return { ok: false, results, stopped: status };
+  }
+
+  async function stopRunWithStep(status, { goal = "", results = [], stepIndex = null } = {}) {
+    if (stepIndex !== null) {
+      updateControlStep(stepIndex, "cancelled", "Stopped by human.", {
+        phase: "cancelled",
+        nextHumanAction: "Review the page state and restart or resume the browser task when ready."
+      });
+    }
+    return stopRun(status, { goal, results });
+  }
+
   async function continueControlLoop({ goal, history = [], results = [], startIndex = 0, maxSteps = 12 } = {}) {
     try {
       for (let loopIndex = startIndex; loopIndex < maxSteps; loopIndex += 1) {
+        const stoppedBeforeLoop = stoppedJobStatus();
+        if (stoppedBeforeLoop) {
+          return stopRun(stoppedBeforeLoop, { goal, results });
+        }
         await updateBrowserJob(getActiveJobId(), { status: "running" });
         await setPageControlOverlay(true, "reading", "reading");
         const snapshot = await deps.observeControlPage();
@@ -516,6 +555,10 @@ export function createAgentControlRunner(deps) {
           return { ok: false, results, approvalRequired: isApproval };
         }
 
+        const stoppedBeforeAction = stoppedJobStatus();
+        if (stoppedBeforeAction) {
+          return stopRun(stoppedBeforeAction, { goal, results });
+        }
         const step = decision.action;
         const repeatedNoChange = repeatedNoChangeActionEvidence(history, step);
         if (repeatedNoChange) {
@@ -596,6 +639,10 @@ export function createAgentControlRunner(deps) {
         await setPageControlOverlay(true, overlayAction.label, overlayAction.phase);
         setActivity("tool-running", `Executing browser action ${stepIndex + 1}`, controlStepLabel(step));
         const result = await executeControlStep(step);
+        const stoppedAfterAction = stoppedJobStatus();
+        if (stoppedAfterAction) {
+          return stopRunWithStep(stoppedAfterAction, { goal, results, stepIndex });
+        }
         await setPageControlOverlay(true, "verifying", "verifying");
         const verificationSnapshot = await deps.observeControlPage().catch(() => null);
         const verification = verifyBrowserAction({
@@ -608,6 +655,10 @@ export function createAgentControlRunner(deps) {
         const consent = result?.approvalRequired && boundary === "safe"
           ? await taskConsentForStep({ goal, step, result })
           : null;
+        const stoppedBeforeConsentExecute = stoppedJobStatus();
+        if (stoppedBeforeConsentExecute) {
+          return stopRunWithStep(stoppedBeforeConsentExecute, { goal, results, stepIndex });
+        }
         const finalStep = consent ? { ...step, userApproved: true } : step;
         const finalResult = consent ? await executeControlStep(finalStep) : result;
         let postActionSnapshot = verificationSnapshot;
@@ -647,6 +698,10 @@ export function createAgentControlRunner(deps) {
           verification: finalVerification
         });
         if (retryStep) {
+          const stoppedBeforeRetry = stoppedJobStatus();
+          if (stoppedBeforeRetry) {
+            return stopRunWithStep(stoppedBeforeRetry, { goal, results, stepIndex });
+          }
           actionRetry = retryStep.retryStrategy;
           await setPageControlOverlay(true, "clicking", "clicking");
           executedStep = retryStep;
@@ -838,6 +893,14 @@ export function createAgentControlRunner(deps) {
 
   async function approvePendingControlStep(approval) {
     if (!approval || !getCurrentControlRun()) return;
+    const stoppedWhileApproval = stoppedJobStatus();
+    if (stoppedWhileApproval) {
+      setPendingApproval(null);
+      return stopRun(stoppedWhileApproval, {
+        goal: getCurrentControlRun().goal,
+        results: Array.isArray(approval.results) ? approval.results : []
+      });
+    }
     setPendingApproval(null);
     renderControlMonitor();
     setStatus("Approved once");

--- a/browser-first/resonantos-side-panel-extension/src/lib/monitor-progress.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/monitor-progress.js
@@ -122,6 +122,13 @@ export function controlRunSummary(run) {
       body: "Augmentor stopped at a gated action. Review the page, then approve once, trust safe actions for this task class, deny, or delegate the issue.",
     };
   }
+  if (run?.status === "cancelled") {
+    return {
+      state: "cancelled",
+      title: "Task stopped",
+      body: "Augmentor stopped before the next browser action. No pending approval or page control remains active. Review the page state, then continue the job, start a new task, or save a report.",
+    };
+  }
   if (run?.status === "denied") {
     return {
       state: "blocked",

--- a/browser-first/resonantos-side-panel-extension/src/lib/side-panel-scheduled-browser-job-runner.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/side-panel-scheduled-browser-job-runner.js
@@ -151,6 +151,7 @@ export function createSidePanelScheduledBrowserJobRunner({
         syncFocusedLocalRun();
       },
       getActiveJobId: () => job.id,
+      getActiveJobStatus: () => browserJobStore.findJob(job.id)?.status ?? null,
       getCurrentControlRun: () => localRun,
       getLastSnapshot: () => localLastSnapshot,
       observeControlPage: () => observeQueuedJobPage(job, {

--- a/browser-first/resonantos-side-panel-extension/src/side-panel.js
+++ b/browser-first/resonantos-side-panel-extension/src/side-panel.js
@@ -823,6 +823,7 @@ const agentControlRunner = createAgentControlRunner({
   executeControlStep,
   finishControlRun,
   getActiveJobId: () => browserJobStore.getActiveJobId(),
+  getActiveJobStatus: () => browserJobStore.findJob(browserJobStore.getActiveJobId())?.status ?? null,
   getCurrentControlRun: () => currentControlRun,
   getLastSnapshot: () => lastSnapshot,
   observeControlPage,

--- a/browser-first/test/agent-control-runner.test.mjs
+++ b/browser-first/test/agent-control-runner.test.mjs
@@ -33,6 +33,7 @@ function createHarness(overrides = {}) {
   const stepResults = overrides.stepResults ?? [{ ok: true, clickedText: "Next" }];
   const savedReports = [];
   let stepResultIndex = 0;
+  let jobStatus = overrides.jobStatus ?? null;
 
   const deps = {
     addMessage: async (role, content) => events.push(["message", role, content]),
@@ -55,6 +56,7 @@ function createHarness(overrides = {}) {
     },
     executeControlStep: async (step) => {
       events.push(["execute", step]);
+      if (overrides.executeControlStep) return overrides.executeControlStep(step);
       return stepResults[stepResultIndex++] ?? { ok: true };
     },
     finishControlRun: (status, artifact = null) => {
@@ -66,6 +68,7 @@ function createHarness(overrides = {}) {
       events.push(["finish", status]);
     },
     getActiveJobId: () => activeJobId,
+    getActiveJobStatus: () => jobStatus,
     getCurrentControlRun: () => controlRun,
     getLastSnapshot: () => lastSnapshot,
     observeControlPage: async () => {
@@ -123,6 +126,9 @@ function createHarness(overrides = {}) {
     nextActionRequests,
     getPendingApproval: () => pendingApproval,
     runner: createAgentControlRunner(deps),
+    setJobStatus: (status) => {
+      jobStatus = status;
+    },
     setLastSnapshot: (snapshot) => {
       lastSnapshot = snapshot;
     }
@@ -523,4 +529,79 @@ test("agent control runner can approve or deny a pending step through injected s
   assert.equal(denyHarness.getControlRun().steps[0].details.approvalDecision, "denied");
   assert.equal(denyHarness.getSavedReports().at(-1).status, "denied");
   assert.equal(denyHarness.getSavedReports().at(-1).results.at(-1).result.error, "denied by human");
+});
+
+test("#226: cancellation during preflight halts the run before any step executes", async () => {
+  const harness = createHarness({ jobStatus: "cancelled" });
+
+  const result = await harness.runner.continueControlLoop({ goal: "click next" });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.stopped, "cancelled");
+  assert.equal(harness.events.filter((event) => event[0] === "execute").length, 0);
+  assert.equal(harness.nextActionRequests.length, 0);
+  assert.equal(harness.getControlRun().status, "cancelled");
+  assert.equal(harness.getPendingApproval(), null);
+  assert.ok(harness.events.some((event) => event[0] === "message" && /stopped by human/.test(event[2])));
+  assert.ok(harness.events.some((event) => event[0] === "job" && event[2].status === "cancelled"));
+});
+
+test("#226: cancellation mid-step halts the run before the next action plans or executes", async () => {
+  const harness = createHarness({
+    executeControlStep: async (step) => {
+      harness.setJobStatus("cancelled");
+      return { ok: true, clickedText: "Next" };
+    }
+  });
+
+  const result = await harness.runner.continueControlLoop({ goal: "click next" });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.stopped, "cancelled");
+  assert.equal(harness.events.filter((event) => event[0] === "execute").length, 1);
+  assert.equal(harness.nextActionRequests.length, 1);
+  assert.equal(harness.getControlRun().status, "cancelled");
+  assert.equal(harness.getControlRun().steps[0].state, "cancelled");
+  assert.equal(harness.getControlRun().steps[0].note, "Stopped by human.");
+  assert.match(harness.getControlRun().steps[0].details.nextHumanAction, /restart or resume/);
+  assert.equal(harness.getPendingApproval(), null);
+});
+
+test("#226: pause mid-step halts the run as paused without executing further steps", async () => {
+  const harness = createHarness({
+    executeControlStep: async (step) => {
+      harness.setJobStatus("paused");
+      return { ok: true, clickedText: "Next" };
+    }
+  });
+
+  const result = await harness.runner.continueControlLoop({ goal: "click next" });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.stopped, "paused");
+  assert.equal(harness.events.filter((event) => event[0] === "execute").length, 1);
+  assert.equal(harness.nextActionRequests.length, 1);
+  assert.equal(harness.getControlRun().status, "paused");
+  assert.equal(harness.getPendingApproval(), null);
+});
+
+test("#226: approving a pending step after cancellation executes nothing and clears the approval", async () => {
+  const harness = createHarness({ jobStatus: "cancelled" });
+  harness.getControlRun().steps.push({ type: "click", text: "Place order", state: "blocked" });
+  const approval = {
+    step: { type: "click", text: "Place order", submit: true },
+    stepIndex: 0,
+    reason: "public submit requires human approval",
+    results: [],
+    history: []
+  };
+
+  const result = await harness.runner.approvePendingControlStep(approval);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.stopped, "cancelled");
+  assert.equal(harness.events.filter((event) => event[0] === "execute").length, 0);
+  assert.equal(harness.getControlRun().status, "cancelled");
+  assert.equal(harness.getPendingApproval(), null);
+  assert.ok(harness.events.some((event) => event[0] === "message" && /stopped by human/.test(event[2])));
 });

--- a/browser-first/test/monitor-progress.test.mjs
+++ b/browser-first/test/monitor-progress.test.mjs
@@ -70,4 +70,12 @@ test("monitor progress helpers summarize terminal runs", () => {
     steps: [{ state: "blocked", details: { nextHumanAction: "Pick the target." } }],
   }).body, /Pick the target/);
   assert.equal(controlRunSummary({ status: "running", steps: [] }), null);
+  assert.deepEqual(controlRunSummary({
+    status: "cancelled",
+    steps: [{ state: "cancelled", details: { nextHumanAction: "Review the page state." } }],
+  }), {
+    state: "cancelled",
+    title: "Task stopped",
+    body: "Augmentor stopped before the next browser action. No pending approval or page control remains active. Review the page state, then continue the job, start a new task, or save a report.",
+  });
 });


### PR DESCRIPTION
Closes #226 (implementation; live-browser proof still gated on #267)

## What changed and why

Stop/cancel previously marked the durable job `cancelled` but the running
observe-act-verify loop never observed it: steps kept planning and
executing up to the step limit, a late blocked step could re-arm a
pending approval after cancel, and the monitor showed cancelled runs with
the generic "blocked" summary instead of a clear stopped state.

- **Runner (`agent-control-runner.js`)**: the loop now checks the durable
  job status at every boundary — before each iteration (preflight),
  before executing a step, immediately after an in-flight step resolves,
  and before consent / precise-ref retry re-execution. A stopped job
  halts the run with `cancelled`/`paused` status, marks the interrupted
  step `cancelled` ("Stopped by human."), clears pending approval, and
  messages the human with the safe recovery action. No further step
  plans or executes after stop.
- **Approval gate**: `approvePendingControlStep` refuses to execute when
  the job was already cancelled — the approval card is cleared instead of
  a stale "Approve once" acting on a cancelled run.
- **Monitor (`monitor-progress.js`)**: cancelled runs render a distinct
  "Task stopped" summary card: "No pending approval or page control
  remains active. Review the page state, then continue the job, start a
  new task, or save a report."
- **Wiring**: `getActiveJobStatus` added to both runner instantiations
  (side-panel chat path and the scheduled browser-job runner).

## Ownership / security / privacy impact

- Files touched: `src/lib/agent-control-runner.js`,
  `src/lib/monitor-progress.js`, `src/lib/side-panel-scheduled-browser-job-runner.js`,
  `src/side-panel.js` — all in the governed browser-control module.
- No wallet, signing, credential, login, payment, checkout, public-submit,
  raw-secret, bridge-auth, or trusted-memory safeguard is weakened; the
  change only removes the ability to *continue* after a human stop.
- Cancellation now clears pending approval and persists the stopped job
  status — it cannot leave dangling approval authority.

## Checks run (all green)

- `npm run test:browser-first` — 833/833 pass (4 new tests)
- `node scripts/security-pipeline/run-check.mjs` — all checks pass (exit 0)
- Focused: `node --test browser-first/test/agent-control-runner.test.mjs browser-first/test/monitor-progress.test.mjs browser-first/test/monitor-renderers.test.mjs` — 37/37 pass

## Known limitation

Live-browser proof for the stop button UX is required before #226 closes;
the live harness is gated on #267 (CI currently red until #279/#240 land).
