### PR TITLE
fix(agent-control): stop/cancel halts runs via the run's own job id (#226)

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/lib/agent-control-runner.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/agent-control-runner.js
@@ -391,6 +391,9 @@ export function createAgentControlRunner(deps) {
     executeControlStep,
     finishControlRun,
     getActiveJobId,
+    // (jobId) => status: MUST resolve status by the exact job id it is given
+    // (strict id equality, no fuzzy/goal-substring matching) so a run always
+    // reads its own job, never whichever job happens to be "active".
     getActiveJobStatus = () => null,
     getCurrentControlRun,
     getLastSnapshot,
@@ -409,8 +412,17 @@ export function createAgentControlRunner(deps) {
     updateControlStep
   } = deps;
 
+  // #226: always resolve stop/cancel state against the job THIS run started
+  // with. browserJobStore.getActiveJobId() is reassigned to the next active
+  // job the moment the cancelled job goes terminal, so reading the "active"
+  // job's status would inspect an innocent queued/paused job and let the
+  // cancelled run keep executing.
+  function controlRunJobId() {
+    return getCurrentControlRun()?.id ?? getActiveJobId();
+  }
+
   function stoppedJobStatus() {
-    const status = getActiveJobStatus();
+    const status = getActiveJobStatus(controlRunJobId());
     return ["cancelled", "paused"].includes(status) ? status : null;
   }
 
@@ -429,7 +441,7 @@ export function createAgentControlRunner(deps) {
         "Review the page state, then continue the job or start a new task when ready."
       ].join("\n")
     );
-    await updateBrowserJob(getActiveJobId(), { status });
+    await updateBrowserJob(controlRunJobId(), { status });
     return { ok: false, results, stopped: status };
   }
 
@@ -450,7 +462,7 @@ export function createAgentControlRunner(deps) {
         if (stoppedBeforeLoop) {
           return stopRun(stoppedBeforeLoop, { goal, results });
         }
-        await updateBrowserJob(getActiveJobId(), { status: "running" });
+        await updateBrowserJob(controlRunJobId(), { status: "running" });
         await setPageControlOverlay(true, "reading", "reading");
         const snapshot = await deps.observeControlPage();
         await setPageControlOverlay(true, "reading", "reading");
@@ -555,10 +567,6 @@ export function createAgentControlRunner(deps) {
           return { ok: false, results, approvalRequired: isApproval };
         }
 
-        const stoppedBeforeAction = stoppedJobStatus();
-        if (stoppedBeforeAction) {
-          return stopRun(stoppedBeforeAction, { goal, results });
-        }
         const step = decision.action;
         const repeatedNoChange = repeatedNoChangeActionEvidence(history, step);
         if (repeatedNoChange) {
@@ -638,6 +646,12 @@ export function createAgentControlRunner(deps) {
         const overlayAction = publicControlOverlayActionForStep(step);
         await setPageControlOverlay(true, overlayAction.label, overlayAction.phase);
         setActivity("tool-running", `Executing browser action ${stepIndex + 1}`, controlStepLabel(step));
+        // #226: last-instant stop check — nothing may await between this read
+        // and executeControlStep, or a stop landing in that window is missed.
+        const stoppedBeforeAction = stoppedJobStatus();
+        if (stoppedBeforeAction) {
+          return stopRunWithStep(stoppedBeforeAction, { goal, results, stepIndex });
+        }
         const result = await executeControlStep(step);
         const stoppedAfterAction = stoppedJobStatus();
         if (stoppedAfterAction) {
@@ -655,11 +669,13 @@ export function createAgentControlRunner(deps) {
         const consent = result?.approvalRequired && boundary === "safe"
           ? await taskConsentForStep({ goal, step, result })
           : null;
+        const finalStep = consent ? { ...step, userApproved: true } : step;
+        // #226: last-instant stop check before the consent re-execute; no
+        // await may sit between this read and executeControlStep.
         const stoppedBeforeConsentExecute = stoppedJobStatus();
         if (stoppedBeforeConsentExecute) {
           return stopRunWithStep(stoppedBeforeConsentExecute, { goal, results, stepIndex });
         }
-        const finalStep = consent ? { ...step, userApproved: true } : step;
         const finalResult = consent ? await executeControlStep(finalStep) : result;
         let postActionSnapshot = verificationSnapshot;
         let finalVerification = consent
@@ -698,13 +714,15 @@ export function createAgentControlRunner(deps) {
           verification: finalVerification
         });
         if (retryStep) {
+          actionRetry = retryStep.retryStrategy;
+          await setPageControlOverlay(true, "clicking", "clicking");
+          executedStep = retryStep;
+          // #226: last-instant stop check — must follow the overlay await so
+          // no await separates this read from executeControlStep.
           const stoppedBeforeRetry = stoppedJobStatus();
           if (stoppedBeforeRetry) {
             return stopRunWithStep(stoppedBeforeRetry, { goal, results, stepIndex });
           }
-          actionRetry = retryStep.retryStrategy;
-          await setPageControlOverlay(true, "clicking", "clicking");
-          executedStep = retryStep;
           executedResult = await executeControlStep(retryStep);
           await setPageControlOverlay(true, "verifying", "verifying");
           const retrySnapshot = await deps.observeControlPage().catch(() => postActionSnapshot);
@@ -846,7 +864,7 @@ export function createAgentControlRunner(deps) {
       const message = error instanceof Error ? error.message : String(error);
       const status = /cancelled/i.test(message) ? "cancelled" : /paused/i.test(message) ? "paused" : "failed";
       finishControlRun(status);
-      await updateBrowserJob(getActiveJobId(), { status, lastError: message });
+      await updateBrowserJob(controlRunJobId(), { status, lastError: message });
       setStatus(status === "paused" ? "Paused" : status === "cancelled" ? "Cancelled" : "Control failed");
       setActivity(status === "paused" ? "paused" : "failed", `Control mode ${status}`, message);
       await addMessage("system", `Agent Control Mode ${status}.\nGoal: ${goal}\nReason: ${message}`);
@@ -904,6 +922,18 @@ export function createAgentControlRunner(deps) {
 
   async function approvePendingControlStep(approval) {
     if (!approval || !getCurrentControlRun()) return;
+    // #226: a run the human already stopped can never execute an approved
+    // step, whatever its safety class — clear the stale approval card and
+    // finish the stop instead. Checked before the #240 handoff branch so a
+    // stopped run does not post handoff guidance for a step that will not run.
+    const stoppedWhileApproval = stoppedJobStatus();
+    if (stoppedWhileApproval) {
+      setPendingApproval(null);
+      return stopRun(stoppedWhileApproval, {
+        goal: getCurrentControlRun().goal,
+        results: Array.isArray(approval.results) ? approval.results : []
+      });
+    }
     // #240: hard and public-submit steps can never be approved into execution.
     // An in-panel "Approve once" must never turn a wallet/payment/login/
     // credential/public-commit action into an agent click. If a stale approval
@@ -950,14 +980,6 @@ export function createAgentControlRunner(deps) {
       ], "blocked-human-handoff");
       return;
     }
-    const stoppedWhileApproval = stoppedJobStatus();
-    if (stoppedWhileApproval) {
-      setPendingApproval(null);
-      return stopRun(stoppedWhileApproval, {
-        goal: getCurrentControlRun().goal,
-        results: Array.isArray(approval.results) ? approval.results : []
-      });
-    }
     setPendingApproval(null);
     renderControlMonitor();
     setStatus("Approved once");
@@ -975,6 +997,17 @@ export function createAgentControlRunner(deps) {
       confidence: "medium",
       uncertainty: "Human approval was required before this step could run."
     });
+    // #226: last-instant stop check — the addMessage await above is a window
+    // where the human can stop the run; nothing may await between this read
+    // and executeControlStep.
+    const stoppedBeforeApprovedExecute = stoppedJobStatus();
+    if (stoppedBeforeApprovedExecute) {
+      return stopRunWithStep(stoppedBeforeApprovedExecute, {
+        goal: getCurrentControlRun().goal,
+        results,
+        stepIndex: approval.stepIndex
+      });
+    }
     const result = await executeControlStep(step);
     results.push({ step, result });
     if (!result?.ok) {

--- a/browser-first/resonantos-side-panel-extension/src/lib/agent-control-runner.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/agent-control-runner.js
@@ -391,6 +391,7 @@ export function createAgentControlRunner(deps) {
     executeControlStep,
     finishControlRun,
     getActiveJobId,
+    getActiveJobStatus = () => null,
     getCurrentControlRun,
     getLastSnapshot,
     renderControlMonitor,
@@ -408,9 +409,47 @@ export function createAgentControlRunner(deps) {
     updateControlStep
   } = deps;
 
+  function stoppedJobStatus() {
+    const status = getActiveJobStatus();
+    return ["cancelled", "paused"].includes(status) ? status : null;
+  }
+
+  async function stopRun(status, { goal = "", results = [] } = {}) {
+    finishControlRun(status);
+    setPendingApproval(null);
+    renderControlMonitor();
+    setStatus(status === "paused" ? "Paused" : "Cancelled");
+    setActivity(status === "paused" ? "paused" : "failed", status === "paused" ? "Control paused" : "Control stopped", goal);
+    await addMessage(
+      "system",
+      [
+        `Agent Control Mode ${status === "paused" ? "paused" : "stopped by human"}.`,
+        `Goal: ${goal}`,
+        "No further browser actions ran after stop. Pending approval and page control are cleared.",
+        "Review the page state, then continue the job or start a new task when ready."
+      ].join("\n")
+    );
+    await updateBrowserJob(getActiveJobId(), { status });
+    return { ok: false, results, stopped: status };
+  }
+
+  async function stopRunWithStep(status, { goal = "", results = [], stepIndex = null } = {}) {
+    if (stepIndex !== null) {
+      updateControlStep(stepIndex, "cancelled", "Stopped by human.", {
+        phase: "cancelled",
+        nextHumanAction: "Review the page state and restart or resume the browser task when ready."
+      });
+    }
+    return stopRun(status, { goal, results });
+  }
+
   async function continueControlLoop({ goal, history = [], results = [], startIndex = 0, maxSteps = 12 } = {}) {
     try {
       for (let loopIndex = startIndex; loopIndex < maxSteps; loopIndex += 1) {
+        const stoppedBeforeLoop = stoppedJobStatus();
+        if (stoppedBeforeLoop) {
+          return stopRun(stoppedBeforeLoop, { goal, results });
+        }
         await updateBrowserJob(getActiveJobId(), { status: "running" });
         await setPageControlOverlay(true, "reading", "reading");
         const snapshot = await deps.observeControlPage();
@@ -516,6 +555,10 @@ export function createAgentControlRunner(deps) {
           return { ok: false, results, approvalRequired: isApproval };
         }
 
+        const stoppedBeforeAction = stoppedJobStatus();
+        if (stoppedBeforeAction) {
+          return stopRun(stoppedBeforeAction, { goal, results });
+        }
         const step = decision.action;
         const repeatedNoChange = repeatedNoChangeActionEvidence(history, step);
         if (repeatedNoChange) {
@@ -596,6 +639,10 @@ export function createAgentControlRunner(deps) {
         await setPageControlOverlay(true, overlayAction.label, overlayAction.phase);
         setActivity("tool-running", `Executing browser action ${stepIndex + 1}`, controlStepLabel(step));
         const result = await executeControlStep(step);
+        const stoppedAfterAction = stoppedJobStatus();
+        if (stoppedAfterAction) {
+          return stopRunWithStep(stoppedAfterAction, { goal, results, stepIndex });
+        }
         await setPageControlOverlay(true, "verifying", "verifying");
         const verificationSnapshot = await deps.observeControlPage().catch(() => null);
         const verification = verifyBrowserAction({
@@ -608,6 +655,10 @@ export function createAgentControlRunner(deps) {
         const consent = result?.approvalRequired && boundary === "safe"
           ? await taskConsentForStep({ goal, step, result })
           : null;
+        const stoppedBeforeConsentExecute = stoppedJobStatus();
+        if (stoppedBeforeConsentExecute) {
+          return stopRunWithStep(stoppedBeforeConsentExecute, { goal, results, stepIndex });
+        }
         const finalStep = consent ? { ...step, userApproved: true } : step;
         const finalResult = consent ? await executeControlStep(finalStep) : result;
         let postActionSnapshot = verificationSnapshot;
@@ -647,6 +698,10 @@ export function createAgentControlRunner(deps) {
           verification: finalVerification
         });
         if (retryStep) {
+          const stoppedBeforeRetry = stoppedJobStatus();
+          if (stoppedBeforeRetry) {
+            return stopRunWithStep(stoppedBeforeRetry, { goal, results, stepIndex });
+          }
           actionRetry = retryStep.retryStrategy;
           await setPageControlOverlay(true, "clicking", "clicking");
           executedStep = retryStep;
@@ -894,6 +949,14 @@ export function createAgentControlRunner(deps) {
         }
       ], "blocked-human-handoff");
       return;
+    }
+    const stoppedWhileApproval = stoppedJobStatus();
+    if (stoppedWhileApproval) {
+      setPendingApproval(null);
+      return stopRun(stoppedWhileApproval, {
+        goal: getCurrentControlRun().goal,
+        results: Array.isArray(approval.results) ? approval.results : []
+      });
     }
     setPendingApproval(null);
     renderControlMonitor();

--- a/browser-first/resonantos-side-panel-extension/src/lib/monitor-progress.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/monitor-progress.js
@@ -122,6 +122,13 @@ export function controlRunSummary(run) {
       body: "Augmentor stopped at a gated action. Review the page, then approve once, trust safe actions for this task class, deny, or delegate the issue.",
     };
   }
+  if (run?.status === "cancelled") {
+    return {
+      state: "cancelled",
+      title: "Task stopped",
+      body: "Augmentor stopped before the next browser action. No pending approval or page control remains active. Review the page state, then continue the job, start a new task, or save a report.",
+    };
+  }
   if (run?.status === "denied") {
     return {
       state: "blocked",

--- a/browser-first/resonantos-side-panel-extension/src/lib/side-panel-scheduled-browser-job-runner.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/side-panel-scheduled-browser-job-runner.js
@@ -151,7 +151,12 @@ export function createSidePanelScheduledBrowserJobRunner({
         syncFocusedLocalRun();
       },
       getActiveJobId: () => job.id,
-      getActiveJobStatus: () => browserJobStore.findJob(job.id)?.status ?? null,
+      // #226: strict id equality against this scheduled run's own job; no
+      // findJob fuzzy/goal-substring fallback may resolve a different job.
+      getActiveJobStatus: (jobId) => {
+        const id = String(jobId ?? job.id);
+        return browserJobStore.getJobs().find((item) => item.id === id)?.status ?? null;
+      },
       getCurrentControlRun: () => localRun,
       getLastSnapshot: () => localLastSnapshot,
       observeControlPage: () => observeQueuedJobPage(job, {

--- a/browser-first/resonantos-side-panel-extension/src/lib/side-panel-scheduled-browser-job-runner.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/side-panel-scheduled-browser-job-runner.js
@@ -151,6 +151,7 @@ export function createSidePanelScheduledBrowserJobRunner({
         syncFocusedLocalRun();
       },
       getActiveJobId: () => job.id,
+      getActiveJobStatus: () => browserJobStore.findJob(job.id)?.status ?? null,
       getCurrentControlRun: () => localRun,
       getLastSnapshot: () => localLastSnapshot,
       observeControlPage: () => observeQueuedJobPage(job, {

--- a/browser-first/resonantos-side-panel-extension/src/side-panel.js
+++ b/browser-first/resonantos-side-panel-extension/src/side-panel.js
@@ -823,7 +823,14 @@ const agentControlRunner = createAgentControlRunner({
   executeControlStep,
   finishControlRun,
   getActiveJobId: () => browserJobStore.getActiveJobId(),
-  getActiveJobStatus: () => browserJobStore.findJob(browserJobStore.getActiveJobId())?.status ?? null,
+  // #226: exact-id lookup of the run's OWN job. Never findJob (fuzzy) and
+  // never getActiveJobId() here: the store re-points activeJobId at the next
+  // active job as soon as the cancelled job goes terminal, which would make a
+  // cancelled run read an innocent queued job's status and keep executing.
+  getActiveJobStatus: (jobId) => {
+    const id = String(jobId ?? browserJobStore.getActiveJobId() ?? "");
+    return browserJobStore.getJobs().find((job) => job.id === id)?.status ?? null;
+  },
   getCurrentControlRun: () => currentControlRun,
   getLastSnapshot: () => lastSnapshot,
   observeControlPage,

--- a/browser-first/resonantos-side-panel-extension/src/side-panel.js
+++ b/browser-first/resonantos-side-panel-extension/src/side-panel.js
@@ -823,6 +823,7 @@ const agentControlRunner = createAgentControlRunner({
   executeControlStep,
   finishControlRun,
   getActiveJobId: () => browserJobStore.getActiveJobId(),
+  getActiveJobStatus: () => browserJobStore.findJob(browserJobStore.getActiveJobId())?.status ?? null,
   getCurrentControlRun: () => currentControlRun,
   getLastSnapshot: () => lastSnapshot,
   observeControlPage,

--- a/browser-first/test/agent-control-runner.test.mjs
+++ b/browser-first/test/agent-control-runner.test.mjs
@@ -9,6 +9,7 @@ import {
   createAgentControlRunner
 } from "../resonantos-side-panel-extension/src/lib/agent-control-runner.js";
 import { createCertifiedExecutor, loadCertificationPage } from "./agent-control-certification-fixtures.mjs";
+import { createBrowserJobStore } from "../resonantos-side-panel-extension/src/lib/browser-job-store.js";
 
 function createHarness(overrides = {}) {
   const events = [];
@@ -120,6 +121,8 @@ function createHarness(overrides = {}) {
       events.push(["step", index, state, note]);
     }
   };
+
+  Object.assign(deps, overrides.deps ?? {});
 
   return {
     events,
@@ -748,4 +751,77 @@ test("#226: approving a pending step after cancellation executes nothing and cle
   assert.equal(harness.getControlRun().status, "cancelled");
   assert.equal(harness.getPendingApproval(), null);
   assert.ok(harness.events.some((event) => event[0] === "message" && /stopped by human/.test(event[2])));
+});
+
+test("#226: cancelling the run job mid-loop with a queued job in the REAL store halts the run and never touches the queued job", async () => {
+  // Real browser-job-store: when the cancelled job goes terminal the store
+  // re-points activeJobId at the next active job (firstActiveJobId). The run
+  // must still resolve stop state by ITS OWN job id, not the reassigned
+  // active id, or the innocent queued job's status is read and the cancelled
+  // run keeps executing.
+  const initial = {};
+  const storage = {
+    get: async () => initial,
+    set: async (payload) => Object.assign(initial, payload)
+  };
+  let idIndex = 0;
+  const store = createBrowserJobStore({
+    storage,
+    storageKeys: {
+      activeBrowserJob: "active",
+      browserJobs: "jobs",
+      jobMonitorCollapsed: "collapsed"
+    },
+    createId: () => (idIndex++ === 0 ? "job-test" : `job-queued-${idIndex}`)
+  });
+  const runJob = await store.createJob({ goal: "primary control run goal" });
+  const queuedJob = await store.createJob({ goal: "second unrelated queued goal", status: "queued", activate: false });
+  assert.equal(store.getActiveJobId(), runJob.id);
+
+  const jobWrites = [];
+  const harness = createHarness({
+    decisions: [
+      { status: "continue", thought: "click next", action: { type: "click", text: "Next" } },
+      { status: "continue", thought: "click continue", action: { type: "click", text: "Continue" } },
+      { status: "continue", thought: "click save", action: { type: "click", text: "Save" } },
+      { status: "done", thought: "done", doneSummary: "Finished." }
+    ],
+    executeControlStep: async () => {
+      // Human hits Stop while the step is in flight: the run job goes
+      // terminal and the store immediately re-points activeJobId at the
+      // innocent queued job.
+      await store.updateJob(runJob.id, { status: "cancelled" });
+      assert.equal(store.getActiveJobId(), queuedJob.id);
+      return { ok: true, clickedText: "Next" };
+    },
+    deps: {
+      getActiveJobId: () => store.getActiveJobId(),
+      // Mirrors the side-panel wiring: exact-id lookup of the id the runner
+      // asks about (the run's own job id).
+      getActiveJobStatus: (jobId) => {
+        const id = String(jobId ?? store.getActiveJobId() ?? "");
+        return store.getJobs().find((job) => job.id === id)?.status ?? null;
+      },
+      updateBrowserJob: async (jobId, patch) => {
+        jobWrites.push([jobId, patch]);
+        return store.updateJob(jobId, patch);
+      }
+    }
+  });
+
+  const result = await harness.runner.continueControlLoop({ goal: "primary control run goal" });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.stopped, "cancelled");
+  // The step whose execution the human interrupted is the ONLY execute; no
+  // further browser action executes after cancellation.
+  assert.equal(harness.events.filter((event) => event[0] === "execute").length, 1);
+  assert.equal(harness.nextActionRequests.length, 1);
+  // The run's own durable job stays cancelled in the real store.
+  assert.equal(store.getJobs().find((job) => job.id === runJob.id)?.status, "cancelled");
+  // The innocent queued job is untouched: still queued, never flipped to
+  // running, and never the target of any runner write.
+  assert.equal(store.getJobs().find((job) => job.id === queuedJob.id)?.status, "queued");
+  assert.ok(jobWrites.every(([jobId]) => jobId !== queuedJob.id));
+  assert.equal(harness.getPendingApproval(), null);
 });

--- a/browser-first/test/agent-control-runner.test.mjs
+++ b/browser-first/test/agent-control-runner.test.mjs
@@ -35,6 +35,7 @@ function createHarness(overrides = {}) {
   const stepResults = overrides.stepResults ?? [{ ok: true, clickedText: "Next" }];
   const savedReports = [];
   let stepResultIndex = 0;
+  let jobStatus = overrides.jobStatus ?? null;
 
   const deps = {
     addMessage: async (role, content) => events.push(["message", role, content]),
@@ -69,6 +70,7 @@ function createHarness(overrides = {}) {
       events.push(["finish", status]);
     },
     getActiveJobId: () => activeJobId,
+    getActiveJobStatus: () => jobStatus,
     getCurrentControlRun: () => controlRun,
     getLastSnapshot: () => lastSnapshot,
     observeControlPage: async () => {
@@ -126,6 +128,9 @@ function createHarness(overrides = {}) {
     nextActionRequests,
     getPendingApproval: () => pendingApproval,
     runner: createAgentControlRunner(deps),
+    setJobStatus: (status) => {
+      jobStatus = status;
+    },
     setLastSnapshot: (snapshot) => {
       lastSnapshot = snapshot;
     }
@@ -668,4 +673,79 @@ test("#223: credential typing attempt blocks the run with the credential boundar
   assert.match(step.details.result, /credential|human/i, "step evidence must name the credential boundary");
   assert.match(step.details.humanInterventionState, /login|credential|human/i, "human intervention state must reflect the boundary");
   assert.equal(win.document.getElementById("cert-password").value, "", "the password field must stay empty");
+});
+
+test("#226: cancellation during preflight halts the run before any step executes", async () => {
+  const harness = createHarness({ jobStatus: "cancelled" });
+
+  const result = await harness.runner.continueControlLoop({ goal: "click next" });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.stopped, "cancelled");
+  assert.equal(harness.events.filter((event) => event[0] === "execute").length, 0);
+  assert.equal(harness.nextActionRequests.length, 0);
+  assert.equal(harness.getControlRun().status, "cancelled");
+  assert.equal(harness.getPendingApproval(), null);
+  assert.ok(harness.events.some((event) => event[0] === "message" && /stopped by human/.test(event[2])));
+  assert.ok(harness.events.some((event) => event[0] === "job" && event[2].status === "cancelled"));
+});
+
+test("#226: cancellation mid-step halts the run before the next action plans or executes", async () => {
+  const harness = createHarness({
+    executeControlStep: async (step) => {
+      harness.setJobStatus("cancelled");
+      return { ok: true, clickedText: "Next" };
+    }
+  });
+
+  const result = await harness.runner.continueControlLoop({ goal: "click next" });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.stopped, "cancelled");
+  assert.equal(harness.events.filter((event) => event[0] === "execute").length, 1);
+  assert.equal(harness.nextActionRequests.length, 1);
+  assert.equal(harness.getControlRun().status, "cancelled");
+  assert.equal(harness.getControlRun().steps[0].state, "cancelled");
+  assert.equal(harness.getControlRun().steps[0].note, "Stopped by human.");
+  assert.match(harness.getControlRun().steps[0].details.nextHumanAction, /restart or resume/);
+  assert.equal(harness.getPendingApproval(), null);
+});
+
+test("#226: pause mid-step halts the run as paused without executing further steps", async () => {
+  const harness = createHarness({
+    executeControlStep: async (step) => {
+      harness.setJobStatus("paused");
+      return { ok: true, clickedText: "Next" };
+    }
+  });
+
+  const result = await harness.runner.continueControlLoop({ goal: "click next" });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.stopped, "paused");
+  assert.equal(harness.events.filter((event) => event[0] === "execute").length, 1);
+  assert.equal(harness.nextActionRequests.length, 1);
+  assert.equal(harness.getControlRun().status, "paused");
+  assert.equal(harness.getPendingApproval(), null);
+});
+
+test("#226: approving a pending step after cancellation executes nothing and clears the approval", async () => {
+  const harness = createHarness({ jobStatus: "cancelled" });
+  harness.getControlRun().steps.push({ type: "click", text: "Place order", state: "blocked" });
+  const approval = {
+    step: { type: "click", text: "Place order", submit: true },
+    stepIndex: 0,
+    reason: "public submit requires human approval",
+    results: [],
+    history: []
+  };
+
+  const result = await harness.runner.approvePendingControlStep(approval);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.stopped, "cancelled");
+  assert.equal(harness.events.filter((event) => event[0] === "execute").length, 0);
+  assert.equal(harness.getControlRun().status, "cancelled");
+  assert.equal(harness.getPendingApproval(), null);
+  assert.ok(harness.events.some((event) => event[0] === "message" && /stopped by human/.test(event[2])));
 });

--- a/browser-first/test/monitor-progress.test.mjs
+++ b/browser-first/test/monitor-progress.test.mjs
@@ -70,4 +70,12 @@ test("monitor progress helpers summarize terminal runs", () => {
     steps: [{ state: "blocked", details: { nextHumanAction: "Pick the target." } }],
   }).body, /Pick the target/);
   assert.equal(controlRunSummary({ status: "running", steps: [] }), null);
+  assert.deepEqual(controlRunSummary({
+    status: "cancelled",
+    steps: [{ state: "cancelled", details: { nextHumanAction: "Review the page state." } }],
+  }), {
+    state: "cancelled",
+    title: "Task stopped",
+    body: "Augmentor stopped before the next browser action. No pending approval or page control remains active. Review the page state, then continue the job, start a new task, or save a report.",
+  });
 });


### PR DESCRIPTION
Lands #226 from PR #284 plus the adjudication-required fix: run status resolved by the run's OWN job id with strict exact-id lookups. All runner job writes target the run's job; every stop check is the last statement before executeControlStep; new two-job regression test against the REAL store; #240 handoff ordering preserved. Suite 839/839; rig-mutate non-vacuous twice. Credit @Resonant-Jones (#284) + @vonstegen (#294 adjudicated). Refs #226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)