### PR TITLE
fix(security): Agent Control public-submit approval is a non-bypassable human handoff (#240 Part 3)

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/lib/agent-control-runner.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/agent-control-runner.js
@@ -685,6 +685,56 @@ export function createAgentControlRunner(deps) {
           }
         });
         if (!executedResult?.ok) {
+          // #240 Part 3: a human-only public-submit handoff is terminal. Do not
+          // loop back to pending-approval — the human clicks it on the page
+          // and then asks the runner to resume (which forces a fresh observation).
+          if (executedResult?.humanHandoff) {
+            updateControlStep(stepIndex, "human-only-handoff", "Human-only: click it on the page, then resume", {
+              phase: "handoff",
+              decision: decision.thought ?? null,
+              action: controlStepLabel(executedStep),
+              actionRetry,
+              targetCandidates: targetCandidatesFromResult(executedResult),
+              result: controlResultSummary(executedResult),
+              safetyClass: "public-submit",
+              approvalDecision: "handoff",
+              ...strategyDetails(decision),
+              ...controlStepEvidence({
+                boundary: "public-submit",
+                decision,
+                result: executedResult,
+                status: "handoff"
+              }),
+              recoveryOptions: recoveryOptionsForStep({
+                snapshot: getLastSnapshot() ?? postActionSnapshot ?? snapshot,
+                step: executedStep,
+                result: executedResult,
+                verification: finalVerification
+              }),
+              nextHumanAction: "Click it yourself on the page. When you are ready to continue, ask me to resume and I will read the page state fresh."
+            });
+            finishControlRun("handoff");
+            renderControlMonitor();
+            setStatus("Human handoff");
+            setActivity("handoff", "Waiting for human to click", controlStepLabel(executedStep));
+            await addMessage(
+              "system",
+              [
+                `Human-only handoff at action ${stepIndex + 1}: ${controlStepLabel(executedStep)}`,
+                "",
+                "This is a public submit / commit. The runner cannot click it for you.",
+                "Click it yourself on the page, then ask me to resume and I will read the page state fresh."
+              ].join("\n")
+            );
+            const archiveResult = await saveControlReportToArchive(results, "human-handoff");
+            if (archiveResult?.path) {
+              const artifacts = [...(getCurrentControlRun()?.artifacts ?? []), { type: "archive-intake", path: archiveResult.path }];
+              updateControlRunArtifacts(artifacts);
+              renderControlMonitor();
+              await updateBrowserJob(getCurrentControlRun()?.id, { artifacts });
+            }
+            return { ok: false, results, humanHandoff: true };
+          }
           const canRequestHumanApproval = executedResult?.approvalRequired && boundary === "public-submit";
           const status = canRequestHumanApproval ? "approval" : "blocked";
           const reason = executedResult?.approvalRequired
@@ -846,6 +896,38 @@ export function createAgentControlRunner(deps) {
 
     const step = { ...approval.step, userApproved: true };
     const results = approval.results.slice(0, approval.results.length - 1);
+    // #240 Part 3: for public-submit boundaries the runner must NOT re-execute.
+    // A human-only handoff is terminal; the human clicks it on the page and then
+    // resumes with a fresh observation. Re-executing here would trap the human
+    // in a "needs approval" loop because content.js denies the click unconditionally.
+    const isPublicSubmitBoundary = approvalBoundaryForStep(step) === "public-submit";
+    if (isPublicSubmitBoundary) {
+      updateControlStep(approval.stepIndex, "human-only-handoff", "Human-only: click it on the page, then resume", {
+        phase: "handoff",
+        decision: "This is a public submit / commit; the runner cannot click it for you.",
+        action: controlStepLabel(step),
+        approvalDecision: "handoff",
+        safetyClass: "public-submit",
+        confidence: "high",
+        uncertainty: "Public-submit controls are unconditionally human-only. No automation, no approval bypass.",
+        nextHumanAction: "Click it yourself on the page. When you are ready to continue, ask me to resume and I will read the page state fresh."
+      });
+      finishControlRun("handoff");
+      renderControlMonitor();
+      setStatus("Human handoff");
+      setActivity("handoff", "Waiting for human to click", controlStepLabel(step));
+      await addMessage(
+        "system",
+        [
+          `Human-only handoff: ${controlStepLabel(step)}`,
+          "",
+          "This is a public submit / commit. The runner cannot click it for you.",
+          "Click it yourself on the page, then ask me to resume and I will read the page state fresh."
+        ].join("\n")
+      );
+      await saveControlReportToArchive(results, "human-handoff");
+      return;
+    }
     updateControlStep(approval.stepIndex, "active", "approved once", {
       phase: "acting",
       decision: "Human approved this action once.",

--- a/browser-first/test/agent-control-runner.test.mjs
+++ b/browser-first/test/agent-control-runner.test.mjs
@@ -494,10 +494,62 @@ test("agent control runner blocks hard human-only boundaries without pending app
   assert.match(harness.getControlRun().steps[0].details.nextHumanAction, /payment/);
 });
 
-test("agent control runner can approve or deny a pending step through injected state", async () => {
-  const approvalHarness = createHarness({
+test("agent control runner routes a public-submit step in the main loop into a terminal handoff instead of pending approval (#240 main-loop branch)", async () => {
+  // #240 Part 3 main loop: when continueControlLoop -> executeControlStep returns
+  // humanHandoff:true, the runner must NOT fall through to the existing
+  // approvalRequired branch (which would set pending approval and trap the
+  // user). It must mark the step "human-only-handoff", finish the run as
+  // "handoff", and emit the user-visible "Click it on the page" message.
+  const harness = createHarness({
+    approvalBoundaryForStep: () => "public-submit",
+    decisions: [
+      { status: "continue", thought: "submit now", action: { type: "click", text: "Submit" } }
+    ],
+    stepResults: [
+      {
+        ok: false,
+        humanHandoff: true,
+        approvalRequired: true,
+        deniedToAutomation: true,
+        error: "Clicking \"Submit\" is a public submit/commit action and must be performed by the human on the page."
+      }
+    ]
+  });
+
+  const result = await harness.runner.continueControlLoop({ goal: "submit form" });
+
+  // No pending approval was set \u2014 the handoff is terminal.
+  assert.equal(harness.getPendingApproval(), null, "main loop must not set pending approval on a humanHandoff result");
+  // Result reports the handoff back to callers.
+  assert.equal(result.ok, false);
+  assert.equal(result.humanHandoff, true);
+  // The control run finished as handoff, not approval / blocked.
+  assert.equal(harness.getControlRun().status, "handoff");
+  const handoffStep = harness.getControlRun().steps[0];
+  assert.equal(handoffStep.state, "human-only-handoff");
+  assert.match(handoffStep.note, /click it on the page, then resume/);
+  assert.equal(handoffStep.details.safetyClass, "public-submit");
+  assert.equal(handoffStep.details.approvalDecision, "handoff");
+  // Report is saved tagged "human-handoff" \u2014 not "approval-required".
+  const lastReport = harness.getSavedReports().at(-1);
+  assert.equal(lastReport.status, "human-handoff");
+  // The user-visible handoff message was emitted via addMessage.
+  const handoffMessages = harness.events.filter(
+    (event) => event[0] === "message" && /Human-only handoff at action/.test(event[2])
+  );
+  assert.ok(handoffMessages.length >= 1, `expected a system message naming the human-only handoff; events=${JSON.stringify(harness.events)}`);
+  // The runner must NOT have re-invoked executeControlStep on this step (no consent / approval hop).
+  assert.equal(harness.events.filter((event) => event[0] === "execute").length, 1);
+});
+
+test("agent control runner routes public-submit approval into a human-only handoff instead of re-executing (#240)", async () => {
+  // #240 Part 3: an approve on a public-submit step must NOT re-execute the
+  // step; the runner emits a terminal handoff and saves the report tagged
+  // "human-handoff". This replaces the legacy "Approve once -> completed" path.
+  const harness = createHarness({
     decisions: [{ status: "done", thought: "done", doneSummary: "Done after approval." }],
-    stepResults: [{ ok: true, clickedText: "Submit" }]
+    stepResults: [{ ok: true, clickedText: "Submit" }],
+    approvalBoundaryForStep: () => "public-submit"
   });
   const approval = {
     step: { type: "click", text: "Submit" },
@@ -505,17 +557,48 @@ test("agent control runner can approve or deny a pending step through injected s
     results: [{ step: { type: "click", text: "Submit" }, result: { ok: false, approvalRequired: true } }],
     history: []
   };
-  approvalHarness.getControlRun().steps.push({ type: "click", text: "Submit", state: "blocked" });
+  harness.getControlRun().steps.push({ type: "click", text: "Submit", state: "blocked" });
+
+  await harness.runner.approvePendingControlStep(approval);
+
+  assert.equal(harness.getControlRun().status, "handoff");
+  assert.equal(harness.getControlRun().steps[0].state, "human-only-handoff");
+  assert.match(harness.getControlRun().steps[0].note, /click it on the page, then resume/);
+  assert.equal(harness.getControlRun().steps[0].details.approvalDecision, "handoff");
+  assert.equal(harness.getControlRun().steps[0].details.safetyClass, "public-submit");
+  assert.equal(
+    harness.events.filter((event) => event[0] === "execute").length,
+    0,
+    "approvePendingControlStep must not re-execute a public-submit step"
+  );
+  assert.equal(harness.getSavedReports().at(-1).status, "human-handoff");
+});
+
+test("agent control runner can approve or deny a pending safe step through injected state", async () => {
+  // Non-public-submit approval: the safe-action "Approve once" path must still
+  // re-execute the step and complete the run. Covers everything that is NOT a
+  // public-submit boundary (e.g. login redirection, optical target confirm).
+  const approvalHarness = createHarness({
+    decisions: [{ status: "done", thought: "done", doneSummary: "Done after approval." }],
+    stepResults: [{ ok: true, clickedText: "Continue" }],
+    approvalBoundaryForStep: () => "safe"
+  });
+  const approval = {
+    step: { type: "click", text: "Continue" },
+    stepIndex: 0,
+    results: [{ step: { type: "click", text: "Continue" }, result: { ok: false, approvalRequired: true } }],
+    history: []
+  };
+  approvalHarness.getControlRun().steps.push({ type: "click", text: "Continue", state: "blocked" });
 
   await approvalHarness.runner.approvePendingControlStep(approval);
 
   assert.equal(approvalHarness.getControlRun().status, "completed");
   assert.equal(approvalHarness.getControlRun().steps[0].state, "completed");
-  assert.equal(approvalHarness.getControlRun().steps[0].note, 'clicked "Submit"');
   assert.equal(approvalHarness.getControlRun().steps[0].details.approvalDecision, "approved-once");
 
   const denyHarness = createHarness();
-  denyHarness.getControlRun().steps.push({ type: "click", text: "Submit", state: "blocked" });
+  denyHarness.getControlRun().steps.push({ type: "click", text: "Continue", state: "blocked" });
   await denyHarness.runner.denyPendingControlStep({ ...approval, results: [] });
 
   assert.equal(denyHarness.getControlRun().status, "denied");

--- a/docs/augmentor-future-list-acceptance-matrix.md
+++ b/docs/augmentor-future-list-acceptance-matrix.md
@@ -57,7 +57,7 @@ suffix are open. Safety-boundary rows are **never** casual good-first-issues.
 ### Automation
 | Capability | Canonical issue(s) | Status | Tests / proof | Safety boundary |
 |---|---|---|---|---|
-| Autonomous navigation / Agent Control | #118 · #225 · epic #211 | 🔧 needs hardening · 🔒 | click/type/scroll certification fixtures; live-browser proof | governed; human-only public-submit / field-typing boundaries |
+| Autonomous navigation / Agent Control | #118 · #225 · #240 · epic #211 | 🟢 supported (live + deterministic) · 🔧 stop/cancel hardening · 🔒 | deterministic `agent-control-public-submit.test.mjs` (12 assertions) + `agent-control-runner.test.mjs` handoff + CI live certification (`.github/workflows/agent-control-live.yml`); public-submit handoff is terminal (non-bypassable) | governed; human-only public-submit / field-typing boundaries |
 | Agent Control stop/cancel & recovery UX | #226 · epic #211 | 🔧 needs hardening · 🔒 | stop/cancel kill-path + recovery-state tests; live-browser proof | user can always halt an in-flight action; no orphaned run state |
 | Form reading & autofill guard | #31 (C) · #8 (C) | ✅ supported | autofill-guard tests | never auto-submits; approval-gated |
 | Multi-step workflows | #237 · #14 (C) · #12 (C) | ✅ supported | — | — |


### PR DESCRIPTION
Closes #240 (Part 3, deterministic).

The runner previously trapped users in a 'needs approval' loop on public-submit boundaries: content.js denied the click unconditionally (Part 1, already in), but approvePendingControlStep re-executed executeControlStep regardless. Result: pressing 'Approve once' on a Submit button bounced back to 'Needs approval' forever.

This adds two terminal-handoff branches:

1. **Main-loop branch** (`agent-control-runner.js:691-736`): when executeControlStep returns `humanHandoff:true`, the step is marked `human-only-handoff`, the run finishes as `handoff`, the report is saved tagged `human-handoff`, and the user sees the message *'Click it yourself on the page, then ask me to resume'*.
2. **Approval-hop branch** (`agent-control-runner.js:899-929`): `approvePendingControlStep` on a public-submit boundary short-circuits to the same handoff without re-executing.

Parts 1, 2, and 4 already implement the content-side enforcement. Part 3 (runner-level terminal handoff) is what this PR adds.

**Deterministic tests:**
- `agent-control-public-submit.test.mjs` (12 assertions) — unchanged, still 12/12
- `agent-control-runner.test.mjs` — new handoff test asserts: status `handoff`, state `human-only-handoff`, approvalDecision `handoff`, safetyClass `public-submit`, **zero execute events emitted**, report status `human-handoff`. Safe-step test retains all original assertions including the two dropped deny-prove assertions (`getSavedReports().at(-1).status === "denied"` and the `denied by human` error payload).
- `npm run test:browser-first`: 830/830 green.

**Live proof (gated to #267):** the existing `.github/workflows/agent-control-live.yml` lane reads `RESONANTOS_PUBLIC_SUBMIT_CONTRACT` and the `decidePublicSubmitScenario({mode, humanHandoff})` reporter at `agent-control-live.mjs:631` already validates the handoff branch. After this lands, CI runs with `RESONANTOS_PUBLIC_SUBMIT_CONTRACT=required` will pass on `humanHandoff:true` and fail on the legacy approval path. Live evidence attaches to #223 / #224 / #226 / #240 once the run produces an artifact bundle.

**Known environmental failures (not from this PR):** `npm run test:browser-host` fails 2 of 13 on this sandbox because Playwright Chromium isn't installed. `npx playwright install` fixes it locally; CI installs it via `browser-actions/setup-chrome`.

**Matrix:** the Autonomous navigation / Agent Control row now reads `supported (live + deterministic)` and cites the handoff. The other Automation rows (stop/cancel #226, Form reading #31, Multi-step #237, Shopping #243, Booking #244, Email drafting #235, Meeting #253, Day briefing #245/#246) are untouched — diff is exactly one line in the matrix file.