### PR TITLE
security(#215): audit-trail for execution toggles, honest capability chips, tester cleanup docs

### DIFF
--- a/browser-first/host/addon-delegation-service.mjs
+++ b/browser-first/host/addon-delegation-service.mjs
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { appendFile, chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import { spawn } from "node:child_process";
@@ -399,6 +399,10 @@ export function createAddonDelegationService(dependencies) {
     return path.join(browserFirstRoot(), "Settings", "addon-execution.json");
   }
 
+  function addonGovernanceAuditPath() {
+    return path.join(browserFirstRoot(), "Settings", "addon-governance-audit.jsonl");
+  }
+
   function defaultAddonExecutionSettings() {
     return {
       hermes: { localCliExecution: false },
@@ -431,6 +435,13 @@ export function createAddonDelegationService(dependencies) {
     await writeFile(filePath, `${JSON.stringify(normalized, null, 2)}\n`, { mode: 0o600 });
     await chmod(filePath, 0o600).catch(() => undefined);
     return normalized;
+  }
+
+  async function appendAddonGovernanceAuditEntry(entry) {
+    const filePath = addonGovernanceAuditPath();
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await appendFile(filePath, `${JSON.stringify(entry)}\n`, { mode: 0o600 });
+    await chmod(filePath, 0o600).catch(() => undefined);
   }
 
   function addonLocalCliExecutionEnabled(addon, payload = {}, settings = defaultAddonExecutionSettings()) {
@@ -1794,11 +1805,22 @@ except BaseException as exc:
       throw new Error("Execution settings can only be updated for Hermes or OpenCode.");
     }
     const next = normalizeAddonExecutionSettings(current);
+    const previousLocalCliExecution = Boolean(next[addon].localCliExecution);
+    const nextLocalCliExecution = Boolean(payload.localCliExecution);
     next[addon] = {
       ...next[addon],
-      localCliExecution: Boolean(payload.localCliExecution),
+      localCliExecution: nextLocalCliExecution,
     };
     const settings = await writeAddonExecutionSettings(next);
+    if (previousLocalCliExecution !== nextLocalCliExecution) {
+      await appendAddonGovernanceAuditEntry({
+        at: new Date().toISOString(),
+        addonId: addon,
+        field: "localCliExecution",
+        from: previousLocalCliExecution,
+        to: nextLocalCliExecution,
+      });
+    }
     return {
       addon,
       settings,

--- a/browser-first/resonantos-side-panel-extension/src/lib/addon-capability-review.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/addon-capability-review.js
@@ -8,6 +8,8 @@ function uniqueCapabilities(values) {
   return [...new Set(values)];
 }
 
+export const CAPABILITY_CONTRACT_NOTE = "Capability enforcement happens at the bridge via per-route tokens; these chips describe the add-on contract.";
+
 export function capabilityReviewState(addon = {}) {
   const granted = uniqueCapabilities(capabilityList(addon.grantedCapabilities ?? addon.grants));
   const denied = uniqueCapabilities(capabilityList(addon.deniedCapabilities ?? addon.denials));
@@ -17,6 +19,28 @@ export function capabilityReviewState(addon = {}) {
     ...requested.filter((capability) => !granted.includes(capability) && !denied.includes(capability))
   ]);
   return { denied, granted, pending, requested };
+}
+
+export function capabilityContractState(addon = {}) {
+  const state = capabilityReviewState(addon);
+  const shellRequested = state.requested.includes("shell") || state.granted.includes("shell") || state.denied.includes("shell");
+  const hasLiveOpenCodeShell = addon.id === "addon.opencode" && shellRequested;
+  if (!hasLiveOpenCodeShell) {
+    return { ...state, live: [] };
+  }
+  const withoutShell = (capabilities) => capabilities.filter((capability) => capability !== "shell");
+  const enabled = Boolean(addon.execution?.localCliExecution);
+  return {
+    denied: withoutShell(state.denied),
+    granted: withoutShell(state.granted),
+    pending: withoutShell(state.pending),
+    requested: state.requested,
+    live: [{
+      label: enabled ? "Enabled by you" : "Disabled",
+      state: enabled ? "enabled-by-user" : "disabled",
+      capabilities: ["shell"],
+    }],
+  };
 }
 
 export function capabilityGroup(label, state, capabilities) {
@@ -34,21 +58,33 @@ export function capabilityGroup(label, state, capabilities) {
   return group;
 }
 
-export function capabilityReviewElement(addon = {}) {
-  const state = capabilityReviewState(addon);
+export function capabilityReviewElement(addon = {}, options = {}) {
+  const state = capabilityContractState(addon);
   const wrapper = document.createElement("div");
   wrapper.className = "settings-addon-capabilities";
+  if (options.heading !== false) {
+    const heading = document.createElement("strong");
+    heading.textContent = "Capability contract";
+    wrapper.append(heading);
+  }
   const groups = [
-    ["Granted", "granted", state.granted],
+    ["Declared", "declared", state.granted],
     ["Needs review", "pending", state.pending],
-    ["Denied", "denied", state.denied]
+    ["Denied by policy", "denied", state.denied],
+    ...state.live.map((entry) => [entry.label, entry.state, entry.capabilities])
   ].filter(([, , capabilities]) => capabilities.length);
   if (!groups.length) {
-    wrapper.append(capabilityGroup("Capability state", "empty", ["explicit grants required"]));
+    wrapper.append(capabilityGroup("Declared", "empty", ["explicit grants required"]));
+    const note = document.createElement("small");
+    note.textContent = CAPABILITY_CONTRACT_NOTE;
+    wrapper.append(note);
     return wrapper;
   }
   for (const [label, status, capabilities] of groups) {
     wrapper.append(capabilityGroup(label, status, capabilities));
   }
+  const note = document.createElement("small");
+  note.textContent = CAPABILITY_CONTRACT_NOTE;
+  wrapper.append(note);
   return wrapper;
 }

--- a/browser-first/resonantos-side-panel-extension/src/lib/settings/addons-section.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/settings/addons-section.js
@@ -1,5 +1,5 @@
 import { noteCard, safeErrorMessage, setStatus, settingsHeader } from "./settings-common.js";
-import { capabilityReviewElement, capabilityReviewState } from "../addon-capability-review.js";
+import { capabilityContractState, capabilityReviewElement } from "../addon-capability-review.js";
 
 function addonTone(addon) {
   if (addon.available || addon.enabled) return "success";
@@ -21,11 +21,14 @@ function addonBoundary(addon) {
 }
 
 function addonCapabilitySummary(addon) {
-  const state = capabilityReviewState(addon);
+  const state = capabilityContractState(addon);
   const parts = [];
-  if (state.granted.length) parts.push(`${state.granted.length} granted`);
+  if (state.granted.length) parts.push(`${state.granted.length} declared`);
   if (state.pending.length) parts.push(`${state.pending.length} needs review`);
-  if (state.denied.length) parts.push(`${state.denied.length} denied`);
+  for (const live of state.live) {
+    if (live.capabilities.length) parts.push(`${live.capabilities.length} ${live.label.toLowerCase()}`);
+  }
+  if (state.denied.length) parts.push(`${state.denied.length} denied by policy`);
   return parts.length ? parts.join(" · ") : "Explicit grants required";
 }
 
@@ -86,9 +89,9 @@ function addonCard(addon, actions = {}) {
   }
 
   const capabilities = addonDisclosure(
-    "Capabilities and grants",
-    "Review exactly what this add-on can request, what is granted, and what remains denied or pending.",
-    [capabilityReviewElement(addon)]
+    "Capability contract",
+    "Review what this add-on declares, what still needs review, and what policy blocks.",
+    [capabilityReviewElement(addon, { heading: false })]
   );
 
   card.append(header, boundary, summary, capabilities);

--- a/browser-first/test/addon-delegation-service-error-handling.test.mjs
+++ b/browser-first/test/addon-delegation-service-error-handling.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
-import { chmod, mkdtemp, mkdir, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, mkdir, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -116,6 +116,56 @@ test("Hermes delegation records failed status when artifact finalization fails",
 
 test("OpenCode delegation records failed status when artifact finalization fails", async () => {
   await assertFinalizationFailureIsTerminal("opencode");
+});
+
+test("add-on execution setting updates append an operator audit trail only for real toggles", async () => {
+  await withTempService(async (service, root) => {
+    const auditPath = path.join(root, "BrowserFirst", "Settings", "addon-governance-audit.jsonl");
+
+    await service.executeAddonExecutionSettingsUpdate({
+      addon: "opencode",
+      localCliExecution: true,
+    });
+
+    const firstLines = (await readFile(auditPath, "utf8")).trim().split("\n");
+    assert.equal(firstLines.length, 1);
+    const first = JSON.parse(firstLines[0]);
+    assert.equal(first.addonId, "opencode");
+    assert.equal(first.field, "localCliExecution");
+    assert.equal(first.from, false);
+    assert.equal(first.to, true);
+    assert.doesNotThrow(() => new Date(first.at).toISOString());
+    assert.equal((await stat(auditPath)).mode & 0o777, 0o600);
+
+    await service.executeAddonExecutionSettingsUpdate({
+      addon: "opencode",
+      localCliExecution: true,
+    });
+
+    const afterNoopLines = (await readFile(auditPath, "utf8")).trim().split("\n");
+    assert.equal(afterNoopLines.length, 1);
+
+    await service.executeAddonExecutionSettingsUpdate({
+      addon: "opencode",
+      localCliExecution: false,
+    });
+    await service.executeAddonExecutionSettingsUpdate({
+      addon: "opencode",
+      localCliExecution: true,
+    });
+
+    const entries = (await readFile(auditPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    assert.deepEqual(entries.map((entry) => [entry.from, entry.to]), [
+      [false, true],
+      [true, false],
+      [false, true],
+    ]);
+    assert.deepEqual(entries.map((entry) => entry.addonId), ["opencode", "opencode", "opencode"]);
+    assert.ok(entries.every((entry) => entry.field === "localCliExecution"));
+  });
 });
 
 test("Hermes status prefers session MiniMax credentials for alpha provider routing", async () => {

--- a/browser-first/test/main-workspace-addons.test.mjs
+++ b/browser-first/test/main-workspace-addons.test.mjs
@@ -234,9 +234,12 @@ test("add-ons workspace renders registry status and governed open actions", asyn
   assert.match(container.textContent, /not trusted core agents/i);
   assert.match(container.textContent, /Direct trusted wiki writes remain blocked/);
   assert.match(container.textContent, /Sending and scheduling remain human-approval gated/);
-  assert.match(container.textContent, /Grantedagent-delegation/);
+  assert.match(container.textContent, /Capability contract/);
+  assert.match(container.textContent, /Capability enforcement happens at the bridge via per-route tokens; these chips describe the add-on contract\./);
+  assert.match(container.textContent, /Declaredagent-delegation/);
   assert.match(container.textContent, /Needs reviewnotifications/);
-  assert.match(container.textContent, /Deniednetwork/);
+  assert.match(container.textContent, /Denied by policynetwork/);
+  assert.match(container.textContent, /Disabledshell/);
   assert.match(container.textContent, /archive-knowledge-write/);
   assert.match(container.textContent, /Local CLI execution disabled/);
   assert.match(container.textContent, /Draft approval/);

--- a/browser-first/test/main-workspace-settings.test.mjs
+++ b/browser-first/test/main-workspace-settings.test.mjs
@@ -2191,6 +2191,9 @@ test("settings workspace renders add-on status and capability boundaries", async
             available: false,
             mode: "coding-addon",
             trust: "add-on agent",
+            requestedCapabilities: ["agent-delegation", "filesystem-scoped", "shell", "providers"],
+            grantedCapabilities: ["agent-delegation"],
+            deniedCapabilities: ["shell"],
             execution: { localCliExecution: false }
           }
         ]
@@ -2220,22 +2223,24 @@ test("settings workspace renders add-on status and capability boundaries", async
     assert.match(container.textContent, /Hermes/);
     assert.match(container.textContent, /Living Archive/);
     assert.match(container.textContent, /OpenCode/);
-    assert.match(container.textContent, /2 granted · 1 denied/);
-    assert.match(container.textContent, /2 granted · 1 denied/);
-    assert.match(container.textContent, /Explicit grants required/);
+    assert.match(container.textContent, /2 declared · 1 denied by policy/);
+    assert.match(container.textContent, /2 declared · 1 denied by policy/);
+    assert.match(container.textContent, /1 declared · 2 needs review · 1 disabled/);
     assert.deepEqual(
       [...container.querySelectorAll(".settings-addon-disclosure")].map((details) => details.open),
       [false, false, false, false, false]
     );
-    assert.match(container.textContent, /Granted/);
+    assert.match(container.textContent, /Capability contract/);
+    assert.match(container.textContent, /Capability enforcement happens at the bridge via per-route tokens; these chips describe the add-on contract\./);
+    assert.match(container.textContent, /Declared/);
     assert.match(container.textContent, /agent-delegation/);
     assert.match(container.textContent, /notifications/);
-    assert.match(container.textContent, /Denied/);
+    assert.match(container.textContent, /Denied by policy/);
     assert.match(container.textContent, /network/);
     assert.match(container.textContent, /archive-read/);
     assert.match(container.textContent, /archive-intake-write/);
     assert.match(container.textContent, /archive-knowledge-write/);
-    assert.match(container.textContent, /Capability state/);
+    assert.match(container.textContent, /Disabledshell/);
     assert.match(container.textContent, /Direct trusted wiki writes remain blocked/);
     assert.match(container.textContent, /Coding add-ons receive bounded delegation packets/);
     assert.match(container.textContent, /Local CLI execution disabled/);

--- a/docs/augmentor-tester-runbook.md
+++ b/docs/augmentor-tester-runbook.md
@@ -76,7 +76,25 @@ a security issue** — that is a boundary regression, not a feature.
 | Provider won't route / "no available route" | no credential or model disabled → *Settings › Providers* / *Routing* (the error message names the fix) |
 | WebSocket `code 1006` in chat/model panel | Caddy TLS ALPN not pinned to `http/1.1` → bridge setup runbook, Bug 3 |
 
-## 6. Recording evidence
+## 6. Add-ons: what "disable" does and does not do
+
+The Add-ons workspace ships a fixed, locally bundled catalog — there is no
+install path for third-party add-ons in this build, and no uninstall flow
+(tracked for beta.2 in #180). Know the semantics before testing:
+
+- **Disable is not uninstall.** Disabling an add-on (or turning off its local
+  CLI execution) stops future execution but retains its configuration and any
+  delegation artifacts on disk. Re-enabling restores the prior state without a
+  fresh consent prompt.
+- **Manual cleanup**, if you want an add-on's residue gone after testing:
+  delete its entry from `BrowserFirst/Settings/addon-execution.json` and
+  remove its folder under `DelegationArtifacts/` (both live in the bridge's
+  data directory). Restart the bridge afterwards.
+- **Capability chips describe the add-on's declared contract**, enforced at
+  the bridge by per-route capability tokens — they are not per-chip toggles.
+  The one live control is each add-on's local CLI execution switch.
+
+## 7. Recording evidence
 
 For each proof, capture: the check, expected vs. observed, and the build/commit.
 Redact tokens, endpoints, and private paths. Cite the canonical issue from the


### PR DESCRIPTION
## Scope

The Option-B close-out for epic #215 — the two hardening items the seven-agent audit identified as the *real* beta-relevant gaps, plus the tester documentation:

1. **Audit trail for the highest-privilege toggle**: every actual change to an add-on's `localCliExecution` setting appends a 0600 JSONL entry (`Settings/addon-governance-audit.jsonl`): `{at, addonId, field, from, to}`. No-op updates write nothing. Operators can now reconstruct when local shell/CLI execution was enabled.
2. **Capability chips no longer overstate control**: the hardcoded per-add-on capability registry now renders as a declared **capability contract** (with an explicit note that enforcement happens at the bridge via per-route tokens), while the one genuinely live control — OpenCode shell, driven by the execution setting — renders as a distinct live chip ("Enabled by you" / "Disabled").
3. **Tester runbook §6**: disable-vs-uninstall semantics, manual cleanup paths, what the chips mean.

No permission or policy behavior changed — one additive audit write, copy-truth UI, docs.

## Validation (re-run by maintainer on a verified-clean tree)

- Focused: 51/51 across the three touched test files
- Anti-false-green: audit-trail test proven **red** against dev's service, green with the change
- Full suite: **939/939** · security pipeline check: pass · docs check + strict scope audit: clean

## Epic context

Lands ahead of closing #215 re-scoped: #194 closed moot, #180 deferred to beta.2 security with full audit evidence, #109/#136/#137/#181 deferred to beta.2 with per-issue findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)