### PR TITLE
feat(augmentor): summary/extraction templates with deterministic prompt contracts (#221)

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/lib/browser-page-actions.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/browser-page-actions.js
@@ -7,6 +7,7 @@ import {
   walletDaoAuditMarkdown
 } from "./wallet-dao-audit-markdown.js";
 import { normalizeWalletProviderState, walletStateMarkdown } from "./wallet-state.js";
+import { buildSummaryIntakeTitle, buildSummaryPrompt, getSummaryTemplate, isTemplateSupported } from "./summary-templates.js";
 
 const readOnlyAllowedContentActions = new Set([
   "control_overlay",
@@ -831,13 +832,19 @@ export function createBrowserPageActions(deps) {
     ].join("\n").trim();
   }
 
-  async function summarizeCurrentPageToArchive() {
+  async function summarizeCurrentPageToArchive(templateId = "summary") {
     const response = deps.getLastSnapshot() ? { ok: true, snapshot: deps.getLastSnapshot() } : await readActivePage({ announce: false });
     const snapshot = response?.snapshot;
     if (!snapshot) {
       await addMessage("system", "There is no browser page context to summarize. Open a normal web page and read it first.");
       setStatus("Summary unavailable");
       return { ok: false, error: "No browser page context available." };
+    }
+    const template = getSummaryTemplate(templateId);
+    if (!isTemplateSupported(templateId, snapshot)) {
+      await addMessage("system", `This page has no readable text to summarize with the ${template.label} template. Open a normal web page with readable text and try again.`);
+      setStatus("Summary unavailable");
+      return { ok: false, error: `No readable page content for the ${template.label} template.` };
     }
     setActivity("thinking", "Summarising page for Living Archive intake", snapshot.title || snapshot.url);
     setStatus("Summarising page");
@@ -855,15 +862,7 @@ export function createBrowserPageActions(deps) {
           runtimeContext: "Create a source-grounded Living Archive intake summary. Do not claim trusted wiki promotion. Preserve uncertainty and cite visible source facts only.",
           messages: [{
             role: "user",
-            content: [
-              "Summarize this browser page for Living Archive intake.",
-              "Return concise markdown with:",
-              "- What this page is",
-              "- Key facts visible in the page",
-              "- Why it may matter",
-              "- Questions or uncertainties for review",
-              "- Suggested wiki entities/concepts to consider"
-            ].join("\n")
+            content: buildSummaryPrompt(templateId, snapshot)
           }]
         }
       });
@@ -883,7 +882,7 @@ export function createBrowserPageActions(deps) {
     const result = await bridge()("/archive/intake", {
       method: "POST",
       body: {
-        title: `Summary: ${snapshot.title || snapshot.url || "Untitled"}`,
+        title: buildSummaryIntakeTitle(templateId, snapshot),
         url: snapshot.url,
         origin: "browser-page-summary",
         content: pageSummaryIntakeMarkdown(snapshot, summary, { model, fallback })

--- a/browser-first/resonantos-side-panel-extension/src/lib/summary-templates.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/summary-templates.js
@@ -1,0 +1,139 @@
+// Summary/extraction templates for the Augmentor one-click / question-driven
+// summarization path (#221).
+//
+// Pure functions: given a page snapshot (the content.js `read_page` contract —
+// { title, url, text, links, ... }), build a deterministic prompt contract for
+// each template. Templates only shape the user prompt; they never write to the
+// trusted Living Archive. The summarize flow in browser-page-actions.js still
+// routes every summary through /archive/intake + /archive/review/request, so a
+// human review handoff always precedes any trusted-memory promotion.
+
+// `summary` reproduces the pre-existing summarize prompt so the default
+// one-click path (Alt+S / the summarize action) is unchanged. The remaining
+// templates are opt-in, structured extraction shapes.
+export const SUMMARY_TEMPLATES = Object.freeze([
+  { id: "summary", label: "Summary", needsReadableText: false },
+  { id: "tldr", label: "TL;DR", needsReadableText: true },
+  { id: "pros-cons", label: "Pros / Cons", needsReadableText: true },
+  { id: "decision-notes", label: "Decision notes", needsReadableText: true },
+  { id: "bullets", label: "Bullets for notes", needsReadableText: true }
+]);
+
+const TEMPLATE_BY_ID = new Map(SUMMARY_TEMPLATES.map((template) => [template.id, template]));
+const DEFAULT_TEMPLATE_ID = "summary";
+
+export function isSummaryTemplateId(value) {
+  return TEMPLATE_BY_ID.has(String(value ?? "").trim());
+}
+
+// Normalize to a valid template id, falling back to the default. Keeps the
+// default one-click path behavior-preserving when no template is supplied or
+// an unknown one is passed.
+export function normalizeSummaryTemplateId(value) {
+  const id = String(value ?? "").trim();
+  return TEMPLATE_BY_ID.has(id) ? id : DEFAULT_TEMPLATE_ID;
+}
+
+export function getSummaryTemplate(templateId) {
+  return TEMPLATE_BY_ID.get(normalizeSummaryTemplateId(templateId));
+}
+
+// A template is "supported" for a page when the page has the content the
+// template needs. Structured templates require readable text; a media-only or
+// empty page is unsupported, so the summarize flow can surface that visibly
+// instead of silently emitting an empty summary.
+export function isTemplateSupported(templateId, snapshot) {
+  const template = getSummaryTemplate(templateId);
+  if (!template) return false;
+  if (!template.needsReadableText) return true;
+  return String(snapshot?.text ?? "").trim().length > 0;
+}
+
+function provenanceLine(snapshot) {
+  const title = snapshot?.title || "Untitled";
+  const url = snapshot?.url || "(no url)";
+  return `Source page: ${title} — ${url}`;
+}
+
+function pageExcerpt(snapshot) {
+  const text = String(snapshot?.text ?? "").trim();
+  return text.slice(0, 12000) || "(no readable text on this page)";
+}
+
+const SHAPES = {
+  // Reproduces the pre-existing summarize prompt exactly (default path).
+  summary: [
+    "Summarize this browser page for Living Archive intake.",
+    "Return concise markdown with:",
+    "- What this page is",
+    "- Key facts visible in the page",
+    "- Why it may matter",
+    "- Questions or uncertainties for review",
+    "- Suggested wiki entities/concepts to consider"
+  ],
+  tldr: [
+    "Summarize this browser page for Living Archive intake using the TL;DR template.",
+    "Return concise markdown:",
+    "- TL;DR: one or two sentences.",
+    "- Key facts: up to 5 bullets.",
+    "- Why it may matter: one bullet.",
+    "- Questions or uncertainties for review: up to 3 bullets.",
+    "Do not claim trusted wiki promotion; cite only visible source facts."
+  ],
+  "pros-cons": [
+    "Summarize this browser page for Living Archive intake using the Pros / Cons template.",
+    "Return concise markdown:",
+    "- Overview: one sentence.",
+    "- Pros: bullets for what the page argues or shows in favor.",
+    "- Cons: bullets for what it argues or shows against, or risks it raises.",
+    "- Caveats / uncertainties for review: bullets.",
+    "Do not claim trusted wiki promotion; cite only visible source facts."
+  ],
+  "decision-notes": [
+    "Summarize this browser page for Living Archive intake using the Decision notes template.",
+    "Return concise markdown:",
+    "- Decision question: the choice this page informs.",
+    "- Options considered: bullets.",
+    "- Evidence or risks per option: bullets.",
+    "- Recommendation or open question for review: one bullet.",
+    "Do not claim trusted wiki promotion; cite only visible source facts."
+  ],
+  bullets: [
+    "Summarize this browser page for Living Archive intake using the Bullets-for-notes template.",
+    "Return concise markdown:",
+    "- Up to 10 concise note bullets capturing the page's content.",
+    "- One final bullet: an open question for review.",
+    "Do not claim trusted wiki promotion; cite only visible source facts."
+  ]
+};
+
+// Deterministic prompt contract for a template + page snapshot. Every opt-in
+// template references the page title and URL (provenance line) and embeds the
+// page text so the generated summary stays source-grounded. The default
+// `summary` template reproduces the pre-existing prompt verbatim.
+export function buildSummaryPrompt(templateId, snapshot) {
+  const id = normalizeSummaryTemplateId(templateId);
+  const shape = SHAPES[id];
+  if (id === DEFAULT_TEMPLATE_ID) {
+    return shape.join("\n");
+  }
+  return [
+    ...shape,
+    "",
+    provenanceLine(snapshot),
+    "",
+    "## Page text",
+    pageExcerpt(snapshot)
+  ].join("\n");
+}
+
+// Intake artifact title for a template + page. The default reproduces the
+// pre-existing `Summary: <title>` title; opt-in templates are prefixed so a
+// reviewer can see which extraction shape produced the intake.
+export function buildSummaryIntakeTitle(templateId, snapshot) {
+  const id = normalizeSummaryTemplateId(templateId);
+  const subject = snapshot?.title || snapshot?.url || "Untitled";
+  if (id === DEFAULT_TEMPLATE_ID) return `Summary: ${subject}`;
+  const label = TEMPLATE_BY_ID.get(id).label;
+  return `Summary (${label}): ${subject}`;
+}

--- a/browser-first/test/browser-page-actions.test.mjs
+++ b/browser-first/test/browser-page-actions.test.mjs
@@ -628,6 +628,70 @@ test("browser page actions create deterministic summary intake when provider fai
   assert.match(bridgeCall[2].body.content, /First fact/);
 });
 
+test("browser page actions summarize current page with a chosen template sends the template prompt and labels the intake", async () => {
+  const harness = createHarness({
+    lastSnapshot: {
+      title: "Template Page",
+      url: "https://example.test/template",
+      text: "The page argues for quantum-resistant cryptography and notes some migration risks.",
+      links: [],
+      controls: [],
+      fields: []
+    },
+    bridgeRequest: async (route) => {
+      if (route === "/augmentor/chat") return { reply: "## TL;DR\nA page about cryptography migration.", model: "MiniMax-M3" };
+      if (route === "/archive/intake") return { path: "INTAKE/browser/template.md", bytes: 120 };
+      return { path: "REVIEW/requests/template.md", status: "pending" };
+    }
+  });
+
+  const result = await harness.actions.summarizeCurrentPageToArchive("tldr");
+
+  assert.equal(result.ok, true);
+  assert.equal(result.reviewRequestPath, "REVIEW/requests/template.md");
+  // The template prompt contract drove the user message: TL;DR marker + source grounding (title + url).
+  const chatCall = harness.events.find((event) => event[0] === "bridge" && event[1] === "/augmentor/chat");
+  assert.match(chatCall[2].body.messages[0].content, /TL;DR/);
+  assert.match(chatCall[2].body.messages[0].content, /Template Page/);
+  assert.match(chatCall[2].body.messages[0].content, /https:\/\/example\.test\/template/);
+  // The intake is labelled with the template so a reviewer can see the shape.
+  const intakeCall = harness.events.find((event) => event[0] === "bridge" && event[1] === "/archive/intake");
+  assert.equal(intakeCall[2].body.title, "Summary (TL;DR): Template Page");
+  assert.equal(intakeCall[2].body.origin, "browser-page-summary");
+  // No trusted write: every summary still hands off to review.
+  const reviewCall = harness.events.find((event) => event[0] === "bridge" && event[1] === "/archive/review/request");
+  assert.equal(reviewCall[2].body.path, "INTAKE/browser/template.md");
+});
+
+test("browser page actions surface unsupported content for a media-only page with a structured template", async () => {
+  const harness = createHarness({
+    lastSnapshot: {
+      title: "Media Only",
+      url: "https://example.test/media",
+      text: "\n\n\n",
+      links: [],
+      controls: [],
+      fields: []
+    },
+    bridgeRequest: async (route) => {
+      if (route === "/augmentor/chat") return { reply: "should not be called", model: "MiniMax-M3" };
+      if (route === "/archive/intake") return { path: "INTAKE/browser/media.md", bytes: 120 };
+      return { path: "REVIEW/requests/media.md", status: "pending" };
+    }
+  });
+
+  const result = await harness.actions.summarizeCurrentPageToArchive("tldr");
+
+  assert.equal(result.ok, false);
+  assert.match(result.error, /No readable page content for the TL;DR template/);
+  // Skipped/unsupported content is visible to the user.
+  assert.ok(harness.events.some((event) => event[0] === "message" && /no readable text/i.test(event[2]) && /TL;DR/i.test(event[2])));
+  // No trusted write occurs for unsupported content: the chat model and the
+  // archive intake are never touched, so no review handoff starts.
+  assert.equal(harness.events.some((event) => event[0] === "bridge" && event[1] === "/augmentor/chat"), false);
+  assert.equal(harness.events.some((event) => event[0] === "bridge" && event[1] === "/archive/intake"), false);
+});
+
 test("browser page actions save multi-tab research trail to reviewed intake", async () => {
   const harness = createHarness({
     controlledTabId: 1,

--- a/browser-first/test/summary-templates.test.mjs
+++ b/browser-first/test/summary-templates.test.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  SUMMARY_TEMPLATES,
+  buildSummaryIntakeTitle,
+  buildSummaryPrompt,
+  getSummaryTemplate,
+  isSummaryTemplateId,
+  isTemplateSupported,
+  normalizeSummaryTemplateId
+} from "../resonantos-side-panel-extension/src/lib/summary-templates.js";
+
+// A representative read_page snapshot (the content.js extraction contract).
+const article = {
+  title: "Quantum Computing Breakthrough",
+  url: "https://example.com/article",
+  text: "Scientists demonstrated a 256-qubit processor with low error rates.",
+  links: [{ text: "MIT", href: "https://example.com/mit" }],
+  controls: [],
+  fields: []
+};
+
+const mediaOnly = {
+  title: "Product Gallery",
+  url: "https://example.com/gallery",
+  text: "\n\n\n",
+  links: [],
+  controls: [],
+  fields: []
+};
+
+const EXPECTED_IDS = ["summary", "tldr", "pros-cons", "decision-notes", "bullets"];
+
+test("summary templates registry exposes the expected template ids", () => {
+  assert.deepEqual(SUMMARY_TEMPLATES.map((t) => t.id), EXPECTED_IDS);
+  for (const id of EXPECTED_IDS) {
+    assert.equal(isSummaryTemplateId(id), true, `${id} recognised`);
+  }
+  assert.equal(isSummaryTemplateId("unknown"), false);
+  assert.equal(isSummaryTemplateId(undefined), false);
+});
+
+test("unknown template ids normalize to the behavior-preserving default", () => {
+  assert.equal(normalizeSummaryTemplateId("tldr"), "tldr");
+  assert.equal(normalizeSummaryTemplateId("unknown"), "summary");
+  assert.equal(normalizeSummaryTemplateId(undefined), "summary");
+  assert.equal(normalizeSummaryTemplateId(""), "summary");
+});
+
+test("the default summary template reproduces the pre-existing prompt verbatim", () => {
+  const prompt = buildSummaryPrompt("summary", article);
+  assert.equal(
+    prompt,
+    [
+      "Summarize this browser page for Living Archive intake.",
+      "Return concise markdown with:",
+      "- What this page is",
+      "- Key facts visible in the page",
+      "- Why it may matter",
+      "- Questions or uncertainties for review",
+      "- Suggested wiki entities/concepts to consider"
+    ].join("\n")
+  );
+  // The default is intentionally not source-grounded in the user message
+  // (provenance lives in pageContext), so it must NOT embed the title/url.
+  assert.equal(prompt.includes(article.title), false);
+  assert.equal(prompt.includes(article.url), false);
+});
+
+test("each opt-in template is deterministic and references the page title and url", () => {
+  const optIn = ["tldr", "pros-cons", "decision-notes", "bullets"];
+  const markers = {
+    tldr: "TL;DR",
+    "pros-cons": "Pros / Cons",
+    "decision-notes": "Decision notes",
+    bullets: "Bullets-for-notes"
+  };
+  for (const id of optIn) {
+    const prompt = buildSummaryPrompt(id, article);
+    // Determinism: same input yields byte-identical output.
+    assert.equal(prompt, buildSummaryPrompt(id, article), `${id} is deterministic`);
+    // The prompt contract requires source grounding (acceptance: output
+    // references the page title/url).
+    assert.ok(prompt.includes(article.title), `${id} references the page title`);
+    assert.ok(prompt.includes(article.url), `${id} references the page url`);
+    assert.ok(prompt.includes("Source page:"), `${id} carries a provenance line`);
+    assert.ok(prompt.includes("## Page text"), `${id} embeds the page text`);
+    assert.ok(prompt.includes(markers[id]), `${id} carries its template marker`);
+  }
+});
+
+test("opt-in templates embed the captured page text excerpt", () => {
+  const prompt = buildSummaryPrompt("tldr", article);
+  assert.ok(prompt.includes("256-qubit processor"), "tldr embeds the page text");
+});
+
+test("structured templates are unsupported on pages with no readable text", () => {
+  // The default template never gates (behavior-preserving), even on media-only.
+  assert.equal(isTemplateSupported("summary", mediaOnly), true);
+  assert.equal(isTemplateSupported("summary", article), true);
+  // Structured templates require readable text.
+  for (const id of ["tldr", "pros-cons", "decision-notes", "bullets"]) {
+    assert.equal(isTemplateSupported(id, article), true, `${id} supported with text`);
+    assert.equal(isTemplateSupported(id, mediaOnly), false, `${id} unsupported without text`);
+    assert.equal(isTemplateSupported(id, { ...mediaOnly, text: "" }), false, `${id} unsupported on empty text`);
+  }
+});
+
+test("the intake title is source-grounded and template-labelled for opt-in templates", () => {
+  assert.equal(buildSummaryIntakeTitle("summary", article), "Summary: Quantum Computing Breakthrough");
+  assert.equal(buildSummaryIntakeTitle("tldr", article), "Summary (TL;DR): Quantum Computing Breakthrough");
+  assert.equal(buildSummaryIntakeTitle("pros-cons", article), "Summary (Pros / Cons): Quantum Computing Breakthrough");
+  // Falls back to url, then Untitled, when no title is present.
+  assert.equal(buildSummaryIntakeTitle("tldr", { url: "https://example.com/x" }), "Summary (TL;DR): https://example.com/x");
+  assert.equal(buildSummaryIntakeTitle("tldr", {}), "Summary (TL;DR): Untitled");
+  // Unknown template id normalizes to the default title.
+  assert.equal(buildSummaryIntakeTitle("nope", article), "Summary: Quantum Computing Breakthrough");
+});
+
+test("getSummaryTemplate returns the normalized template metadata", () => {
+  assert.equal(getSummaryTemplate("tldr").label, "TL;DR");
+  assert.equal(getSummaryTemplate("unknown").id, "summary");
+});


### PR DESCRIPTION
Closes #221 (deterministic layer).

## What
Adds opt-in summary/extraction templates (TL;DR, Pros/Cons, Decision notes, Bullets for notes) to the Augmentor one-click / question-driven summarize path.

- New pure module `browser-first/resonantos-side-panel-extension/src/lib/summary-templates.js` — `buildSummaryPrompt` / `buildSummaryIntakeTitle` / `isTemplateSupported` produce a deterministic, source-grounded prompt contract for each template (references the page title + url, embeds the page text).
- `summarizeCurrentPageToArchive(templateId)` accepts a template id; the default `summary` reproduces the pre-existing prompt verbatim, so Alt+S / the summarize action is unchanged.
- Structured templates gate on readable text; a media-only or empty page surfaces a visible "no readable text" message and skips both the model call and the archive write.
- Every summary still routes through `/archive/intake` + `/archive/review/request` — no trusted write without review handoff.

## Acceptance criteria (#221)
- [x] At least one summary template has deterministic prompt contract tests — `summary-templates.test.mjs` pins each template's prompt (marker, title, url, page text) + determinism + `isTemplateSupported`.
- [x] Skipped/unsupported page content is visible — a media-only page with a structured template returns `ok:false` plus a user-visible "no readable text" message.
- [x] Output references the page title/URL — every opt-in template's prompt carries a `Source page: <title> — <url>` provenance line; the intake title is `Summary (<template>): <title|url>`.
- [x] No trusted archive write without review handoff — templates only shape the prompt; the flow still does `/archive/intake` → `/archive/review/request`. On unsupported content neither the chat model nor the intake is touched.

## Verification
- `node --test browser-first/test/summary-templates.test.mjs` → 8/8
- `node --test browser-first/test/browser-page-actions.test.mjs` → 25/25 (incl. the new TL;DR flow + media-only unsupported path; existing summarize/fallback tests unchanged)
- `npm run test:browser-first` → 918/918
- `npm run docs:check` → passed
- `npm run build` (`tsc && vite build`) → ✓ built
- `node scripts/browser-first-release-scope-audit.mjs --committed --strict` → exit 0 (4/4 paths include, 0 review)

## Governance
This PR closes the deterministic layer of #221. Per `docs/PROJECT_GOVERNANCE.md`, only maintainers with Project 2 write access may promote an item's status; the matrix row for #221 already reads `✅ supported`, so no status change is made or requested here.
