### PR TITLE
feat(augmentor): inline counterpoint and explain-jargon actions (#219, landed from #295)

### DIFF
--- a/browser-first/resonantos-side-panel-extension/manifest.json
+++ b/browser-first/resonantos-side-panel-extension/manifest.json
@@ -17,7 +17,7 @@
   "content_scripts": [
     {
       "matches": ["http://*/*", "https://*/*"],
-      "js": ["src/lib/resonant-context.js", "src/lib/context-plugins.js", "src/lib/resonator.js", "src/lib/control-overlay.js", "src/lib/content-field-safety.js", "src/lib/content-inline-actions.js", "src/lib/augmentor-shortcut-controller.js", "src/lib/content-control-refs.js", "src/content.js"],
+      "js": ["src/lib/resonant-context.js", "src/lib/context-plugins.js", "src/lib/resonator.js", "src/lib/control-overlay.js", "src/lib/content-field-safety.js", "src/lib/content-inline-actions.js", "src/lib/augmentor-shortcut-controller.js", "src/lib/content-control-refs.js", "src/lib/content-inline-action-surface-gate.js", "src/content.js"],
       "run_at": "document_idle",
       "all_frames": true
     }

--- a/browser-first/resonantos-side-panel-extension/src/content.js
+++ b/browser-first/resonantos-side-panel-extension/src/content.js
@@ -1053,6 +1053,69 @@ const showInlinePanel = (initialAction = "summarize") => {
   void runInlineAction(initialAction);
 };
 
+const uniqueInlineTerms = (items) => {
+  const seen = new Set();
+  return items.filter((item) => {
+    const key = item.toLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+};
+
+const localCounterpointResult = (clipped) => {
+  const absoluteWords = uniqueInlineTerms(Array.from(
+    clipped.matchAll(/\b(always|never|all|none|every|everyone|everything|only|must|guaranteed|proves|obvious|impossible)\b/gi),
+    (match) => match[0]
+  )).slice(0, 6);
+  const hasEvidenceMarker = /\b\d+(?:\.\d+)?%?\b|https?:\/\/|\[[0-9]+\]|\([A-Z][A-Za-z]+,\s*\d{4}\)|\b(study|survey|source|data|evidence|because|according to)\b/i.test(clipped);
+  const considerations = [];
+  if (absoluteWords.length) {
+    considerations.push(`Absolute wording: "${absoluteWords.join("\", \"")}" may need exceptions, scope, or a weaker claim.`);
+  } else {
+    considerations.push("Scope check: ask what cases, audience, timeframe, or constraints might make this claim less general.");
+  }
+  considerations.push(hasEvidenceMarker
+    ? "Evidence check: verify whether the cited numbers or sources actually support the full claim."
+    : "Evidence gap: this selection does not show sources, measurements, or examples that would let a reader test the claim.");
+  considerations.push("Alternative explanations: consider incentives, timing, implementation quality, or selection effects before treating the claim as settled.");
+  return `Counterpoint:\nLocal heuristic only; no sources were checked.\n- ${considerations.join("\n- ")}\nSelected claim: ${clipped}`;
+};
+
+const localSimpleSentenceStructure = (sentence) => {
+  const words = sentence.split(/\s+/).filter(Boolean);
+  const verbIndex = words.findIndex((word, index) =>
+    index > 0 && /^(is|are|was|were|be|being|been|has|have|had|will|can|could|should|must|may|might|does|do|did)$/i.test(word.replace(/[^A-Za-z]/g, ""))
+      || index > 0 && /(?:ed|ing|izes?|ises?|ates?|ifies?|s)$/.test(word.replace(/[^A-Za-z]/g, ""))
+  );
+  if (verbIndex <= 0 || verbIndex >= words.length - 1) {
+    return sentence
+      ? `Simple structure: main idea = "${sentence}".`
+      : "Simple structure: identify the main actor, the action, and what the action affects.";
+  }
+  const subject = words.slice(0, verbIndex).join(" ");
+  const action = words[verbIndex];
+  const object = words.slice(verbIndex + 1).join(" ");
+  return `Simple structure: "${subject}" does "${action}" to or with "${object}".`;
+};
+
+const localPlainTermsResult = (clipped) => {
+  const jargonTerms = uniqueInlineTerms(Array.from(
+    clipped.matchAll(/\b(?:[A-Z]{2,}|[A-Za-z]+(?:[A-Z][a-z]+)+|[A-Za-z]{11,})\b/g),
+    (match) => match[0]
+  )).slice(0, 8);
+  const simpleStructure = clipped
+    .split(/[.!?]/)[0]
+    .replace(/[,;:]\s*/g, ". ")
+    .replace(/\s+/g, " ")
+    .trim();
+  const simpler = localSimpleSentenceStructure(simpleStructure);
+  const terms = jargonTerms.length
+    ? `Possible jargon-like terms: ${jargonTerms.join(", ")}.`
+    : "No obvious acronym or long technical terms stood out; simplify by naming who does what and why.";
+  return `Plain terms:\nLocal heuristic only; no glossary or network lookup was used.\n${terms}\n${simpler}`;
+};
+
 const localInlineResult = (action, text) => {
   const clipped = String(text ?? "").replace(/\s+/g, " ").trim().slice(0, 800);
   if (action === "custom") return `Apply the custom instruction to this selected text:\n${clipped}`;
@@ -1060,6 +1123,8 @@ const localInlineResult = (action, text) => {
   if (action === "fact-check") return `Fact-check this claim with primary sources before relying on it:\n${clipped}`;
   if (action === "translate") return `Translation requires the configured model. Selected text:\n${clipped}`;
   if (action === "explain") return `Explanation:\n${clipped}`;
+  if (action === "counterpoint") return localCounterpointResult(clipped);
+  if (action === "explain-jargon") return localPlainTermsResult(clipped);
   return `Summary:\n${clipped}`;
 };
 

--- a/browser-first/resonantos-side-panel-extension/src/content.js
+++ b/browser-first/resonantos-side-panel-extension/src/content.js
@@ -18,6 +18,11 @@ function sanitizeBrowserContextUrl(value, base = window.location.href) {
     return "";
   }
 }
+// Inline action surface gate — sourced from src/lib/content-inline-action-surface-gate.js
+// (loaded earlier in the content_scripts array). Keep the import here so the
+// helper is available synchronously at panel-render time and the gate logic
+// can be unit-tested independently of the content script.
+const { inlineActionAllowedForLocationGate } = globalThis.ResonantOSInlineActionSurfaceGate ?? {};
 (function initResonantContextSDK() {
   try {
     if (typeof window.ResonantContext === 'undefined' || typeof window._ResonantContext === 'undefined') {
@@ -1068,6 +1073,20 @@ const runInlineAction = async (action) => {
   const selection = panel.dataset.selection || currentSelectionDetails()?.text || "";
   if (!selection) {
     result.textContent = "No selected text is available.";
+    return;
+  }
+  const locationGate = inlineActionAllowedForLocationGate
+    ? inlineActionAllowedForLocationGate(location.href)
+    : { allowed: true };
+  if (!locationGate.allowed) {
+    result.textContent = locationGate.message;
+    return;
+  }
+  const sitePermissionMode = await chrome.storage?.local?.get?.("augmentorSitePermissions")
+    .then((value) => value?.augmentorSitePermissions?.mode)
+    .catch(() => null);
+  if (sitePermissionMode === "blocked") {
+    result.textContent = "Augmentor inline actions are blocked for this site by your saved site permission. Toggle the site permission in the side panel to re-enable inline actions.";
     return;
   }
   if (action === "send") {

--- a/browser-first/resonantos-side-panel-extension/src/lib/content-inline-action-surface-gate.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/content-inline-action-surface-gate.js
@@ -1,0 +1,44 @@
+// Inline action surface gate: same restricted-scheme prefixes Agent Control
+// uses (see control-target-classification.js), kept in sync locally so the
+// content script need not import the runner. Order matters — the first match
+// wins. Loaded as a content-script file before content.js so the functions
+// are available on globalThis. Also importable as an ESM module for tests.
+
+(() => {
+  if (globalThis.ResonantOSInlineActionSurfaceGate) return;
+  const INLINE_RESTRICTED_SCHEMES = Object.freeze([
+    "chrome://",
+    "chrome-untrusted://",
+    "chrome-extension://",
+    "devtools://",
+    "view-source:",
+    "about:",
+    "edge://",
+    "brave://"
+  ]);
+  const inlineActionRestrictedScheme = (url) => {
+    const value = String(url ?? "").trim().toLowerCase();
+    if (!value) return "no open web page";
+    return INLINE_RESTRICTED_SCHEMES.find((prefix) => value.startsWith(prefix)) ?? "";
+  };
+  const inlineActionAllowedForLocationGate = (url) => {
+    const restricted = inlineActionRestrictedScheme(url);
+    if (restricted) {
+      return {
+        allowed: false,
+        reason: "restricted-scheme",
+        message: `Augmentor inline actions are disabled on this page (${restricted}); Chrome blocks extensions from reading or acting on this kind of page. Open a normal website to use the inline assistant.`
+      };
+    }
+    return { allowed: true };
+  };
+  globalThis.ResonantOSInlineActionSurfaceGate = Object.freeze({
+    INLINE_RESTRICTED_SCHEMES,
+    inlineActionRestrictedScheme,
+    inlineActionAllowedForLocationGate
+  });
+})();
+
+export const INLINE_RESTRICTED_SCHEMES = globalThis.ResonantOSInlineActionSurfaceGate.INLINE_RESTRICTED_SCHEMES;
+export const inlineActionRestrictedScheme = globalThis.ResonantOSInlineActionSurfaceGate.inlineActionRestrictedScheme;
+export const inlineActionAllowedForLocationGate = globalThis.ResonantOSInlineActionSurfaceGate.inlineActionAllowedForLocationGate;

--- a/browser-first/resonantos-side-panel-extension/src/lib/content-inline-actions.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/content-inline-actions.js
@@ -4,6 +4,8 @@
     { action: "custom", label: "Ask", shortcut: "A" },
     { action: "summarize", label: "Summarize", shortcut: "S" },
     { action: "explain", label: "Explain", shortcut: "E" },
+    { action: "counterpoint", label: "Counterpoint", shortcut: "C" },
+    { action: "explain-jargon", label: "Explain jargon", shortcut: "J" },
     { action: "fact-check", label: "Fact-check", shortcut: "F" },
     { action: "translate", label: "Translate", shortcut: "T" },
     { action: "rewrite", label: "Rewrite", shortcut: "R" },

--- a/browser-first/test/content-inline-action-surface-gate.test.mjs
+++ b/browser-first/test/content-inline-action-surface-gate.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  INLINE_RESTRICTED_SCHEMES,
+  inlineActionRestrictedScheme,
+  inlineActionAllowedForLocationGate
+} from "../resonantos-side-panel-extension/src/lib/content-inline-action-surface-gate.js";
+
+test("inline-action surface gate exposes the same restricted-scheme prefixes as control-target-classification (#219)", () => {
+  // The two sources of truth must agree. control-target-classification.js
+  // defines the prefixes used by Agent Control; this module mirrors them for
+  assert.ok(INLINE_RESTRICTED_SCHEMES.includes("chrome://"));
+  assert.ok(INLINE_RESTRICTED_SCHEMES.includes("chrome-untrusted://"));
+  assert.ok(INLINE_RESTRICTED_SCHEMES.includes("chrome-extension://"));
+  assert.ok(INLINE_RESTRICTED_SCHEMES.includes("devtools://"));
+  assert.ok(INLINE_RESTRICTED_SCHEMES.includes("view-source:"));
+  assert.ok(INLINE_RESTRICTED_SCHEMES.includes("about:"));
+  assert.ok(INLINE_RESTRICTED_SCHEMES.includes("edge://"));
+  assert.ok(INLINE_RESTRICTED_SCHEMES.includes("brave://"));
+});
+
+test("inline-action surface gate allows ordinary http(s) URLs (#219)", () => {
+  const result = inlineActionAllowedForLocationGate("https://example.com/article");
+  assert.equal(result.allowed, true);
+  const result2 = inlineActionAllowedForLocationGate("http://example.com/");
+  assert.equal(result2.allowed, true);
+});
+
+test("inline-action surface gate denies restricted-scheme URLs with a clear message (#219)", () => {
+  const cases = [
+    "chrome://settings/",
+    "chrome-extension://abcd/popup.html",
+    "devtools://devtools/bundled/inspector.html",
+    "view-source:https://example.com/",
+    "about:blank",
+    "edge://settings/",
+    "brave://settings/",
+    "chrome-untrusted://terminal/"
+  ];
+  for (const url of cases) {
+    const result = inlineActionAllowedForLocationGate(url);
+    assert.equal(result.allowed, false, `expected denied for ${url}`);
+    assert.equal(result.reason, "restricted-scheme");
+    assert.match(result.message, /Augmentor inline actions are disabled on this page/);
+    assert.match(result.message, /Chrome blocks extensions/);
+  }
+});
+
+test("inline-action surface gate denies empty URLs (#219)", () => {
+  const result = inlineActionAllowedForLocationGate("");
+  assert.equal(result.allowed, false);
+  assert.equal(typeof result.message, "string");
+  assert.ok(result.message.length > 0);
+});
+
+test("inlineActionRestrictedScheme returns the matching prefix string (#219)", () => {
+  assert.equal(inlineActionRestrictedScheme("chrome://settings/"), "chrome://");
+  assert.equal(inlineActionRestrictedScheme("CHROME://settings/"), "chrome://");
+  assert.equal(inlineActionRestrictedScheme("about:blank"), "about:");
+  assert.equal(inlineActionRestrictedScheme("https://example.com/"), "");
+  assert.equal(inlineActionRestrictedScheme(null), "no open web page");
+  assert.equal(inlineActionRestrictedScheme(""), "no open web page");
+});

--- a/browser-first/test/content-redaction.test.mjs
+++ b/browser-first/test/content-redaction.test.mjs
@@ -108,6 +108,11 @@ async function loadContentScript(html, { asChildFrame = false, loadSdk = false, 
       },
     },
     storage: {
+      local: {
+        get() {
+          return Promise.resolve({ augmentorSitePermissions: {} });
+        },
+      },
       onChanged: {
         addListener() {},
       },
@@ -149,9 +154,58 @@ test("content inline actions expose stable shortcuts and button markup", async (
   assert.match(renderInlineActions(), /data-action="summarize"/);
   assert.match(renderInlineActions(), /data-action="counterpoint"/);
   assert.match(renderInlineActions(), /data-action="explain-jargon"/);
+  assert.match(renderInlineActions(), /title="Counterpoint \(C\)">Counterpoint/);
+  assert.match(renderInlineActions(), /title="Explain jargon \(J\)">Explain jargon/);
   assert.match(renderInlineActions(), /<kbd>S<\/kbd>/);
   assert.match(renderInlineActions(), /<kbd>C<\/kbd>/);
   assert.match(renderInlineActions(), /<kbd>J<\/kbd>/);
+});
+
+test("content inline counterpoint action uses a labeled local heuristic fallback (#219)", async () => {
+  const { dom, listener } = await loadContentScript(`
+    <!doctype html>
+    <main>The rollout will always improve every workflow without tradeoffs.</main>
+  `);
+  listener({
+    channel: "resonantos.browser_first.content",
+    type: "show_inline_assistant_for_text",
+    text: "The rollout will always improve every workflow without tradeoffs.",
+    rect: { bottom: 120, left: 24, top: 96, width: 320 },
+  }, {}, () => {});
+
+  dom.window.document.querySelector("#resonantos-inline-button").click();
+  dom.window.document.querySelector('[data-action="counterpoint"]').click();
+  await new Promise((resolve) => dom.window.setTimeout(resolve, 0));
+
+  const result = dom.window.document.querySelector("#resonantos-inline-assistant .ros-inline-result")?.textContent ?? "";
+  assert.match(result, /^Counterpoint:/);
+  assert.doesNotMatch(result, /^Summary:/);
+  assert.match(result, /local heuristic/i);
+  assert.match(result, /always|every/i);
+});
+
+test("content inline explain-jargon action uses a labeled local heuristic fallback (#219)", async () => {
+  const { dom, listener } = await loadContentScript(`
+    <!doctype html>
+    <main>The API pipeline synchronizes cryptographic metadata across Kubernetes clusters.</main>
+  `);
+  listener({
+    channel: "resonantos.browser_first.content",
+    type: "show_inline_assistant_for_text",
+    text: "The API pipeline synchronizes cryptographic metadata across Kubernetes clusters.",
+    rect: { bottom: 120, left: 24, top: 96, width: 320 },
+  }, {}, () => {});
+
+  dom.window.document.querySelector("#resonantos-inline-button").click();
+  dom.window.document.querySelector('[data-action="explain-jargon"]').click();
+  await new Promise((resolve) => dom.window.setTimeout(resolve, 0));
+
+  const result = dom.window.document.querySelector("#resonantos-inline-assistant .ros-inline-result")?.textContent ?? "";
+  assert.match(result, /^Plain terms:/);
+  assert.doesNotMatch(result, /^Summary:/);
+  assert.match(result, /local heuristic/i);
+  assert.match(result, /API|Kubernetes|cryptographic/i);
+  assert.match(result, /Simple structure:/);
 });
 
 test("content control refs preserve existing refs and find escaped values", async () => {

--- a/browser-first/test/content-redaction.test.mjs
+++ b/browser-first/test/content-redaction.test.mjs
@@ -139,12 +139,19 @@ test("content inline actions expose stable shortcuts and button markup", async (
     renderInlineActions,
   } = dom.window.ResonantOSInlineActions;
 
+
   assert.equal(inlineActionByShortcut("s"), "summarize");
+  assert.equal(inlineActionByShortcut("c"), "counterpoint");
+  assert.equal(inlineActionByShortcut("J"), "explain-jargon");
   assert.equal(inlineActionByShortcut("P"), "send");
   assert.equal(inlineActionByShortcut("x"), "");
-  assert.equal(inlineActionList.length, 8);
+  assert.equal(inlineActionList.length, 10);
   assert.match(renderInlineActions(), /data-action="summarize"/);
+  assert.match(renderInlineActions(), /data-action="counterpoint"/);
+  assert.match(renderInlineActions(), /data-action="explain-jargon"/);
   assert.match(renderInlineActions(), /<kbd>S<\/kbd>/);
+  assert.match(renderInlineActions(), /<kbd>C<\/kbd>/);
+  assert.match(renderInlineActions(), /<kbd>J<\/kbd>/);
 });
 
 test("content control refs preserve existing refs and find escaped values", async () => {

--- a/docs/augmentor-future-list-acceptance-matrix.md
+++ b/docs/augmentor-future-list-acceptance-matrix.md
@@ -38,7 +38,7 @@ suffix are open. Safety-boundary rows are **never** casual good-first-issues.
 |---|---|---|---|---|
 | Page content analysis / Q&A | #218 · #8 (C) | ✅ supported | page-understanding fixture coverage (#218); `npm run test:browser-first` | — |
 | Highlight-to-ask (inline assistant) | #9 (C) | ✅ supported | inline-assistant path in `provider-bridge-service` tests | — |
-| Counterpoints / explain-jargon | #219 | 🔮 future | fixtures TBD | — |
+| Counterpoints / explain-jargon | #219 | 🟢 supported (deterministic) · 🔒 live proof gated to #267 | `content-inline-actions.js` (counterpoint=C, explain-jargon=J handlers); `inline-action-surface-gate.js` blocks restricted-scheme + blocked-site; deterministic tests in `inline-action-surface-gate.test.mjs` and `content-redaction.test.mjs` | reads-only actions on user-selected text; no page mutation outside the selection; offline fallback for both new actions |
 | Image / media understanding | #242 | ⏸ deferred · 🔒 | live-browser proof; bounded media handling | privacy/security-sensitive |
 
 ### Cross-tab intelligence


### PR DESCRIPTION
Lands #219 from PR #295 (@vonstegen's commit, authorship preserved) plus the review fix: localInlineResult now has real branches for both actions — 'Counterpoint:' surfaces absolute-language/evidence considerations, 'Plain terms:' identifies jargon-like terms, both explicitly honest about being local heuristics — instead of falling through to the mislabeled Summary fallback. Regression tests prove the labels. Suite 885/885. Executed via the fleet's codex lane, conductor-gated. Refs #219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)