### PR TITLE
feat(agent-control): stop/cancel clears approval and marks in-flight step cancelled (#226)

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/lib/agent-control-runner.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/agent-control-runner.js
@@ -597,7 +597,7 @@ export function createAgentControlRunner(deps) {
         setActivity("tool-running", `Executing browser action ${stepIndex + 1}`, controlStepLabel(step));
         const result = await executeControlStep(step);
         await setPageControlOverlay(true, "verifying", "verifying");
-        const verificationSnapshot = await deps.observeControlPage().catch(() => null);
+        const verificationSnapshot = await deps.observeControlPage().catch((err) => { if (err && /cancelled|paused/i.test(err.message ?? "")) throw err; return null; });
         const verification = verifyBrowserAction({
           after: verificationSnapshot,
           before: snapshot,
@@ -613,7 +613,7 @@ export function createAgentControlRunner(deps) {
         let postActionSnapshot = verificationSnapshot;
         let finalVerification = consent
           ? verifyBrowserAction({
-            after: (postActionSnapshot = await deps.observeControlPage().catch(() => verificationSnapshot)),
+            after: (postActionSnapshot = await deps.observeControlPage().catch((err) => { if (err && /cancelled|paused/i.test(err.message ?? "")) throw err; return verificationSnapshot; })),
             before: verificationSnapshot ?? snapshot,
             result: finalResult,
             step: finalStep
@@ -624,7 +624,7 @@ export function createAgentControlRunner(deps) {
           verificationRetry = "settle-reread";
           await setPageControlOverlay(true, "verifying", "verifying");
           await sleep(650);
-          const settledSnapshot = await deps.observeControlPage().catch(() => null);
+          const settledSnapshot = await deps.observeControlPage().catch((err) => { if (err && /cancelled|paused/i.test(err.message ?? "")) throw err; return null; });
           postActionSnapshot = settledSnapshot ?? postActionSnapshot;
           const settledVerification = verifyBrowserAction({
             after: postActionSnapshot,
@@ -652,7 +652,7 @@ export function createAgentControlRunner(deps) {
           executedStep = retryStep;
           executedResult = await executeControlStep(retryStep);
           await setPageControlOverlay(true, "verifying", "verifying");
-          const retrySnapshot = await deps.observeControlPage().catch(() => postActionSnapshot);
+          const retrySnapshot = await deps.observeControlPage().catch((err) => { if (err && /cancelled|paused/i.test(err.message ?? "")) throw err; return postActionSnapshot; });
           postActionSnapshot = retrySnapshot ?? postActionSnapshot;
           finalVerification = verifyBrowserAction({
             after: postActionSnapshot,
@@ -779,12 +779,51 @@ export function createAgentControlRunner(deps) {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       const status = /cancelled/i.test(message) ? "cancelled" : /paused/i.test(message) ? "paused" : "failed";
+      // #226: clear any pending approval so a cancelled run does not leave the
+      // approval card pinned to the panel until the next run starts.
+      setPendingApproval(null);
+      renderControlMonitor();
+      // #226: transition the in-flight step (active / approval / blocked /
+      // waiting-for-human) to "cancelled" so the trail does not strand a
+      // half-finished action.
+      const runForCleanup = getCurrentControlRun();
+      let inFlightIndex = -1;
+      if (runForCleanup?.steps?.length) {
+        for (let index = runForCleanup.steps.length - 1; index >= 0; index -= 1) {
+          const entryState = runForCleanup.steps[index]?.state;
+          if (entryState === "active" || entryState === "approval" || entryState === "blocked" || entryState === "waiting-for-human") {
+            inFlightIndex = index;
+            break;
+          }
+        }
+      }
+      const nextHumanAction = status === "cancelled"
+        ? "Restart the task or ask me to resume after you make any page changes yourself."
+        : status === "paused"
+        ? "Resume the task when you are ready, or cancel it from the panel."
+        : "Review the failure, then restart or resume the task from the panel.";
+      if (inFlightIndex !== -1) {
+        updateControlStep(inFlightIndex, "cancelled", `Cancelled during ${status}`, {
+          phase: "cancelled",
+          approvalDecision: "cancelled",
+          nextHumanAction
+        });
+      }
       finishControlRun(status);
       await updateBrowserJob(getActiveJobId(), { status, lastError: message });
       setStatus(status === "paused" ? "Paused" : status === "cancelled" ? "Cancelled" : "Control failed");
       setActivity(status === "paused" ? "paused" : "failed", `Control mode ${status}`, message);
-      await addMessage("system", `Agent Control Mode ${status}.\nGoal: ${goal}\nReason: ${message}`);
-      return { ok: false, results, error: message };
+      await addMessage(
+        "system",
+        [
+          `Agent Control Mode ${status}.`,
+          `Goal: ${goal}`,
+          `Reason: ${message}`,
+          `Next: ${nextHumanAction}`
+        ].join("\n")
+      );
+      await saveControlReportToArchive(results, status);
+      return { ok: false, results, error: message, status };
     }
   }
 

--- a/browser-first/test/agent-control-runner.test.mjs
+++ b/browser-first/test/agent-control-runner.test.mjs
@@ -33,6 +33,13 @@ function createHarness(overrides = {}) {
   const stepResults = overrides.stepResults ?? [{ ok: true, clickedText: "Next" }];
   const savedReports = [];
   let stepResultIndex = 0;
+  const defaultObserveControlPage = async () => {
+    events.push(["observe"]);
+    if (snapshotSequence?.length) {
+      lastSnapshot = snapshotSequence.shift();
+    }
+    return lastSnapshot;
+  };
 
   const deps = {
     addMessage: async (role, content) => events.push(["message", role, content]),
@@ -68,13 +75,7 @@ function createHarness(overrides = {}) {
     getActiveJobId: () => activeJobId,
     getCurrentControlRun: () => controlRun,
     getLastSnapshot: () => lastSnapshot,
-    observeControlPage: async () => {
-      events.push(["observe"]);
-      if (snapshotSequence?.length) {
-        lastSnapshot = snapshotSequence.shift();
-      }
-      return lastSnapshot;
-    },
+    observeControlPage: overrides.observeControlPage ?? defaultObserveControlPage,
     renderControlMonitor: () => events.push(["render"]),
     requestNextControlAction: async (request) => {
       nextActionRequests.push(request);
@@ -523,4 +524,116 @@ test("agent control runner can approve or deny a pending step through injected s
   assert.equal(denyHarness.getControlRun().steps[0].details.approvalDecision, "denied");
   assert.equal(denyHarness.getSavedReports().at(-1).status, "denied");
   assert.equal(denyHarness.getSavedReports().at(-1).results.at(-1).result.error, "denied by human");
+});
+
+test("agent control runner cancels during preflight: no execute fired, approval cleared, status cancelled (#226)", async () => {
+  // #226 acceptance criterion (preflight): cancel lands before the first
+  // executeControlStep call. observeControlPage throws a cancel error on the
+  // very first observation in the run loop.
+  const harness = createHarness({
+    decisions: [{ status: "continue", thought: "submit", action: { type: "click", text: "Submit" } }],
+    stepResults: [{ ok: true }],
+    observeControlPage: async () => {
+      throw new Error("Browser job was cancelled.");
+    }
+  });
+
+  const result = await harness.runner.continueControlLoop({ goal: "submit form" });
+
+  assert.equal(result.status, "cancelled");
+  assert.equal(harness.getControlRun().status, "cancelled");
+  assert.equal(harness.getPendingApproval(), null, "pending approval must be cleared on cancel");
+  assert.equal(harness.events.filter((event) => event[0] === "execute").length, 0, "preflight cancel must not invoke executeControlStep");
+  const cancelMessages = harness.events.filter(
+    (event) => event[0] === "message" && /Agent Control Mode cancelled/.test(event[2])
+  );
+  assert.ok(cancelMessages.length >= 1, "a system message naming the cancellation must be emitted");
+  assert.match(cancelMessages[0][2], /Next: Restart the task or ask me to resume/);
+  assert.equal(harness.getSavedReports().at(-1).status, "cancelled");
+});
+
+test("agent control runner cancels during a running step: in-flight step marked cancelled, approval cleared (#226)", async () => {
+  // #226 acceptance criterion (running): the first executeControlStep
+  // succeeds and completes; the second observe (verification snapshot for
+  // the next step) trips a cancel error mid-run. The previously active
+  // step must be marked cancelled and pending approval cleared.
+  const observeFactory = () => {
+    let count = 0;
+    return async () => {
+      count += 1;
+      // The second observe throws cancel to simulate the user hitting Cancel
+      // mid-run. The first observe returns a usable snapshot.
+      if (count >= 2) throw new Error("Browser job was cancelled by human.");
+      return { title: "Fixture", url: "https://example.test/", text: "Before", controls: [{ ref: "c1", text: "Next" }] };
+    };
+  };
+  const harness = createHarness({
+    decisions: [
+      { status: "continue", thought: "click next", action: { type: "click", text: "Next" } },
+      { status: "continue", thought: "click next again", action: { type: "click", text: "Next" } }
+    ],
+    snapshots: [
+      { title: "Fixture", url: "https://example.test/", text: "Before", controls: [{ ref: "c1", text: "Next" }] },
+      { title: "Fixture", url: "https://example.test/", text: "After click", controls: [{ ref: "c2", text: "Done" }] }
+    ],
+    stepResults: [
+      { ok: true, clickedText: "Next" },
+      { ok: true, clickedText: "Next" }
+    ],
+    observeControlPage: observeFactory()
+  });
+
+  const result = await harness.runner.continueControlLoop({ goal: "click next twice" });
+
+  assert.equal(result.status, "cancelled");
+  assert.equal(harness.getControlRun().status, "cancelled");
+  assert.equal(harness.getPendingApproval(), null);
+  // The in-flight step at the moment of cancel must be marked cancelled
+  // (no stranded "active" step in the trail).
+  const states = harness.getControlRun().steps.map((step) => step.state);
+  assert.ok(states.includes("cancelled"), `expected a cancelled step in the trail; got states=${JSON.stringify(states)}`);
+  assert.ok(!states.includes("active"), `no step should stay "active" after a cancel; got states=${JSON.stringify(states)}`);
+  const lastStep = harness.getControlRun().steps.at(-1);
+  assert.equal(lastStep.state, "cancelled");
+  assert.match(lastStep.details.nextHumanAction ?? "", /Restart the task or ask me to resume/);
+  assert.equal(harness.getSavedReports().at(-1).status, "cancelled");
+});
+
+test("agent control runner cancels after a blocked step: pending approval cleared, blocked step marked cancelled (#226)", async () => {
+  // #226 acceptance criterion (blocked): a step ends in blocked (with a
+  // pending approval). The next executeControlStep is never reached because
+  // observeControlPage throws cancel. Both the pending approval and the
+  // blocked step must be cleaned up.
+  const observeFactory = () => {
+    let count = 0;
+    return async () => {
+      count += 1;
+      if (count >= 2) throw new Error("Browser job was cancelled.");
+      return { title: "Fixture", url: "https://example.test/", text: "Before", controls: [{ ref: "c1", text: "Submit" }] };
+    };
+  };
+  const harness = createHarness({
+    decisions: [
+      { status: "continue", thought: "submit", action: { type: "click", text: "Submit" } },
+      { status: "continue", thought: "submit again", action: { type: "click", text: "Submit" } }
+    ],
+    approvalBoundaryForStep: () => "public-submit",
+    stepResults: [
+      { ok: false, approvalRequired: true, deniedToAutomation: true, error: "Public submit denied", safetyClass: "public-submit" },
+      { ok: false, approvalRequired: true, deniedToAutomation: true, error: "Public submit denied", safetyClass: "public-submit" }
+    ],
+    observeControlPage: observeFactory()
+  });
+
+  const result = await harness.runner.continueControlLoop({ goal: "submit public form" });
+
+  assert.equal(result.status, "cancelled");
+  assert.equal(harness.getControlRun().status, "cancelled");
+  // Pending approval must be cleared.
+  assert.equal(harness.getPendingApproval(), null);
+  // The blocked step must end up cancelled (not stranded in blocked state).
+  const states = harness.getControlRun().steps.map((step) => step.state);
+  assert.ok(states.includes("cancelled"), `expected a cancelled step in the trail; got states=${JSON.stringify(states)}`);
+  assert.ok(!states.includes("blocked"), `blocked step must be transitioned on cancel; got states=${JSON.stringify(states)}`);
+  assert.equal(harness.getSavedReports().at(-1).status, "cancelled");
 });

--- a/docs/augmentor-future-list-acceptance-matrix.md
+++ b/docs/augmentor-future-list-acceptance-matrix.md
@@ -58,7 +58,7 @@ suffix are open. Safety-boundary rows are **never** casual good-first-issues.
 | Capability | Canonical issue(s) | Status | Tests / proof | Safety boundary |
 |---|---|---|---|---|
 | Autonomous navigation / Agent Control | #118 · #225 · epic #211 | 🔧 needs hardening · 🔒 | click/type/scroll certification fixtures; live-browser proof | governed; human-only public-submit / field-typing boundaries |
-| Agent Control stop/cancel & recovery UX | #226 · epic #211 | 🔧 needs hardening · 🔒 | stop/cancel kill-path + recovery-state tests; live-browser proof | user can always halt an in-flight action; no orphaned run state |
+| Agent Control stop/cancel & recovery UX | #226 · epic #211 | 🟢 supported (deterministic) · 🔒 live proof gated to #267 | deterministic cancel-path tests in `agent-control-runner.test.mjs` (preflight / running / blocked); pending approval cleared, in-flight step marked cancelled, `nextHumanAction` in user message | user can always halt an in-flight action; no orphaned run state |
 | Form reading & autofill guard | #31 (C) · #8 (C) | ✅ supported | autofill-guard tests | never auto-submits; approval-gated |
 | Multi-step workflows | #237 · #14 (C) · #12 (C) | ✅ supported | — | — |
 | Shopping decision packet / checkout handoff | #243 · #16 (C) | ⏸ deferred · 🔒 | packet assembly + human-confirm gate | **human-only** checkout; draft/packet only |


### PR DESCRIPTION
## Summary

The catch branch in `continueControlLoop` previously mapped a thrown cancel/pause/failed to `finishControlRun` status but left the panel and trail in an inconsistent state:

- pending approval stayed pinned until the next run started
- the in-flight step kept its prior state (active / approval / blocked / waiting-for-human)
- the user message contained no explicit recovery guidance

This change hardens the catch branch and propagates cancel/pause signals through the observation wrappers (the existing `.catch(() => null)` on `observeControlPage` calls silently swallowed cancellations, leaving the runner trapped in a "running" state).

## What changes

1. **Catch branch hardening** (`agent-control-runner.js:782-825`):
   - `setPendingApproval(null)` + `renderControlMonitor()` clears any approval card so the panel no longer carries authority over the cancelled run.
   - In-flight step transition: the most recent step in `active | approval | blocked | waiting-for-human` state is updated to `state=cancelled` with a `nextHumanAction` line ("Restart the task or ask me to resume after you make any page changes yourself.").
   - Richer user message: the system message now embeds the `nextHumanAction` line and the report is saved tagged `cancelled` / `paused` / `failed` (not the old `blocked-step-limit` default).

2. **Cancel propagation** (`agent-control-runner.js:600, 616, 627, 655`):
   - The four `observeControlPage` call-sites (preflight + 3 verification paths) now re-throw cancel/pause signals so a mid-run cancellation actually reaches the catch branch.
   - Non-cancel observation failures still default to `null` (existing tolerance preserved).

3. **Three deterministic tests** (`test/agent-control-runner.test.mjs`):
   - preflight cancel: no `executeControlStep` fires
   - running cancel: in-flight `active` step becomes `cancelled`, pending approval null
   - blocked cancel: `blocked` step transitions to `cancelled`, pending approval null

4. **Test harness** (`test/agent-control-runner.test.mjs`):
   - Added `observeControlPage` override support via the existing `overrides` knob.
   - Extracted `defaultObserveControlPage` helper to keep the default body DRY.

5. **Acceptance matrix** (`docs/augmentor-future-list-acceptance-matrix.md`):
   - Single-row update: stop/cancel row now reads "supported (deterministic)" with live proof gated to #267.

## Acceptance criteria coverage

From Project 2 issue #226 AC list:

- [x] Stop/cancel immediately halts runnable steps (catch sets status synchronously)
- [x] UI shows final cancelled state and next safe recovery action (nextHumanAction in system message)
- [x] No pending approval or capability remains active after cancel (setPendingApproval(null))
- [ ] Tests cover cancellation during preflight / running step / blocked state — **deterministic only**, live-browser proof gated to #267
- [ ] Run targeted tests for touched modules — **covered** (`npm run test:browser-first`, 832/832 green)
- [ ] Browser-visible behavior: live-browser proof required per AC #4 — **blocked on #267**

## Verification

- `npm run test:browser-first`: **832/832** green (was 829 on dev, +3 for new tests).
- `node --check` on both files: ok.
- `node scripts/security-pipeline/run-check.mjs`: **72/72 verdicts pass** (security-sensitive approval-gate change — AGENTS.md L89). Added after a post-merge compliance audit caught the omission.
- Matrix diff: single-row (1 line changed, 1 line added, 0 lines removed elsewhere).

## Note on overlapping PR #284

PR #284 takes a complementary approach: durable-job polling via `getActiveJobStatus` checks at every loop boundary instead of re-throwing cancel through observation wrappers. The two PRs are not duplicates — they could be merged together for defense-in-depth or one could be picked over the other. Reviewer call.

## Closes

#226 (deterministic layer; live-browser proof gated to #267).

## Checklist

- [x] Branch from `dev` (fresh branch `fix/agent-control-stop-cancel-recovery`).
- [x] PR targets `dev`.
- [x] No secrets, generated bridge credentials, or browser state committed.
- [x] Linked issue.
- [x] Single-row matrix update.
- [x] Change-to-check matrix rows run (test:browser-first + security-pipeline).
- [ ] Live-browser proof gated to #267 (out of scope for this PR; PR #286 is the prerequisite for that CI lane).
