### PR TITLE
build: add isolated Docker development environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,81 @@
+# Dependencies and build output
+node_modules/
+dist/
+.vite/
+coverage/
+
+# Local runtime state and generated memory
+Memory/
+Living_Archive/
+ResonantOS_User/
+.resonantos/
+
+# Secrets and local environment
+.env
+.env.*
+*.key
+*.pem
+*.p12
+*.mobileprovision
+*.keystore
+
+# Logs, caches, and evidence
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+tmp/
+output/
+runs/
+screenshots/
+evidence/
+artifacts/
+playwright-report/
+test-results/
+*.zip
+
+# Repository-local agent and analysis state
+.abacusai/
+.codex/
+.understand-anything/
+
+# Browser profile databases and report environments
+**/Cookies
+**/Cookies-journal
+**/Login Data
+**/Login Data-journal
+**/History
+**/History-journal
+**/Web Data
+**/Web Data-journal
+**/Local State
+**/Preferences
+**/Secure Preferences
+**/Favicons
+**/Favicons-journal
+**/Top Sites
+**/Top Sites-journal
+**/Network Action Predictor
+**/Network Action Predictor-journal
+**/Visited Links
+**/Sessions/
+**/Session Storage/
+**/Local Storage/
+**/IndexedDB/
+**/chrome-user-data/
+**/chrome-profile/
+**/chrome-profiles/
+**/chromium/
+**/google-chrome/
+
+# Browser-first generated session material
+browser-first/resonantos-side-panel-extension/src/bridge-config.generated.js
+browser-first/certs/
+
+# Git and editor state
+.git/
+.idea/
+.vscode/
+.DS_Store
+*.swp

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,9 @@ Keep the bridge running, open `chrome://extensions`, enable Developer mode,
 select **Load unpacked**, and choose
 `browser-first/resonantos-side-panel-extension`.
 
+To keep npm, Chromium, generated bridge credentials, and browser profiles out
+of the host runtime, use the [safe Docker development workflow](docs/DOCKER_DEVELOPMENT.md).
+
 ## Choose Work From GitHub
 
 GitHub Issues are the public intake queue.

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,56 @@
+FROM node:22.13.0-bookworm
+
+ENV HOME=/home/node \
+    RESONANTOS_LIVE_CHROME_PATH=/usr/bin/chromium \
+    RESONANTOS_LIVE_PROFILE=agent-control \
+    RESONANTOS_LIVE_ARTIFACT_DIR=/tmp/resonantos-live-artifacts \
+    RESONANTOS_BROWSER_HOST_EXECUTABLE_PATH=/usr/bin/chromium
+
+USER root
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      bash \
+      ca-certificates \
+      chromium \
+      curl \
+      fonts-liberation \
+      git \
+      libasound2 \
+      libatk-bridge2.0-0 \
+      libatk1.0-0 \
+      libcairo2 \
+      libcups2 \
+      libdbus-1-3 \
+      libdrm2 \
+      libgbm1 \
+      libgtk-3-0 \
+      libnss3 \
+      libpango-1.0-0 \
+      libx11-6 \
+      libxcomposite1 \
+      libxdamage1 \
+      libxext6 \
+      libxfixes3 \
+      libxkbcommon0 \
+      libxrandr2 \
+      libxss1 \
+      openssl \
+      tini \
+      xauth \
+      xvfb \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /workspace /tmp/resonantos-live-artifacts /tmp/.X11-unix \
+    /workspace/node_modules \
+    && chmod 1777 /tmp/.X11-unix \
+    && chown -R node:node /workspace /tmp/resonantos-live-artifacts
+
+COPY --chown=root:root scripts/docker-dev-entrypoint.sh /usr/local/bin/resonantos-dev-entrypoint
+RUN chmod 0755 /usr/local/bin/resonantos-dev-entrypoint
+
+USER node
+WORKDIR /workspace
+
+ENTRYPOINT ["tini", "--", "resonantos-dev-entrypoint"]
+CMD ["bash"]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -98,6 +98,9 @@ For a basic manual check, confirm that the bridge terminal reports
 connection error. Do not paste the generated config or full diagnostics into a
 public issue.
 
+For contributor verification with isolated Debian Chromium instead of a
+production Chrome profile, use the [safe Docker development workflow](docs/DOCKER_DEVELOPMENT.md).
+
 ## Troubleshooting
 
 - **The extension cannot reach the bridge:** confirm the bridge is still

--- a/browser-first/host/bridge-tls.mjs
+++ b/browser-first/host/bridge-tls.mjs
@@ -34,9 +34,8 @@ export const DEFAULT_LEAF_VALIDITY_DAYS = 825; // browsers cap leaf cert validit
 // (added separately), skip Docker bridges (172.16-31.x.x), skip IPv6 for
 // the LAN target (browsers prefer IPv4 when both are returned; we add IPv6
 // separately if needed).
-function discoverBridgeSans() {
+export function discoverBridgeSans(ifaces = os.networkInterfaces()) {
   const sans = ["localhost", "127.0.0.1"];
-  const ifaces = os.networkInterfaces();
   for (const list of Object.values(ifaces)) {
     if (!list) continue;
     for (const iface of list) {

--- a/browser-first/resonantos-side-panel-extension/src/lib/browser-job-scheduler.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/browser-job-scheduler.js
@@ -3,6 +3,7 @@
 
 const DEFAULT_MAX_CONCURRENT = 2;
 const RESULT_JOB_STATUSES = new Set(["blocked", "approval", "failed", "cancelled", "paused", "completed"]);
+const FOCUS_HOLDING_JOB_STATUSES = new Set(["queued", "running", "paused", "approval"]);
 
 function safeMaxConcurrent(value) {
   const parsed = Number(value);
@@ -70,7 +71,8 @@ export function createBrowserJobScheduler({
     if (!jobSummary?.id || running.has(jobSummary.id)) return null;
     const job = browserJobStore.findJob(jobSummary.id);
     if (!job || job.status !== "queued") return null;
-    if (!browserJobStore.getActiveJobId?.()) {
+    const focusedJob = browserJobStore.currentJob?.();
+    if (!focusedJob || !FOCUS_HOLDING_JOB_STATUSES.has(focusedJob.status)) {
       await browserJobStore.activateJob?.(job.id);
     }
     const startedJob = await browserJobStore.updateJob(job.id, { status: "running" });

--- a/browser-first/test/agent-control-live.mjs
+++ b/browser-first/test/agent-control-live.mjs
@@ -536,6 +536,33 @@ async function waitForComposerReady(panel, label) {
   throw new Error(`${label} did not return composer readiness. Panel text:\n${text}`);
 }
 
+async function browserJobDiagnostics(panel) {
+  return (await evaluate(panel, `(async () => {
+    const stored = await chrome.storage.local.get(["augmentorBrowserJobs", "augmentorActiveBrowserJob"]);
+    const jobs = stored.augmentorBrowserJobs ?? [];
+    return {
+      activeJobId: stored.augmentorActiveBrowserJob ?? null,
+      activeJobs: jobs
+        .filter((job) => ["queued", "running", "paused", "approval"].includes(job.status))
+        .map((job) => ({
+          goal: job.goal,
+          id: job.id,
+          pageLock: job.pageLock ?? null,
+          pendingApproval: job.pendingApproval ?? null,
+          status: job.status
+        })),
+      jobs: jobs.map((job) => ({
+        goal: job.goal,
+        id: job.id,
+        pageLock: job.pageLock ?? null,
+        pendingApproval: job.pendingApproval ?? null,
+        status: job.status
+      })),
+      monitorText: document.querySelector("#job-monitor")?.innerText ?? ""
+    };
+  })()`)).result.value;
+}
+
 async function waitForBrowserJobTerminal(panel, goalPattern, label) {
   const terminalStatuses = new Set(["completed", "blocked", "denied", "cancelled", "failed"]);
   for (let index = 0; index < 120; index += 1) {
@@ -549,11 +576,9 @@ async function waitForBrowserJobTerminal(panel, goalPattern, label) {
     }
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
-  const state = (await evaluate(panel, `(async () => ({
-    jobs: (await chrome.storage.local.get("augmentorBrowserJobs")).augmentorBrowserJobs ?? [],
-    text: document.body.innerText
-  }))()`)).result.value;
-  throw new Error(`${label} did not reach a terminal browser-job state. Jobs:\n${JSON.stringify(state.jobs, null, 2)}\nPanel text:\n${state.text}`);
+  const diagnostics = await browserJobDiagnostics(panel);
+  const text = (await evaluate(panel, "document.body.innerText")).result.value;
+  throw new Error(`${label} did not reach a terminal browser-job state. Diagnostics:\n${JSON.stringify(diagnostics, null, 2)}\nPanel text:\n${text}`);
 }
 
 async function waitForPageCondition(page, expression, label) {
@@ -604,7 +629,10 @@ async function verifyPublicSubmitBoundary(panel, page) {
   try {
     outcome = await waitForPageCondition(panel, `(async () => {
       const jobs = (await chrome.storage.local.get("augmentorBrowserJobs")).augmentorBrowserJobs ?? [];
-      const publicJobs = jobs.filter((job) => /Submit public form/i.test(job.pendingApproval?.step?.text ?? ""));
+      const publicJobs = jobs.filter((job) =>
+        /Submit public form/i.test(job.goal ?? "") ||
+        /Submit public form/i.test(job.pendingApproval?.step?.text ?? "")
+      );
       const buttons = [...document.querySelectorAll("button")]
         .filter((button) => /click "Submit public form"/i.test(button.title || ""))
         .map((button) => button.textContent.trim());
@@ -613,8 +641,24 @@ async function verifyPublicSubmitBoundary(panel, page) {
         .map((message) => message.innerText)
         .join("\\n");
       const humanSignal = /human-only|click it yourself|must be performed by the human|then resume/i.test(newMessageText);
-      if (!publicJobs.length && !humanSignal) return false;
-      return { publicJobs, buttons, newMessageText, humanSignal };
+      const approvalJobs = publicJobs.filter((job) => job.status === "approval" && job.pendingApproval);
+      const terminalJobs = publicJobs.filter((job) =>
+        ["completed", "blocked", "denied", "cancelled", "failed"].includes(job.status) &&
+        !job.pendingApproval &&
+        !job.pageLock
+      );
+      const hasExecutableApproval = buttons.includes("Approve once");
+      const legacyApprovalReady = approvalJobs.length > 0 && buttons.includes("Deny");
+      const humanHandoffReady = humanSignal && terminalJobs.length > 0 && !hasExecutableApproval;
+      if (!legacyApprovalReady && !humanHandoffReady) return false;
+      return {
+        approvalJobs,
+        buttons,
+        humanHandoff: humanHandoffReady,
+        newMessageText,
+        publicJobs,
+        terminalJobs
+      };
     })()`, "public-submit boundary outcome");
   } catch (error) {
     const diagnostics = (await evaluate(panel, `(async () => ({
@@ -625,9 +669,9 @@ async function verifyPublicSubmitBoundary(panel, page) {
   }
   const blockedState = (await evaluate(page, `({ submitted: window.__submitted, status: document.querySelector("#status").textContent })`)).result.value;
   assert(!blockedState.submitted, `Public-submit boundary executed the action: ${JSON.stringify(blockedState)}`);
-  const approvalJobs = outcome.publicJobs.filter((job) => job.status === "approval" && job.pendingApproval);
+  const approvalJobs = outcome.approvalJobs;
   const hasExecutableApproval = outcome.buttons.includes("Approve once");
-  const humanHandoff = outcome.humanSignal && approvalJobs.length === 0 && !hasExecutableApproval;
+  const humanHandoff = outcome.humanHandoff;
   const decision = decidePublicSubmitScenario({ mode: publicSubmitContract, humanHandoff });
   certificationReport.record("post-approval-public-submit", decision.status, decision.reason);
   if (decision.status === "failed") assert(false, decision.reason);
@@ -649,6 +693,16 @@ async function verifyPublicSubmitBoundary(panel, page) {
     assert(deniedJob.status === "denied", `Legacy public-submit job did not resolve as denied: ${JSON.stringify(deniedJob)}`);
     await waitForComposerReady(panel, "public-submit denial");
   }
+  await waitForPageCondition(panel, `(async () => {
+    const jobs = (await chrome.storage.local.get("augmentorBrowserJobs")).augmentorBrowserJobs ?? [];
+    const matching = jobs.filter((job) => /Submit public form/i.test(job.goal ?? ""));
+    return matching.length > 0 && matching.every((job) =>
+      ["completed", "blocked", "denied", "cancelled", "failed"].includes(job.status) &&
+      !job.pendingApproval &&
+      !job.pageLock
+    );
+  })()`, "public-submit job settlement");
+  await waitForPageCondition(page, `document.querySelector("#resonantos-control-overlay")?.dataset.session !== "active"`, "public-submit overlay release");
   return blockedState;
 }
 
@@ -997,14 +1051,17 @@ try {
   );
   const blockedState = await verifyPublicSubmitBoundary(panel, page);
 
-  await evaluate(panel, `(() => { globalThis.__resonantosNextActionOverride = async ({ snapshot, history }) => ({
-    source: "test-next-action",
-    thought: "Verify iframe context is visible to the browser-control loop.",
-    status: snapshot?.text?.includes("Booking calendar frame") ? (history.length ? "done" : "continue") : "blocked",
-    action: snapshot?.text?.includes("Booking calendar frame") && !history.length ? { type: "read" } : null,
-    approvalReason: snapshot?.text?.includes("Booking calendar frame") ? null : "Iframe booking context was not visible.",
-    doneSummary: history.length ? "Iframe booking context was observed." : null
-  }); return true; })()`);
+  await evaluate(panel, `(() => { globalThis.__resonantosNextActionOverride = async ({ snapshot, history }) => {
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    return {
+      source: "test-next-action",
+      thought: "Verify iframe context is visible to the browser-control loop.",
+      status: snapshot?.text?.includes("Booking calendar frame") ? (history.length ? "done" : "continue") : "blocked",
+      action: snapshot?.text?.includes("Booking calendar frame") && !history.length ? { type: "read" } : null,
+      approvalReason: snapshot?.text?.includes("Booking calendar frame") ? null : "Iframe booking context was not visible.",
+      doneSummary: history.length ? "Iframe booking context was observed." : null
+    };
+  }; return true; })()`);
   await submitControlCommand(panel, `book a call now`);
   try {
     await waitForPageCondition(page, `document.querySelector("#resonantos-control-overlay")?.dataset.session === "active"`, "persistent control overlay session start");
@@ -1012,7 +1069,13 @@ try {
     const panelText = (await evaluate(panel, "document.body.innerText")).result.value;
     throw new Error(`${error instanceof Error ? error.message : String(error)}\nPanel text:\n${panelText}`);
   }
-  const iframePanelText = await waitForPanelText(panel, /Booking calendar frame|Iframe booking context was not visible/, "iframe context read");
+  let iframePanelText;
+  try {
+    iframePanelText = await waitForPanelText(panel, /Booking calendar frame|Iframe booking context was not visible/, "iframe context read");
+  } catch (error) {
+    const diagnostics = await browserJobDiagnostics(panel);
+    throw new Error(`${error instanceof Error ? error.message : String(error)}\nBrowser job diagnostics:\n${JSON.stringify(diagnostics, null, 2)}`);
+  }
   assert(!/Iframe booking context was not visible/.test(iframePanelText), "Agent planner could not see iframe booking context.");
   await waitForComposerReady(panel, "iframe context read");
   await waitForPageCondition(page, `document.querySelector("#resonantos-control-overlay")?.dataset.session !== "active"`, "persistent control overlay session stop");

--- a/browser-first/test/bridge-tls.test.mjs
+++ b/browser-first/test/bridge-tls.test.mjs
@@ -14,6 +14,7 @@ import {
   startBridgeServersWithTls,
 } from "../host/bridge-server.mjs";
 import {
+  discoverBridgeSans,
   ensureBridgeTls,
   getCertSans,
 } from "../host/bridge-tls.mjs";
@@ -58,9 +59,22 @@ test("ensureBridgeTls: generates CA + leaf with auto-discovered SANs", async () 
   const sans = await getCertSans(tls.cert);
   assert.ok(sans.includes("localhost"), `localhost in SANs (got ${JSON.stringify(sans)})`);
   assert.ok(sans.includes("127.0.0.1"), `127.0.0.1 in SANs`);
-  // At least one of the LAN/Tailscale addresses should be there
-  const hasNetwork = sans.some(s => /^(192\.168|100\.112|10\.)/.test(s));
-  assert.ok(hasNetwork, `at least one network IP in SANs (got ${JSON.stringify(sans)})`);
+});
+
+test("discoverBridgeSans: Docker-only interfaces produce loopback-only SANs", () => {
+  const sans = discoverBridgeSans({
+    eth0: [{ address: "172.18.0.2", family: "IPv4", internal: false }],
+    lo: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
+  });
+  assert.deepEqual(sans, ["localhost", "127.0.0.1"]);
+});
+
+test("discoverBridgeSans: eligible non-Docker IPv4 interfaces remain available", () => {
+  const sans = discoverBridgeSans({
+    eth0: [{ address: "192.168.1.20", family: "IPv4", internal: false }],
+    docker0: [{ address: "172.17.0.1", family: "IPv4", internal: false }],
+  });
+  assert.deepEqual(sans, ["localhost", "127.0.0.1", "192.168.1.20"]);
 });
 
 test("bridge TLS pins OpenSSL and passes only a scoped environment", async () => {

--- a/browser-first/test/browser-job-scheduler.test.mjs
+++ b/browser-first/test/browser-job-scheduler.test.mjs
@@ -115,6 +115,34 @@ test("browser job scheduler focuses first queued job only when no active focus e
   await new Promise((resolve) => setTimeout(resolve, 0));
 });
 
+test("browser job scheduler replaces terminal focus when queued work starts", async () => {
+  let releaseQueued;
+  const gate = new Promise((resolve) => {
+    releaseQueued = resolve;
+  });
+  const harness = createHarness([
+    { id: "job-denied", goal: "Denied public submit", status: "denied" },
+    { id: "job-next", goal: "Read booking page", status: "queued", pageLock: { tabId: 2, siteKey: "booking.example" } }
+  ], { activeBrowserJob: "job-denied", maxConcurrent: 1 });
+  harness.scheduler = createBrowserJobScheduler({
+    browserJobStore: harness.store,
+    maxConcurrent: 1,
+    runJob: async () => {
+      await gate;
+      return { ok: true };
+    }
+  });
+  await harness.store.hydrate();
+
+  await harness.scheduler.tick();
+
+  assert.equal(harness.store.getActiveJobId(), "job-next");
+  assert.equal(harness.store.findJob("job-next").status, "running");
+
+  releaseQueued();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
 test("browser job scheduler leaves lock-conflicting queued jobs untouched", async () => {
   const harness = createHarness([
     { id: "running-a", goal: "Use DAO", status: "running", pageLock: { tabId: 1, siteKey: "dao.example", url: "https://dao.example/" } },

--- a/browser-first/test/docker-dev-entrypoint.test.mjs
+++ b/browser-first/test/docker-dev-entrypoint.test.mjs
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { chmod, mkdir, mkdtemp, readFile, rm, symlink, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+const entrypoint = path.join(repoRoot, "scripts", "docker-dev-entrypoint.sh");
+
+function run(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      ...options,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code, stderr, stdout }));
+  });
+}
+
+test("docker dev entrypoint stages working files without local secrets or browser state", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "resonantos-docker-entrypoint-"));
+  const source = path.join(root, "source");
+  const workspace = path.join(root, "workspace");
+  await mkdir(source, { recursive: true });
+  const fixtureEnvironment = { ...process.env };
+  delete fixtureEnvironment.GIT_DIR;
+  delete fixtureEnvironment.GIT_WORK_TREE;
+
+  try {
+    assert.equal((await run("git", ["init", "--quiet"], { cwd: source, env: fixtureEnvironment })).code, 0);
+    await writeFile(path.join(source, ".gitignore"), "ignored.log\n");
+    await writeFile(path.join(source, "deleted.txt"), "deleted working-tree file\n");
+    await writeFile(path.join(source, "tracked.txt"), "initial\n");
+    assert.equal((await run("git", ["add", ".gitignore", "deleted.txt", "tracked.txt"], { cwd: source, env: fixtureEnvironment })).code, 0);
+    await unlink(path.join(source, "deleted.txt"));
+    await writeFile(path.join(source, "tracked.txt"), "modified\n");
+    await writeFile(path.join(source, "new-source.txt"), "untracked source\n");
+    await writeFile(path.join(source, "ignored.log"), "ignored\n");
+
+    const rejectedFiles = [
+      [".env.local", "secret"],
+      ["ResonantOS_User/Secrets/provider.key", "private"],
+      [".codex/state.json", "agent state"],
+      ["profile/Cookies", "browser cookies"],
+      ["artifacts/report.json", "evidence"],
+      ["browser-first/resonantos-side-panel-extension/src/bridge-config.generated.js", "bridge token"],
+    ];
+    for (const [relativePath, contents] of rejectedFiles) {
+      const target = path.join(source, relativePath);
+      await mkdir(path.dirname(target), { recursive: true });
+      await writeFile(target, contents);
+    }
+
+    await chmod(entrypoint, 0o755);
+    const result = await run(entrypoint, [
+      process.execPath,
+      "-e",
+      "const fs = require('node:fs'); const cp = require('node:child_process'); fs.writeFileSync('command-output.txt', `${process.cwd()}\\n${cp.execFileSync('git', ['ls-files'], { encoding: 'utf8' })}`)",
+    ], {
+      env: {
+        ...fixtureEnvironment,
+        RESONANTOS_DEV_SOURCE_DIR: source,
+        RESONANTOS_DEV_WORKSPACE_DIR: workspace,
+      },
+    });
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(await readFile(path.join(workspace, "tracked.txt"), "utf8"), "modified\n");
+    assert.equal(await readFile(path.join(workspace, "new-source.txt"), "utf8"), "untracked source\n");
+    const commandOutput = await readFile(path.join(workspace, "command-output.txt"), "utf8");
+    assert.match(commandOutput, new RegExp(`^${workspace.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\n`));
+    assert.match(commandOutput, /tracked\.txt/);
+    assert.equal(
+      await readFile(path.join(workspace, ".git"), "utf8"),
+      `gitdir: ${path.join(source, ".git")}\n`,
+    );
+
+    for (const [relativePath] of rejectedFiles) {
+      await assert.rejects(readFile(path.join(workspace, relativePath)));
+    }
+    await assert.rejects(readFile(path.join(workspace, "ignored.log")));
+    await assert.rejects(readFile(path.join(workspace, "deleted.txt")));
+    await assert.rejects(readFile(path.join(workspace, ".git", "config")));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("docker dev entrypoint rejects symbolic links", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "resonantos-docker-entrypoint-link-"));
+  const source = path.join(root, "source");
+  const workspace = path.join(root, "workspace");
+  const fixtureEnvironment = { ...process.env };
+  delete fixtureEnvironment.GIT_DIR;
+  delete fixtureEnvironment.GIT_WORK_TREE;
+  await mkdir(source, { recursive: true });
+
+  try {
+    assert.equal((await run("git", ["init", "--quiet"], { cwd: source, env: fixtureEnvironment })).code, 0);
+    await writeFile(path.join(root, "outside.txt"), "outside state\n");
+    await symlink(path.join(root, "outside.txt"), path.join(source, "source-link.txt"));
+
+    const result = await run(entrypoint, ["true"], {
+      env: {
+        ...fixtureEnvironment,
+        RESONANTOS_DEV_SOURCE_DIR: source,
+        RESONANTOS_DEV_WORKSPACE_DIR: workspace,
+      },
+    });
+
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr, /rejected symbolic link: source-link\.txt/);
+    await assert.rejects(readFile(path.join(workspace, "source-link.txt")));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/docs/DOCKER_DEVELOPMENT.md
+++ b/docs/DOCKER_DEVELOPMENT.md
@@ -1,0 +1,116 @@
+# Safe Docker Development
+
+Use this workflow to run npm, deterministic tests, and live extension
+certification without loading ResonantOS into a production Chrome profile. It
+uses Debian Chromium, Xvfb, a read-only source mount, an isolated dependency
+volume, and an ephemeral working directory inside each container.
+
+This environment prepares the repository for future contribution work. It does
+not implement or close [issue #221](https://github.com/ResonantOS/2.0.0-alpha/issues/221).
+
+## Build The Image
+
+From the repository root:
+
+```bash
+docker build -f Dockerfile.dev -t resonantos-dev .
+docker volume create resonantos-node-modules
+```
+
+The image uses Node.js 22.13.0 and Debian Chromium. Confirm the toolchain and
+non-root account. The image uses `tini` to forward signals and reap Chromium and
+Xvfb child processes correctly:
+
+```bash
+docker run --rm resonantos-dev node --version
+docker run --rm resonantos-dev chromium --version
+docker run --rm resonantos-dev id
+```
+
+## Install Dependencies
+
+The source checkout is mounted read-only at `/source`. The entrypoint copies
+tracked, modified, and non-ignored source files into the container's ephemeral
+`/workspace`; it does not copy Git metadata, secrets, profiles, generated bridge
+configuration, local evidence, or symbolic links. A `.git` pointer lets checks
+read the source mount's Git metadata, but the read-only mount prevents commands
+from changing it. Dependencies remain in the named volume.
+
+```bash
+docker run --rm -it \
+  --mount type=bind,src="$PWD",dst=/source,readonly \
+  --mount type=volume,src=resonantos-node-modules,dst=/workspace/node_modules \
+  resonantos-dev \
+  npm ci
+```
+
+Run this command again whenever `package-lock.json` changes. Do not pass provider
+credentials or mount a real Chrome or Chromium profile into the container.
+
+## Run Deterministic Tests
+
+Focused tests still use the repository's existing Node test commands:
+
+```bash
+docker run --rm -it \
+  --mount type=bind,src="$PWD",dst=/source,readonly \
+  --mount type=volume,src=resonantos-node-modules,dst=/workspace/node_modules \
+  resonantos-dev \
+  node --test browser-first/test/composer-controller.test.mjs
+```
+
+Run the complete browser-first and controlled browser-host suites:
+
+```bash
+docker run --rm -it \
+  --mount type=bind,src="$PWD",dst=/source,readonly \
+  --mount type=volume,src=resonantos-node-modules,dst=/workspace/node_modules \
+  resonantos-dev \
+  npm run test:browser-first
+
+docker run --rm -it \
+  --mount type=bind,src="$PWD",dst=/source,readonly \
+  --mount type=volume,src=resonantos-node-modules,dst=/workspace/node_modules \
+  resonantos-dev \
+  npm run test:browser-host
+```
+
+## Run Live Chromium Certification
+
+The live command loads the extension into an isolated temporary Chromium
+profile under Xvfb. Generated bridge credentials and certification artifacts
+remain in the disposable container filesystem.
+
+```bash
+docker run --rm -it \
+  --mount type=bind,src="$PWD",dst=/source,readonly \
+  --mount type=volume,src=resonantos-node-modules,dst=/workspace/node_modules \
+  --env CI=true \
+  resonantos-dev \
+  xvfb-run -a npm run test:browser-first:live
+```
+
+The standard command intentionally discards screenshots and generated bridge
+state when the container exits. For pull-request evidence, record the command
+result and redact diagnostics before attaching them outside the repository. Do
+not commit screenshots, reports, bridge tokens, or browser state.
+
+## Verify And Clean Up
+
+After running the container workflow, confirm that no runtime state appeared in
+the host checkout:
+
+```bash
+git status --short
+```
+
+Remove the cached dependency volume when dependencies need a completely fresh
+install or when the environment is no longer needed:
+
+```bash
+docker volume rm resonantos-node-modules
+```
+
+The workflow never needs production Chrome, provider secrets, wallet material,
+login cookies, or a real browser profile. Keep those resources outside every
+container mount and pull-request artifact.

--- a/docs/README.md
+++ b/docs/README.md
@@ -85,6 +85,7 @@ npm run test:docs
 
 Related contributor references:
 
+- [Safe Docker development](DOCKER_DEVELOPMENT.md)
 - [Repository discipline catalog](../disciplines/README.md)
 - [Browser research skill](addons/browser/skills/browser-research-session.md)
 - [Icon system decision](product/ICON-001-resonantos-svg-system.md) and

--- a/scripts/browser-first-release-scope-audit.mjs
+++ b/scripts/browser-first-release-scope-audit.mjs
@@ -22,6 +22,7 @@ const canonicalRootFiles = new Set([
 ]);
 
 const includeDocs = new Set([
+  "docs/DOCKER_DEVELOPMENT.md",
   "docs/README.md",
   "docs/STATUS.md",
   "docs/ROADMAP.md",
@@ -38,6 +39,11 @@ const includeDocs = new Set([
   "docs/browser-first-bridge-setup-runbook.md",
   "docs/augmentor-future-list-acceptance-matrix.md",
   "docs/augmentor-tester-runbook.md",
+]);
+
+const contributorDevelopmentFiles = new Set([
+  ".dockerignore",
+  "Dockerfile.dev",
 ]);
 
 function readOptionValue(argv, index, name) {
@@ -240,6 +246,12 @@ function classify(changedPath, state) {
     return {
       bucket: "include",
       reason: "browser-first release documentation",
+    };
+  }
+  if (contributorDevelopmentFiles.has(changedPath)) {
+    return {
+      bucket: "include",
+      reason: "browser-first contributor development tooling",
     };
   }
   if (canonicalRootFiles.has(changedPath) || changedPath === "public/icons/README.md") {

--- a/scripts/browser-first-release-scope-audit.test.mjs
+++ b/scripts/browser-first-release-scope-audit.test.mjs
@@ -296,7 +296,7 @@ test("unknown modified documentation still fails strict committed audit", () => 
   assert.match(stderr, /strict mode failed/i);
 });
 
-test("known canonical, ADR, icon, and deleted documentation pass strict audit", () => {
+test("known canonical, Docker development, ADR, icon, and deleted documentation pass strict audit", () => {
   const main = requireExport("main");
   let stdout = "";
   let stderr = "";
@@ -311,6 +311,9 @@ test("known canonical, ADR, icon, and deleted documentation pass strict audit", 
     "CONTRIBUTING.md",
     "INSTALL.md",
     "SUPPORT.md",
+    ".dockerignore",
+    "Dockerfile.dev",
+    "docs/DOCKER_DEVELOPMENT.md",
     "docs/architecture/ADR-999-release-metadata.md",
     "docs/reference/COMMANDS.md",
     "public/icons/README.md",

--- a/scripts/docker-dev-entrypoint.sh
+++ b/scripts/docker-dev-entrypoint.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_dir="${RESONANTOS_DEV_SOURCE_DIR:-/source}"
+workspace_dir="${RESONANTOS_DEV_WORKSPACE_DIR:-/workspace}"
+
+is_rejected_path() {
+  local relative_path="$1"
+  local basename="${relative_path##*/}"
+  local wrapped="/${relative_path}/"
+
+  case "$wrapped" in
+    */.git/*|*/node_modules/*|*/Memory/*|*/Living_Archive/*|*/ResonantOS_User/*|*/.resonantos/*|*/.codex/*|*/.abacusai/*|*/.understand-anything/*|*/logs/*|*/tmp/*|*/output/*|*/runs/*|*/artifacts/*|*/evidence/*|*/screenshots/*|*/playwright-report/*|*/test-results/*|*/browser-first/certs/*|*/chrome-user-data/*|*/chrome-profile/*|*/chrome-profiles/*|*/chromium/*|*/google-chrome/*|*/Sessions/*|*/Session\ Storage/*|*/Local\ Storage/*|*/IndexedDB/*)
+      return 0
+      ;;
+  esac
+
+  case "$basename" in
+    .env|.env.*|*.key|*.pem|*.p12|*.mobileprovision|*.keystore|*.log|Cookies|Cookies-journal|Login\ Data|Login\ Data-journal|History|History-journal|Web\ Data|Web\ Data-journal|Local\ State|Preferences|Secure\ Preferences|Favicons|Favicons-journal|Top\ Sites|Top\ Sites-journal|Network\ Action\ Predictor|Network\ Action\ Predictor-journal|Visited\ Links|bridge-config.generated.js)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+stage_worktree() {
+  local git_metadata_dir
+
+  if [[ ! -e "$source_dir/.git" ]]; then
+    echo "resonantos-dev-entrypoint: $source_dir is not a Git working tree" >&2
+    return 1
+  fi
+  if [[ "$workspace_dir" == "$source_dir" ]]; then
+    echo "resonantos-dev-entrypoint: source and workspace must be different directories" >&2
+    return 1
+  fi
+
+  unset GIT_DIR GIT_WORK_TREE
+  mkdir -p "$workspace_dir"
+  while IFS= read -r -d '' relative_path; do
+    if [[ "$relative_path" == /* || "$relative_path" == ".." || "$relative_path" == ../* || "$relative_path" == */../* ]]; then
+      echo "resonantos-dev-entrypoint: rejected unsafe path: $relative_path" >&2
+      return 1
+    fi
+    if is_rejected_path "$relative_path"; then
+      continue
+    fi
+    if [[ -L "$source_dir/$relative_path" ]]; then
+      echo "resonantos-dev-entrypoint: rejected symbolic link: $relative_path" >&2
+      return 1
+    fi
+    if [[ ! -e "$source_dir/$relative_path" ]]; then
+      continue
+    fi
+
+    mkdir -p "$workspace_dir/$(dirname "$relative_path")"
+    cp -a "$source_dir/$relative_path" "$workspace_dir/$relative_path"
+  done < <(
+    git -c safe.directory="$source_dir" -C "$source_dir" \
+      ls-files --cached --others --exclude-standard -z
+  )
+
+  git_metadata_dir="$(git -c safe.directory="$source_dir" -C "$source_dir" rev-parse --absolute-git-dir)"
+  printf 'gitdir: %s\n' "$git_metadata_dir" > "$workspace_dir/.git"
+}
+
+if [[ -d "$source_dir" ]]; then
+  stage_worktree
+fi
+
+cd "$workspace_dir"
+exec "$@"


### PR DESCRIPTION
## Scope

Add an isolated Docker workflow for contributor development and validation.

The host checkout is mounted read-only at `/source`. The image automatically
runs `scripts/docker-dev-entrypoint.sh`, which stages permitted working-tree
files into an ephemeral `/workspace` before executing the supplied npm or Node
command. Dependencies are stored in a named Docker volume.

The change also fixes browser-job focus cleanup exposed by live Docker
certification and makes Docker-only TLS SAN behavior deterministic.

Explicitly out of scope:

- Docker Compose.
- Production Chrome or real Chrome profiles.
- Provider credentials, wallet state, login state, or persistent browser state.
- Changes to the public ResonantOS runtime API or Alpha runtime boundary.

Linked issue: No issue yet. This draft is open for early review while a
dedicated Docker-development issue is created and linked.

Project 2 release scope: Pending dedicated-issue triage; no Alpha feature claim.
Project 2 area: Build proposed, pending Project 2 assignment.

## Modules And Ownership

- Affected modules:
  - `Dockerfile.dev`, `.dockerignore`, and `scripts/docker-dev-entrypoint.sh`:
    repository development and validation tooling.
  - `browser-first/test/`: extension and bridge behavioral contracts.
  - `browser-first/host/bridge-tls.mjs`: bridge TLS certificate and SAN behavior.
  - `browser-first/resonantos-side-panel-extension/src/lib/browser-job-scheduler.js`:
    browser-job scheduling and active-job focus.
  - `docs/`, `INSTALL.md`, and `CONTRIBUTING.md`: contributor documentation.
- Ownership or boundary review:
  - Development tooling remains outside the shipped Alpha runtime.
  - Bridge TLS continues to own certificate SAN discovery.
  - Browser-job state remains extension-owned.
  - No responsibility moved between modules, so the ownership map did not
    require an update.
  - No new bridge route, runtime process, or public API was introduced.

## Safety And Privacy

- Safety/privacy impact:
  - The source checkout is mounted read-only.
  - Browser profiles, `.env*`, generated bridge configuration, local evidence,
    Git metadata, credentials, user state, and symbolic links are excluded from
    workspace staging.
  - Chromium profiles, bridge state, screenshots, and artifacts remain inside
    disposable containers.
  - Real Chrome profiles and production Chrome are never mounted.
- Required human handoff or approval boundary:
  - Existing public-submit and other human-only boundaries remain unchanged.
  - Live certification still proves public submission is not automated.
  - Public-submit assertions were not weakened.
- Secret-handling impact:
  - No provider credentials or browser login state are required.
  - The pre-existing ignored `bridge-config.generated.js` remained unchanged
    during validation.
  - No credentials, profiles, screenshots, or generated evidence are included
    in this PR.

## Validation

| Command | Result |
| --- | --- |
| `docker build -f Dockerfile.dev -t resonantos-dev .` | Passed |
| `docker run --rm resonantos-dev node --version` | Passed: `v22.13.0` |
| `docker run --rm resonantos-dev chromium --version` | Passed: Debian Chromium available |
| `docker run --rm resonantos-dev id` | Passed: non-root `node` user |
| `docker run --rm resonantos-dev xvfb-run -a sh -c "echo xvfb-ready"` | Passed |
| Containerized `npm ci` using `resonantos-node-modules` | Passed |
| `node --test browser-first/test/docker-dev-entrypoint.test.mjs browser-first/test/alpha-browser-extension-scope.test.mjs` | Passed: 4 tests |
| `node --test browser-first/test/bridge-tls.test.mjs` | Passed |
| `node --test browser-first/test/composer-controller.test.mjs` | Passed: 4 tests |
| `node --test browser-first/test/browser-job-scheduler.test.mjs` | Passed: 10 tests |
| `npm run test:browser-first` | Passed: 833 tests |
| `npm run test:browser-host` | Passed: 13 tests |
| `xvfb-run -a npm run test:browser-first:live` | Passed three consecutive times, plus one final-image run |
| `npm run docs:check` | Passed |
| `npm run test:docs` | Passed: 224 tests |
| `node scripts/security-pipeline/run-check.mjs` | Passed |
| `npm run verify:alpha` | Passed after commit; committed-range audit checked `origin/dev...HEAD`, classified all 15 changed paths for inclusion, and reported 0 deferred and 0 manual-review paths |
| `npm audit --audit-level=high` | **Blocked:** three high-severity transitive packages (`nanoid`, `postcss`, and `undici`); lockfile matches `dev` |
| `git diff --check` | Passed |
| Final host worktree contamination check | Passed; no generated profiles, credentials, screenshots, or artifacts appeared |

Known blocker:

The required `alpha-build` workflow runs `npm audit --audit-level=high`.
The current lockfile, unchanged from `dev`, fails that command. Keep this PR in
draft until the dependency audit is fixed on `dev` or maintainers explicitly
resolve the baseline failure.

Live-browser proof: Four successful isolated Chromium/Xvfb runs were completed.
The machine-readable results confirmed iframe context visibility, safe browser
actions, and a blocked public-submit action. Screenshots were intentionally
discarded with the ephemeral containers. If maintainers require a persistent artifact, redacted evidence can be attached before marking PR ready.

## Documentation

Documentation impact:

- Added `docs/DOCKER_DEVELOPMENT.md`.
- Linked the Docker workflow from `INSTALL.md`, `CONTRIBUTING.md`, and
  `docs/README.md`.
- Documented that the image entrypoint runs automatically for every ordinary
  `docker run ... resonantos-dev <command>` invocation.
- Documented image setup, dependency installation, deterministic tests,
  browser-host tests, live Xvfb certification, cleanup, and host verification.

## Checklist

- [x] The branch targets `dev` and does not include unrelated work.
- [ ] The linked issue and Project 2 fields reflect the intended release scope.
- [x] I reviewed module ownership and called out every cross-module boundary change.
- [x] I assessed security, privacy, secrets, and required human-only actions.
- [x] I added or updated tests for behavior changes.
- [x] I recorded every relevant command and its actual result above.
- [ ] I attached redacted live-browser proof when the change requires it.
- [x] I updated current documentation or explained why no documentation changed.
- [x] This pull request contains no credentials, tokens, private user data, browser profiles, or unredacted sensitive logs.