### PR TITLE
feat(opencode): desktop-app-style live workspace — session browser + resume

### DIFF
--- a/browser-first/host/opencode-client.mjs
+++ b/browser-first/host/opencode-client.mjs
@@ -93,6 +93,8 @@ export function createOpencodeHttpClient({ fetchImpl, baseUrl, headers = {} } = 
         ...(decision?.remember ? { remember: true } : {})
       }),
     listAgents: () => call("GET", "/agent"),
+    listSessions: () => call("GET", "/session"),
+    messages: (sessionId) => call("GET", `/session/${encodeURIComponent(sessionId)}/message`),
     eventUrl: () => `${baseUrl}/event`
   };
 }

--- a/browser-first/host/opencode-session-host-service.mjs
+++ b/browser-first/host/opencode-session-host-service.mjs
@@ -39,6 +39,18 @@ export function createOpencodeSessionHostService(handlers = {}) {
         requiredCapability: "addon-runtime-control",
         handler: required("executeOpenCodeSessionStop"),
       },
+      {
+        method: "POST",
+        path: "/opencode/sessions/list",
+        requiredCapability: "addon-runtime-control",
+        handler: required("executeOpenCodeSessionsList"),
+      },
+      {
+        method: "POST",
+        path: "/opencode/session/messages",
+        requiredCapability: "addon-runtime-control",
+        handler: required("executeOpenCodeSessionMessages"),
+      },
     ],
   };
 }
@@ -80,6 +92,28 @@ export function createOpencodeSessionHandlers({ ensureServer, createClient }) {
       const c = await ensureClient();
       await c.replyPermission(sessionId, permissionId, decision ?? {});
       return { ok: true };
+    },
+    executeOpenCodeSessionsList: async () => {
+      const c = await ensureClient();
+      const sessions = await c.listSessions();
+      return {
+        ok: true,
+        eventUrl: c.eventUrl?.() ?? "",
+        baseUrl: serverInfo?.baseUrl ?? "",
+        sessions: (Array.isArray(sessions) ? sessions : []).map((s) => ({
+          id: s.id ?? s.sessionID ?? "",
+          title: s.title ?? "",
+          created: s.time?.created ?? 0,
+          updated: s.time?.updated ?? s.time?.created ?? 0
+        })).filter((s) => s.id)
+      };
+    },
+    executeOpenCodeSessionMessages: async (req) => {
+      const { sessionId } = bodyOf(req);
+      if (!sessionId) throw new Error("messages requires sessionId.");
+      const c = await ensureClient();
+      const messages = await c.messages(sessionId);
+      return { ok: true, messages: Array.isArray(messages) ? messages : [] };
     },
     executeOpenCodeSessionStop: async () => {
       try { serverInfo?.process?.kill?.(); } catch { /* noop */ }

--- a/browser-first/resonantos-side-panel-extension/src/lib/bridge-client.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/bridge-client.js
@@ -86,6 +86,8 @@ const BRIDGE_ROUTE_CAPABILITIES = Object.freeze({
   "POST /opencode/session/prompt": "addon-runtime-control",
   "POST /opencode/session/permission": "addon-runtime-control",
   "POST /opencode/session/stop": "addon-runtime-control",
+  "POST /opencode/sessions/list": "addon-runtime-control",
+  "POST /opencode/session/messages": "addon-runtime-control",
   "POST /addons/draft": "addon-record-write",
   "POST /addons/draft/list": "addon-record-read",
   "POST /addons/draft/read": "addon-record-read",

--- a/browser-first/resonantos-side-panel-extension/src/lib/main-workspace-opencode.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/main-workspace-opencode.js
@@ -4,6 +4,7 @@
 import { delegationGuidanceText } from "./delegation-guidance.js";
 import { createOpenCodeSession } from "./main-workspace-opencode-session.js";
 import { createOpenCodeBridgeSource } from "./opencode-bridge-source.js";
+import { createOpenCodeSessionBrowser, seedEventsFromMessages } from "./opencode-session-browser.js";
 import { opencodeStatusMessage } from "./runtime-error-messages.js";
 
 function setStatus(node, text, tone = "neutral") {
@@ -204,44 +205,100 @@ export function renderOpenCodeWorkspace({ container, bridgeRequest, getBridgeReq
     }
   });
 
-  // Live session: mount the streaming OpenCode workspace element. The bridge
-  // starts (reuses) `opencode serve` and returns the session + its /event URL;
-  // the element streams events directly from the server (host_permissions cover
-  // 127.0.0.1) and routes prompts/permissions back through the bridge.
+  // Live workspace: a desktop-app-style two-pane shell — session browser rail
+  // (search, Today/Older groups, resume-on-click, New session) on the left,
+  // the streaming session element on the right. The bridge starts (reuses)
+  // `opencode serve`; the element streams events directly from the server
+  // (host_permissions cover 127.0.0.1) and routes prompts/permissions back
+  // through the bridge. Resume replays history through the SAME event path the
+  // live stream uses, so both render identically.
+  const ide = document.createElement("div");
+  ide.className = "opencode-ide";
+  ide.hidden = true;
+  const railMount = document.createElement("div");
+  railMount.className = "opencode-ide-rail";
   const sessionArea = document.createElement("div");
   sessionArea.className = "opencode-session-area";
-  section.append(sessionArea);
+  ide.append(railMount, sessionArea);
+  section.append(ide);
   let activeSession = null;
+  let browserRail = null;
 
-  async function startLiveSession() {
-    startSessionButton.disabled = true;
+  function mountSession(info, seedMessages = []) {
+    activeSession?.destroy?.();
+    sessionArea.replaceChildren();
+    const source = createOpenCodeBridgeSource({
+      // Idempotent: return the already-known session so subscribe + prompt share it.
+      startSession: async () => ({ sessionId: info.sessionId, eventUrl: info.eventUrl }),
+      openEventStream: (eventUrl) => fetch(eventUrl),
+      postJson: (path, body) => bridge()(path, { method: "POST", body })
+    });
+    const seeds = seedEventsFromMessages(seedMessages);
+    const subscribe = (onEvent) => {
+      for (const event of seeds) onEvent(event);
+      return source.subscribe(onEvent);
+    };
+    activeSession = createOpenCodeSession({
+      document,
+      container: sessionArea,
+      scope: "",
+      subscribe,
+      sendPrompt: source.sendPrompt,
+      replyPermission: source.replyPermission,
+      revert: async () => {}
+    });
+    browserRail?.setActive?.(info.sessionId);
+  }
+
+  function openWorkspaceShell() {
+    header.hidden = true;
+    boundaryCard.hidden = true;
+    taskForm.hidden = true;
+    ide.hidden = false;
+    if (!browserRail) {
+      browserRail = createOpenCodeSessionBrowser({
+        document,
+        container: railMount,
+        projectName: "2.0.0-alpha",
+        listSessions: () => bridge()("/opencode/sessions/list", { method: "POST", body: {} }),
+        onNewSession: () => void newSession(),
+        onOpenSession: (sessionId) => void resumeSession(sessionId)
+      });
+    }
+    void browserRail.refresh();
+  }
+
+  async function newSession() {
     setStatus(taskStatus, "Starting OpenCode session…");
     try {
       const info = await bridge()("/opencode/session/start", { method: "POST", body: {} });
       if (!info?.sessionId) throw new Error("No session id returned.");
-      header.hidden = true;
-      boundaryCard.hidden = true;
-      taskForm.hidden = true;
-      activeSession?.destroy?.();
-      sessionArea.replaceChildren();
-      const source = createOpenCodeBridgeSource({
-        // Idempotent: return the already-started session so subscribe + prompt share it.
-        startSession: async () => ({ sessionId: info.sessionId, eventUrl: info.eventUrl }),
-        openEventStream: (eventUrl) => fetch(eventUrl),
-        postJson: (path, body) => bridge()(path, { method: "POST", body })
-      });
-      activeSession = createOpenCodeSession({
-        document,
-        container: sessionArea,
-        scope: info.baseUrl ? "" : "",
-        subscribe: source.subscribe,
-        sendPrompt: source.sendPrompt,
-        replyPermission: source.replyPermission,
-        revert: async () => {}
-      });
+      openWorkspaceShell();
+      mountSession(info, []);
+      await browserRail.refresh();
+      browserRail.setActive(info.sessionId);
       setStatus(taskStatus, "");
     } catch (error) {
       setStatus(taskStatus, opencodeStatusMessage(error, "Could not start OpenCode session"), "error");
+    }
+  }
+
+  async function resumeSession(sessionId) {
+    setStatus(taskStatus, "Resuming session…");
+    try {
+      const list = await bridge()("/opencode/sessions/list", { method: "POST", body: {} });
+      const history = await bridge()("/opencode/session/messages", { method: "POST", body: { sessionId } });
+      mountSession({ sessionId, eventUrl: list.eventUrl, baseUrl: list.baseUrl }, history.messages ?? []);
+      setStatus(taskStatus, "");
+    } catch (error) {
+      setStatus(taskStatus, opencodeStatusMessage(error, "Could not resume OpenCode session"), "error");
+    }
+  }
+
+  async function startLiveSession() {
+    startSessionButton.disabled = true;
+    try {
+      await newSession();
     } finally {
       startSessionButton.disabled = false;
     }

--- a/browser-first/resonantos-side-panel-extension/src/lib/opencode-session-browser.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/opencode-session-browser.js
@@ -1,0 +1,142 @@
+// OpenCode session browser — the desktop-app-style left rail for the live
+// workspace: project header, session search, sessions grouped Today / Older
+// (resume on click), and a New session action. Pure DOM + injected callbacks so
+// it unit-tests in jsdom without a bridge.
+
+export function groupSessions(sessions = [], now = Date.now()) {
+  const dayStart = new Date(now); dayStart.setHours(0, 0, 0, 0);
+  const today = [], older = [];
+  for (const s of [...sessions].sort((a, b) => (b.updated ?? 0) - (a.updated ?? 0))) {
+    ((s.updated ?? s.created ?? 0) >= dayStart.getTime() ? today : older).push(s);
+  }
+  return { today, older };
+}
+
+export function filterSessions(sessions = [], query = "") {
+  const q = String(query ?? "").trim().toLowerCase();
+  if (!q) return sessions;
+  return sessions.filter((s) => (s.title || s.id || "").toLowerCase().includes(q));
+}
+
+export function sessionLabel(session) {
+  const title = String(session?.title ?? "").trim();
+  return title || `Session ${String(session?.id ?? "").slice(-6)}`;
+}
+
+export function createOpenCodeSessionBrowser({
+  document: doc,
+  container,
+  projectName = "2.0.0-alpha",
+  listSessions,     // async () => [{id,title,created,updated}]
+  onOpenSession,    // (sessionId) => void
+  onNewSession      // () => void
+} = {}) {
+  const root = doc.createElement("aside");
+  root.className = "ocb-rail";
+
+  const project = doc.createElement("div");
+  project.className = "ocb-project";
+  const mark = doc.createElement("span");
+  mark.className = "ocb-project-mark";
+  mark.textContent = projectName.slice(0, 1).toUpperCase();
+  const name = doc.createElement("strong");
+  name.textContent = projectName;
+  project.append(mark, name);
+
+  const search = doc.createElement("input");
+  search.type = "search";
+  search.className = "ocb-search";
+  search.placeholder = `Search sessions in ${projectName}`;
+
+  const newButton = doc.createElement("button");
+  newButton.type = "button";
+  newButton.className = "ocb-new";
+  newButton.textContent = "+ New session";
+  newButton.addEventListener("click", () => onNewSession?.());
+
+  const list = doc.createElement("div");
+  list.className = "ocb-list";
+
+  root.append(project, search, newButton, list);
+  container.append(root);
+
+  let sessions = [];
+  let activeId = "";
+
+  function renderList() {
+    list.replaceChildren();
+    const visible = filterSessions(sessions, search.value);
+    const { today, older } = groupSessions(visible);
+    for (const [label, group] of [["Today", today], ["Older", older]]) {
+      if (!group.length) continue;
+      const heading = doc.createElement("div");
+      heading.className = "ocb-group";
+      heading.textContent = label;
+      list.append(heading);
+      for (const s of group) {
+        const row = doc.createElement("button");
+        row.type = "button";
+        row.className = "ocb-session";
+        row.dataset.sessionId = s.id;
+        row.dataset.active = s.id === activeId ? "true" : "false";
+        const dot = doc.createElement("span");
+        dot.className = "ocb-session-mark";
+        const text = doc.createElement("span");
+        text.className = "ocb-session-title";
+        text.textContent = sessionLabel(s);
+        row.append(dot, text);
+        row.addEventListener("click", () => {
+          setActive(s.id);
+          onOpenSession?.(s.id);
+        });
+        list.append(row);
+      }
+    }
+    if (!visible.length) {
+      const empty = doc.createElement("p");
+      empty.className = "ocb-empty";
+      empty.textContent = "No sessions yet — start one.";
+      list.append(empty);
+    }
+  }
+
+  function setActive(id) {
+    activeId = id || "";
+    for (const row of list.querySelectorAll(".ocb-session")) {
+      row.dataset.active = row.dataset.sessionId === activeId ? "true" : "false";
+    }
+  }
+
+  async function refresh() {
+    try {
+      const result = await listSessions();
+      sessions = Array.isArray(result?.sessions) ? result.sessions : [];
+    } catch {
+      sessions = [];
+    }
+    renderList();
+  }
+
+  search.addEventListener("input", renderList);
+
+  return { root, refresh, setActive, getSessions: () => sessions };
+}
+
+// Seed a live-session reducer with an existing session's message history by
+// replaying it as synthetic v1.18-schema events (message-info + text-set per
+// part) — the same path live events take, so resume and live rendering agree.
+export function seedEventsFromMessages(messages = []) {
+  const events = [];
+  for (const m of messages) {
+    const info = m?.info ?? m ?? {};
+    if (info.id && info.role) {
+      events.push({ type: "message.updated", properties: { info: { id: info.id, role: info.role } } });
+    }
+    for (const part of m?.parts ?? []) {
+      if ((part?.type === "text" || part?.type === "reasoning") && String(part.text ?? "").trim()) {
+        events.push({ type: "message.part.updated", properties: { part: { ...part, messageID: part.messageID ?? info.id } } });
+      }
+    }
+  }
+  return events;
+}

--- a/browser-first/resonantos-side-panel-extension/src/styles/main-workspace/opencode-session.css
+++ b/browser-first/resonantos-side-panel-extension/src/styles/main-workspace/opencode-session.css
@@ -148,3 +148,78 @@
 }
 .opencode-start-session[hidden] { display: none; }
 .opencode-session-area:not(:empty) { min-height: 480px; margin-top: 10px; }
+
+/* Desktop-app-style live workspace shell: session-browser rail + session pane */
+.opencode-ide {
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr);
+  gap: 14px;
+  min-height: 520px;
+  margin-top: 10px;
+}
+.opencode-ide[hidden] { display: none; }
+.ocb-rail {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border: 1px solid rgba(36, 209, 143, 0.14);
+  border-radius: 14px;
+  background: rgba(10, 15, 12, 0.72);
+  padding: 12px;
+  min-height: 0;
+}
+.ocb-project { display: flex; align-items: center; gap: 8px; }
+.ocb-project strong { color: rgba(247, 255, 249, 0.95); font-size: 0.8rem; }
+.ocb-project-mark {
+  display: inline-grid; place-items: center;
+  width: 22px; height: 22px;
+  border: 1px solid rgba(36, 209, 143, 0.35);
+  border-radius: 7px;
+  background: rgba(36, 209, 143, 0.14);
+  color: #24d18f; font-size: 0.66rem; font-weight: 900;
+}
+.ocb-search {
+  border: 1px solid rgba(148, 255, 198, 0.15);
+  border-radius: 9px;
+  background: rgba(5, 8, 7, 0.6);
+  color: #eef7f0;
+  font: inherit; font-size: 0.66rem;
+  padding: 7px 9px;
+}
+.ocb-new {
+  border: 1px solid rgba(36, 209, 143, 0.4);
+  border-radius: 9px;
+  background: rgba(36, 209, 143, 0.12);
+  color: #eef7f0; font-size: 0.66rem; font-weight: 800;
+  padding: 7px 9px; cursor: pointer; text-align: left;
+}
+.ocb-list { display: flex; flex-direction: column; gap: 3px; overflow: auto; min-height: 0; }
+.ocb-group {
+  margin: 8px 2px 3px;
+  color: rgba(143, 159, 149, 0.75);
+  font-size: 0.56rem; font-weight: 900; letter-spacing: 0.12em; text-transform: uppercase;
+}
+.ocb-session {
+  display: flex; align-items: center; gap: 8px;
+  border: 1px solid transparent;
+  border-radius: 9px;
+  background: transparent;
+  color: rgba(214, 229, 219, 0.82);
+  font-size: 0.68rem; text-align: left;
+  padding: 7px 8px; cursor: pointer;
+  overflow: hidden;
+}
+.ocb-session:hover { background: rgba(36, 209, 143, 0.07); }
+.ocb-session[data-active="true"] {
+  border-color: rgba(36, 209, 143, 0.3);
+  background: rgba(36, 209, 143, 0.12);
+  color: #f7fff9;
+}
+.ocb-session-mark {
+  flex: 0 0 auto;
+  width: 8px; height: 8px;
+  border-radius: 999px;
+  background: rgba(36, 209, 143, 0.55);
+}
+.ocb-session-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ocb-empty { color: rgba(143, 159, 149, 0.7); font-size: 0.66rem; margin: 6px 2px; }

--- a/browser-first/test/opencode-session-browser.test.mjs
+++ b/browser-first/test/opencode-session-browser.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { JSDOM } from "jsdom";
+
+import {
+  createOpenCodeSessionBrowser,
+  filterSessions,
+  groupSessions,
+  seedEventsFromMessages,
+  sessionLabel
+} from "../resonantos-side-panel-extension/src/lib/opencode-session-browser.js";
+import {
+  applyOpenCodeEvent,
+  createOpenCodeSessionState,
+  normalizeOpenCodeEvent
+} from "../resonantos-side-panel-extension/src/lib/opencode-session-model.js";
+
+const NOW = new Date("2026-08-18T20:00:00Z").getTime();
+const DAY = 24 * 3600 * 1000;
+
+test("groupSessions splits Today from Older, newest first", () => {
+  const { today, older } = groupSessions([
+    { id: "a", updated: NOW - 2 * DAY },
+    { id: "b", updated: NOW - 3600 * 1000 },
+    { id: "c", updated: NOW - 60 * 1000 }
+  ], NOW);
+  assert.deepEqual(today.map((s) => s.id), ["c", "b"]);
+  assert.deepEqual(older.map((s) => s.id), ["a"]);
+});
+
+test("filterSessions matches title and id, case-insensitive", () => {
+  const sessions = [{ id: "ses_abc", title: "Fix bridge" }, { id: "ses_xyz", title: "" }];
+  assert.equal(filterSessions(sessions, "BRIDGE").length, 1);
+  assert.equal(filterSessions(sessions, "xyz").length, 1);
+  assert.equal(filterSessions(sessions, "").length, 2);
+});
+
+test("sessionLabel falls back to a short id", () => {
+  assert.equal(sessionLabel({ id: "ses_123456789", title: "" }), "Session 456789");
+  assert.equal(sessionLabel({ id: "x", title: "My run" }), "My run");
+});
+
+test("browser renders groups, resumes on click, and starts new sessions", async () => {
+  const dom = new JSDOM("<!doctype html><main id=\"m\"></main>");
+  const doc = dom.window.document;
+  const opened = [];
+  let newCount = 0;
+  const browser = createOpenCodeSessionBrowser({
+    document: doc,
+    container: doc.querySelector("#m"),
+    listSessions: async () => ({ sessions: [
+      { id: "ses_now", title: "Live proof", created: Date.now(), updated: Date.now() },
+      { id: "ses_old", title: "July run", created: 1, updated: 1 }
+    ] }),
+    onOpenSession: (id) => opened.push(id),
+    onNewSession: () => { newCount += 1; }
+  });
+  await browser.refresh();
+  const rows = [...doc.querySelectorAll(".ocb-session")];
+  assert.equal(rows.length, 2);
+  assert.deepEqual([...doc.querySelectorAll(".ocb-group")].map((g) => g.textContent), ["Today", "Older"]);
+  rows[1].click();
+  assert.deepEqual(opened, ["ses_old"]);
+  assert.equal(rows[1].dataset.active, "true");
+  doc.querySelector(".ocb-new").click();
+  assert.equal(newCount, 1);
+});
+
+test("seedEventsFromMessages replays history through the live reducer identically", () => {
+  const messages = [
+    { info: { id: "m1", role: "user" }, parts: [{ type: "text", text: "do the thing", id: "p1" }] },
+    { info: { id: "m2", role: "assistant" }, parts: [{ type: "text", text: "done: the thing", id: "p2" }] }
+  ];
+  let state = createOpenCodeSessionState();
+  for (const raw of seedEventsFromMessages(messages)) {
+    state = applyOpenCodeEvent(state, normalizeOpenCodeEvent(raw));
+  }
+  // User text filtered (composer echoes it); assistant text present.
+  assert.equal(state.entries.length, 1);
+  assert.equal(state.entries[0].text, "done: the thing");
+});

--- a/browser-first/test/opencode-session-host-service.test.mjs
+++ b/browser-first/test/opencode-session-host-service.test.mjs
@@ -12,11 +12,13 @@ test("the service exposes the session routes with runtime-control capability", (
     executeOpenCodeSessionStart: noop,
     executeOpenCodeSessionPrompt: noop,
     executeOpenCodeSessionPermission: noop,
-    executeOpenCodeSessionStop: noop
+    executeOpenCodeSessionStop: noop,
+    executeOpenCodeSessionsList: noop,
+    executeOpenCodeSessionMessages: noop
   });
   assert.deepEqual(
     opencodeSessionRoutes.map((r) => `${r.method} ${r.path}`),
-    ["POST /opencode/session/start", "POST /opencode/session/prompt", "POST /opencode/session/permission", "POST /opencode/session/stop"]
+    ["POST /opencode/session/start", "POST /opencode/session/prompt", "POST /opencode/session/permission", "POST /opencode/session/stop", "POST /opencode/sessions/list", "POST /opencode/session/messages"]
   );
   assert.ok(opencodeSessionRoutes.every((r) => r.requiredCapability === "addon-runtime-control"));
 });
@@ -68,4 +70,33 @@ test("prompt and permission validate their inputs", async () => {
   });
   await assert.rejects(() => handlers.executeOpenCodeSessionPrompt({ body: { sessionId: "", text: "" } }), /requires sessionId and text/);
   await assert.rejects(() => handlers.executeOpenCodeSessionPermission({ body: { sessionId: "s1" } }), /requires sessionId and permissionId/);
+});
+
+test("sessions list returns normalized sessions plus server urls", async () => {
+  const handlers = createOpencodeSessionHandlers({
+    ensureServer: async () => ({ baseUrl: "http://127.0.0.1:9999" }),
+    createClient: () => ({
+      listSessions: async () => [
+        { id: "ses_1", title: "A", time: { created: 5, updated: 9 } },
+        { sessionID: "", title: "dropped" }
+      ],
+      eventUrl: () => "http://127.0.0.1:9999/event"
+    })
+  });
+  const result = await handlers.executeOpenCodeSessionsList();
+  assert.equal(result.ok, true);
+  assert.equal(result.baseUrl, "http://127.0.0.1:9999");
+  assert.equal(result.eventUrl, "http://127.0.0.1:9999/event");
+  assert.deepEqual(result.sessions, [{ id: "ses_1", title: "A", created: 5, updated: 9 }]);
+});
+
+test("session messages requires an id and passes history through", async () => {
+  const handlers = createOpencodeSessionHandlers({
+    ensureServer: async () => ({ baseUrl: "http://x" }),
+    createClient: () => ({ messages: async (id) => [{ info: { id: "m1" }, forSession: id }] })
+  });
+  await assert.rejects(() => handlers.executeOpenCodeSessionMessages({ body: {} }), /requires sessionId/);
+  const result = await handlers.executeOpenCodeSessionMessages({ body: { sessionId: "ses_9" } });
+  assert.equal(result.ok, true);
+  assert.equal(result.messages[0].forSession, "ses_9");
 });


### PR DESCRIPTION
The OpenCode panel now opens into a **two-pane workspace matching the OpenCode desktop app**: session-browser rail (project header, search, Today/Older groups newest-first, resume-on-click, + New session) beside the streaming session pane.

- Host: \`listSessions\`/\`messages\` client methods + two capability-gated routes (\`/opencode/sessions/list\` incl. baseUrl/eventUrl, \`/opencode/session/messages\`)
- Resume replays server history through the **same v1.18 event path** as the live stream (\`seedEventsFromMessages\`) — resumed and live rendering agree by construction; user-role parts filtered
- Pure, jsdom-tested rail module; IDE-shell CSS in the dark theme

**Live proof in real Chrome**: 30 sessions listed (incl. Codex-era sessions from the same server store), new session streams, older session resumes with seeded history — screenshots in the session record. Suite **846/846**; seed path rig-mutate non-vacuous.

First increment of the OpenCode workspace-refinement track. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)