### PR TITLE
feat(#225): durable job trace with visible step counter and redacted exports

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/lib/control-reporting-service.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/control-reporting-service.js
@@ -2,6 +2,7 @@ import {
   controlRunProgress,
   controlRunProgressSummary
 } from "./monitor-renderers.js";
+import { redactTraceText } from "./trace-redaction.js";
 
 export function createControlReportingService({
   addMessage,
@@ -98,7 +99,7 @@ export function createControlReportingService({
     const currentControlRun = getCurrentControlRun();
     if (!currentControlRun) return "";
     const lastSnapshot = getLastSnapshot();
-    return [
+    const report = [
       "# Browser Agent Control Report",
       "",
       `- id: ${currentControlRun.id}`,
@@ -131,6 +132,7 @@ export function createControlReportingService({
       "This is an intake artifact only. Wallet, credential, public-submit, payment, and destructive actions require explicit human approval.",
       ""
     ].join("\n");
+    return redactTraceText(report);
   };
 
   const saveControlReportToArchive = async (results, status) => {
@@ -154,7 +156,7 @@ export function createControlReportingService({
     const steps = Array.isArray(job.steps) ? job.steps : [];
     const artifacts = Array.isArray(job.artifacts) ? job.artifacts : [];
     const preflight = job.preflightDecision;
-    return [
+    const report = [
       "# Browser Job Report",
       "",
       `- id: ${job.id}`,
@@ -206,6 +208,7 @@ export function createControlReportingService({
       "This is an intake artifact only. Wallet, credential, public-submit, payment, and destructive actions require explicit human approval.",
       ""
     ].join("\n");
+    return redactTraceText(report);
   };
 
   const buildControlDelegationPacket = () => {
@@ -215,7 +218,7 @@ export function createControlReportingService({
     const lastSnapshot = getLastSnapshot();
     const step = pendingApproval?.step;
     const steps = Array.isArray(currentControlRun?.steps) ? currentControlRun.steps : [];
-    return [
+    const packet = [
       "# Browser Control Delegation Context",
       "",
       "## Requested Outcome",
@@ -251,6 +254,7 @@ export function createControlReportingService({
       "The receiving add-on gets this context packet only. ResonantOS keeps provider routing, wallet actions, credentials, browser permissions, and trusted memory writes mediated.",
       ""
     ].join("\n");
+    return redactTraceText(packet);
   };
 
   const saveBrowserJobReportToArchive = async (job) => {
@@ -279,12 +283,12 @@ export function createControlReportingService({
         contextMarkdown: buildControlDelegationPacket(),
         source: "browser-control-blocker",
         sourceControlRunId: currentControlRun?.id ?? "",
-        mission: [
+        mission: redactTraceText([
           "Investigate blocked browser-control task.",
           `Goal: ${currentControlRun?.goal ?? "unknown"}`,
           step ? `Blocked step: ${controlStepLabel(step)}` : "",
           pendingApproval?.reason ? `Reason: ${pendingApproval.reason}` : ""
-        ].filter(Boolean).join("\n")
+        ].filter(Boolean).join("\n"))
       }
     }).catch((error) => ({ error: error instanceof Error ? error.message : String(error) }));
     await addMessage(

--- a/browser-first/resonantos-side-panel-extension/src/lib/trace-redaction.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/trace-redaction.js
@@ -1,0 +1,20 @@
+// Redaction pass for durable Agent Control trace artifacts (reports and
+// delegation packets). The in-memory run keeps full fidelity for resume and
+// UX; only exported artifacts pass through this scrubber so secrets echoed in
+// goals, URLs, notes, or errors never reach the archive.
+
+const SECRET_URL_PARAM_NAMES =
+  "(?:token|key|secret|password|passwd|pwd|pin|otp|auth[_-]?code|access[_-]?token|refresh[_-]?token|api[_-]?key|session|sid|signature|csrf|jwt)";
+const URL_PARAM_PATTERN = new RegExp(`([?&])(${SECRET_URL_PARAM_NAMES})(=)([^&#\\s]*)`, "gi");
+const SECRET_ASSIGNMENT_NAMES =
+  "(?:password|passwd|pwd|token|secret|api[_-]?key|access[_-]?token|refresh[_-]?token|otp|pin|auth[_-]?code|signature|jwt)";
+const ASSIGNMENT_PATTERN = new RegExp(`\\b(${SECRET_ASSIGNMENT_NAMES})(\\s*[=:]\\s*)[^\\s,;&#]+`, "gi");
+const HEX_TOKEN_PATTERN = /\b[0-9a-fA-F]{32,}\b/g;
+
+export function redactTraceText(value) {
+  if (typeof value !== "string") return "";
+  return String(value)
+    .replace(URL_PARAM_PATTERN, (match, separator, name, eq) => `${separator}${name}${eq}REDACTED`)
+    .replace(ASSIGNMENT_PATTERN, (match, name, separator) => `${name}${separator}REDACTED`)
+    .replace(HEX_TOKEN_PATTERN, "[REDACTED-TOKEN]");
+}

--- a/browser-first/test/control-reporting-service.test.mjs
+++ b/browser-first/test/control-reporting-service.test.mjs
@@ -94,6 +94,75 @@ test("control reporting service builds browser control reports with boundaries",
   assert.match(report, /Wallet, credential, public-submit, payment, and destructive actions/);
 });
 
+test("control reporting service redacts secret-like values from reports", () => {
+  const harness = createHarness({
+    currentControlRun: {
+      id: "job-1",
+      goal: "book with password=hunter2secret and pin: 9876",
+      planner: "observe-act-verify-loop",
+      startedAt: "2026-05-26T10:00:00.000Z",
+      summary: "Observe and act",
+      status: "completed",
+      timing: { durationMs: 1000 },
+      steps: [
+        { type: "type", field: "Search", state: "completed", note: 'typed "vintage synths"', details: { confidence: "high" } },
+        { type: "click", text: "Submit", state: "blocked", note: "auth token 7f3c9a1b2d4e5f68790a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f", details: { confidence: "low" } }
+      ],
+      pageLock: { tabId: 7, siteKey: "example.test", url: "https://example.test/login?token=abc123&email=a@b.com", reason: "Agent Control goal" }
+    }
+  });
+
+  const report = harness.service.buildControlReport([
+    { step: { type: "type", field: "Search", state: "completed", note: 'typed "vintage synths"' }, result: { ok: true } },
+    { step: { type: "click", text: "Submit", state: "blocked" }, result: { ok: false, error: "auth token 7f3c9a1b2d4e5f68790a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f" } }
+  ], "blocked");
+
+  assert.match(report, /password=REDACTED/);
+  assert.doesNotMatch(report, /hunter2secret/);
+  assert.match(report, /pin: REDACTED/);
+  assert.match(report, /token=REDACTED/);
+  assert.doesNotMatch(report, /abc123/);
+  assert.match(report, /email=a@b\.com/);
+  assert.match(report, /\[REDACTED-TOKEN\]/);
+  assert.doesNotMatch(report, /7f3c9a1b/);
+});
+
+test("control reporting service redacts secrets from job reports and delegation packets", async () => {
+  const harness = createHarness({
+    pendingApproval: {
+      step: { type: "click", text: "Submit" },
+      reason: "Public submit requires approval with token=xyz789"
+    }
+  });
+  const job = {
+    id: "job-2",
+    goal: "compare a product",
+    status: "blocked",
+    planner: "observe-act-verify-loop",
+    createdAt: "2026-05-26T09:00:00.000Z",
+    updatedAt: "2026-05-26T09:02:00.000Z",
+    timing: { durationMs: 122000 },
+    summary: "Observed and compared",
+    pageLock: { tabId: 12, siteKey: "example.com", url: "https://example.com/session?session=abc", reason: "Product comparison task" },
+    steps: [
+      { label: "Read page", state: "completed", note: "read product page", timing: { durationMs: 1500 }, details: { confidence: "high" } },
+      { label: "Click details", state: "blocked", note: "clicked details", details: { confidence: "low", nextHumanAction: "Focus the correct product row before resuming." } }
+    ],
+    artifacts: []
+  };
+
+  const report = harness.service.buildBrowserJobReport(job);
+  assert.match(report, /session=REDACTED/);
+  assert.doesNotMatch(report, /abc/);
+
+  await harness.service.delegateControlIssue();
+  const bridgeCall = harness.events.find((event) => event[0] === "bridge");
+  assert.match(bridgeCall[2].contextMarkdown, /token=REDACTED/);
+  assert.doesNotMatch(bridgeCall[2].contextMarkdown, /xyz789/);
+  assert.match(bridgeCall[2].mission, /token=REDACTED/);
+  assert.doesNotMatch(bridgeCall[2].mission, /xyz789/);
+});
+
 test("control reporting service saves reports to archive intake", async () => {
   const harness = createHarness();
 

--- a/browser-first/test/trace-redaction.test.mjs
+++ b/browser-first/test/trace-redaction.test.mjs
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { redactTraceText } from "../resonantos-side-panel-extension/src/lib/trace-redaction.js";
+
+test("redactTraceText redacts secret URL query parameters and preserves benign ones", () => {
+  const input = "https://example.test/login?token=abc123&email=a@b.com&api_key=sekrit&ref=home";
+  const output = redactTraceText(input);
+  assert.equal(output, "https://example.test/login?token=REDACTED&email=a@b.com&api_key=REDACTED&ref=home");
+});
+
+test("redactTraceText redacts secret assignment forms", () => {
+  assert.equal(redactTraceText("password=hunter2secret"), "password=REDACTED");
+  assert.equal(redactTraceText("password: hunter2secret"), "password: REDACTED");
+  assert.equal(redactTraceText("password:hunter2secret"), "password:REDACTED");
+  const bearer = redactTraceText("Token: Bearer abc123");
+  assert.match(bearer, /Token: REDACTED/);
+  assert.doesNotMatch(bearer, /Bearer/);
+  assert.equal(redactTraceText("api_key = super-secret-value"), "api_key = REDACTED");
+  assert.equal(redactTraceText("pin: 9876"), "pin: REDACTED");
+  assert.equal(redactTraceText("otp is 123456"), "otp is 123456");
+});
+
+test("redactTraceText redacts long hex tokens and preserves short hex and normal text", () => {
+  const longHex = "7f3c9a1b2d4e5f68790a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f";
+  assert.equal(redactTraceText(`token ${longHex} end`), "token [REDACTED-TOKEN] end");
+  assert.equal(redactTraceText("color #f3c9a1"), "color #f3c9a1");
+  assert.equal(redactTraceText("the quick brown fox"), "the quick brown fox");
+});
+
+test("redactTraceText returns an empty string for non-string input", () => {
+  assert.equal(redactTraceText(undefined), "");
+  assert.equal(redactTraceText(null), "");
+  assert.equal(redactTraceText(42), "");
+  assert.equal(redactTraceText({ token: "abc" }), "");
+});
+
+test("redactTraceText leaves clean trace text unchanged", () => {
+  const clean = [
+    "# Browser Job Report",
+    "- status: completed",
+    "1. Read page - ok - read product page",
+    "## Boundary",
+    "Intake artifact only."
+  ].join("\n");
+  assert.equal(redactTraceText(clean), clean);
+});


### PR DESCRIPTION
## What

Issue [#225](https://github.com/ResonantOS/2.0.0-alpha/issues/225): Agent Control exposes a durable job trace with a visible step counter, and exported traces do not leak sensitive data.

This PR covers the outstanding acceptance item plus certification of the already-present step-counter and report features:

- **Redacted exports (AC 4):** new `trace-redaction.js` `redactTraceText()` pass scrubs durable artifacts — Agent Control reports, browser job reports, delegation context packets, and delegation missions. It redacts secret URL query params (`token`, `key`, `secret`, `password`, `passwd`, `pwd`, `pin`, `otp`, `auth-code`, `access-token`, `refresh-token`, `api-key`, `session`, `sid`, `signature`, `csrf`, `jwt`), `name=value` / `name: value` assignments, and 32+ char hex tokens, while preserving benign params (`email`, `ref`, …), prose, and step evidence.
- **In-memory fidelity preserved:** the live run keeps full fidelity for resume and UX; only exported artifacts pass through the scrubber.
- **Focused tests:** standalone `trace-redaction` unit tests plus reporting-service assertions that secrets in goals, page URLs, notes, and errors never reach report markdown, archive content, or delegation packets.
- **Certification of existing behavior:** the step counter (`N of M` pill, `controlRunProgress` "step 2/3", job replay transcript) and reports retaining target refs (`targetSite`, `targetTab`, `targetUrl`) and blocker guidance (`nextHumanAction`) were already implemented and tested (`step-list.test.mjs`, `monitor-renderers.test.mjs`, `control-run-state.test.mjs`); no changes needed there.

## Why

Durable job traces are exported to the archive and to delegated add-ons. Goals, URLs, notes, and errors can echo tokens and credentials verbatim; those artifacts must be safe to store and forward. Visible step counting was already shipped; this closes the remaining gap from the issue handoff.

## Ownership / security impact

- New module stays within the Agent Control file ownership area (`browser-first/resonantos-side-panel-extension/src/lib/`). No host routes, no module-ownership changes.
- Redaction applies only to exported artifacts; nothing weakens resume, consent, or approval gating.
- No secrets, credentials, or local evidence in this commit.

## Checks run

- `npm run test:browser-first`: **836/836 pass** (829 dev baseline + 7 new focused tests)
- `node scripts/security-pipeline/run-check.mjs`: exit 0, no fail/error findings

## Known limitations

- Redaction is heuristic: it targets known secret parameter/assignment names and 32+ hex tokens. Unlabeled secrets (e.g. an opaque value in an unnamed query param) are not scrubbed.
- A two-word value after a secret label (`Token: Bearer abc123`) redacts the label and first token only.
- Live browser proof for the step counter is available on request; deterministic tests cover rendering and report output.