### PR TITLE
security(browser-first): block protected system roots and ~/Library in move-import at any depth

### DIFF
--- a/browser-first/host/memory-source-move.mjs
+++ b/browser-first/host/memory-source-move.mjs
@@ -112,8 +112,20 @@ export function assertSafeMoveSource(sourcePath, memoryRoot) {
   }
   const protectedNames = new Set(["Applications", "Library", "System", "Volumes", "bin", "dev", "etc", "private", "sbin", "usr", "var"]);
   const parts = source.split(path.sep).filter(Boolean);
-  if (process.platform === "darwin" && parts.length === 1 && protectedNames.has(parts[0])) {
-    throw new Error("Move import cannot target a protected system folder.");
+  // The OS temp directory legitimately resolves under a protected root on macOS
+  // (e.g. /var/folders/...) yet holds only scratch data, so it must stay importable.
+  const insideTempDir = isSameOrInside(source, path.resolve(os.tmpdir()));
+  if (process.platform === "darwin" && !insideTempDir) {
+    // Reject any source whose first path component is a protected system root,
+    // regardless of depth — /private/etc and /usr/local are as dangerous as /private.
+    if (protectedNames.has(parts[0])) {
+      throw new Error("Move import cannot target a protected system folder.");
+    }
+    // The macOS user Library sits under the home folder (first component "Users"),
+    // so the protected-root check above never sees it; reject it and its subtree.
+    if (isSameOrInside(source, path.join(home, "Library"))) {
+      throw new Error("Move import cannot target the macOS user Library folder.");
+    }
   }
   const relativeToHome = path.relative(home, source);
   if (!relativeToHome.startsWith("..") && !path.isAbsolute(relativeToHome) && relativeToHome.split(path.sep).filter(Boolean).length < 1) {

--- a/browser-first/test/memory-source-move.test.mjs
+++ b/browser-first/test/memory-source-move.test.mjs
@@ -29,6 +29,25 @@ test("move import preflight rejects broad user root and existing memory root", a
   }
 });
 
+test("move import rejects protected system folders and the user Library at any depth", async () => {
+  const root = await fixtureRoot("move-protected-depth");
+  const memoryRoot = path.join(root, "ResonantOS_User", "Memory");
+  await mkdir(memoryRoot, { recursive: true });
+  try {
+    if (process.platform === "darwin") {
+      // Multi-level system paths must be blocked even though the protected root is not their only component.
+      assert.throws(() => assertSafeMoveSource("/private/etc", memoryRoot), /protected system folder/);
+      assert.throws(() => assertSafeMoveSource("/usr/local", memoryRoot), /protected system folder/);
+      // The macOS user Library is a top-level home folder that still holds sensitive application state.
+      assert.throws(() => assertSafeMoveSource(path.join(os.homedir(), "Library"), memoryRoot), /Library/);
+    }
+    // A specific deep folder under the user's home must remain importable on every platform.
+    assert.doesNotThrow(() => assertSafeMoveSource(path.join(os.homedir(), "projects", "knowledge-vault"), memoryRoot));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("move rollback deregistration requires zero skipped files", () => {
   assert.equal(shouldDeregisterMovedSourceAfterRollback({ restoredCount: 2, skippedCount: 0, skippedDirectoryCount: 0, sourceRootRestored: true, skippedRootCleanupCount: 0 }), true);
   assert.equal(shouldDeregisterMovedSourceAfterRollback({ restoredCount: 1, skippedCount: 1, skippedDirectoryCount: 0, sourceRootRestored: true, skippedRootCleanupCount: 0 }), false);


### PR DESCRIPTION
## Summary

The move-import guard (`assertSafeMoveSource` in `browser-first/host/memory-source-move.mjs`) only rejected a protected system root when it was the **only** path component (`parts.length === 1`). Multi-level paths slipped through validation and could be moved — and deleted from source — into ResonantOS Memory by the move-import flow:

- `/private/etc`
- `/usr/local`
- `~/Library` (a top-level home folder; its first component is `Users`, so the protected-root check never saw it)

## Fix

- Reject any source whose **first path component** is a protected system root, regardless of depth.
- Reject `~/Library` and its subtree explicitly.
- Preserve legitimate imports: deep user paths (`/Users/<u>/projects/x`) and the OS temp directory, which resolves under `/var/folders/...` on macOS — a protected root by name, but scratch-only, so it must stay importable.

## Tests

Added `move import rejects protected system folders and the user Library at any depth`, proving `/private/etc`, `/usr/local`, and `~/Library` are rejected while a normal deep home path is accepted. The new assertions were verified **red against the un-fixed guard** (`Missing expected exception` on `/private/etc`) before the fix was applied.

`npm run test:browser-first` → **940 passed, 0 failed, 0 skipped**.

Finding credit: gemini review panel 2026-08-20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
