### PR TITLE
test(agent-control): certification fixtures for safe/blocked actions (#223, reworked)

### DIFF
--- a/browser-first/README.md
+++ b/browser-first/README.md
@@ -43,6 +43,10 @@ in extension source, generated config, Chrome storage, fixtures, or diagnostics.
 npm run test:browser-first
 ```
 
+The [Agent Control certification fixtures](test/agent-control-certification/README.md)
+prove safe click/type/scroll completion and hard-boundary denial against the
+real content-mediation layer (fixture page:
+[agent-control-certification-page.html](test/fixtures/agent-control-certification/agent-control-certification-page.html)).
 The [HRR-033 deterministic certification gate](test/hrr033-certification/README.md)
 documents the focused context and Resonator evidence workflow used for deeper
 browser-first regression certification. Implementation notes for the Alpha

--- a/browser-first/test/agent-control-certification-fixtures.mjs
+++ b/browser-first/test/agent-control-certification-fixtures.mjs
@@ -1,0 +1,111 @@
+// Shared certification fixtures for issue #223: Agent Control safe
+// click/type/scroll certification. Loads the static fixture page into jsdom,
+// evaluates the real content.js safety layer, and exposes a certified
+// control-step executor whose page actions run against that layer.
+//
+// The runner-level certification tests in agent-control-runner.test.mjs and
+// the executor-level tests in control-step-executor.test.mjs share this module
+// so the focused test command stays:
+//   node --test browser-first/test/control-step-executor.test.mjs browser-first/test/agent-control-runner.test.mjs
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { JSDOM } from "jsdom";
+
+import { createControlStepExecutor } from "../resonantos-side-panel-extension/src/lib/control-step-executor.js";
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+const ext = (...p) => path.join(repoRoot, "browser-first", "resonantos-side-panel-extension", "src", ...p);
+const fixturePath = path.join(import.meta.dirname, "fixtures", "agent-control-certification", "agent-control-certification-page.html");
+
+const contentScripts = [
+  ext("lib", "control-overlay.js"),
+  ext("lib", "content-field-safety.js"),
+  ext("lib", "content-inline-actions.js"),
+  ext("lib", "content-control-refs.js"),
+  ext("content.js")
+];
+
+export const certificationFixture = {
+  pageUrl: "https://certification.test/",
+  fixturePath
+};
+
+// Builds a jsdom instance of the certification fixture page with the real
+// content.js safety layer running inside it.
+export async function loadCertificationPage() {
+  const html = await readFile(fixturePath, "utf8");
+  const dom = new JSDOM(html, { runScripts: "dangerously", url: certificationFixture.pageUrl, pretendToBeVisual: true });
+  const win = dom.window;
+  let listener = null;
+  win.chrome = {
+    runtime: {
+      onMessage: { addListener(cb) { listener = cb; } },
+      sendMessage: () => Promise.resolve()
+    },
+    storage: { onChanged: { addListener() {} } }
+  };
+  win.HTMLElement.prototype.scrollIntoView = function scrollIntoView() {};
+  win.__resonantosControlDwellMs = 0;
+  for (const scriptPath of contentScripts) win.eval(await readFile(scriptPath, "utf8"));
+  if (typeof listener !== "function") throw new Error("content.js should register a message listener on the certification fixture");
+  // jsdom has no layout engine; stub the scrolling surface so scrollPage's
+  // window.scrollBy/scrollY contract stays observable.
+  const scrollHeight = win.document.documentElement.scrollHeight || 6000;
+  Object.defineProperty(win.document.documentElement, "scrollHeight", { configurable: true, get: () => scrollHeight });
+  win.scrollY = 0;
+  win.scrollBy = ({ top = 0 }) => {
+    win.scrollY = Math.max(0, Math.min(scrollHeight - win.innerHeight, win.scrollY + top));
+    win.dispatchEvent(new win.Event("scroll"));
+    return undefined;
+  };
+  const send = (message) => new Promise((resolve) => {
+    listener({ channel: "resonantos.browser_first.content", ...message }, {}, resolve);
+  });
+  return { dom, win, send };
+}
+
+// Builds a certified control-step executor: the executor's page-action
+// dependencies are wired to the real content.js safety layer inside the
+// fixture page instead of stubs, so step results certify page-side behavior.
+export function createCertifiedExecutor({ win, send }) {
+  const events = [];
+  let controlledTabId = 1;
+  const executor = createControlStepExecutor({
+    addMessage: async (role, content) => events.push(["message", role, content]),
+    chrome: {
+      tabs: {
+        get: async (id) => ({ id, active: id === 1, title: "Certification Fixture", url: certificationFixture.pageUrl }),
+        query: async () => [{ id: 1, active: true, title: "Certification Fixture", url: certificationFixture.pageUrl }],
+        update: async (id, patch) => events.push(["tab-update", id, patch])
+      }
+    },
+    clickActivePageText: async ({ text, ref, userApproved }) => {
+      const result = await send({ type: "click_text", text, ref, userApproved: Boolean(userApproved) });
+      events.push(["click", text ?? ref, result]);
+      return result;
+    },
+    detectActivePageForms: async () => send({ type: "detect_forms" }),
+    getControlledTabId: () => controlledTabId,
+    isReadableBrowserTab: (tab) => /^https?:\/\//i.test(String(tab?.url ?? "")),
+    openBrowserUrl: async (target) => ({ ok: true, action: "open", url: target }),
+    scrollActivePage: async ({ direction }) => {
+      const result = await send({ type: "scroll_page", direction });
+      events.push(["scroll", direction, result]);
+      return result;
+    },
+    searchBrowser: async () => ({ ok: true }),
+    setActivity: () => undefined,
+    setContextMeter: () => undefined,
+    setControlledTabId: (id) => { controlledTabId = id; },
+    setLastSnapshot: () => undefined,
+    sleep: async () => undefined,
+    summarizeSnapshot: async () => ({ ok: true, snapshot: { title: "Certification Fixture", url: certificationFixture.pageUrl } }),
+    typeIntoActivePage: async ({ text, field, ref, submit, userApproved }) => {
+      const result = await send({ type: "type_text", text, field, ref, submit, userApproved: Boolean(userApproved) });
+      events.push(["type", field ?? ref, result]);
+      return result;
+    }
+  });
+  return { events, executor };
+}

--- a/browser-first/test/agent-control-certification/README.md
+++ b/browser-first/test/agent-control-certification/README.md
@@ -1,0 +1,40 @@
+# Agent Control Certification Fixtures (issue #223)
+
+Deterministic certification gate for Agent Control safe click/type/scroll
+fixtures and blocked high-risk paths.
+
+Run:
+
+```bash
+node browser-first/test/agent-control-certification/run-certification.mjs
+```
+
+Artifacts are written to:
+
+```text
+output/runtime-evidence/agent-control-certification/AC-CERT-<timestamp>-<hash>/
+```
+
+## What it verifies
+
+- a fresh run ID for every execution; every artifact is bound to that ID and
+  fails the gate if stale or foreign-run;
+- source hashes binding the certification to the exact fixture page and
+  enforcement sources used;
+- `node --check` for the harness and fixture sources;
+- the focused certification tests from the issue handoff
+  (`node --test browser-first/test/control-step-executor.test.mjs
+  browser-first/test/agent-control-runner.test.mjs`) including assertion-content
+  checks, so the gate fails if the declared certification claims stop executing;
+- full `npm run test:browser-first` regression;
+- optional live browser proof attach from `RESONANTOS_CERT_PROOF_DIR` (the
+  live harness, issue #267, writes screenshots there); absence is recorded as
+  `excluded`, never as a pass;
+- sentinel scan of generated artifacts;
+- nonzero process exit for any certification failure.
+
+## Certification claims
+
+Safe clicks/type/scroll complete with page-side effects; wallet connect,
+public submit, and credential/payment typing stay blocked with the correct
+boundary named and nothing actuated.

--- a/browser-first/test/agent-control-certification/certification.config.json
+++ b/browser-first/test/agent-control-certification/certification.config.json
@@ -30,11 +30,11 @@
     "typing into credential and payment fields is denied with the boundary named",
     "safe click/type/scroll plan completes on the certification fixture",
     "wallet connect attempt blocks the run with the wallet boundary named",
-    "public-submit attempt creates an approval card",
+    "public-submit attempt is a terminal human handoff",
     "credential typing attempt blocks the run with the credential boundary named"
   ],
   "fullRegressionCommand": ["npm", "run", "test:browser-first"],
-  "minFullRegressionPassCount": 649,
+  "minFullRegressionPassCount": 840,
   "forbiddenEvidenceText": [
     "AC_CERT_SENTINEL_DO_NOT_LEAK"
   ],

--- a/browser-first/test/agent-control-certification/certification.config.json
+++ b/browser-first/test/agent-control-certification/certification.config.json
@@ -1,0 +1,42 @@
+{
+  "artifactKind": "agent-control-certification",
+  "artifactsRoot": "output/runtime-evidence/agent-control-certification",
+  "targetFiles": [
+    "browser-first/test/agent-control-certification-fixtures.mjs",
+    "browser-first/test/fixtures/agent-control-certification/agent-control-certification-page.html",
+    "browser-first/test/control-step-executor.test.mjs",
+    "browser-first/test/agent-control-runner.test.mjs",
+    "browser-first/resonantos-side-panel-extension/src/content.js",
+    "browser-first/resonantos-side-panel-extension/src/lib/content-field-safety.js",
+    "browser-first/resonantos-side-panel-extension/src/lib/control-step-executor.js",
+    "browser-first/resonantos-side-panel-extension/src/lib/agent-control-runner.js"
+  ],
+  "certificationFiles": [
+    "browser-first/test/agent-control-certification/README.md",
+    "browser-first/test/agent-control-certification/certification.config.json",
+    "browser-first/test/agent-control-certification/run-certification.mjs"
+  ],
+  "focusedTestFiles": [
+    "browser-first/test/control-step-executor.test.mjs",
+    "browser-first/test/agent-control-runner.test.mjs"
+  ],
+  "focusedTestAssertions": [
+    "safe click on the certification fixture completes",
+    "safe type into the search field on the certification fixture completes",
+    "safe type into the generic notes field completes",
+    "safe scroll on the certification fixture completes",
+    "wallet connect click is denied with the wallet boundary named",
+    "public submit clicks are denied as human-only handoffs",
+    "typing into credential and payment fields is denied with the boundary named",
+    "safe click/type/scroll plan completes on the certification fixture",
+    "wallet connect attempt blocks the run with the wallet boundary named",
+    "public-submit attempt creates an approval card",
+    "credential typing attempt blocks the run with the credential boundary named"
+  ],
+  "fullRegressionCommand": ["npm", "run", "test:browser-first"],
+  "minFullRegressionPassCount": 649,
+  "forbiddenEvidenceText": [
+    "AC_CERT_SENTINEL_DO_NOT_LEAK"
+  ],
+  "liveProofDirEnv": "RESONANTOS_CERT_PROOF_DIR"
+}

--- a/browser-first/test/agent-control-certification/run-certification.mjs
+++ b/browser-first/test/agent-control-certification/run-certification.mjs
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+
+// Issue #223 deterministic certification gate for Agent Control safe
+// click/type/scroll fixtures. Every run gets a fresh run ID; artifacts are
+// bound to that ID and hashed against the exact fixture/source revisions, so
+// stale screenshots or foreign-run artifacts can never certify a claim.
+
+import { spawnSync } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..", "..", "..");
+const config = JSON.parse(fs.readFileSync(path.join(__dirname, "certification.config.json"), "utf8"));
+
+const runId = `AC-CERT-${new Date().toISOString().replace(/[^0-9]/g, "").slice(0, 14)}-${crypto.randomBytes(4).toString("hex")}`;
+const artifactsRoot = path.resolve(repoRoot, config.artifactsRoot);
+const runDir = path.join(artifactsRoot, runId);
+const logsDir = path.join(runDir, "logs");
+const proofDir = path.join(runDir, "proof");
+const liveProofDir = process.env[config.liveProofDirEnv];
+
+const now = () => new Date().toISOString();
+const rel = (absolutePath) => path.relative(runDir, absolutePath);
+const ensureDir = (dir) => fs.mkdirSync(dir, { recursive: true });
+const writeJson = (file, data) => fs.writeFileSync(file, `${JSON.stringify(data, null, 2)}\n`);
+const writeText = (file, data) => fs.writeFileSync(file, data ?? "");
+const slug = (value) => String(value).replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-|-$/g, "");
+const sha256 = (file) => crypto.createHash("sha256").update(fs.readFileSync(file)).digest("hex");
+
+ensureDir(logsDir);
+ensureDir(proofDir);
+
+const ledger = [];
+const failures = [];
+const runStartedAt = now();
+
+function record(entry) {
+  const normalized = { recordedAt: now(), runId, ...entry };
+  ledger.push(normalized);
+  writeJson(path.join(runDir, "execution-ledger.json"), ledger);
+  return normalized;
+}
+
+function addFailure(id, severity, description, evidence = []) {
+  const finding = { id, severity, description, evidence };
+  failures.push(finding);
+  return finding;
+}
+
+function runCommand(label, command, options = {}) {
+  const [cmd, ...args] = command;
+  const stdoutPath = path.join(logsDir, `${slug(label)}.stdout.log`);
+  const stderrPath = path.join(logsDir, `${slug(label)}.stderr.log`);
+  const startedAt = now();
+  const result = spawnSync(cmd, args, {
+    cwd: options.cwd ?? repoRoot,
+    encoding: "utf8",
+    timeout: options.timeoutMs ?? 300000,
+    shell: false
+  });
+  const endedAt = now();
+  writeText(stdoutPath, result.stdout ?? "");
+  writeText(stderrPath, result.stderr ?? "");
+  const entry = {
+    type: "exec",
+    label,
+    command,
+    cwd: options.cwd ?? repoRoot,
+    startedAt,
+    endedAt,
+    exitCode: result.status,
+    signal: result.signal,
+    timedOut: result.error?.code === "ETIMEDOUT",
+    error: result.error ? String(result.error.message || result.error) : null,
+    stdout: rel(stdoutPath),
+    stderr: rel(stderrPath)
+  };
+  record(entry);
+  return entry;
+}
+
+function readLog(entry) {
+  return `${fs.readFileSync(path.join(runDir, entry.stdout), "utf8")}\n${fs.readFileSync(path.join(runDir, entry.stderr), "utf8")}`;
+}
+
+function artifactHashInfo(file) {
+  return { file: rel(file), sha256: sha256(file), sizeBytes: fs.statSync(file).size };
+}
+
+const preflight = {
+  runId,
+  repoRoot,
+  startedAt: runStartedAt,
+  node: process.version,
+  platform: process.platform,
+  liveProofDir: liveProofDir ?? null
+};
+writeJson(path.join(runDir, "00-preflight.json"), preflight);
+
+// Stage 1: scope audit — certification claims only cover the declared target
+// files, and dirty out-of-scope files are quarantined from the claims.
+const gitStatusEntry = runCommand("01-git-status-porcelain", ["git", "status", "--porcelain=v1", "-uall"]);
+const statusLines = fs.readFileSync(path.join(runDir, gitStatusEntry.stdout), "utf8")
+  .split("\n").map((line) => line.trimEnd()).filter((line) => line && !line.startsWith("##"));
+const targetSet = new Set([...config.targetFiles, ...config.certificationFiles, ...config.focusedTestFiles]);
+const scopeAudit = {
+  runId,
+  capturedAt: now(),
+  inScopeDirty: statusLines.filter((line) => targetSet.has(line.slice(3).trim())),
+  outOfScopeDirty: statusLines.filter((line) => !targetSet.has(line.slice(3).trim())),
+  targetFiles: [...targetSet].sort(),
+  enforcement: "Out-of-scope dirty files are quarantined from certification claims. In-scope files are covered by syntax, focused, full-regression, and freshness gates."
+};
+writeJson(path.join(runDir, "01-scope-audit.json"), scopeAudit);
+
+// Stage 2: source integrity — hash every certification input so the artifacts
+// are provably tied to the exact fixture and enforcement sources used.
+const sourceIntegrity = {
+  runId,
+  capturedAt: now(),
+  files: config.targetFiles.filter((file) => fs.existsSync(path.join(repoRoot, file))).map((file) => artifactHashInfo(path.join(repoRoot, file)))
+};
+writeJson(path.join(runDir, "02-source-integrity.json"), sourceIntegrity);
+
+// Stage 3: syntax checks for the harness and fixture module.
+const syntaxFiles = [...config.certificationFiles, ...config.targetFiles].filter((file) => file.endsWith(".mjs") || file.endsWith(".js"));
+const syntaxChecks = syntaxFiles.map((file) => {
+  const entry = runCommand(`03-node-check-${slug(file)}`, ["node", "--check", path.join(repoRoot, file)], { timeoutMs: 60000 });
+  return { file, pass: entry.exitCode === 0, exitCode: entry.exitCode, stdout: entry.stdout, stderr: entry.stderr };
+});
+const syntaxPass = syntaxChecks.every((check) => check.pass);
+if (!syntaxPass) addFailure("SYNTAX", "CRITICAL", "Certification harness or fixture sources failed node --check.", ["03-syntax-checks.json"]);
+writeJson(path.join(runDir, "03-syntax-checks.json"), { runId, checks: syntaxChecks, pass: syntaxPass });
+
+// Stage 4: focused certification tests (the exact command from issue #223's
+// contributor handoff) plus assertion-content checks so the gate fails closed
+// if the named certification tests disappear or stop exercising the claims.
+const focusedEntry = runCommand("04-focused-certification-tests", [
+  "node", "--test", "--test-concurrency=1", ...config.focusedTestFiles
+], { timeoutMs: 180000 });
+const focusedLog = readLog(focusedEntry);
+const focusedAssertions = config.focusedTestAssertions.map((needle) => ({ needle, present: focusedLog.includes(needle) }));
+const focusedPass = focusedEntry.exitCode === 0 && focusedAssertions.every((assertion) => assertion.present);
+if (!focusedPass) addFailure("FOCUSED_TESTS", "CRITICAL", "Focused certification tests failed or did not exercise every declared claim.", ["04-focused-tests.json"]);
+writeJson(path.join(runDir, "04-focused-tests.json"), {
+  runId,
+  command: focusedEntry.command,
+  pass: focusedPass,
+  exitCode: focusedEntry.exitCode,
+  stdout: focusedEntry.stdout,
+  stderr: focusedEntry.stderr,
+  assertions: focusedAssertions
+});
+
+// Stage 5: full browser-first regression.
+const fullEntry = runCommand("05-full-browser-first-regression", config.fullRegressionCommand, { timeoutMs: 600000 });
+const fullLog = readLog(fullEntry);
+const passMatch = fullLog.match(/[iℹ]\s+pass\s+(\d+)/i) ?? fullLog.match(/#\s*pass\s+(\d+)/i);
+const failMatch = fullLog.match(/[iℹ]\s+fail\s+(\d+)/i) ?? fullLog.match(/#\s*fail\s+(\d+)/i);
+const fullPass = fullEntry.exitCode === 0 && Number(passMatch?.[1] ?? 0) >= config.minFullRegressionPassCount && Number(failMatch?.[1] ?? 1) === 0;
+if (!fullPass) addFailure("FULL_REGRESSION", "CRITICAL", "Full browser-first regression failed or did not report the expected pass/fail counts.", ["05-full-regression.json"]);
+writeJson(path.join(runDir, "05-full-regression.json"), {
+  runId,
+  command: fullEntry.command,
+  pass: fullPass,
+  exitCode: fullEntry.exitCode,
+  passCount: Number(passMatch?.[1] ?? 0),
+  failCount: Number(failMatch?.[1] ?? -1),
+  stdout: fullEntry.stdout,
+  stderr: fullEntry.stderr
+});
+
+// Stage 6: freshness and binding gate. Every artifact must carry this run's
+// ID; a stale artifact (different run ID, or predating this run) is a FAIL,
+// because "fresh artifacts tied to a run ID" is an issue acceptance criterion.
+const freshnessFiles = [
+  "00-preflight.json", "01-scope-audit.json", "02-source-integrity.json",
+  "03-syntax-checks.json", "04-focused-tests.json", "05-full-regression.json",
+  "execution-ledger.json"
+];
+const freshnessFindings = [];
+for (const file of freshnessFiles) {
+  const absolute = path.join(runDir, file);
+  if (!fs.existsSync(absolute)) {
+    freshnessFindings.push({ file, finding: "missing artifact" });
+    continue;
+  }
+  const parsed = JSON.parse(fs.readFileSync(absolute, "utf8"));
+  const bound = Array.isArray(parsed)
+    ? parsed.length > 0 && parsed.every((entry) => entry.runId === runId)
+    : parsed.runId === runId;
+  const fresh = fs.statSync(absolute).mtimeMs >= Date.parse(runStartedAt);
+  if (!bound || !fresh) freshnessFindings.push({ file, bound, fresh });
+}
+const freshnessPass = freshnessFindings.length === 0;
+if (!freshnessPass) addFailure("FRESHNESS", "CRITICAL", "One or more artifacts are missing, stale, or not bound to this run ID.", ["06-freshness-gate.json"]);
+writeJson(path.join(runDir, "06-freshness-gate.json"), { runId, generatedAt: now(), findings: freshnessFindings, pass: freshnessPass });
+
+// Stage 7: live browser proof attach. The live harness (issue #267) writes
+// screenshots/ledgers into RESONANTOS_CERT_PROOF_DIR when available; this gate
+// hashes and binds them to this run ID. Absence is recorded as "excluded",
+// never as a pass — live proof is a separate live-browser certification.
+const proofResults = [];
+if (liveProofDir && fs.existsSync(liveProofDir)) {
+  const candidates = fs.readdirSync(liveProofDir, { recursive: true })
+    .filter((entry) => fs.statSync(path.join(liveProofDir, entry)).isFile());
+  for (const entry of candidates) {
+    const source = path.join(liveProofDir, entry);
+    const destination = path.join(proofDir, slug(entry));
+    fs.copyFileSync(source, destination);
+    proofResults.push({ id: slug(entry), source: entry, artifact: artifactHashInfo(destination) });
+  }
+  if (!proofResults.length) {
+    addFailure("LIVE_PROOF_EMPTY", "HIGH", "Live proof directory was provided but contained no files.", ["07-live-proof-attach.json"]);
+  }
+}
+const liveProofAttach = {
+  runId,
+  generatedAt: now(),
+  mode: liveProofDir ? "attached" : "excluded",
+  note: "Live browser proof is provided by the live harness (#267); this run certifies deterministic behavior and binds any supplied proof to this run ID.",
+  proofResults
+};
+writeJson(path.join(runDir, "07-live-proof-attach.json"), liveProofAttach);
+const liveProofPass = liveProofDir ? proofResults.length > 0 : true;
+
+// Stage 8: secret scan across generated artifacts and runtime logs.
+const leakScanFiles = freshnessFiles.map((file) => path.join(runDir, file)).filter((file) => fs.existsSync(file))
+  .concat(proofResults.map((proof) => proof.artifact.file).map((file) => path.join(runDir, file)));
+const leakFindings = [];
+for (const file of leakScanFiles) {
+  const haystack = fs.readFileSync(file);
+  for (const needle of config.forbiddenEvidenceText) {
+    if (haystack.includes(Buffer.from(needle))) leakFindings.push({ file: path.relative(repoRoot, file), needle });
+  }
+}
+const leakPass = leakFindings.length === 0;
+if (!leakPass) addFailure("SECRET_SCAN", "CRITICAL", "Forbidden sentinel text appeared in certification artifacts.", ["08-secret-scan.json"]);
+writeJson(path.join(runDir, "08-secret-scan.json"), { runId, scannedFiles: leakScanFiles.map((file) => path.relative(repoRoot, file)), leaks: leakFindings, pass: leakPass });
+
+const families = [
+  { family: "security", checks: ["source-integrity", "secret-scan"], blockers: failures.filter((finding) => ["SYNTAX", "SECRET_SCAN"].includes(finding.id)) },
+  { family: "browser-runtime", checks: ["focused-certification", "assertion-content"], blockers: failures.filter((finding) => finding.id.includes("FOCUSED")) },
+  { family: "code-quality", checks: ["syntax", "full-regression"], blockers: failures.filter((finding) => ["SYNTAX", "FULL_REGRESSION"].includes(finding.id)) },
+  { family: "certification-integrity", checks: ["freshness", "run-id-binding", "live-proof-binding"], blockers: failures.filter((finding) => ["FRESHNESS", "LIVE_PROOF_EMPTY"].includes(finding.id)) },
+  { family: "scope-governance", checks: ["scope-audit", "quarantine"], blockers: failures.filter((finding) => finding.id.startsWith("SCOPE")) }
+];
+writeJson(path.join(runDir, "09-five-family-review.json"), {
+  runId,
+  generatedAt: now(),
+  note: "Deterministic adversarial panel encoded as explicit gate checks; unresolved blockers are derived from executed commands and artifact validation.",
+  families
+});
+
+const claims = [
+  { claim: "Fresh artifacts are bound to run ID " + runId, status: freshnessPass ? "CERTIFIED" : "BLOCKED", evidence: ["06-freshness-gate.json"] },
+  { claim: "Source hashes bind the certification to exact fixture and enforcement revisions.", status: "CERTIFIED", evidence: ["02-source-integrity.json"] },
+  { claim: "Certification harness and fixture sources pass syntax checks.", status: syntaxPass ? "CERTIFIED" : "BLOCKED", evidence: ["03-syntax-checks.json"] },
+  { claim: "Focused certification tests execute every declared safe/blocked claim.", status: focusedPass ? "CERTIFIED" : "BLOCKED", evidence: ["04-focused-tests.json"] },
+  { claim: "Full browser-first regression passes.", status: fullPass ? "CERTIFIED" : "BLOCKED", evidence: ["05-full-regression.json"] },
+  { claim: "Attached live proof (when supplied) is bound and hashed for this run.", status: liveProofPass ? "CERTIFIED" : "BLOCKED", evidence: ["07-live-proof-attach.json"] },
+  { claim: "Generated artifacts are sentinel-clean.", status: leakPass ? "CERTIFIED" : "BLOCKED", evidence: ["08-secret-scan.json"] }
+];
+writeJson(path.join(runDir, "10-claim-map.json"), { runId, generatedAt: now(), claims });
+
+const pass = syntaxPass && focusedPass && fullPass && freshnessPass && liveProofPass && leakPass && failures.length === 0;
+const summary = {
+  runId,
+  completedAt: now(),
+  status: pass ? "PASS" : "FAIL",
+  failures,
+  artifactsRoot: runDir,
+  liveProofMode: liveProofAttach.mode,
+  reports: freshnessFiles.slice(0, 6).concat("06-freshness-gate.json", "07-live-proof-attach.json", "08-secret-scan.json", "09-five-family-review.json", "10-claim-map.json", "execution-ledger.json")
+};
+writeJson(path.join(runDir, "11-final-certification-summary.json"), summary);
+console.log(JSON.stringify(summary, null, 2));
+process.exit(pass ? 0 : 2);

--- a/browser-first/test/agent-control-runner.test.mjs
+++ b/browser-first/test/agent-control-runner.test.mjs
@@ -3,7 +3,6 @@ import test from "node:test";
 
 import { approvalBoundaryForStep } from "../resonantos-side-panel-extension/src/lib/approval-policy.js";
 import { controlStepLabel } from "../resonantos-side-panel-extension/src/lib/agent-control-planner.js";
-import { approvalBoundaryForStep } from "../resonantos-side-panel-extension/src/lib/approval-policy.js";
 import {
   browserJobStepHistory,
   controlResultSummary,
@@ -564,6 +563,9 @@ test("agent control runner can approve or deny a pending step through injected s
   assert.equal(denyHarness.getControlRun().status, "denied");
   assert.equal(denyHarness.getControlRun().steps[0].state, "blocked");
   assert.equal(denyHarness.getControlRun().steps[0].details.approvalDecision, "denied");
+  assert.equal(denyHarness.getSavedReports().at(-1).status, "denied");
+  assert.equal(denyHarness.getSavedReports().at(-1).results.at(-1).result.error, "denied by human");
+});
 
 // #223: runner-level certification on the fixture page. The runner executes
 // through the REAL content.js safety layer, so run statuses and step details
@@ -625,7 +627,7 @@ test("#223: wallet connect attempt blocks the run with the wallet boundary named
   assert.equal(win.__certActivity, "fixture ready", "the page must remain untouched");
 });
 
-test("#223: public-submit attempt creates an approval card and actuates nothing", async () => {
+test("#223: public-submit attempt is a terminal human handoff with no approval job and nothing actuated", async () => {
   const { harness, win } = await createCertifiedRunner({
     decisions: [
       { status: "continue", thought: "place order", action: { type: "click", text: "Place order" } }
@@ -636,10 +638,14 @@ test("#223: public-submit attempt creates an approval card and actuates nothing"
 
   assert.equal(result.ok, false);
   assert.equal(result.approvalRequired, true);
-  assert.equal(harness.getControlRun().status, "approval", "public-submit must surface an approval card");
-  assert.ok(harness.getPendingApproval(), "public-submit must carry a pending approval card");
+  assert.equal(result.handoff, true, "#240: public-submit must be a terminal human handoff");
+  assert.equal(harness.getControlRun().status, "blocked");
+  assert.equal(harness.getPendingApproval(), null, "#240: public-submit must never create a pending approval");
   const step = harness.getControlRun().steps[0];
-  assert.equal(step.details.safetyClass, "public-submit");
+  assert.equal(step.state, "blocked");
+  // "Place order" is classified into the more specific checkout human-only
+  // state; either way the step must land in a human-only intervention state.
+  assert.match(step.details.humanInterventionState, /^(checkout|public-submit)$/, "the step must carry a human-only intervention state");
   assert.match(step.details.result, /public submit|commit|human/, "step evidence must name the public-submit boundary");
   assert.equal(win.__certClicks.placeOrder, 0, "the order control must never be actuated");
 });
@@ -662,7 +668,4 @@ test("#223: credential typing attempt blocks the run with the credential boundar
   assert.match(step.details.result, /credential|human/i, "step evidence must name the credential boundary");
   assert.match(step.details.humanInterventionState, /login|credential|human/i, "human intervention state must reflect the boundary");
   assert.equal(win.document.getElementById("cert-password").value, "", "the password field must stay empty");
-});
-  assert.equal(denyHarness.getSavedReports().at(-1).status, "denied");
-  assert.equal(denyHarness.getSavedReports().at(-1).results.at(-1).result.error, "denied by human");
 });

--- a/browser-first/test/agent-control-runner.test.mjs
+++ b/browser-first/test/agent-control-runner.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { approvalBoundaryForStep } from "../resonantos-side-panel-extension/src/lib/approval-policy.js";
 import { controlStepLabel } from "../resonantos-side-panel-extension/src/lib/agent-control-planner.js";
 import { approvalBoundaryForStep } from "../resonantos-side-panel-extension/src/lib/approval-policy.js";
 import {
@@ -8,6 +9,7 @@ import {
   controlResultSummary,
   createAgentControlRunner
 } from "../resonantos-side-panel-extension/src/lib/agent-control-runner.js";
+import { createCertifiedExecutor, loadCertificationPage } from "./agent-control-certification-fixtures.mjs";
 
 function createHarness(overrides = {}) {
   const events = [];
@@ -56,6 +58,7 @@ function createHarness(overrides = {}) {
     },
     executeControlStep: async (step) => {
       events.push(["execute", step]);
+      if (overrides.executeControlStep) return overrides.executeControlStep(step);
       return stepResults[stepResultIndex++] ?? { ok: true };
     },
     finishControlRun: (status, artifact = null) => {
@@ -561,6 +564,105 @@ test("agent control runner can approve or deny a pending step through injected s
   assert.equal(denyHarness.getControlRun().status, "denied");
   assert.equal(denyHarness.getControlRun().steps[0].state, "blocked");
   assert.equal(denyHarness.getControlRun().steps[0].details.approvalDecision, "denied");
+
+// #223: runner-level certification on the fixture page. The runner executes
+// through the REAL content.js safety layer, so run statuses and step details
+// certify user-visible behavior: safe plans complete with page effects, and
+// high-risk plans stop at the exact boundary named in the step evidence.
+async function createCertifiedRunner({ decisions }) {
+  const { win, send } = await loadCertificationPage();
+  const { executor } = createCertifiedExecutor({ win, send });
+  const harness = createHarness({
+    approvalBoundaryForStep,
+    decisions,
+    executeControlStep: executor.executeControlStep
+  });
+  return { harness, win };
+}
+
+test("#223: safe click/type/scroll plan completes on the certification fixture with visible page effects", async () => {
+  const { harness, win } = await createCertifiedRunner({
+    decisions: [
+      { status: "continue", thought: "load more rows", action: { type: "click", text: "Load more" } },
+      { status: "continue", thought: "search the catalog", action: { type: "type", text: "vintage synths", field: "Search the catalog" } },
+      { status: "continue", thought: "scroll the feed", action: { type: "scroll", direction: "down" } },
+      { status: "done", thought: "done", doneSummary: "Certification plan completed." }
+    ]
+  });
+
+  const result = await harness.runner.continueControlLoop({ goal: "certify safe actions" });
+
+  assert.equal(result.ok, true, "the safe plan must complete");
+  assert.equal(harness.getControlRun().status, "completed");
+  assert.ok(harness.getControlRun().steps.length >= 3, "all safe steps must be recorded");
+  for (const step of harness.getControlRun().steps) {
+    assert.equal(step.state, "completed", `${step.type} must show a completed state`);
+  }
+  assert.ok(win.__certClicks.loadMore >= 1, "the safe click must actuate the page handler");
+  assert.equal(win.document.getElementById("cert-search").value, "vintage synths", "the safe typed value must land on the page");
+  assert.ok(win.scrollY > 0, "the safe scroll must move the page");
+});
+
+test("#223: wallet connect attempt blocks the run with the wallet boundary named and nothing actuated", async () => {
+  const { harness, win } = await createCertifiedRunner({
+    decisions: [
+      { status: "continue", thought: "connect wallet", action: { type: "click", text: "Connect wallet" } }
+    ]
+  });
+
+  const result = await harness.runner.continueControlLoop({ goal: "connect wallet" });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.approvalRequired, true);
+  assert.equal(harness.getControlRun().status, "blocked");
+  assert.equal(harness.getPendingApproval(), null, "hard boundaries must never create an approval job");
+  const step = harness.getControlRun().steps[0];
+  assert.equal(step.state, "blocked");
+  assert.equal(step.details.safetyClass, "hard");
+  assert.match(step.details.result, /wallet|payment|login|credential/, "step evidence must name the boundary");
+  assert.match(step.note, /wallet|payment|login|credential|human/i, "step note must name the boundary");
+  assert.equal(win.__certClicks.wallet, 0, "the wallet control must never be actuated");
+  assert.equal(win.__certActivity, "fixture ready", "the page must remain untouched");
+});
+
+test("#223: public-submit attempt creates an approval card and actuates nothing", async () => {
+  const { harness, win } = await createCertifiedRunner({
+    decisions: [
+      { status: "continue", thought: "place order", action: { type: "click", text: "Place order" } }
+    ]
+  });
+
+  const result = await harness.runner.continueControlLoop({ goal: "checkout" });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.approvalRequired, true);
+  assert.equal(harness.getControlRun().status, "approval", "public-submit must surface an approval card");
+  assert.ok(harness.getPendingApproval(), "public-submit must carry a pending approval card");
+  const step = harness.getControlRun().steps[0];
+  assert.equal(step.details.safetyClass, "public-submit");
+  assert.match(step.details.result, /public submit|commit|human/, "step evidence must name the public-submit boundary");
+  assert.equal(win.__certClicks.placeOrder, 0, "the order control must never be actuated");
+});
+
+test("#223: credential typing attempt blocks the run with the credential boundary named and the field untouched", async () => {
+  const { harness, win } = await createCertifiedRunner({
+    decisions: [
+      { status: "continue", thought: "enter password", action: { type: "type", text: "hunter2", field: "Password" } }
+    ]
+  });
+
+  const result = await harness.runner.continueControlLoop({ goal: "sign in" });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.approvalRequired, true);
+  assert.equal(harness.getControlRun().status, "blocked", "credential typing must block without an approval job");
+  assert.equal(harness.getPendingApproval(), null);
+  const step = harness.getControlRun().steps[0];
+  assert.equal(step.details.safetyClass, "hard");
+  assert.match(step.details.result, /credential|human/i, "step evidence must name the credential boundary");
+  assert.match(step.details.humanInterventionState, /login|credential|human/i, "human intervention state must reflect the boundary");
+  assert.equal(win.document.getElementById("cert-password").value, "", "the password field must stay empty");
+});
   assert.equal(denyHarness.getSavedReports().at(-1).status, "denied");
   assert.equal(denyHarness.getSavedReports().at(-1).results.at(-1).result.error, "denied by human");
 });

--- a/browser-first/test/control-step-executor.test.mjs
+++ b/browser-first/test/control-step-executor.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { createControlStepExecutor } from "../resonantos-side-panel-extension/src/lib/control-step-executor.js";
+import { createCertifiedExecutor, loadCertificationPage } from "./agent-control-certification-fixtures.mjs";
 
 function createHarness(overrides = {}) {
   const events = [];
@@ -138,4 +139,116 @@ test("control step executor summarizes read steps and rejects unknown steps", as
   assert.ok(harness.events.some((event) => event[0] === "summary"));
   assert.equal(unknown.ok, false);
   assert.match(unknown.error, /Unknown control step/);
+});
+
+// #223: certification fixtures. The executor below is wired to the REAL
+// content.js safety layer inside the fixture page (not stubs), so safe actions
+// certify a completed state with observable page-side effects, and high-risk
+// actions certify boundary-named denials before any page mutation.
+
+test("#223: safe click on the certification fixture completes and visibly mutates the page", async () => {
+  const { win, send } = await loadCertificationPage();
+  const { executor } = createCertifiedExecutor({ win, send });
+
+  const result = await executor.executeControlStep({ type: "click", text: "Load more", userApproved: true });
+
+  assert.equal(result.ok, true, "safe click must complete");
+  // content.js fires the dispatched click sequence and then element.click(),
+  // so a single certification step can actuate the handler more than once;
+  // the fixture asserts honest page-side activation (>= 1), not an exact count.
+  assert.ok(win.__certClicks.loadMore >= 1, "page-side click handler must have run");
+  assert.ok(win.document.getElementById("cert-feed").querySelectorAll("article").length > 12, "click must have visibly loaded a new row");
+  assert.equal(win.__certActivity, "loaded more rows", "certification activity log must show the completed click");
+});
+
+test("#223: safe type into the search field on the certification fixture completes and lands the value", async () => {
+  const { win, send } = await loadCertificationPage();
+  const { executor } = createCertifiedExecutor({ win, send });
+
+  const result = await executor.executeControlStep({ type: "type", text: "vintage synths", field: "Search the catalog", userApproved: true });
+
+  assert.equal(result.ok, true, "search typing must complete");
+  assert.equal(win.document.getElementById("cert-search").value, "vintage synths", "typed value must land in the page");
+  assert.equal(win.__certActivity, "typed vintage synths", "certification activity log must show the typed value");
+});
+
+test("#223: safe type into the generic notes field completes and lands the value", async () => {
+  const { win, send } = await loadCertificationPage();
+  const { executor } = createCertifiedExecutor({ win, send });
+
+  const result = await executor.executeControlStep({ type: "type", text: "audit notes", field: "Notes", userApproved: true });
+
+  assert.equal(result.ok, true, "generic typing must complete");
+  assert.equal(win.document.getElementById("cert-notes").value, "audit notes", "typed value must land in the page");
+});
+
+test("#223: safe scroll on the certification fixture completes and reports real scroll position", async () => {
+  const { win, send } = await loadCertificationPage();
+  const { executor } = createCertifiedExecutor({ win, send });
+
+  const down = await executor.executeControlStep({ type: "scroll", direction: "down" });
+
+  assert.equal(down.ok, true, "scroll down must complete");
+  assert.ok(down.scrollY > 0, "scroll down must report a positive scroll position");
+  assert.equal(win.scrollY, down.scrollY, "page-side scroll position must match the certified result");
+
+  const top = await executor.executeControlStep({ type: "scroll", direction: "top" });
+
+  assert.equal(top.ok, true, "scroll to top must complete");
+  assert.equal(top.scrollY, 0, "scroll to top must return to the top of the page");
+  assert.equal(win.__certScrollY, 0, "page-side scroll listener must observe the top position");
+});
+
+test("#223: wallet connect click is denied with the wallet boundary named", async () => {
+  const { win, send } = await loadCertificationPage();
+  const { executor } = createCertifiedExecutor({ win, send });
+
+  const result = await executor.executeControlStep({ type: "click", text: "Connect wallet", userApproved: true });
+
+  assert.equal(result.ok, false, "wallet connect must be denied to automation");
+  assert.equal(result.approvalRequired, true);
+  assert.equal(result.deniedToAutomation, true);
+  assert.match(result.error, /wallet|payment|login|credential/, "denial must name the wallet/payment boundary, not an ambiguous target");
+  assert.equal(win.__certClicks.wallet, 0, "the wallet control must never be actuated");
+  assert.equal(win.__certActivity, "fixture ready", "the page must remain untouched by the denied click");
+});
+
+test("#223: public submit clicks are denied as human-only handoffs", async () => {
+  const { win, send } = await loadCertificationPage();
+  const { executor } = createCertifiedExecutor({ win, send });
+
+  const order = await executor.executeControlStep({ type: "click", text: "Place order", userApproved: true });
+
+  assert.equal(order.ok, false, "Place order must be denied");
+  assert.equal(order.deniedToAutomation, true);
+  assert.equal(order.humanHandoff, true);
+  assert.match(order.error, /public submit|commit|human/, "denial must name the public-submit boundary");
+  assert.equal(win.__certClicks.placeOrder, 0, "the order control must never be actuated");
+
+  const post = await executor.executeControlStep({ type: "click", text: "Post comment", userApproved: true });
+
+  assert.equal(post.ok, false, "Post comment must be denied");
+  assert.equal(post.humanHandoff, true);
+  assert.match(post.error, /public submit|commit|human/, "denial must name the public-submit boundary");
+  assert.equal(win.__certClicks.post, 0, "the post control must never be actuated");
+});
+
+test("#223: typing into credential and payment fields is denied with the boundary named and values untouched", async () => {
+  const { win, send } = await loadCertificationPage();
+  const { executor } = createCertifiedExecutor({ win, send });
+
+  const password = await executor.executeControlStep({ type: "type", text: "hunter2", field: "Password", userApproved: true });
+
+  assert.equal(password.ok, false, "password typing must be denied");
+  assert.equal(password.deniedToAutomation, true);
+  assert.equal(password.fieldSafety.kind, "credential", "denial must report the credential boundary");
+  assert.match(password.error, /credential|human/i, "denial message must name the boundary");
+  assert.equal(win.document.getElementById("cert-password").value, "", "the password field must stay empty");
+
+  const card = await executor.executeControlStep({ type: "type", text: "4111 2222 3333 4444", field: "Card number", userApproved: true });
+
+  assert.equal(card.ok, false, "card number typing must be denied");
+  assert.equal(card.fieldSafety.kind, "payment", "denial must report the payment boundary");
+  assert.match(card.error, /payment|human/i, "denial message must name the boundary");
+  assert.equal(win.document.getElementById("cert-card").value, "", "the card field must stay empty");
 });

--- a/browser-first/test/fixtures/agent-control-certification/agent-control-certification-page.html
+++ b/browser-first/test/fixtures/agent-control-certification/agent-control-certification-page.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Agent Control Certification Fixture</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 720px; margin: 0 auto; padding: 24px; }
+    section { border: 1px solid #ddd; border-radius: 8px; padding: 16px; margin: 16px 0; }
+    label { display: block; margin: 8px 0 4px; font-weight: 600; }
+    input, button { font-size: 14px; padding: 6px 10px; margin: 4px 0; }
+    .log { font-family: monospace; background: #f4f4f4; padding: 8px; min-height: 18px; white-space: pre-wrap; }
+    .feed { border-top: 1px dashed #ccc; padding-top: 8px; }
+    .feed article { padding: 6px 0; }
+  </style>
+</head>
+<body>
+  <h1>Agent Control Certification Fixture</h1>
+  <p id="cert-banner">AC-CERT-FIXTURE</p>
+
+  <section id="safe-section">
+    <h2>Safe controls</h2>
+    <form id="search-form" role="search">
+      <label for="cert-search">Search the catalog</label>
+      <input id="cert-search" name="q" type="search" aria-label="Search the catalog">
+      <button id="cert-search-go" type="submit">Go</button>
+    </form>
+    <label for="cert-notes">Notes</label>
+    <input id="cert-notes" name="notes" type="text" aria-label="Notes">
+    <button id="cert-load-more" type="button">Load more</button>
+    <button id="cert-next" type="button">Next page</button>
+  </section>
+
+  <section id="highrisk-section">
+    <h2>Human-only controls</h2>
+    <form id="checkout-form">
+      <label for="cert-password">Password</label>
+      <input id="cert-password" name="password" type="text" aria-label="Password">
+      <label for="cert-card">Card number</label>
+      <input id="cert-card" name="card_number" type="text" aria-label="Card number">
+      <button id="cert-place-order" type="submit">Place order</button>
+    </form>
+    <button id="cert-connect-wallet" type="button">Connect wallet</button>
+    <button id="cert-post" type="button">Post comment</button>
+  </section>
+
+  <section id="scroll-section" aria-label="Long-form section">
+    <h2>Scrollable content</h2>
+    <div id="cert-feed" class="feed">
+      <article>Row 1 of the certification feed.</article>
+      <article>Row 2 of the certification feed.</article>
+      <article>Row 3 of the certification feed.</article>
+      <article>Row 4 of the certification feed.</article>
+      <article>Row 5 of the certification feed.</article>
+      <article>Row 6 of the certification feed.</article>
+      <article>Row 7 of the certification feed.</article>
+      <article>Row 8 of the certification feed.</article>
+      <article>Row 9 of the certification feed.</article>
+      <article>Row 10 of the certification feed.</article>
+      <article>Row 11 of the certification feed.</article>
+      <article>Row 12 of the certification feed.</article>
+    </div>
+    <div id="cert-scroll-status" class="log">scroll-y: 0</div>
+  </section>
+
+  <div id="cert-activity" class="log">idle</div>
+  <script>
+    const activity = document.getElementById("cert-activity");
+    const scrollStatus = document.getElementById("cert-scroll-status");
+    const record = (entry) => { activity.textContent = entry; window.__certActivity = entry; };
+    window.__certClicks = { loadMore: 0, next: 0, wallet: 0, post: 0, placeOrder: 0, searchGo: 0 };
+    document.getElementById("cert-load-more").addEventListener("click", () => {
+      window.__certClicks.loadMore += 1;
+      const row = document.createElement("article");
+      row.textContent = `Row ${window.__certClicks.loadMore + 12} loaded by Agent Control.`;
+      document.getElementById("cert-feed").appendChild(row);
+      record("loaded more rows");
+    });
+    document.getElementById("cert-next").addEventListener("click", () => {
+      window.__certClicks.next += 1;
+      record("advanced to next page");
+    });
+    document.getElementById("cert-connect-wallet").addEventListener("click", () => {
+      window.__certClicks.wallet += 1;
+      record("wallet connect opened");
+    });
+    document.getElementById("cert-post").addEventListener("click", () => {
+      window.__certClicks.post += 1;
+      record("comment posted");
+    });
+    document.getElementById("cert-place-order").addEventListener("click", () => {
+      window.__certClicks.placeOrder += 1;
+      record("order placed");
+    });
+    document.getElementById("search-form").addEventListener("submit", (event) => {
+      event.preventDefault();
+      window.__certClicks.searchGo += 1;
+      record(`searched for ${document.getElementById("cert-search").value}`);
+    });
+    for (const id of ["cert-search", "cert-notes"]) {
+      document.getElementById(id).addEventListener("input", () => {
+        record(`typed ${document.getElementById(id).value}`);
+      });
+    }
+    window.addEventListener("scroll", () => {
+      scrollStatus.textContent = `scroll-y: ${window.scrollY}`;
+      window.__certScrollY = window.scrollY;
+    });
+    record("fixture ready");
+  </script>
+</body>
+</html>

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -61,7 +61,13 @@ public-submit handoff from
 [#240](https://github.com/ResonantOS/2.0.0-alpha/issues/240) is present in the
 runner, so the post-approval-public-submit scenario reports a real pass or fail
 instead of a gate. Manual dispatch can set `public_submit_contract=required` to
-fail certification if the handoff regresses.
+fail certification if the handoff regresses. Deterministic certification
+fixtures for safe click/type/scroll and blocked high-risk paths
+([#223](https://github.com/ResonantOS/2.0.0-alpha/issues/223)) run through
+`browser-first/test/agent-control-certification/run-certification.mjs` with
+run-ID-bound artifacts, and credential alias fields
+(`passwd`/`pwd`/`pin`/`passkey`/`security_code`) are hard typing boundaries
+([#224](https://github.com/ResonantOS/2.0.0-alpha/issues/224)).
 
 Runtime discovery is fixed-root and canonical: ambient `PATH`, arbitrary
 Hermes profile roots, and arbitrary OpenCode command paths are not executable


### PR DESCRIPTION
Lands #223 from PR #283, reworked per review: the four certification tests + \`createCertifiedRunner\` moved to top level (they were nested inside an unrelated test body), the stacked #282 commit dropped (landed via #281/#299), and the regression floor raised to bite. Fixtures exercise the **real content.js layer** in jsdom; blocked cases assert affirmative denial with \`userApproved:true\`. Blocked-case guard rig-mutate-proven. Part of the #211 gate series. Refs #223. Credit @Resonant-Jones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)