### PR TITLE
security(#240): graft boundary hardening from closed PR #288 with credit

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/content.js
+++ b/browser-first/resonantos-side-panel-extension/src/content.js
@@ -433,6 +433,9 @@ const ambiguousTargetResponse = (kind, target, candidates) => ({
 // public submit even without a <form> (SPA buttons, links, type="button" that
 // wire up JS submit) — it is a human-only handoff, never auto-clicked.
 const PUBLIC_COMMIT_VERBS = /\b(submit|send|post|publish|save|share|buy|pay|confirm|connect|sign|reserve|book|order|checkout|apply|vote|subscribe|register|comment)\b/i;
+// Destructive account/data controls are human-only just like commit verbs:
+// deleting, revoking, or terminating anything is never an agent action.
+const DESTRUCTIVE_CONTROL_VERBS = /\b(delete|remove|destroy|erase|revoke|deactivate|terminate|wipe|close\s+account|delete\s+account)\b/i;
 const isSubmitLikeElement = (element) => {
   const type = String(element.getAttribute("type") || "").toLowerCase();
   const role = String(element.getAttribute("role") || "").toLowerCase();
@@ -454,14 +457,30 @@ const isSubmitLikeElement = (element) => {
 };
 
 const isHardRestrictedElement = (element, fallbackText = "") => {
+  // A sensitive field anywhere in the enclosing form makes every control in
+  // that form hard-restricted: a click near a password/payment field is a
+  // human-only action even when the control's own label looks harmless.
+  const form = element?.closest?.("form");
+  const formFields = form
+    ? Array.from(form.querySelectorAll("input, textarea, select"))
+    : [];
+  const sensitiveForm = formFields.some((field) => {
+    const safety = classifyEditableField(field);
+    return safety && !safety.safeToType;
+  });
   const text = [
     visibleText(element),
     element?.getAttribute?.("aria-label"),
     element?.id,
     element?.className,
-    fallbackText
+    fallbackText,
+    form?.getAttribute?.("aria-label"),
+    form?.getAttribute?.("role"),
+    form?.innerText?.slice?.(0, 1200)
   ].filter(Boolean).join(" ").toLowerCase();
-  return /\b(wallet|phantom|sign|signature|approve|connect wallet|buy|sell|swap|stake|unstake|bridge|mint|claim|pay|payment|checkout|login|credential|password|transfer)\b/i.test(text);
+  return sensitiveForm ||
+    DESTRUCTIVE_CONTROL_VERBS.test(text) ||
+    /\b(wallet|phantom|sign|signature|approve|connect wallet|buy|sell|swap|stake|unstake|bridge|mint|claim|pay|payment|checkout|login|credential|password|transfer)\b/i.test(text);
 };
 
 // How long the target spotlight dwells before the click fires, so the human can
@@ -481,6 +500,7 @@ const clickElement = async (element, { userApproved = false, fallbackText = "" }
       ok: false,
       approvalRequired: true,
       deniedToAutomation: true,
+      humanHandoff: true,
       error: `Clicking "${visibleText(element) || fallbackText}" crosses a wallet/payment/login/credential boundary and must be completed by the human.`
     };
   }
@@ -721,6 +741,18 @@ const setNativeValue = (element, value) => {
 // form whose every data field classifies as a search query.
 const formIsSafeToAutoSubmit = (form) => {
   if (!form) return true; // no enclosing form -> Enter only affects the field itself
+  // Auto-submit is only ever safe for a same-origin GET (a search): a POST or
+  // cross-origin action commits data somewhere and is human-only.
+  const method = String(form.getAttribute("method") || "get").trim().toLowerCase();
+  if (method !== "get") return false;
+  const action = form.getAttribute("action") || window.location.href;
+  let actionUrl;
+  try {
+    actionUrl = new URL(action, window.location.href);
+  } catch {
+    return false;
+  }
+  if (actionUrl.origin !== window.location.origin) return false;
   const fields = form.querySelectorAll("input, textarea, select");
   for (const candidate of fields) {
     const candidateType = String(candidate.getAttribute("type") || "").toLowerCase();
@@ -733,6 +765,18 @@ const formIsSafeToAutoSubmit = (form) => {
   for (const control of form.querySelectorAll("button, input[type=submit], input[type=image], input[type=button], [role=button]")) {
     const controlLabel = `${visibleText(control)} ${control.getAttribute("value") || ""}`.toLowerCase();
     if (PUBLIC_COMMIT_VERBS.test(controlLabel)) return false;
+    // A per-control formmethod/formaction override can redirect the submit to
+    // a POST or another origin — the same human-only rule applies to those.
+    const overrideMethod = String(control.getAttribute("formmethod") || "").trim().toLowerCase();
+    if (overrideMethod && overrideMethod !== "get") return false;
+    const overrideAction = control.getAttribute("formaction");
+    if (overrideAction) {
+      try {
+        if (new URL(overrideAction, window.location.href).origin !== window.location.origin) return false;
+      } catch {
+        return false;
+      }
+    }
   }
   return true;
 };
@@ -785,9 +829,20 @@ const typeIntoPage = ({ text, field = "", ref = "", submit = false, userApproved
         error: "This search field is inside a form with sensitive or public-submit fields; the human must submit it on the page."
       };
     }
-    element.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", code: "Enter", bubbles: true, cancelable: true }));
-    element.dispatchEvent(new KeyboardEvent("keyup", { key: "Enter", code: "Enter", bubbles: true, cancelable: true }));
-    element.form?.requestSubmit?.();
+    // requestSubmit() is the only submission path: it honors form validation
+    // and submit handlers. Synthetic Enter keystrokes could trigger arbitrary
+    // page handlers beyond the vetted form, so they are never dispatched.
+    if (typeof element.form?.requestSubmit !== "function") {
+      return {
+        ok: false,
+        approvalRequired: true,
+        deniedToAutomation: true,
+        humanHandoff: true,
+        fieldSafety,
+        error: "This browser does not expose a safe form submission API; the human must submit it on the page."
+      };
+    }
+    element.form.requestSubmit();
   }
   pulseControlOverlay({ state: "done", label: `Typed ${value.slice(0, 80)}`, phase: "done", target: element });
   return {
@@ -927,6 +982,10 @@ const editableRootForSelection = () => {
 
 const editableSelectionDetails = (element) => {
   if (!element || !isEditable(element)) return null;
+  // Never read a selection out of a sensitive field (password, payment,
+  // credential): the inline assistant must not see that text at all.
+  const fieldSafety = classifyEditableField(element);
+  if (fieldSafety && !fieldSafety.safeToType) return null;
   if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
     const start = element.selectionStart ?? 0;
     const end = element.selectionEnd ?? start;
@@ -973,7 +1032,10 @@ const firstUsefulRangeRect = (range) => {
 };
 
 const currentSelectionDetails = () => {
-  const editableDetails = editableSelectionDetails(editableRootForSelection());
+  const editableRoot = editableRootForSelection();
+  const editableSafety = editableRoot ? classifyEditableField(editableRoot) : null;
+  if (editableSafety && !editableSafety.safeToType) return null;
+  const editableDetails = editableSelectionDetails(editableRoot);
   if (editableDetails) return editableDetails;
   const selection = window.getSelection();
   const text = selection?.toString?.().trim() ?? "";
@@ -1011,6 +1073,7 @@ const positionInlineButton = () => {
     const details = currentSelectionDetails();
     const { button } = ensureInlineAssistantUi();
     if (!details || details.text.length < 2 || details.rect.width === 0) {
+      lastInlineSelectionDetails = null;
       button.style.display = "none";
       return;
     }
@@ -1028,6 +1091,7 @@ const positionInlineButtonSync = () => {
   const details = currentSelectionDetails();
   const { button } = ensureInlineAssistantUi();
   if (!details || details.text.length < 2 || details.rect.width === 0) {
+    lastInlineSelectionDetails = null;
     button.style.display = "none";
     return;
   }
@@ -1135,6 +1199,16 @@ const timeoutAfter = (ms, errorMessage) => new Promise((_, reject) => {
 const runInlineAction = async (action) => {
   const { panel } = ensureInlineAssistantUi();
   const result = panel.querySelector(".ros-inline-result");
+  // If the panel is anchored to a field that classifies as sensitive, refuse
+  // the action outright and drop any captured selection state.
+  const activeField = panel.dataset.activeRef ? elementByControlRef(panel.dataset.activeRef) : null;
+  const activeFieldSafety = activeField ? classifyEditableField(activeField) : null;
+  if (activeFieldSafety && !activeFieldSafety.safeToType) {
+    result.textContent = activeFieldSafety.reason;
+    panel.style.display = "none";
+    lastInlineSelectionDetails = null;
+    return;
+  }
   const selection = panel.dataset.selection || currentSelectionDetails()?.text || "";
   if (!selection) {
     result.textContent = "No selected text is available.";

--- a/browser-first/test/agent-control-public-submit.test.mjs
+++ b/browser-first/test/agent-control-public-submit.test.mjs
@@ -177,3 +177,94 @@ test("#240: the runner boundary classifier agrees with the widened commit verbs"
   // a plain safe action stays safe
   assert.equal(approvalBoundaryForStep({ type: "click", text: "open details" }), "safe");
 });
+
+// --- #240 hardening graft (from community PR #288, credit GeneraI44) ---
+// Destructive controls, sensitive-form context, and POST/cross-origin
+// auto-submit gates. Each denial asserts the human-handoff contract.
+
+const GRAFT_PAGE = `<!doctype html>
+  <form id="postsearch" method="post">
+    <input name="q2" aria-label="Post query" placeholder="Post query">
+    <button type="submit">Go</button>
+  </form>
+  <form id="crossorigin" action="https://collector.example/submit">
+    <input name="q3" aria-label="Cross query" placeholder="Cross query">
+    <button type="submit">Go</button>
+  </form>
+  <form id="overrideform">
+    <input name="q4" aria-label="Override query" placeholder="Override query">
+    <button type="submit" formmethod="post">Go</button>
+  </form>
+  <form id="pwform" aria-label="Account details">
+    <input type="password" name="pw" aria-label="Passphrase">
+    <button id="innocent" type="button">View details</button>
+  </form>
+  <button id="deleteacct" type="button">Delete account</button>
+  <div id="status">idle</div>`;
+
+async function loadGraftPage() {
+  const dom = new JSDOM(GRAFT_PAGE, { runScripts: "outside-only", url: "https://shop.test/checkout" });
+  const win = dom.window;
+  let listener = null;
+  win.chrome = {
+    runtime: { onMessage: { addListener(cb) { listener = cb; } }, sendMessage: () => Promise.resolve() },
+    storage: { onChanged: { addListener() {} } },
+  };
+  win.HTMLElement.prototype.scrollIntoView = function scrollIntoView() {};
+  win.__resonantosControlDwellMs = 0;
+  for (const scriptPath of scripts) win.eval(await readFile(scriptPath, "utf8"));
+  win.eval(`
+    window.__deleted = false;
+    window.__innocentClicked = false;
+    window.__postSubmitted = false;
+    window.__crossSubmitted = false;
+    window.__overrideSubmitted = false;
+    document.querySelector("#deleteacct").addEventListener("click", () => { window.__deleted = true; });
+    document.querySelector("#innocent").addEventListener("click", () => { window.__innocentClicked = true; });
+    document.querySelector("#postsearch").addEventListener("submit", (e) => { e.preventDefault(); window.__postSubmitted = true; });
+    document.querySelector("#crossorigin").addEventListener("submit", (e) => { e.preventDefault(); window.__crossSubmitted = true; });
+    document.querySelector("#overrideform").addEventListener("submit", (e) => { e.preventDefault(); window.__overrideSubmitted = true; });
+  `);
+  const send = (message) => new Promise((resolve) => {
+    listener({ channel: "resonantos.browser_first.content", ...message }, {}, resolve);
+  });
+  return { win, send };
+}
+
+test("#240 graft: a destructive control (Delete account) is human-only even with approval", async () => {
+  const { win, send } = await loadGraftPage();
+  const res = await send({ type: "click_text", text: "Delete account", userApproved: true });
+  assert.equal(res.ok, false, "destructive verbs must never be agent-clicked");
+  assert.equal(res.deniedToAutomation, true);
+  assert.equal(res.humanHandoff, true);
+  assert.equal(win.__deleted, false, "the destructive control must NOT have fired");
+});
+
+test("#240 graft: an innocent-label button inside a form with a password field is human-only", async () => {
+  const { win, send } = await loadGraftPage();
+  const res = await send({ type: "click_text", text: "View details", userApproved: true });
+  assert.equal(res.ok, false, "a sensitive enclosing form makes every control human-only");
+  assert.equal(res.deniedToAutomation, true);
+  assert.equal(win.__innocentClicked, false);
+});
+
+test("#240 graft: typing+submit into a POST form is refused (auto-submit is GET-only)", async () => {
+  const { win, send } = await loadGraftPage();
+  const res = await send({ type: "type_text", field: "Post query", text: "hello", submit: true, userApproved: true });
+  assert.equal(res.ok, false, "POST forms commit data and are human-submit only");
+  assert.equal(win.__postSubmitted, false);
+});
+
+test("#240 graft: typing+submit into a cross-origin action form is refused", async () => {
+  const { win, send } = await loadGraftPage();
+  const res = await send({ type: "type_text", field: "Cross query", text: "hello", submit: true, userApproved: true });
+  assert.equal(res.ok, false, "cross-origin form actions are human-submit only");
+  assert.equal(win.__crossSubmitted, false);
+});
+
+test("#240 graft: a formmethod=post override on the submit control is refused", async () => {
+  const { win, send } = await loadGraftPage();
+  const res = await send({ type: "type_text", field: "Override query", text: "hello", submit: true, userApproved: true });
+  assert.equal(res.ok, false, "per-control method overrides get the same GET-only rule");
+  assert.equal(win.__overrideSubmitted, false);
+});


### PR DESCRIPTION
## Scope

The strictly-tightening `content.js` hunks from GeneraI44's closed omnibus #288, grafted with credit (Co-authored-by trailer), adjudicated hunk-by-hunk:

**Included (all tighten the #240/safety boundary):**
- Destructive-control verbs (delete, revoke, terminate, wipe, close account…) are human-only like commit verbs
- A sensitive field anywhere in the enclosing form hard-restricts **every** control in that form (innocent-label buttons included)
- Form aria-label/role/innerText feed the restriction classifier
- Auto-submit is same-origin **GET only** — POST and cross-origin actions are human-submit, including per-control `formmethod`/`formaction` overrides
- `typeIntoPage` no longer dispatches synthetic Enter keystrokes; `requestSubmit()` or human handoff
- Inline assistant refuses to read selections from or act on sensitive fields; stale selection state cleared on hide

**Excluded:** the hunk removing the synthetic `click` event from the *approved* path — that alters allowed behavior (would break certified clicking), not the boundary.

## Validation

- 5 new boundary tests in `agent-control-public-submit.test.mjs`, **each proven red against un-grafted dev** (revert-test-restore)
- Focused: 17/17 · Full suite: **927/927**
- Live-certification lane runs on this PR (content.js path trigger)

Closes nothing; pure hardening. Credit: @GeneraI44 (#288).

🤖 Generated with [Claude Code](https://claude.com/claude-code)