### PR TITLE
feat(agent-control): durable job trace with hardened redaction (#225)

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/lib/control-reporting-service.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/control-reporting-service.js
@@ -143,9 +143,9 @@ export function createControlReportingService({
     return bridge()("/archive/intake", {
       method: "POST",
       body: {
-        title: `Browser control ${status}: ${currentControlRun?.goal ?? "task"}`.slice(0, 160),
+        title: redactTraceText(`Browser control ${status}: ${currentControlRun?.goal ?? "task"}`).slice(0, 160),
         content,
-        url: lastSnapshot?.url ?? null,
+        url: lastSnapshot?.url ? redactTraceText(lastSnapshot.url) : null,
         sourceMessageId: currentControlRun?.id ?? null
       }
     }).catch((error) => ({ error: error instanceof Error ? error.message : String(error) }));
@@ -263,7 +263,7 @@ export function createControlReportingService({
     return bridge()("/archive/intake", {
       method: "POST",
       body: {
-        title: `Browser job ${job.status}: ${job.goal ?? "task"}`.slice(0, 160),
+        title: redactTraceText(`Browser job ${job.status}: ${job.goal ?? "task"}`).slice(0, 160),
         content,
         url: null,
         sourceMessageId: job.id ?? null

--- a/browser-first/resonantos-side-panel-extension/src/lib/control-reporting-service.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/control-reporting-service.js
@@ -2,6 +2,7 @@ import {
   controlRunProgress,
   controlRunProgressSummary
 } from "./monitor-renderers.js";
+import { redactTraceText } from "./trace-redaction.js";
 
 export function createControlReportingService({
   addMessage,
@@ -98,7 +99,7 @@ export function createControlReportingService({
     const currentControlRun = getCurrentControlRun();
     if (!currentControlRun) return "";
     const lastSnapshot = getLastSnapshot();
-    return [
+    const report = [
       "# Browser Agent Control Report",
       "",
       `- id: ${currentControlRun.id}`,
@@ -131,6 +132,7 @@ export function createControlReportingService({
       "This is an intake artifact only. Wallet, credential, public-submit, payment, and destructive actions require explicit human approval.",
       ""
     ].join("\n");
+    return redactTraceText(report);
   };
 
   const saveControlReportToArchive = async (results, status) => {
@@ -154,7 +156,7 @@ export function createControlReportingService({
     const steps = Array.isArray(job.steps) ? job.steps : [];
     const artifacts = Array.isArray(job.artifacts) ? job.artifacts : [];
     const preflight = job.preflightDecision;
-    return [
+    const report = [
       "# Browser Job Report",
       "",
       `- id: ${job.id}`,
@@ -206,6 +208,7 @@ export function createControlReportingService({
       "This is an intake artifact only. Wallet, credential, public-submit, payment, and destructive actions require explicit human approval.",
       ""
     ].join("\n");
+    return redactTraceText(report);
   };
 
   const buildControlDelegationPacket = () => {
@@ -215,7 +218,7 @@ export function createControlReportingService({
     const lastSnapshot = getLastSnapshot();
     const step = pendingApproval?.step;
     const steps = Array.isArray(currentControlRun?.steps) ? currentControlRun.steps : [];
-    return [
+    const packet = [
       "# Browser Control Delegation Context",
       "",
       "## Requested Outcome",
@@ -251,6 +254,7 @@ export function createControlReportingService({
       "The receiving add-on gets this context packet only. ResonantOS keeps provider routing, wallet actions, credentials, browser permissions, and trusted memory writes mediated.",
       ""
     ].join("\n");
+    return redactTraceText(packet);
   };
 
   const saveBrowserJobReportToArchive = async (job) => {
@@ -279,12 +283,12 @@ export function createControlReportingService({
         contextMarkdown: buildControlDelegationPacket(),
         source: "browser-control-blocker",
         sourceControlRunId: currentControlRun?.id ?? "",
-        mission: [
+        mission: redactTraceText([
           "Investigate blocked browser-control task.",
           `Goal: ${currentControlRun?.goal ?? "unknown"}`,
           step ? `Blocked step: ${controlStepLabel(step)}` : "",
           pendingApproval?.reason ? `Reason: ${pendingApproval.reason}` : ""
-        ].filter(Boolean).join("\n")
+        ].filter(Boolean).join("\n"))
       }
     }).catch((error) => ({ error: error instanceof Error ? error.message : String(error) }));
     await addMessage(

--- a/browser-first/resonantos-side-panel-extension/src/lib/trace-redaction.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/trace-redaction.js
@@ -1,0 +1,20 @@
+// Redaction pass for durable Agent Control trace artifacts (reports and
+// delegation packets). The in-memory run keeps full fidelity for resume and
+// UX; only exported artifacts pass through this scrubber so secrets echoed in
+// goals, URLs, notes, or errors never reach the archive.
+
+const SECRET_URL_PARAM_NAMES =
+  "(?:token|key|secret|password|passwd|pwd|pin|otp|auth[_-]?code|access[_-]?token|refresh[_-]?token|api[_-]?key|session|sid|signature|csrf|jwt)";
+const URL_PARAM_PATTERN = new RegExp(`([?&])(${SECRET_URL_PARAM_NAMES})(=)([^&#\\s]*)`, "gi");
+const SECRET_ASSIGNMENT_NAMES =
+  "(?:password|passwd|pwd|token|secret|api[_-]?key|access[_-]?token|refresh[_-]?token|otp|pin|auth[_-]?code|signature|jwt)";
+const ASSIGNMENT_PATTERN = new RegExp(`\\b(${SECRET_ASSIGNMENT_NAMES})(\\s*[=:]\\s*)[^\\s,;&#]+`, "gi");
+const HEX_TOKEN_PATTERN = /\b[0-9a-fA-F]{32,}\b/g;
+
+export function redactTraceText(value) {
+  if (typeof value !== "string") return "";
+  return String(value)
+    .replace(URL_PARAM_PATTERN, (match, separator, name, eq) => `${separator}${name}${eq}REDACTED`)
+    .replace(ASSIGNMENT_PATTERN, (match, name, separator) => `${name}${separator}REDACTED`)
+    .replace(HEX_TOKEN_PATTERN, "[REDACTED-TOKEN]");
+}

--- a/browser-first/resonantos-side-panel-extension/src/lib/trace-redaction.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/trace-redaction.js
@@ -4,17 +4,33 @@
 // goals, URLs, notes, or errors never reach the archive.
 
 const SECRET_URL_PARAM_NAMES =
-  "(?:token|key|secret|password|passwd|pwd|pin|otp|auth[_-]?code|access[_-]?token|refresh[_-]?token|api[_-]?key|session|sid|signature|csrf|jwt)";
+  "(?:token|key|secret|password|passwd|pwd|pin|otp|auth[_-]?code|access[_-]?token|refresh[_-]?token|api[_-]?key|session|sid|signature|csrf|jwt|code)";
 const URL_PARAM_PATTERN = new RegExp(`([?&])(${SECRET_URL_PARAM_NAMES})(=)([^&#\\s]*)`, "gi");
+// Percent-encoded URLs nested inside another URL's query value keep their
+// separators as %3F / %26 / %3D; the plain pattern above never sees them, so a
+// redirect like ?next=https%3A%2F%2Fb.com%2F%3Ftoken%3Dabc would leak.
+const ENCODED_URL_PARAM_PATTERN = new RegExp(
+  `(%3F|%26)(${SECRET_URL_PARAM_NAMES})(%3D)((?:(?!%26|%23)[^&#\\s])*)`,
+  "gi"
+);
 const SECRET_ASSIGNMENT_NAMES =
-  "(?:password|passwd|pwd|token|secret|api[_-]?key|access[_-]?token|refresh[_-]?token|otp|pin|auth[_-]?code|signature|jwt)";
-const ASSIGNMENT_PATTERN = new RegExp(`\\b(${SECRET_ASSIGNMENT_NAMES})(\\s*[=:]\\s*)[^\\s,;&#]+`, "gi");
+  "(?:password|passwd|pwd|token|secret|api[_-]?key|access[_-]?token|refresh[_-]?token|otp|pin|auth[_-]?code|signature|jwt|session|sid|csrf|key|code)";
+// The value match runs through to whitespace, &, or # so values containing
+// commas or semicolons (password=abc,defsecret) are redacted in full.
+const ASSIGNMENT_PATTERN = new RegExp(`\\b(${SECRET_ASSIGNMENT_NAMES})(\\s*[=:]\\s*)[^\\s&#]+`, "gi");
+// "Authorization: Bearer <token>" / "Token: Bearer <x>" — the credential is
+// the word after Bearer, so redact the whole scheme+token span. This must run
+// before ASSIGNMENT_PATTERN, which would otherwise consume only the literal
+// word "Bearer" as the value and leave the token itself in the artifact.
+const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9\-._~+/=]+/g;
 const HEX_TOKEN_PATTERN = /\b[0-9a-fA-F]{32,}\b/g;
 
 export function redactTraceText(value) {
   if (typeof value !== "string") return "";
   return String(value)
     .replace(URL_PARAM_PATTERN, (match, separator, name, eq) => `${separator}${name}${eq}REDACTED`)
+    .replace(ENCODED_URL_PARAM_PATTERN, (match, separator, name, eq) => `${separator}${name}${eq}REDACTED`)
+    .replace(BEARER_PATTERN, "REDACTED")
     .replace(ASSIGNMENT_PATTERN, (match, name, separator) => `${name}${separator}REDACTED`)
     .replace(HEX_TOKEN_PATTERN, "[REDACTED-TOKEN]");
 }

--- a/browser-first/test/control-reporting-service.test.mjs
+++ b/browser-first/test/control-reporting-service.test.mjs
@@ -163,6 +163,56 @@ test("control reporting service redacts secrets from job reports and delegation 
   assert.doesNotMatch(bridgeCall[2].mission, /xyz789/);
 });
 
+test("control reporting service redacts archive metadata (titles and url) alongside content", async () => {
+  const harness = createHarness({
+    currentControlRun: {
+      id: "job-9",
+      goal: "log in with password=hunter2secret",
+      planner: "observe-act-verify-loop",
+      startedAt: "2026-05-26T10:00:00.000Z",
+      summary: "Observe and act",
+      status: "blocked",
+      timing: { durationMs: 1000 },
+      steps: [],
+      pageLock: { tabId: 7, siteKey: "example.test", url: "https://example.test/login", reason: "Agent Control goal" }
+    },
+    lastSnapshot: {
+      title: "Login",
+      url: "https://example.test/callback?code=4AbCdEfSecret&token=abc123&state=home"
+    }
+  });
+
+  await harness.service.saveControlReportToArchive([], "blocked");
+  const controlCall = harness.events.find((event) => event[0] === "bridge");
+  assert.match(controlCall[2].title, /Browser control blocked/);
+  assert.match(controlCall[2].title, /password=REDACTED/);
+  assert.doesNotMatch(controlCall[2].title, /hunter2secret/);
+  assert.match(controlCall[2].url, /code=REDACTED/);
+  assert.match(controlCall[2].url, /token=REDACTED/);
+  assert.match(controlCall[2].url, /state=home/);
+  assert.doesNotMatch(controlCall[2].url, /4AbCdEfSecret/);
+  assert.doesNotMatch(controlCall[2].url, /abc123/);
+
+  harness.events.length = 0;
+  await harness.service.saveBrowserJobReportToArchive({
+    id: "job-10",
+    goal: "resume with api_key=sekrit99",
+    status: "blocked",
+    planner: "observe-act-verify-loop",
+    createdAt: "2026-05-26T09:00:00.000Z",
+    updatedAt: "2026-05-26T09:02:00.000Z",
+    timing: { durationMs: 1000 },
+    summary: "Observed",
+    pageLock: null,
+    steps: [],
+    artifacts: []
+  });
+  const jobCall = harness.events.find((event) => event[0] === "bridge");
+  assert.match(jobCall[2].title, /Browser job blocked/);
+  assert.match(jobCall[2].title, /api_key=REDACTED/);
+  assert.doesNotMatch(jobCall[2].title, /sekrit99/);
+});
+
 test("control reporting service saves reports to archive intake", async () => {
   const harness = createHarness();
 

--- a/browser-first/test/control-reporting-service.test.mjs
+++ b/browser-first/test/control-reporting-service.test.mjs
@@ -94,6 +94,75 @@ test("control reporting service builds browser control reports with boundaries",
   assert.match(report, /Wallet, credential, public-submit, payment, and destructive actions/);
 });
 
+test("control reporting service redacts secret-like values from reports", () => {
+  const harness = createHarness({
+    currentControlRun: {
+      id: "job-1",
+      goal: "book with password=hunter2secret and pin: 9876",
+      planner: "observe-act-verify-loop",
+      startedAt: "2026-05-26T10:00:00.000Z",
+      summary: "Observe and act",
+      status: "completed",
+      timing: { durationMs: 1000 },
+      steps: [
+        { type: "type", field: "Search", state: "completed", note: 'typed "vintage synths"', details: { confidence: "high" } },
+        { type: "click", text: "Submit", state: "blocked", note: "auth token 7f3c9a1b2d4e5f68790a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f", details: { confidence: "low" } }
+      ],
+      pageLock: { tabId: 7, siteKey: "example.test", url: "https://example.test/login?token=abc123&email=a@b.com", reason: "Agent Control goal" }
+    }
+  });
+
+  const report = harness.service.buildControlReport([
+    { step: { type: "type", field: "Search", state: "completed", note: 'typed "vintage synths"' }, result: { ok: true } },
+    { step: { type: "click", text: "Submit", state: "blocked" }, result: { ok: false, error: "auth token 7f3c9a1b2d4e5f68790a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f" } }
+  ], "blocked");
+
+  assert.match(report, /password=REDACTED/);
+  assert.doesNotMatch(report, /hunter2secret/);
+  assert.match(report, /pin: REDACTED/);
+  assert.match(report, /token=REDACTED/);
+  assert.doesNotMatch(report, /abc123/);
+  assert.match(report, /email=a@b\.com/);
+  assert.match(report, /\[REDACTED-TOKEN\]/);
+  assert.doesNotMatch(report, /7f3c9a1b/);
+});
+
+test("control reporting service redacts secrets from job reports and delegation packets", async () => {
+  const harness = createHarness({
+    pendingApproval: {
+      step: { type: "click", text: "Submit" },
+      reason: "Public submit requires approval with token=xyz789"
+    }
+  });
+  const job = {
+    id: "job-2",
+    goal: "compare a product",
+    status: "blocked",
+    planner: "observe-act-verify-loop",
+    createdAt: "2026-05-26T09:00:00.000Z",
+    updatedAt: "2026-05-26T09:02:00.000Z",
+    timing: { durationMs: 122000 },
+    summary: "Observed and compared",
+    pageLock: { tabId: 12, siteKey: "example.com", url: "https://example.com/session?session=abc", reason: "Product comparison task" },
+    steps: [
+      { label: "Read page", state: "completed", note: "read product page", timing: { durationMs: 1500 }, details: { confidence: "high" } },
+      { label: "Click details", state: "blocked", note: "clicked details", details: { confidence: "low", nextHumanAction: "Focus the correct product row before resuming." } }
+    ],
+    artifacts: []
+  };
+
+  const report = harness.service.buildBrowserJobReport(job);
+  assert.match(report, /session=REDACTED/);
+  assert.doesNotMatch(report, /abc/);
+
+  await harness.service.delegateControlIssue();
+  const bridgeCall = harness.events.find((event) => event[0] === "bridge");
+  assert.match(bridgeCall[2].contextMarkdown, /token=REDACTED/);
+  assert.doesNotMatch(bridgeCall[2].contextMarkdown, /xyz789/);
+  assert.match(bridgeCall[2].mission, /token=REDACTED/);
+  assert.doesNotMatch(bridgeCall[2].mission, /xyz789/);
+});
+
 test("control reporting service saves reports to archive intake", async () => {
   const harness = createHarness();
 

--- a/browser-first/test/trace-redaction.test.mjs
+++ b/browser-first/test/trace-redaction.test.mjs
@@ -13,12 +13,47 @@ test("redactTraceText redacts secret assignment forms", () => {
   assert.equal(redactTraceText("password=hunter2secret"), "password=REDACTED");
   assert.equal(redactTraceText("password: hunter2secret"), "password: REDACTED");
   assert.equal(redactTraceText("password:hunter2secret"), "password:REDACTED");
-  const bearer = redactTraceText("Token: Bearer abc123");
-  assert.match(bearer, /Token: REDACTED/);
-  assert.doesNotMatch(bearer, /Bearer/);
   assert.equal(redactTraceText("api_key = super-secret-value"), "api_key = REDACTED");
   assert.equal(redactTraceText("pin: 9876"), "pin: REDACTED");
   assert.equal(redactTraceText("otp is 123456"), "otp is 123456");
+});
+
+test("redactTraceText redacts the token following a Bearer scheme", () => {
+  const bearer = redactTraceText("Token: Bearer abc123");
+  assert.match(bearer, /Token: REDACTED/);
+  assert.doesNotMatch(bearer, /Bearer/);
+  assert.doesNotMatch(bearer, /abc123/);
+  const authorization = redactTraceText("Authorization: Bearer eyJhbGci.payload.signature-x");
+  assert.match(authorization, /Authorization: REDACTED/);
+  assert.doesNotMatch(authorization, /Bearer/);
+  assert.doesNotMatch(authorization, /eyJhbGci/);
+});
+
+test("redactTraceText redacts session, sid, csrf, key, and code assignments", () => {
+  assert.equal(redactTraceText("session=abc123def"), "session=REDACTED");
+  assert.equal(redactTraceText("sid: s-778899"), "sid: REDACTED");
+  assert.equal(redactTraceText("csrf=t0k3n-v4lue"), "csrf=REDACTED");
+  assert.equal(redactTraceText("key = private-key-material"), "key = REDACTED");
+  assert.equal(redactTraceText("code: 84h2k9"), "code: REDACTED");
+  const oauth = redactTraceText("https://a.test/cb?code=4/0AbCdEf&state=xyz");
+  assert.match(oauth, /code=REDACTED/);
+  assert.doesNotMatch(oauth, /4\/0AbCdEf/);
+});
+
+test("redactTraceText redacts secrets inside percent-encoded nested URLs", () => {
+  const nested = redactTraceText("https://a.test/login?next=https%3A%2F%2Fb.com%2F%3Ftoken%3Dabc123");
+  assert.match(nested, /%3Ftoken%3DREDACTED/i);
+  assert.doesNotMatch(nested, /abc123/);
+  const chained = redactTraceText("?return=https%3A%2F%2Fc.com%2Fpage%3Fa%3D1%26api_key%3Dsekrit99%26b%3D2");
+  assert.match(chained, /%26api_key%3DREDACTED/i);
+  assert.doesNotMatch(chained, /sekrit99/);
+  assert.match(chained, /%26b%3D2/i);
+});
+
+test("redactTraceText redacts full assignment values through commas and semicolons", () => {
+  assert.equal(redactTraceText("password=abc,defsecret"), "password=REDACTED");
+  assert.equal(redactTraceText("token: v1;part2;part3 done"), "token: REDACTED done");
+  assert.doesNotMatch(redactTraceText("secret=left,right tail"), /right/);
 });
 
 test("redactTraceText redacts long hex tokens and preserves short hex and normal text", () => {

--- a/browser-first/test/trace-redaction.test.mjs
+++ b/browser-first/test/trace-redaction.test.mjs
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { redactTraceText } from "../resonantos-side-panel-extension/src/lib/trace-redaction.js";
+
+test("redactTraceText redacts secret URL query parameters and preserves benign ones", () => {
+  const input = "https://example.test/login?token=abc123&email=a@b.com&api_key=sekrit&ref=home";
+  const output = redactTraceText(input);
+  assert.equal(output, "https://example.test/login?token=REDACTED&email=a@b.com&api_key=REDACTED&ref=home");
+});
+
+test("redactTraceText redacts secret assignment forms", () => {
+  assert.equal(redactTraceText("password=hunter2secret"), "password=REDACTED");
+  assert.equal(redactTraceText("password: hunter2secret"), "password: REDACTED");
+  assert.equal(redactTraceText("password:hunter2secret"), "password:REDACTED");
+  const bearer = redactTraceText("Token: Bearer abc123");
+  assert.match(bearer, /Token: REDACTED/);
+  assert.doesNotMatch(bearer, /Bearer/);
+  assert.equal(redactTraceText("api_key = super-secret-value"), "api_key = REDACTED");
+  assert.equal(redactTraceText("pin: 9876"), "pin: REDACTED");
+  assert.equal(redactTraceText("otp is 123456"), "otp is 123456");
+});
+
+test("redactTraceText redacts long hex tokens and preserves short hex and normal text", () => {
+  const longHex = "7f3c9a1b2d4e5f68790a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f";
+  assert.equal(redactTraceText(`token ${longHex} end`), "token [REDACTED-TOKEN] end");
+  assert.equal(redactTraceText("color #f3c9a1"), "color #f3c9a1");
+  assert.equal(redactTraceText("the quick brown fox"), "the quick brown fox");
+});
+
+test("redactTraceText returns an empty string for non-string input", () => {
+  assert.equal(redactTraceText(undefined), "");
+  assert.equal(redactTraceText(null), "");
+  assert.equal(redactTraceText(42), "");
+  assert.equal(redactTraceText({ token: "abc" }), "");
+});
+
+test("redactTraceText leaves clean trace text unchanged", () => {
+  const clean = [
+    "# Browser Job Report",
+    "- status: completed",
+    "1. Read page - ok - read product page",
+    "## Boundary",
+    "Intake artifact only."
+  ].join("\n");
+  assert.equal(redactTraceText(clean), clean);
+});


### PR DESCRIPTION
Lands #225 from PR #285 plus closure of every review-proven leak: archive title/url through redactTraceText; session/sid/csrf/key/code names + bare OAuth ?code=; Bearer tokens; percent-encoded nested URL params; full-value redaction past ,;# separators. Leak-documenting test flipped to assert redaction. Suite 871/871 on the rebased tip; Bearer guard rig-mutate non-vacuous. Credit @Resonant-Jones (#285). Refs #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)