### PR TITLE
fix(agent-control): close the #224 credential-alias bypass with token-exact matching

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/lib/approval-policy.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/approval-policy.js
@@ -1,5 +1,8 @@
-const restrictedPlannerText = /\b(seed|private key|password|passphrase|passwd|pwd|pin|passkey|security code|wallet|phantom|sign|signature|approve|buy|sell|swap|stake|unstake|bridge|mint|claim|pay|payment|checkout|login|delete|remove|destroy|credential|2fa|otp|transfer)\b/i;
-const hardApprovalBoundaryText = /\b(seed|private key|password|passphrase|passwd|pwd|pin|passkey|security code|wallet|phantom|sign|signature|approve|buy|sell|swap|stake|unstake|bridge|mint|claim|pay|payment|checkout|login|delete|remove|destroy|credential|2fa|otp|transfer|card|cvc|cvv|iban|billing|autofill|personal contact|human-controlled autofill)\b/i;
+// #224: "security code" must match every separator spelling the field
+// classifier accepts (security code / security_code / security-code /
+// securitycode) — mirror content-field-safety.js rather than a space-only literal.
+const restrictedPlannerText = /\b(seed|private key|password|passphrase|passwd|pwd|pin|passkey|security[\s_-]*code|wallet|phantom|sign|signature|approve|buy|sell|swap|stake|unstake|bridge|mint|claim|pay|payment|checkout|login|delete|remove|destroy|credential|2fa|otp|transfer)\b/i;
+const hardApprovalBoundaryText = /\b(seed|private key|password|passphrase|passwd|pwd|pin|passkey|security[\s_-]*code|wallet|phantom|sign|signature|approve|buy|sell|swap|stake|unstake|bridge|mint|claim|pay|payment|checkout|login|delete|remove|destroy|credential|2fa|otp|transfer|card|cvc|cvv|iban|billing|autofill|personal contact|human-controlled autofill)\b/i;
 // #240: keep aligned with content.js PUBLIC_COMMIT_VERBS so the runner classifies
 // the same controls the content script hands off (minus the hard-boundary verbs).
 const publicSubmitBoundaryText = /\b(submit|publish|post|share|send|save|confirm|connect|reserve|book|order|apply|vote|subscribe|register|comment)\b/i;

--- a/browser-first/resonantos-side-panel-extension/src/lib/content-field-safety.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/content-field-safety.js
@@ -2,11 +2,50 @@
 
 (() => {
   if (globalThis.ResonantOSContentFieldSafety) return;
+
+  // #224 hardening: alias matching must be token-exact, never substring.
+  // Candidate strings are split on underscores/hyphens/spaces, on lower->Upper
+  // camelCase transitions, and on letter<->digit boundaries, then pure-digit
+  // tokens are dropped: pin1 -> [pin], passwd2 -> [passwd],
+  // userPin -> [user, pin], txtPasswd -> [txt, passwd]. Word-boundary regexes
+  // alone never fire inside camelCase or digit-suffixed concatenations, which
+  // let "pincode"/"pin1"/"userPin"/"txtPasswd" reach generic-text.
+  const tokenizeFieldDescriptor = (value) => String(value)
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/([A-Za-z])([0-9])/g, "$1 $2")
+    .replace(/([0-9])([A-Za-z])/g, "$1 $2")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((token) => token && !/^[0-9]+$/.test(token));
+
+  // Token-exact credential aliases (single tokens plus compact compounds such
+  // as pincode/passcode/seccode). "pass" is intentionally a standalone alias:
+  // as a whole token it names a password field, while "passenger", "compass",
+  // "shipping", "spinner", and "pinned" stay single non-matching tokens.
+  const credentialTokenAliases = new Set([
+    "password", "passcode", "passphrase", "passwd", "pwd", "pass", "pin",
+    "pincode", "passkey", "seccode", "securitycode", "verificationcode",
+    "credential", "secret", "seed", "otp", "mfa", "authenticator"
+  ]);
+
+  const hasCredentialToken = (descriptors) => {
+    for (const descriptor of descriptors) {
+      const tokens = tokenizeFieldDescriptor(descriptor);
+      for (let index = 0; index < tokens.length; index += 1) {
+        if (credentialTokenAliases.has(tokens[index])) return true;
+        // Adjacent-token compounds keep secCode/sec_code/securityCode aligned
+        // with their compact one-word spellings without substring matching.
+        if (index + 1 < tokens.length && credentialTokenAliases.has(tokens[index] + tokens[index + 1])) return true;
+      }
+    }
+    return false;
+  };
+
   function classifyEditableField(element, { relatedLabelText = () => "" } = {}) {
     const tagName = element?.tagName?.toLowerCase?.() ?? "";
     const type = element instanceof HTMLInputElement ? String(element.getAttribute("type") || "text").toLowerCase() : "";
     const form = element?.closest?.("form");
-    const haystack = [
+    const descriptors = [
       type,
       tagName,
       element?.getAttribute?.("name"),
@@ -22,13 +61,17 @@
       form?.getAttribute?.("id"),
       form?.getAttribute?.("name"),
       form?.getAttribute?.("action")
-    ].filter(Boolean).join(" ").replaceAll("_", " ").toLowerCase();
+    ].filter(Boolean);
+    const haystack = descriptors.join(" ").replaceAll("_", " ").toLowerCase();
 
     if (
       type === "password" ||
       // #224: credential names also cover passwd/pwd/pin/passkey/security-code
       // aliases — sites frequently use type="text" for these, and an unblocked
       // generic-text classification would let Agent Control type into them.
+      // Token-exact matching closes camelCase/digit-suffix bypasses (pincode,
+      // pin1, userPin, txtPasswd, secCode) the \b regex below cannot see.
+      hasCredentialToken(descriptors) ||
       /\b(password|passcode|passphrase|passwd|pwd|pin|passkey|security[\s_-]*code|credential|secret|seed|private\s*key|otp|2fa|mfa|one[-\s]?time|verification\s*code|authenticator)\b/.test(haystack)
     ) {
       return { kind: "credential", safeToType: false, safeToSubmit: false, reason: "Credential fields are human-only until the secure vault approval model exists." };

--- a/browser-first/test/approval-policy.test.mjs
+++ b/browser-first/test/approval-policy.test.mjs
@@ -20,6 +20,13 @@ test("approval policy classifies hard wallet, credential, and signing boundaries
   assert.equal(approvalBoundaryForStep({ type: "click", text: "Details" }), "safe");
 });
 
+test("#224: approval policy matches every security-code separator spelling, aligned with the field classifier", () => {
+  assert.equal(approvalBoundaryForStep({ type: "type", field: "security code", text: "123" }), "hard");
+  assert.equal(approvalBoundaryForStep({ type: "type", field: "security_code", text: "123" }), "hard");
+  assert.equal(approvalBoundaryForStep({ type: "type", field: "security-code", text: "123" }), "hard");
+  assert.equal(approvalBoundaryForStep({ type: "type", field: "securityCode", text: "123" }), "hard");
+});
+
 test("approval policy rejects unsafe planner URLs and restricted targets", () => {
   assert.equal(sanitizePlannerUrl("resonantos.com/dao"), "https://resonantos.com/dao");
   assert.throws(() => sanitizePlannerUrl("file:///tmp/secret.txt"), /http and https/);

--- a/browser-first/test/content-redaction.test.mjs
+++ b/browser-first/test/content-redaction.test.mjs
@@ -739,3 +739,125 @@ test("#224: submit on a generic non-search field stays human-gated while the typ
   assert.match(response.error, /human approval/i, "non-search submit stays human-gated");
   assert.equal(dom.window.document.getElementById("notes").value, "draft note", "the typed draft lands even when auto-submit is denied");
 });
+
+// #224 alias-matrix close: word-boundary regexes never fire inside camelCase or
+// digit-suffixed concatenations, so these probes used to reach generic-text
+// with safeToType:true. Token-exact matching must classify every one of them
+// credential — and must never substring-match innocent words.
+const credentialAliasProbes = [
+  "pincode", "pin1", "pin2", "passwd2", "userPin", "loginPin", "txtPasswd", "secCode", "pass"
+];
+const credentialAliasNegatives = [
+  "shipping", "spinner", "pinned", "passenger", "compass"
+];
+
+test("#224: camelCase/digit-suffixed credential aliases classify credential, never substring-match innocents", async () => {
+  const probeInputs = credentialAliasProbes
+    .map((name, index) => `<input id="f${index}" type="text" name="${name}">`)
+    .join("\n");
+  const negativeInputs = credentialAliasNegatives
+    .map((name, index) => `<input id="n${index}" type="text" name="${name}">`)
+    .join("\n");
+  const dom = new JSDOM(`<!doctype html>\n${probeInputs}\n${negativeInputs}`, {
+    runScripts: "outside-only",
+    url: "https://example.test/",
+  });
+  dom.window.eval(await readFile(fieldSafetyScriptPath, "utf8"));
+  const classify = (selector) => dom.window.ResonantOSContentFieldSafety.classifyEditableField(dom.window.document.querySelector(selector));
+
+  credentialAliasProbes.forEach((name, index) => {
+    const safety = classify(`#f${index}`);
+    assert.equal(safety.kind, "credential", `name="${name}" must classify credential`);
+    assert.equal(safety.safeToType, false, `name="${name}" must not be typable by Agent Control`);
+    assert.equal(safety.safeToSubmit, false, `name="${name}" must not be submittable by Agent Control`);
+  });
+  credentialAliasNegatives.forEach((name, index) => {
+    const safety = classify(`#n${index}`);
+    assert.notEqual(safety.kind, "credential", `name="${name}" must not substring-match a credential alias`);
+    assert.equal(safety.kind, "generic-text", `name="${name}" stays a plain generic-text field`);
+  });
+});
+
+test("#224: typing into camelCase/digit-suffixed credential aliases is denied even with userApproved", async () => {
+  const inputs = credentialAliasProbes
+    .map((name, index) => `<input id="f${index}" type="text" name="${name}" value="human-secret">`)
+    .join("\n");
+  const { dom, listener } = await loadContentScript(`<!doctype html>\n${inputs}`);
+
+  let snapshot = null;
+  listener({
+    channel: "resonantos.browser_first.content",
+    type: "read_page",
+  }, {}, (payload) => {
+    snapshot = payload.snapshot;
+  });
+
+  credentialAliasProbes.forEach((name, index) => {
+    const field = snapshot.fields.find((candidate) => candidate.id === `f${index}`);
+    assert.equal(field?.fieldKind, "credential", `snapshot must report name="${name}" as credential`);
+    assert.equal(field.valuePreview, "[redacted:credential]", `name="${name}" value must be redacted in snapshots`);
+
+    let response = null;
+    listener({
+      channel: "resonantos.browser_first.content",
+      type: "type_text",
+      ref: field.ref,
+      text: "hacked",
+      userApproved: true,
+    }, {}, (payload) => {
+      response = payload;
+    });
+
+    assert.equal(response?.ok, false, `typing into name="${name}" must be blocked`);
+    assert.equal(response.approvalRequired, true, `name="${name}" must require human action`);
+    assert.equal(response.deniedToAutomation, true, `name="${name}" must be denied to automation even with userApproved`);
+    assert.equal(response.fieldSafety.kind, "credential", `name="${name}" must report the credential boundary`);
+    assert.equal(dom.window.document.getElementById(`f${index}`).value, "human-secret", `name="${name}" value must be unchanged`);
+  });
+});
+
+test("#224: underscore-named search fields classify search-query but stay gated by formIsSafeToAutoSubmit", async () => {
+  const { dom, listener } = await loadContentScript(`
+    <!doctype html>
+    <form id="mixed-form">
+      <label for="terms">Search terms</label>
+      <input id="terms" type="text" name="search_terms" value="">
+      <label for="topic">Topic</label>
+      <input id="topic" type="text" name="topic" value="">
+      <button type="submit">Go</button>
+    </form>
+  `);
+
+  let snapshot = null;
+  listener({
+    channel: "resonantos.browser_first.content",
+    type: "read_page",
+  }, {}, (payload) => {
+    snapshot = payload.snapshot;
+  });
+  const termsField = snapshot.fields.find((field) => field.id === "terms");
+  // The underscore normalization added for #224 makes name="search_terms"
+  // classify search-query (it was generic-text before) — document that shift...
+  assert.equal(termsField?.fieldKind, "search-query");
+
+  let response = null;
+  listener({
+    channel: "resonantos.browser_first.content",
+    type: "type_text",
+    ref: termsField.ref,
+    text: "resonantos hardening",
+    submit: true,
+  }, {}, (payload) => {
+    response = payload;
+  });
+
+  // ...and prove it does not widen auto-submit: the enclosing mixed form still
+  // fails formIsSafeToAutoSubmit, so the submit hands off to the human while
+  // the typed query lands in the field.
+  assert.equal(response?.ok, false);
+  assert.equal(response.deniedToAutomation, true);
+  assert.equal(response.humanHandoff, true, "mixed-form submit must hand off to the human");
+  assert.match(response.error, /human must submit/i);
+  assert.equal(dom.window.document.getElementById("terms").value, "resonantos hardening", "the typed query still lands");
+  assert.equal(dom.window.document.getElementById("topic").value, "", "no other field receives text");
+});


### PR DESCRIPTION
Closes the #224 alias-matrix gaps that reached dev via #281's bundled commit: \`pincode\`/\`pin1\`/\`pin2\`/\`passwd2\`/\`userPin\`/\`loginPin\`/\`txtPasswd\`/\`secCode\`/\`pass\` all classified generic-text with \`safeToType:true\`.

- Token-aware normalization (underscore/hyphen/space + camelCase + letter↔digit boundaries, digit tokens stripped) with **token-exact** matching — substring innocents (shipping/spinner/pinned/passenger/compass) stay non-credential, proven by negative tests
- Compact compounds (\`pincode\`/\`seccode\`/\`securitycode\`) + standalone \`pass\`; \`approval-policy.js\` security-code spellings aligned (\`security[\s_-]*code\`)
- Full probe matrix + \`typeIntoPage\` denial with \`userApproved:true\` + \`search_terms\` behavioral test
- Suite **838/838**; digit-boundary guard proven non-vacuous via rig-mutate

Part of the #211 gate series (adjudicated 2026-08-18; execution by isolated rig executor). Refs #224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)