### PR TITLE
fix(provider): local/keyless provider routing and credential fixes

### DIFF
--- a/browser-first/host/provider-bridge-service.mjs
+++ b/browser-first/host/provider-bridge-service.mjs
@@ -228,9 +228,16 @@ export function createProviderBridgeService({
     if (url.protocol !== "https:" && !allowLocal) {
       throw new Error("Provider endpoint must use HTTPS unless it is a known local-runtime provider.");
     }
-    const sendsCredential = String(profile.authType ?? "api-key").toLowerCase() !== "none";
+    const sendsCredential = !["none", "local-runtime"].includes(String(profile.authType ?? "api-key").toLowerCase());
     if (sendsCredential && isLocal && !allowLocal) {
       throw new Error("Credential-bearing provider endpoints cannot target local, private, or metadata-network hosts.");
+    }
+    // Local runtimes expose OpenAI-compatible chat completions under /v1. Older
+    // saved accounts and some presets omit the version path, which makes the
+    // eventual /chat/completions request 404. Normalize once here so existing
+    // accounts self-correct without requiring users to delete and re-add them.
+    if (String(profile.providerType ?? "").toLowerCase() === "local" && !url.pathname.endsWith("/v1") && !url.pathname.includes("/v1/")) {
+      url.pathname = `${url.pathname.replace(/\/+$/, "")}/v1`;
     }
     return url.toString().replace(/\/+$/, "");
   }
@@ -316,9 +323,9 @@ export function createProviderBridgeService({
       };
     }
     const localPresets = {
-      ollama: { apiBaseUrl: "http://127.0.0.1:11434", models: ["batiai/gemma4-e2b:q4"] },
+      ollama: { apiBaseUrl: "http://127.0.0.1:11434/v1", models: ["batiai/gemma4-e2b:q4"] },
       "lm-studio": { apiBaseUrl: "http://127.0.0.1:1234/v1", models: ["local-model"] },
-      "dgx-spark": { apiBaseUrl: "http://dgx-spark.local:11434", models: ["local-model"] },
+      "dgx-spark": { apiBaseUrl: "http://dgx-spark.local:11434/v1", models: ["local-model"] },
     };
     if (localPresets[templateId] || type === "local") {
       const preset = localPresets[templateId] ?? localPresets.ollama;
@@ -358,10 +365,11 @@ export function createProviderBridgeService({
     const model = String(rawModel ?? "").trim().slice(0, 120);
     if (!model) return null;
     const preset = presetModels.find((candidate) => candidate.model === model) ?? modelCatalog.find((candidate) => candidate.model === model) ?? {};
+    const presetRuntime = preset.runtime ?? presetModels[0]?.runtime;
     return {
       model,
       label: String((typeof entry === "string" ? preset.label : entry?.label) ?? preset.label ?? model).trim().slice(0, 120) || model,
-      runtime: String((typeof entry === "string" ? preset.runtime : entry?.runtime) ?? preset.runtime ?? "cloud").trim().slice(0, 40) || "cloud",
+      runtime: String((typeof entry === "string" ? presetRuntime : entry?.runtime) ?? presetRuntime ?? "cloud").trim().slice(0, 40) || "cloud",
       costTier: String((typeof entry === "string" ? preset.costTier : entry?.costTier) ?? preset.costTier ?? "custom").trim().slice(0, 60) || "custom",
       qualityTier: String((typeof entry === "string" ? preset.qualityTier : entry?.qualityTier) ?? preset.qualityTier ?? "custom").trim().slice(0, 100) || "custom",
       wireModel: String((typeof entry === "string" ? preset.wireModel : entry?.wireModel) ?? preset.wireModel ?? model).trim().slice(0, 120) || model,
@@ -394,7 +402,10 @@ export function createProviderBridgeService({
     if (!models.length) {
       throw new Error("At least one model must be declared for a provider account.");
     }
-    const authType = String(raw?.authType ?? preset.authType).trim().slice(0, 40) || "api-key";
+    const authType = String(
+      preset.providerType === "local" ? "local-runtime" :
+      raw?.authType ?? preset.authType
+    ).trim().slice(0, 40) || "api-key";
     const rawEndpoint = String(raw?.apiBaseUrl ?? "").trim();
     const allowsCustomEndpoint = ["custom", "local", "openai-compatible"].includes(preset.providerType);
     if (rawEndpoint && !allowsCustomEndpoint && rawEndpoint !== preset.apiBaseUrl) {
@@ -486,7 +497,8 @@ export function createProviderBridgeService({
   function providerModelRuntimeState(entry, { secrets = {}, preferences = {}, localRuntimeUrl = "", catalog = modelCatalog, profiles = providerProfiles } = {}) {
     const allowed = isModelAllowedForProviderModel(entry.providerId, entry.model, preferences, catalog);
     const profile = profiles.find((candidate) => candidate.id === entry.providerId) ?? {};
-    const requiresCredential = String(profile.authType ?? "api-key").toLowerCase() !== "none";
+    const authType = String(profile.authType ?? "api-key").toLowerCase();
+    const requiresCredential = !["none", "local-runtime"].includes(authType);
     const configured = requiresCredential ? Boolean(secrets[entry.providerId]) : true;
     return {
       ...entry,
@@ -593,7 +605,7 @@ export function createProviderBridgeService({
             routeState: strategy.routeState,
             hardStop: strategy.hardStop,
           })),
-        configured: Boolean(secrets[profile.id]),
+        configured: !["none", "local-runtime"].includes(String(profile.authType ?? "api-key").toLowerCase()) ? Boolean(secrets[profile.id]) : true,
         credentialPreview: secrets[profile.id] ? "session" : "missing",
       })),
     };
@@ -613,8 +625,9 @@ export function createProviderBridgeService({
       allProviderProfiles(),
     ]);
     const models = catalog.filter((entry) => entry.providerId === providerId);
+    const authType = String(profile.authType ?? "api-key").toLowerCase();
     const isDesktopLocal = providerId === "desktop-local";
-    const requiresCredential = !isDesktopLocal && String(profile.authType ?? "api-key").toLowerCase() !== "none";
+    const requiresCredential = !isDesktopLocal && !["none", "local-runtime"].includes(authType);
     const configured = isDesktopLocal
       ? Boolean(process.env.RESONANTOS_LOCAL_RUNTIME_URL)
       : requiresCredential
@@ -867,11 +880,13 @@ export function createProviderBridgeService({
       }
       rememberProviderSecret(normalized.id, credential);
     }
+    const savedSecrets = await readProviderSecrets();
+    const needsCredential = !["none", "local-runtime"].includes(String(normalized.authType ?? "api-key").toLowerCase());
     return {
       provider: normalized,
       savedAt: new Date().toISOString(),
       persistence: "session-only",
-      configured: Boolean(credential || (await readProviderSecrets())[normalized.id]),
+      configured: needsCredential ? Boolean(credential || savedSecrets[normalized.id]) : true,
     };
   }
 
@@ -1003,7 +1018,7 @@ export function createProviderBridgeService({
       allProviderProfiles(),
     ]);
     const route = providerRouteForArchiveVerifier(secrets, requestedModel, { catalog, profiles });
-    const routeSendsCredential = String(route?.authType ?? "api-key").toLowerCase() !== "none";
+    const routeSendsCredential = !["none", "local-runtime"].includes(String(route?.authType ?? "api-key").toLowerCase());
     if (!route || (routeSendsCredential && !secrets[route.providerId])) {
       return {
         semanticStatus: "unavailable",
@@ -1168,7 +1183,7 @@ export function createProviderBridgeService({
     });
     const failures = [];
     for (const { model: attemptModel, route } of uniqueAttempts) {
-      const sendsCredential = String(route.authType ?? "api-key").toLowerCase() !== "none";
+      const sendsCredential = !["none", "local-runtime"].includes(String(route.authType ?? "api-key").toLowerCase());
       const apiKey = sendsCredential ? secrets[route.providerId] : "local-runtime";
       if (sendsCredential && !apiKey) {
         if (routeDecision.source !== "strategy") {
@@ -1274,7 +1289,7 @@ export function createProviderBridgeService({
       allProviderProfiles(),
     ]);
     const route = providerRouteForModel(payload.model, { catalog, profiles });
-    const sendsCredential = String(route.authType ?? "api-key").toLowerCase() !== "none";
+    const sendsCredential = !["none", "local-runtime"].includes(String(route.authType ?? "api-key").toLowerCase());
     const apiKey = sendsCredential ? secrets[route.providerId] : "local-runtime";
     if (sendsCredential && !apiKey) {
       return {

--- a/browser-first/host/provider-bridge-service.mjs
+++ b/browser-first/host/provider-bridge-service.mjs
@@ -483,11 +483,11 @@ export function createProviderBridgeService({
     return new Set(configured.length ? configured : declaredModels).has(model);
   }
 
-  function providerModelRuntimeState(entry, { secrets = {}, preferences = {}, localRuntimeUrl = "", catalog = modelCatalog } = {}) {
+  function providerModelRuntimeState(entry, { secrets = {}, preferences = {}, localRuntimeUrl = "", catalog = modelCatalog, profiles = providerProfiles } = {}) {
     const allowed = isModelAllowedForProviderModel(entry.providerId, entry.model, preferences, catalog);
-    const configured = entry.providerId === "desktop-local"
-      ? Boolean(localRuntimeUrl)
-      : Boolean(secrets[entry.providerId]);
+    const profile = profiles.find((candidate) => candidate.id === entry.providerId) ?? {};
+    const requiresCredential = String(profile.authType ?? "api-key").toLowerCase() !== "none";
+    const configured = requiresCredential ? Boolean(secrets[entry.providerId]) : true;
     return {
       ...entry,
       allowed,
@@ -605,31 +605,42 @@ export function createProviderBridgeService({
     if (!profile) {
       throw new Error("Unknown provider profile.");
     }
-    const [secrets, preferences, strategies, catalog] = await Promise.all([
+    const [secrets, preferences, strategies, catalog, profiles] = await Promise.all([
       readProviderSecrets(),
       readProviderModelPreferences().catch(() => ({})),
       resolvedRoutingStrategies(),
       allModelCatalog(),
+      allProviderProfiles(),
     ]);
     const models = catalog.filter((entry) => entry.providerId === providerId);
-    const configured = Boolean(secrets[providerId]);
+    const isDesktopLocal = providerId === "desktop-local";
+    const requiresCredential = !isDesktopLocal && String(profile.authType ?? "api-key").toLowerCase() !== "none";
+    const configured = isDesktopLocal
+      ? Boolean(process.env.RESONANTOS_LOCAL_RUNTIME_URL)
+      : requiresCredential
+        ? Boolean(secrets[providerId])
+        : true;
     const routeConsumers = strategies.filter((strategy) =>
       [strategy.primary, ...(strategy.fallbackChain ?? [])]
         .some((entry) => entry?.providerId === providerId)
     );
     const blockedConsumers = routeConsumers.filter((strategy) => strategy.routeState !== "routable");
-    const availableModels = models.filter((entry) => providerModelRuntimeState(entry, {
+    const runtimeOptions = {
       secrets,
       preferences,
       catalog,
       localRuntimeUrl: process.env.RESONANTOS_LOCAL_RUNTIME_URL,
-    })?.configured);
+      profiles,
+    };
+    const availableModels = models.filter((entry) => providerModelRuntimeState(entry, runtimeOptions)?.configured);
     const allowedModels = models.filter((entry) => isModelAllowedForProviderModel(providerId, entry.model, preferences, catalog));
     const state = configured && availableModels.length
       ? (blockedConsumers.length ? "degraded" : "ready")
       : configured && !allowedModels.length
         ? "disabled"
-      : "missing-credential";
+      : requiresCredential
+        ? "missing-credential"
+        : "unreachable";
     return {
       providerId,
       label: profile.label,
@@ -641,12 +652,7 @@ export function createProviderBridgeService({
         label: entry.label,
         runtime: entry.runtime,
         allowed: isModelAllowedForProviderModel(providerId, entry.model, preferences, catalog),
-        configured: Boolean(providerModelRuntimeState(entry, {
-          secrets,
-          preferences,
-          catalog,
-          localRuntimeUrl: process.env.RESONANTOS_LOCAL_RUNTIME_URL,
-        })?.configured),
+        configured: Boolean(providerModelRuntimeState(entry, runtimeOptions)?.configured),
       })),
       routeConsumers: routeConsumers.map((strategy) => ({
         id: strategy.id,
@@ -671,8 +677,9 @@ export function createProviderBridgeService({
       throw new Error("Unknown provider profile.");
     }
     const secrets = await readProviderSecrets();
-    const credential = secrets[providerId];
-    if (!credential) {
+    const requiresCredential = String(profile.authType ?? "api-key").toLowerCase() !== "none";
+    const credential = secrets[providerId] ?? "";
+    if (requiresCredential && !credential) {
       const result = {
         providerId,
         label: profile.label,
@@ -690,7 +697,7 @@ export function createProviderBridgeService({
       providerId,
       url: `${String(profile.apiBaseUrl).replace(/\/$/, "")}/models`,
       label: profile.label,
-      sendsCredential: profile.authType !== "none",
+      sendsCredential: requiresCredential,
     } : null);
     if (!target) {
       throw new Error("No connectivity diagnostic target exists for this provider.");
@@ -996,7 +1003,8 @@ export function createProviderBridgeService({
       allProviderProfiles(),
     ]);
     const route = providerRouteForArchiveVerifier(secrets, requestedModel, { catalog, profiles });
-    if (!route) {
+    const routeSendsCredential = String(route?.authType ?? "api-key").toLowerCase() !== "none";
+    if (!route || (routeSendsCredential && !secrets[route.providerId])) {
       return {
         semanticStatus: "unavailable",
         semanticSummary: "No configured provider was available for semantic archive verification.",
@@ -1023,11 +1031,13 @@ export function createProviderBridgeService({
     });
     try {
       const response = await fetchProviderResponse(
-        providerRequestUrl(route, "/chat/completions"),
+        providerRequestUrl(route, "/chat/completions", { sendsCredential: routeSendsCredential }),
         {
           method: "POST",
-          headers: {
+          headers: routeSendsCredential ? {
             "Authorization": `Bearer ${secrets[route.providerId]}`,
+            "Content-Type": "application/json",
+          } : {
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
@@ -1158,8 +1168,9 @@ export function createProviderBridgeService({
     });
     const failures = [];
     for (const { model: attemptModel, route } of uniqueAttempts) {
-      const apiKey = route.providerId === "desktop-local" ? "local-runtime" : secrets[route.providerId];
-      if (!apiKey) {
+      const sendsCredential = String(route.authType ?? "api-key").toLowerCase() !== "none";
+      const apiKey = sendsCredential ? secrets[route.providerId] : "local-runtime";
+      if (sendsCredential && !apiKey) {
         if (routeDecision.source !== "strategy") {
           // A manually selected, catalog-valid model whose provider has no
           // credential: name it and point to recovery, instead of the generic
@@ -1172,11 +1183,13 @@ export function createProviderBridgeService({
       let response;
       try {
         response = await fetchProviderResponse(
-          providerRequestUrl(route, "/chat/completions", { sendsCredential: route.providerId !== "desktop-local" }),
+          providerRequestUrl(route, "/chat/completions", { sendsCredential }),
           {
             method: "POST",
-            headers: {
+            headers: sendsCredential ? {
               "Authorization": `Bearer ${apiKey}`,
+              "Content-Type": "application/json",
+            } : {
               "Content-Type": "application/json",
             },
             body: JSON.stringify({
@@ -1261,8 +1274,9 @@ export function createProviderBridgeService({
       allProviderProfiles(),
     ]);
     const route = providerRouteForModel(payload.model, { catalog, profiles });
-    const apiKey = secrets[route.providerId];
-    if (!apiKey) {
+    const sendsCredential = String(route.authType ?? "api-key").toLowerCase() !== "none";
+    const apiKey = sendsCredential ? secrets[route.providerId] : "local-runtime";
+    if (sendsCredential && !apiKey) {
       return {
         reply: fallbackInlineAssistant({ action, selection, prompt }),
         providerId: "local-fallback",
@@ -1285,11 +1299,13 @@ export function createProviderBridgeService({
     let response;
     try {
       response = await fetchProviderResponse(
-        providerRequestUrl(route, "/chat/completions"),
+        providerRequestUrl(route, "/chat/completions", { sendsCredential }),
         {
           method: "POST",
-          headers: {
+          headers: sendsCredential ? {
             "Authorization": `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+          } : {
             "Content-Type": "application/json",
           },
           body: JSON.stringify({

--- a/browser-first/host/provider-fabric-core.mjs
+++ b/browser-first/host/provider-fabric-core.mjs
@@ -158,7 +158,7 @@ export function modelCatalogEntriesForProvider(profile) {
         providerId,
         providerLabel,
         providerType,
-        runtime: typeof entry === "string" ? (builtIn?.runtime ?? "cloud") : (entry.runtime ?? builtIn?.runtime ?? "cloud"),
+        runtime: typeof entry === "string" ? (builtIn?.runtime ?? (providerType === "local" ? "local" : "cloud")) : (entry.runtime ?? builtIn?.runtime ?? (providerType === "local" ? "local" : "cloud")),
         costTier: typeof entry === "string" ? (builtIn?.costTier ?? "custom") : (entry.costTier ?? builtIn?.costTier ?? "custom"),
         qualityTier: typeof entry === "string" ? (builtIn?.qualityTier ?? "custom") : (entry.qualityTier ?? builtIn?.qualityTier ?? "custom"),
         wireModel: typeof entry === "string" ? (builtIn?.wireModel ?? model) : (entry.wireModel ?? builtIn?.wireModel ?? model),
@@ -213,8 +213,9 @@ export function modelRuntimeState(model, { secrets = {}, preferences = {}, local
   }
   const allowed = isModelAllowed(model, preferences, catalog);
   const profile = providerProfileById(catalogEntry.providerId);
+  const authType = String(profile?.authType ?? "api-key").toLowerCase();
   const isDesktopLocal = catalogEntry.providerId === "desktop-local";
-  const requiresCredential = !isDesktopLocal && String(profile?.authType ?? "api-key").toLowerCase() !== "none";
+  const requiresCredential = !isDesktopLocal && !["none", "local-runtime"].includes(authType);
   const configured = isDesktopLocal
     ? Boolean(localRuntimeUrl)
     : requiresCredential

--- a/browser-first/host/provider-fabric-core.mjs
+++ b/browser-first/host/provider-fabric-core.mjs
@@ -212,9 +212,14 @@ export function modelRuntimeState(model, { secrets = {}, preferences = {}, local
     return null;
   }
   const allowed = isModelAllowed(model, preferences, catalog);
-  const configured = catalogEntry.providerId === "desktop-local"
+  const profile = providerProfileById(catalogEntry.providerId);
+  const isDesktopLocal = catalogEntry.providerId === "desktop-local";
+  const requiresCredential = !isDesktopLocal && String(profile?.authType ?? "api-key").toLowerCase() !== "none";
+  const configured = isDesktopLocal
     ? Boolean(localRuntimeUrl)
-    : Boolean(secrets[catalogEntry.providerId]);
+    : requiresCredential
+      ? Boolean(secrets[catalogEntry.providerId])
+      : true;
   return {
     ...catalogEntry,
     allowed,
@@ -262,6 +267,7 @@ export function providerRouteForModel(model, { localRuntimeUrl = "", catalog = m
         apiBaseUrl: profile.apiBaseUrl,
         wireModel: dynamicEntry.wireModel ?? model,
         label: profile.label ?? dynamicEntry.providerLabel ?? "Provider",
+        authType: profile.authType ?? "api-key",
       };
     }
   }
@@ -272,6 +278,7 @@ export function providerRouteForModel(model, { localRuntimeUrl = "", catalog = m
       apiBaseUrl: localRuntimeUrl || "http://127.0.0.1:11434/v1",
       wireModel: model,
       label: "Desktop Local",
+      authType: "local-runtime",
     };
   }
   if (model?.startsWith("gpt-")) {
@@ -308,6 +315,7 @@ export function providerConnectivityTarget(providerId, { localRuntimeUrl = "" } 
       url: localRuntimeUrl || "http://127.0.0.1:11434/v1/models",
       label: "Desktop Local",
       sendsCredential: false,
+      authType: "local-runtime",
     };
   }
   if (providerId === "shared-openai") {

--- a/browser-first/resonantos-side-panel-extension/src/lib/settings/provider-catalog.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/settings/provider-catalog.js
@@ -251,6 +251,16 @@ export function providerTypeLabel(provider) {
   return providerTypePresets[type]?.label ?? formatLabel(type);
 }
 
+export function allowsCustomProviderEndpoint(templateId) {
+  const preset = providerTypePresets[String(templateId ?? "minimax")];
+  return ["custom", "local", "openai-compatible"].includes(preset?.providerType);
+}
+
+export function providerRequiresCredential(templateId) {
+  const preset = providerTypePresets[String(templateId ?? "minimax")];
+  return preset?.providerType !== "local";
+}
+
 export function providerModelsText(provider) {
   return (provider.models ?? [])
     .map((model) => modelValue(model))

--- a/browser-first/resonantos-side-panel-extension/src/lib/settings/provider-catalog.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/settings/provider-catalog.js
@@ -185,7 +185,7 @@ export const providerTypePresets = {
     label: "Ollama",
     providerType: "local",
     category: "Local software",
-    apiBaseUrl: "http://127.0.0.1:11434",
+    apiBaseUrl: "http://127.0.0.1:11434/v1",
     models: ["batiai/gemma4-e2b:q4"],
   },
   "lm-studio": {

--- a/browser-first/resonantos-side-panel-extension/src/lib/settings/providers-section.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/settings/providers-section.js
@@ -1,5 +1,6 @@
 import { metricCard, noteCard, safeErrorMessage, setStatus, settingsHeader } from "./settings-common.js";
 import {
+  allowsCustomProviderEndpoint,
   formatLabel,
   modelLabel,
   modelValue,
@@ -19,7 +20,7 @@ function labeledField({ label, input }) {
   return wrapper;
 }
 
-function providerAccountPayload(form, provider = {}) {
+export function providerAccountPayload(form, provider = {}) {
   const FormDataCtor = form.ownerDocument?.defaultView?.FormData ?? FormData;
   const data = new FormDataCtor(form);
   const templateId = String(data.get("templateId") ?? provider.templateId ?? provider.providerType ?? "minimax").trim();
@@ -38,7 +39,7 @@ function providerAccountPayload(form, provider = {}) {
   };
 }
 
-function providerAccountForm(provider = {}) {
+export function providerAccountForm(provider = {}) {
   const form = document.createElement("form");
   form.className = "settings-provider-account-form";
 
@@ -88,11 +89,21 @@ function providerAccountForm(provider = {}) {
   credential.autocomplete = "off";
   credential.placeholder = provider.id ? "Leave blank to keep current credential" : "Paste account API key";
 
+  function lockUrlForTemplate(templateId) {
+    const preset = providerTypePresets[templateId] ?? providerTypePresets.minimax;
+    const editable = allowsCustomProviderEndpoint(templateId);
+    apiBaseUrl.disabled = !editable;
+    apiBaseUrl.title = editable ? "" : "This provider requires its built-in endpoint URL.";
+    apiBaseUrl.value = preset.apiBaseUrl;
+  }
+
+  lockUrlForTemplate(template.value);
+
   template.addEventListener("change", () => {
     const preset = providerTypePresets[template.value] ?? providerTypePresets.minimax;
     name.placeholder = `${preset.label} account`;
-    apiBaseUrl.value = preset.apiBaseUrl;
     models.value = preset.models.join("\n");
+    lockUrlForTemplate(template.value);
   });
 
   const grid = document.createElement("div");
@@ -128,13 +139,17 @@ export function openProviderAccountModal({ bridgeRequest, getBridgeRequest, stat
   close.textContent = "Close";
   heading.append(title, close);
   const form = providerAccountForm();
+  const errorNode = document.createElement("p");
+  errorNode.className = "settings-provider-modal-error";
+  errorNode.setAttribute("role", "alert");
+  errorNode.hidden = true;
   const actions = document.createElement("div");
   actions.className = "settings-provider-modal-actions";
   const save = document.createElement("button");
   save.type = "submit";
   save.textContent = "Save account";
   actions.append(save);
-  form.append(actions);
+  form.append(errorNode, actions);
   // Status lives INSIDE the modal so save progress and — critically — save
   // failures are shown to the user while the dialog is still open. Writing them
   // to the settings page behind the modal (the old behavior) hid the error and
@@ -153,6 +168,8 @@ export function openProviderAccountModal({ bridgeRequest, getBridgeRequest, stat
   form.addEventListener("submit", async (event) => {
     event.preventDefault();
     save.disabled = true;
+    setStatus(errorNode, "", "");
+    errorNode.hidden = true;
     setStatus(modalStatus, "Saving provider account…");
     try {
       await bridge()("/providers/accounts", {
@@ -167,7 +184,10 @@ export function openProviderAccountModal({ bridgeRequest, getBridgeRequest, stat
     } catch (error) {
       // Failure: keep the dialog open and show the reason in the dialog so the
       // user can correct the input and retry — do not write it behind the modal.
-      setStatus(modalStatus, `Save failed: ${safeErrorMessage(error)}`, "error");
+      const message = safeErrorMessage(error);
+      setStatus(modalStatus, `Save failed: ${message}`, "error");
+      setStatus(errorNode, `Provider account save failed: ${message}`, "error");
+      errorNode.hidden = false;
     } finally {
       save.disabled = false;
     }

--- a/browser-first/resonantos-side-panel-extension/src/lib/settings/providers-section.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/settings/providers-section.js
@@ -6,6 +6,7 @@ import {
   modelValue,
   parseModelsText,
   providerModelsText,
+  providerRequiresCredential,
   providerSort,
   providerTypeLabel,
   providerTypePresets
@@ -31,7 +32,7 @@ export function providerAccountPayload(form, provider = {}) {
     templateId,
     label: String(data.get("label") ?? "").trim(),
     providerType: preset.providerType,
-    authType: "api-key",
+    authType: preset.providerType === "local" ? "local-runtime" : "api-key",
     apiBaseUrl: String(data.get("apiBaseUrl") ?? "").trim(),
     role: String(data.get("role") ?? "").trim(),
     models: parseModelsText(data.get("models")),
@@ -89,6 +90,18 @@ export function providerAccountForm(provider = {}) {
   credential.autocomplete = "off";
   credential.placeholder = provider.id ? "Leave blank to keep current credential" : "Paste account API key";
 
+  function updateCredentialRequirement(templateId) {
+    const required = providerRequiresCredential(templateId);
+    credential.required = required;
+    credential.placeholder = provider.id
+      ? "Leave blank to keep current credential"
+      : required
+        ? "Paste account API key"
+        : "No API key needed for local runtime";
+  }
+
+  updateCredentialRequirement(template.value);
+
   function lockUrlForTemplate(templateId) {
     const preset = providerTypePresets[templateId] ?? providerTypePresets.minimax;
     const editable = allowsCustomProviderEndpoint(templateId);
@@ -104,6 +117,7 @@ export function providerAccountForm(provider = {}) {
     name.placeholder = `${preset.label} account`;
     models.value = preset.models.join("\n");
     lockUrlForTemplate(template.value);
+    updateCredentialRequirement(template.value);
   });
 
   const grid = document.createElement("div");

--- a/browser-first/test/local-provider-chat.test.mjs
+++ b/browser-first/test/local-provider-chat.test.mjs
@@ -1,0 +1,158 @@
+// #218 follow-up — local/keyless providers must not demand a credential at chat time.
+// A custom Ollama account (authType local-runtime, no API key) must be routable
+// when its model is selected, instead of failing with "no active provider credential".
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { createProviderBridgeService } from "../host/provider-bridge-service.mjs";
+
+const PROVIDER_ENV = [
+  "MINIMAX_API_KEY", "OPENAI_API_KEY", "ZAI_API_KEY", "GLM_API_KEY", "ZHIPUAI_API_KEY",
+  "RESONANTOS_PROVIDER_SECRETS_JSON", "RESONANTOS_LOCAL_RUNTIME_URL",
+];
+
+function createService(root) {
+  return createProviderBridgeService({
+    providerSecretsPath: () => path.join(root, "Secrets", "provider-secrets.json"),
+    providerAccountsPath: () => path.join(root, "ProviderFabric", "provider-accounts.json"),
+    providerRoutingPath: () => path.join(root, "ProviderFabric", "routing-strategies.json"),
+    providerModelPreferencesPath: () => path.join(root, "ProviderFabric", "model-preferences.json"),
+    providerDiagnosticsHistoryPath: () => path.join(root, "ProviderFabric", "diagnostics-history.json"),
+    redactDiagnosticText: (value) => String(value ?? ""),
+    unique: (values) => [...new Set(values.filter(Boolean))],
+    extractJsonObject: (value) => JSON.parse(String(value ?? "{}")),
+  });
+}
+
+function reply(content) {
+  return { ok: true, status: 200, json: async () => ({ choices: [{ message: { content } }], usage: null }) };
+}
+
+async function withService(run) {
+  const previous = Object.fromEntries(PROVIDER_ENV.map((name) => [name, process.env[name]]));
+  for (const name of PROVIDER_ENV) delete process.env[name];
+  const originalFetch = globalThis.fetch;
+  const root = await mkdtemp(path.join(os.tmpdir(), "resonant-local-"));
+  try {
+    await run(createService(root), (stub) => { globalThis.fetch = stub; });
+  } finally {
+    globalThis.fetch = originalFetch;
+    for (const [name, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[name]; else process.env[name] = value;
+    }
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+const localOllamaAccount = {
+  mode: "create",
+  templateId: "ollama",
+  label: "Ollama local",
+  providerType: "local",
+  apiBaseUrl: "http://127.0.0.1:11434/v1",
+  models: ["deepseek-v4-flash:cloud"],
+  credential: "",
+};
+
+test("local Ollama account without API key is routable and does not demand a credential", async () => {
+  await withService(async (svc, setFetch) => {
+    const saveResult = await svc.executeProviderAccountSave(localOllamaAccount);
+    assert.equal(saveResult.provider.authType, "local-runtime", "account should be saved as local-runtime");
+    assert.equal(saveResult.provider.models[0]?.model, "deepseek-v4-flash:cloud");
+
+    let requestedUrl;
+    setFetch(async (url, init) => {
+      requestedUrl = String(url);
+      assert.equal(init.headers?.Authorization, undefined, "local-runtime chat must not send an Authorization header");
+      return reply("hello from local Ollama");
+    });
+
+    const out = await svc.executeBridgeChat({
+      workload: "augmentor-chat",
+      model: "deepseek-v4-flash:cloud",
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    assert.match(requestedUrl, /127\.0\.0\.1:11434/);
+    assert.equal(out.model, "deepseek-v4-flash:cloud");
+    assert.equal(out.requestedModel, "deepseek-v4-flash:cloud");
+    assert.equal(out.routeSource, "manual");
+    assert.equal(out.reply, "hello from local Ollama");
+  });
+});
+
+test("provider status reports a local-runtime account as configured without a credential", async () => {
+  await withService(async (svc) => {
+    const { provider } = await svc.executeProviderAccountSave(localOllamaAccount);
+    const status = await svc.executeProviderStatus();
+    const found = status.providers.find((p) => p.id === provider.id);
+    assert.ok(found, `provider not found in status: ${status.providers.map((p) => p.id).join(", ")}`);
+    assert.equal(found.authType, "local-runtime");
+    assert.equal(found.configured, true, "local-runtime provider should be configured without a credential");
+    const model = found.models.find((m) => m.model === "deepseek-v4-flash:cloud");
+    assert.ok(model, "local model should appear in provider status");
+    assert.equal(model.runtime, "local", "custom local model should inherit local runtime");
+  });
+});
+
+test("local provider accounts saved with stale api-key authType are normalized to local-runtime", async () => {
+  await withService(async (svc) => {
+    const stale = { ...localOllamaAccount, authType: "api-key" };
+    const { provider } = await svc.executeProviderAccountSave(stale);
+    assert.equal(provider.authType, "local-runtime", "providerType local must force local-runtime authType");
+
+    const status = await svc.executeProviderStatus();
+    const found = status.providers.find((p) => p.id === provider.id);
+    assert.equal(found.configured, true, "normalized local account should not require a credential");
+  });
+});
+
+test("legacy Ollama endpoint without /v1 is normalized so chat hits /v1/chat/completions", async () => {
+  await withService(async (svc, setFetch) => {
+    const legacy = { ...localOllamaAccount, apiBaseUrl: "http://127.0.0.1:11434" };
+    const { provider } = await svc.executeProviderAccountSave(legacy);
+    assert.equal(provider.apiBaseUrl, "http://127.0.0.1:11434/v1", "legacy local endpoint should be normalized to /v1");
+
+    let requestedUrl;
+    setFetch(async (url, init) => {
+      requestedUrl = String(url);
+      assert.match(requestedUrl, /\/v1\/chat\/completions$/);
+      assert.equal(init.headers?.Authorization, undefined);
+      return reply("hello from normalized Ollama");
+    });
+
+    const out = await svc.executeBridgeChat({
+      workload: "augmentor-chat",
+      model: "deepseek-v4-flash:cloud",
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    assert.equal(out.reply, "hello from normalized Ollama");
+  });
+});
+
+test("inline assistant routes to local provider instead of falling back to local-fallback", async () => {
+  await withService(async (svc, setFetch) => {
+    await svc.executeProviderAccountSave(localOllamaAccount);
+    let requestedUrl;
+    setFetch(async (url, init) => {
+      requestedUrl = String(url);
+      assert.equal(init.headers?.Authorization, undefined, "local inline assistant must not send Authorization");
+      return reply("local inline reply");
+    });
+
+    const out = await svc.executeInlineAssistant({
+      action: "summarize",
+      model: "deepseek-v4-flash:cloud",
+      selection: "Some selected text to summarize.",
+      pageContext: "",
+    });
+
+    assert.match(requestedUrl, /127\.0\.0\.1:11434/);
+    assert.equal(out.reply, "local inline reply");
+    assert.notEqual(out.model, "local-inline-fallback");
+  });
+});

--- a/browser-first/test/main-workspace-settings.test.mjs
+++ b/browser-first/test/main-workspace-settings.test.mjs
@@ -552,7 +552,7 @@ test("settings provider add modal exposes comprehensive cloud, gateway, local, a
 
     select.value = "ollama";
     select.dispatchEvent(new Event("change", { bubbles: true }));
-    assert.equal(document.querySelector("input[name='apiBaseUrl']").value, "http://127.0.0.1:11434");
+    assert.equal(document.querySelector("input[name='apiBaseUrl']").value, "http://127.0.0.1:11434/v1");
     assert.match(document.querySelector("textarea[name='models']").value, /batiai\/gemma4-e2b:q4/);
   } finally {
     document.querySelector(".settings-provider-modal")?.remove();

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -4417,7 +4417,7 @@ describe("App boot flow", () => {
     expect(requestProviderSetupProbeMock).toHaveBeenCalledWith(
       expect.objectContaining({
         providerType: "local",
-        runtimeNodeEndpoint: "http://127.0.0.1:11434",
+        runtimeNodeEndpoint: "http://127.0.0.1:11434/v1",
       }),
     );
   });

--- a/src/modules/settings/provider-templates.ts
+++ b/src/modules/settings/provider-templates.ts
@@ -478,7 +478,7 @@ export const providerTemplates: ProviderTemplate[] = [
   localTemplate({
     id: "ollama",
     label: "Ollama",
-    apiBaseUrl: "http://127.0.0.1:11434",
+    apiBaseUrl: "http://127.0.0.1:11434/v1",
     models: ["batiai/gemma4-e2b:q4"],
     primaryModel: "batiai/gemma4-e2b:q4",
     fallbackModel: undefined,
@@ -495,7 +495,7 @@ export const providerTemplates: ProviderTemplate[] = [
   localTemplate({
     id: "dgx-spark",
     label: "NVIDIA DGX Spark",
-    apiBaseUrl: "http://dgx-spark.local:11434",
+    apiBaseUrl: "http://dgx-spark.local:11434/v1",
     models: [],
     primaryModel: "",
     runtimeKind: "remote-user-owned",


### PR DESCRIPTION
This is a clean re-cut of the provider changes originally included in #280, with unrelated dictation and fixture work removed.

## What changed

- Make local/keyless provider templates not require an API key.
- Recognize `providerType: \"local\"` and route local-runtime accounts through the local fabric instead of falling back to cloud providers.
- Normalize Ollama endpoints so a legacy `http://127.0.0.1:11434` base URL is rewritten to `http://127.0.0.1:11434/v1` before chat requests.
- Lock API base URL editing for built-in providers while keeping it editable for custom/local/openai-compatible templates.
- Surface add-provider modal errors cleanly.

## Verification

- `node --test browser-first/test/local-provider-chat.test.mjs browser-first/test/main-workspace-settings.test.mjs` — 40/40 passed.
- `npx vitest run src/App.test.tsx` — one unrelated pre-existing failure in a Living Archive layout test.

Closes the local provider routing gap discussed in #280.