### PR TITLE
feat(opencode): honest external-tab cockpit handoff (Option A) — red-team CONFIRMed

### DIFF
--- a/browser-first/host/addon-delegation-host-service.mjs
+++ b/browser-first/host/addon-delegation-host-service.mjs
@@ -91,6 +91,12 @@ export function createAddonDelegationHostService(handlers = {}) {
       },
       {
         method: "POST",
+        path: "/opencode/web/url",
+        requiredCapability: "addon-runtime-control",
+        handler: required("executeOpenCodeWebUrl"),
+      },
+      {
+        method: "POST",
         path: "/addons/draft",
         requiredCapability: "addon-record-write",
         handler: required("executeAddonDraftRecord"),

--- a/browser-first/host/addon-delegation-service.mjs
+++ b/browser-first/host/addon-delegation-service.mjs
@@ -9,6 +9,8 @@ import {
   parseDraftPacketMarkdown,
 } from "./addon-draft-connectors.mjs";
 import { dashboardProxyUrl } from "./bridge-server.mjs";
+import { ensureOpencodeServer } from "./opencode-client.mjs";
+import { createOpenCodeWebUrlHandler } from "./opencode-session-host-service.mjs";
 
 const DEFAULT_OPENCODE_MODEL = "openai/gpt-5.4-mini";
 const MINIMAX_OPENCODE_MODEL = "minimax/MiniMax-M3";
@@ -173,6 +175,7 @@ export function createAddonDelegationService(dependencies) {
     memoryRoot,
     opencodeCommand,
     opencodeRuntimeDiagnostics,
+    ensureOpenCodeServer = ensureOpencodeServer,
     platform = process.platform,
     redactPathForDiagnostics,
     readProviderSecrets = async () => ({}),
@@ -1240,6 +1243,22 @@ except BaseException as exc:
     };
   }
 
+  const executeOpenCodeWebUrl = createOpenCodeWebUrlHandler({
+    executionEnabled: async (payload = {}) => {
+      const executionSettings = await readAddonExecutionSettings();
+      return addonLocalCliExecutionEnabled("opencode", payload, executionSettings);
+    },
+    ensureServer: () => ensureOpenCodeServer({
+      fetchImpl: (...args) => fetch(...args),
+      spawnImpl: (cmd, args, opts) => spawnProcess(cmd, args, opts),
+      command: opencodeCommand(),
+      hostname: "127.0.0.1",
+      port: Number(process.env.RESONANTOS_OPENCODE_PORT ?? 4231),
+      env: process.env,
+    }),
+    appendAuditEntry: appendAddonGovernanceAuditEntry,
+  });
+
   function resolveOpenCodeWorkspacePath(payload = {}) {
     const workspacePath = payload.workspacePath
       ? expandUserPath(payload.workspacePath)
@@ -1931,6 +1950,7 @@ except BaseException as exc:
     executeOpenCodeDelegationStatus,
     executeOpenCodeDelegationArtifact,
     executeOpenCodeDelegationCancel,
+    executeOpenCodeWebUrl,
     executeAddonDraftRead,
     executeAddonDraftTransition,
     executeAddonDraftProviderHandoff,

--- a/browser-first/host/opencode-client.mjs
+++ b/browser-first/host/opencode-client.mjs
@@ -17,6 +17,22 @@ export function opencodeBaseUrl({ hostname = DEFAULT_HOST, port = DEFAULT_PORT }
   return `http://${hostname}:${port}`;
 }
 
+export function opencodeServeBaseUrl(serverInfo = {}) {
+  const raw = typeof serverInfo === "string" ? serverInfo : serverInfo?.baseUrl;
+  const url = new URL(String(raw ?? ""));
+  if (url.protocol !== "http:") {
+    throw new Error("OpenCode serve URL must use http on a loopback literal.");
+  }
+  if (url.hostname !== "127.0.0.1" && url.hostname !== "localhost") {
+    throw new Error("OpenCode serve URL must use the 127.0.0.1 loopback literal.");
+  }
+  url.hostname = "127.0.0.1";
+  url.pathname = "/";
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}
+
 // Is a server already answering at baseUrl? Probes the OpenAPI doc (always
 // present, needs no provider) with a short timeout.
 export async function opencodeServerHealthy({ fetchImpl, baseUrl, timeoutMs = 1500 } = {}) {

--- a/browser-first/host/opencode-session-host-service.mjs
+++ b/browser-first/host/opencode-session-host-service.mjs
@@ -6,6 +6,43 @@
 // /event bus; that streaming glue is bridge-server-specific and is registered
 // alongside these request/response routes.
 
+import { opencodeServeBaseUrl } from "./opencode-client.mjs";
+
+export function createOpenCodeWebUrlError(message) {
+  const error = new Error(message);
+  error.code = "opencode_web_url_execution_disabled";
+  error.addonId = "opencode";
+  error.event = "webCockpitUrlIssued";
+  return error;
+}
+
+export function createOpenCodeWebUrlHandler({ executionEnabled, ensureServer, appendAuditEntry } = {}) {
+  if (typeof executionEnabled !== "function") {
+    throw new Error("OpenCode web URL handler missing executionEnabled.");
+  }
+  if (typeof ensureServer !== "function") {
+    throw new Error("OpenCode web URL handler missing ensureServer.");
+  }
+  if (typeof appendAuditEntry !== "function") {
+    throw new Error("OpenCode web URL handler missing appendAuditEntry.");
+  }
+  return async function executeOpenCodeWebUrl(req) {
+    const payload = req?.body ?? req ?? {};
+    if (!(await executionEnabled(payload))) {
+      throw createOpenCodeWebUrlError("OpenCode web cockpit URL issuance requires explicit OpenCode execution enablement.");
+    }
+    const serverInfo = await ensureServer();
+    const url = opencodeServeBaseUrl(serverInfo);
+    await appendAuditEntry({
+      at: new Date().toISOString(),
+      addonId: "opencode",
+      event: "webCockpitUrlIssued",
+      url,
+    });
+    return { url };
+  };
+}
+
 export function createOpencodeSessionHostService(handlers = {}) {
   function required(name) {
     if (typeof handlers[name] !== "function") {

--- a/browser-first/resonantos-side-panel-extension/src/lib/bridge-client.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/bridge-client.js
@@ -82,6 +82,7 @@ const BRIDGE_ROUTE_CAPABILITIES = Object.freeze({
   "POST /opencode/delegation/status": "addon-runtime-read",
   "POST /opencode/delegation/artifact": "addon-runtime-read",
   "POST /opencode/delegation/cancel": "addon-runtime-control",
+  "POST /opencode/web/url": "addon-runtime-control",
   "POST /opencode/session/start": "addon-runtime-control",
   "POST /opencode/session/prompt": "addon-runtime-control",
   "POST /opencode/session/permission": "addon-runtime-control",

--- a/browser-first/resonantos-side-panel-extension/src/lib/main-workspace-opencode.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/main-workspace-opencode.js
@@ -131,7 +131,31 @@ export function renderOpenCodeWorkspace({ container, bridgeRequest, getBridgeReq
   startSessionButton.className = "opencode-start-session";
   startSessionButton.textContent = "Start live session";
   startSessionButton.hidden = true;
-  statusCard.append(statusTitle, statusBody, statusMeta, refreshButton, startSessionButton);
+  const cockpitButton = document.createElement("button");
+  cockpitButton.type = "button";
+  cockpitButton.className = "opencode-cockpit-button";
+  cockpitButton.textContent = "Open full cockpit (external, ungoverned)";
+  cockpitButton.hidden = true;
+  const cockpitConfirm = document.createElement("div");
+  cockpitConfirm.className = "opencode-cockpit-confirm";
+  cockpitConfirm.hidden = true;
+  const cockpitWarningTitle = document.createElement("strong");
+  cockpitWarningTitle.textContent = "OpenCode cockpit handoff";
+  const cockpitWarning = document.createElement("p");
+  cockpitWarning.textContent = "This opens the full OpenCode cockpit in a separate browser tab. It is LOCAL and UNGOVERNED: actions there bypass ResonantOS approvals, redaction, and audit, and that tab carries no ResonantOS banner.";
+  const cockpitActions = document.createElement("div");
+  cockpitActions.className = "opencode-cockpit-actions";
+  const cockpitCancel = document.createElement("button");
+  cockpitCancel.type = "button";
+  cockpitCancel.textContent = "Cancel";
+  const cockpitOpen = document.createElement("button");
+  cockpitOpen.type = "button";
+  cockpitOpen.textContent = "Open in browser tab";
+  const cockpitStatus = document.createElement("p");
+  cockpitStatus.className = "opencode-cockpit-status";
+  cockpitActions.append(cockpitCancel, cockpitOpen);
+  cockpitConfirm.append(cockpitWarningTitle, cockpitWarning, cockpitActions, cockpitStatus);
+  statusCard.append(statusTitle, statusBody, statusMeta, refreshButton, startSessionButton, cockpitButton, cockpitConfirm);
 
   const boundaryCard = document.createElement("section");
   boundaryCard.className = "opencode-card";
@@ -174,6 +198,8 @@ export function renderOpenCodeWorkspace({ container, bridgeRequest, getBridgeReq
       statusMeta.textContent = openCodeStatusMeta(status);
       statusCard.dataset.ready = status.installed ? "true" : "false";
       startSessionButton.hidden = !status.installed;
+      cockpitButton.hidden = status.executionEnabled !== true;
+      if (cockpitButton.hidden) cockpitConfirm.hidden = true;
       if (!status.installed || !executionEnabled) {
         const guidance = statusCard.querySelector(".delegation-guidance") ?? document.createElement("pre");
         guidance.className = "delegation-guidance";
@@ -194,6 +220,8 @@ export function renderOpenCodeWorkspace({ container, bridgeRequest, getBridgeReq
       statusBody.textContent = opencodeStatusMessage(error);
       statusMeta.textContent = "Status unavailable";
       statusCard.dataset.ready = "false";
+      cockpitButton.hidden = true;
+      cockpitConfirm.hidden = true;
       const guidance = statusCard.querySelector(".delegation-guidance") ?? document.createElement("pre");
       guidance.className = "delegation-guidance";
       guidance.textContent = delegationGuidanceText({
@@ -209,6 +237,29 @@ export function renderOpenCodeWorkspace({ container, bridgeRequest, getBridgeReq
   };
 
   refreshButton.addEventListener("click", () => void loadStatus());
+  cockpitButton.addEventListener("click", () => {
+    cockpitStatus.textContent = "";
+    cockpitConfirm.hidden = false;
+  });
+  cockpitCancel.addEventListener("click", () => {
+    cockpitStatus.textContent = "";
+    cockpitConfirm.hidden = true;
+  });
+  cockpitOpen.addEventListener("click", async () => {
+    cockpitOpen.disabled = true;
+    cockpitStatus.textContent = "Issuing local OpenCode cockpit URL…";
+    try {
+      const result = await bridge()("/opencode/web/url", { method: "POST", body: {} });
+      const url = String(result?.url ?? "");
+      window.open(url, "_blank", "noopener,noreferrer");
+      cockpitConfirm.hidden = true;
+      cockpitStatus.textContent = "";
+    } catch (error) {
+      cockpitStatus.textContent = opencodeStatusMessage(error, "OpenCode cockpit URL unavailable");
+    } finally {
+      cockpitOpen.disabled = false;
+    }
+  });
 
   taskForm.addEventListener("submit", async (event) => {
     event.preventDefault();

--- a/browser-first/resonantos-side-panel-extension/src/styles/main-workspace/opencode-session.css
+++ b/browser-first/resonantos-side-panel-extension/src/styles/main-workspace/opencode-session.css
@@ -268,6 +268,68 @@
 .opencode-start-session[hidden] { display: none; }
 .opencode-session-area:not(:empty) { min-height: 480px; margin-top: 10px; }
 
+.opencode-cockpit-button {
+  margin-top: 10px;
+  border: 1px solid rgba(255, 190, 90, 0.44);
+  border-radius: 10px;
+  background: rgba(255, 190, 90, 0.12);
+  color: #ffde9a;
+  font-weight: 800;
+  font-size: 0.7rem;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+.opencode-cockpit-button[hidden],
+.opencode-cockpit-confirm[hidden] {
+  display: none;
+}
+.opencode-cockpit-confirm {
+  display: grid;
+  gap: 8px;
+  margin-top: 10px;
+  border: 1px solid rgba(255, 190, 90, 0.34);
+  border-radius: 10px;
+  background: rgba(70, 50, 10, 0.24);
+  color: rgba(255, 236, 198, 0.94);
+  padding: 10px 12px;
+}
+.opencode-cockpit-confirm strong {
+  color: #fff6df;
+  font-size: 0.72rem;
+}
+.opencode-cockpit-confirm p {
+  margin: 0;
+  font-size: 0.68rem;
+  line-height: 1.45;
+}
+.opencode-cockpit-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.opencode-cockpit-actions button {
+  border: 1px solid rgba(255, 231, 178, 0.22);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.05);
+  color: #fff6df;
+  cursor: pointer;
+  font-size: 0.62rem;
+  font-weight: 800;
+  padding: 6px 10px;
+}
+.opencode-cockpit-actions button:last-child {
+  border-color: rgba(255, 190, 90, 0.55);
+  background: rgba(255, 190, 90, 0.16);
+}
+.opencode-cockpit-actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+.opencode-cockpit-status {
+  color: rgba(255, 236, 198, 0.8);
+  font-family: ui-monospace, Menlo, monospace;
+}
+
 /* Desktop-app-style live workspace shell: session-browser rail + session pane */
 .opencode-ide {
   display: grid;

--- a/browser-first/test/addon-delegation-host-service.test.mjs
+++ b/browser-first/test/addon-delegation-host-service.test.mjs
@@ -19,6 +19,7 @@ const requiredHandlers = [
   "executeOpenCodeDelegationStatus",
   "executeOpenCodeDelegationArtifact",
   "executeOpenCodeDelegationCancel",
+  "executeOpenCodeWebUrl",
   "executeAddonDraftRecord",
   "executeAddonDraftList",
   "executeAddonDraftRead",
@@ -54,6 +55,7 @@ test("add-on delegation host service owns add-on, delegation, draft, and goal ro
     "POST /opencode/delegation/status",
     "POST /opencode/delegation/artifact",
     "POST /opencode/delegation/cancel",
+    "POST /opencode/web/url",
     "POST /addons/draft",
     "POST /addons/draft/list",
     "POST /addons/draft/read",
@@ -76,6 +78,7 @@ test("add-on delegation host service owns add-on, delegation, draft, and goal ro
   assert.equal(routes.get("POST /opencode/delegation/status").requiredCapability, "addon-runtime-read");
   assert.equal(routes.get("POST /opencode/delegation/artifact").requiredCapability, "addon-runtime-read");
   assert.equal(routes.get("POST /opencode/delegation/cancel").requiredCapability, "addon-runtime-control");
+  assert.equal(routes.get("POST /opencode/web/url").requiredCapability, "addon-runtime-control");
   assert.equal(routes.get("POST /addons/draft").requiredCapability, "addon-record-write");
   assert.equal(routes.get("POST /addons/draft/list").requiredCapability, "addon-record-read");
   assert.equal(routes.get("POST /addons/draft/read").requiredCapability, "addon-record-read");

--- a/browser-first/test/addon-delegation-service-error-handling.test.mjs
+++ b/browser-first/test/addon-delegation-service-error-handling.test.mjs
@@ -39,6 +39,7 @@ function createService(root, overrides = {}) {
     memoryRoot: () => path.join(root, "Memory"),
     opencodeCommand: overrides.opencodeCommand ?? (() => null),
     opencodeRuntimeDiagnostics: overrides.opencodeRuntimeDiagnostics ?? (() => ({ installed: false, command: null })),
+    ensureOpenCodeServer: overrides.ensureOpenCodeServer,
     redactPathForDiagnostics: (value) => String(value ?? "").replace(root, "<root>"),
     readProviderSecrets: overrides.readProviderSecrets ?? (async () => ({})),
     repoRoot: root,
@@ -165,6 +166,57 @@ test("add-on execution setting updates append an operator audit trail only for r
     ]);
     assert.deepEqual(entries.map((entry) => entry.addonId), ["opencode", "opencode", "opencode"]);
     assert.ok(entries.every((entry) => entry.field === "localCliExecution"));
+  });
+});
+
+test("OpenCode web cockpit URL refuses with a structured error when execution is disabled", async () => {
+  await withTempService(async (service) => {
+    await assert.rejects(
+      () => service.executeOpenCodeWebUrl({}),
+      (error) => {
+        assert.equal(error.code, "opencode_web_url_execution_disabled");
+        assert.equal(error.addonId, "opencode");
+        assert.match(error.message, /explicit OpenCode execution/);
+        return true;
+      },
+    );
+  });
+});
+
+test("OpenCode web cockpit URL issuance is execution-gated, loopback-only, and intent-audited", async () => {
+  await withTempService(async (_service, root) => {
+    let ensured = 0;
+    const service = createService(root, {
+      opencodeCommand: () => "/usr/local/bin/opencode",
+      opencodeRuntimeDiagnostics: () => ({
+        installed: true,
+        command: "/usr/local/bin/opencode",
+        commandRedacted: "<opencode>",
+      }),
+      ensureOpenCodeServer: async () => {
+        ensured += 1;
+        return { baseUrl: "http://127.0.0.1:4231/session?directory=%2Frepo" };
+      },
+    });
+    const auditPath = path.join(root, "BrowserFirst", "Settings", "addon-governance-audit.jsonl");
+
+    const first = await service.executeOpenCodeWebUrl({ enableOpenCodeExecution: true });
+    const second = await service.executeOpenCodeWebUrl({ enableOpenCodeExecution: true });
+
+    assert.equal(ensured, 2);
+    assert.equal(new URL(first.url).hostname, "127.0.0.1");
+    assert.deepEqual(first, { url: "http://127.0.0.1:4231/" });
+    assert.deepEqual(second, { url: "http://127.0.0.1:4231/" });
+    assert.equal((await stat(auditPath)).mode & 0o777, 0o600);
+    const entries = (await readFile(auditPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    assert.equal(entries.length, 2);
+    assert.ok(entries.every((entry) => entry.addonId === "opencode"));
+    assert.ok(entries.every((entry) => entry.event === "webCockpitUrlIssued"));
+    assert.ok(entries.every((entry) => entry.url === "http://127.0.0.1:4231/"));
+    assert.ok(entries.every((entry) => new URL(entry.url).hostname === "127.0.0.1"));
   });
 });
 

--- a/browser-first/test/bridge-route-capability-audit.test.mjs
+++ b/browser-first/test/bridge-route-capability-audit.test.mjs
@@ -65,6 +65,7 @@ const addonHandlers = [
   "executeOpenCodeDelegationStatus",
   "executeOpenCodeDelegationArtifact",
   "executeOpenCodeDelegationCancel",
+  "executeOpenCodeWebUrl",
   "executeAddonDraftRecord",
   "executeAddonDraftList",
   "executeAddonDraftRead",

--- a/browser-first/test/main-workspace-opencode.test.mjs
+++ b/browser-first/test/main-workspace-opencode.test.mjs
@@ -7,7 +7,9 @@ import { renderOpenCodeWorkspace } from "../resonantos-side-panel-extension/src/
 function setupDom() {
   const dom = new JSDOM("<!doctype html><main id=\"root\"></main>", { url: "https://resonantos.local/" });
   const previousFetch = globalThis.fetch;
+  const previousWindow = globalThis.window;
   globalThis.document = dom.window.document;
+  globalThis.window = dom.window;
   globalThis.HTMLElement = dom.window.HTMLElement;
   globalThis.Event = dom.window.Event;
   return {
@@ -18,6 +20,11 @@ function setupDom() {
         delete globalThis.fetch;
       } else {
         globalThis.fetch = previousFetch;
+      }
+      if (previousWindow === undefined) {
+        delete globalThis.window;
+      } else {
+        globalThis.window = previousWindow;
       }
       delete globalThis.document;
       delete globalThis.HTMLElement;
@@ -412,6 +419,95 @@ test("opencode workspace routes rail rename and delete actions through the bridg
       options.body.sessionId === "ses_live"
     ));
     assert.equal(container.querySelector(".opencode-session-area").textContent, "");
+  } finally {
+    cleanup();
+  }
+});
+
+test("opencode external cockpit button is hidden unless execution is enabled", async () => {
+  const { container, cleanup } = setupDom();
+  const bridgeRequest = async (route) => {
+    if (route === "/opencode/status") {
+      return {
+        installed: true,
+        executionEnabled: false,
+        command: "/usr/local/bin/opencode",
+        detail: "OpenCode runtime was detected but execution is disabled.",
+      };
+    }
+    throw new Error(`Unexpected route ${route}`);
+  };
+
+  try {
+    renderOpenCodeWorkspace({ container, bridgeRequest });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const cockpitButton = [...container.querySelectorAll("button")]
+      .find((button) => button.textContent === "Open full cockpit (external, ungoverned)");
+    assert.ok(cockpitButton);
+    assert.equal(cockpitButton.hidden, true);
+    assert.equal(container.querySelector("iframe"), null);
+  } finally {
+    cleanup();
+  }
+});
+
+test("opencode external cockpit interstitial gates URL issuance and opens with noopener noreferrer", async () => {
+  const { container, cleanup, window } = setupDom();
+  const calls = [];
+  const openCalls = [];
+  window.open = (...args) => {
+    openCalls.push(args);
+    return null;
+  };
+  const bridgeRequest = async (route, options = {}) => {
+    calls.push([route, options]);
+    if (route === "/opencode/status") {
+      return {
+        installed: true,
+        executionEnabled: true,
+        command: "/usr/local/bin/opencode",
+        model: "openai/gpt-5.4-mini",
+        detail: "OpenCode runtime was detected.",
+      };
+    }
+    if (route === "/opencode/web/url") {
+      return { url: "http://127.0.0.1:4231/" };
+    }
+    throw new Error(`Unexpected route ${route}`);
+  };
+
+  try {
+    renderOpenCodeWorkspace({ container, bridgeRequest });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const cockpitButton = [...container.querySelectorAll("button")]
+      .find((button) => button.textContent === "Open full cockpit (external, ungoverned)");
+    assert.ok(cockpitButton);
+    assert.equal(cockpitButton.hidden, false);
+    cockpitButton.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assert.match(container.textContent, /LOCAL and UNGOVERNED/);
+    assert.match(container.textContent, /bypass ResonantOS approvals, redaction, and audit/);
+    assert.equal(openCalls.length, 0);
+    assert.equal(calls.filter(([route]) => route === "/opencode/web/url").length, 0);
+
+    const cancel = [...container.querySelectorAll("button")].find((button) => button.textContent === "Cancel");
+    cancel.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(openCalls.length, 0);
+    assert.equal(calls.filter(([route]) => route === "/opencode/web/url").length, 0);
+
+    cockpitButton.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const confirm = [...container.querySelectorAll("button")].find((button) => button.textContent === "Open in browser tab");
+    confirm.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assert.ok(calls.some(([route, options]) => route === "/opencode/web/url" && options.method === "POST"));
+    assert.deepEqual(openCalls, [["http://127.0.0.1:4231/", "_blank", "noopener,noreferrer"]]);
+    assert.equal(container.querySelector("iframe"), null);
   } finally {
     cleanup();
   }

--- a/browser-first/test/opencode-client.test.mjs
+++ b/browser-first/test/opencode-client.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   createOpencodeHttpClient,
   ensureOpencodeServer,
+  opencodeServeBaseUrl,
   opencodeServerHealthy
 } from "../host/opencode-client.mjs";
 
@@ -63,6 +64,21 @@ test("ensureOpencodeServer refuses to start without a resolved command", async (
   await assert.rejects(
     () => ensureOpencodeServer({ fetchImpl: async () => errRes(503), command: "", spawnImpl: () => ({}) }),
     /not available to start/
+  );
+});
+
+test("opencodeServeBaseUrl returns only a 127.0.0.1 root URL", () => {
+  assert.equal(
+    opencodeServeBaseUrl({ baseUrl: "http://127.0.0.1:4231/session?directory=%2Frepo" }),
+    "http://127.0.0.1:4231/",
+  );
+  assert.equal(
+    opencodeServeBaseUrl({ baseUrl: "http://localhost:4231" }),
+    "http://127.0.0.1:4231/",
+  );
+  assert.throws(
+    () => opencodeServeBaseUrl({ baseUrl: "http://192.168.1.2:4231" }),
+    /loopback literal/,
   );
 });
 

--- a/browser-first/test/opencode-session-host-service.test.mjs
+++ b/browser-first/test/opencode-session-host-service.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  createOpenCodeWebUrlHandler,
   createOpencodeSessionHandlers,
   createOpencodeSessionHostService
 } from "../host/opencode-session-host-service.mjs";
@@ -174,4 +175,48 @@ test("session messages requires an id and passes history through", async () => {
   const result = await handlers.executeOpenCodeSessionMessages({ body: { sessionId: "ses_9" } });
   assert.equal(result.ok, true);
   assert.equal(result.messages[0].forSession, "ses_9");
+});
+
+test("web url handler refuses before ensuring the OpenCode serve process when execution is disabled", async () => {
+  let ensured = 0;
+  let audited = 0;
+  const executeOpenCodeWebUrl = createOpenCodeWebUrlHandler({
+    executionEnabled: async () => false,
+    ensureServer: async () => {
+      ensured += 1;
+      return { baseUrl: "http://127.0.0.1:4231" };
+    },
+    appendAuditEntry: async () => {
+      audited += 1;
+    }
+  });
+
+  await assert.rejects(
+    () => executeOpenCodeWebUrl({ body: {} }),
+    (error) => {
+      assert.equal(error.code, "opencode_web_url_execution_disabled");
+      assert.match(error.message, /explicit OpenCode execution/);
+      return true;
+    },
+  );
+  assert.equal(ensured, 0);
+  assert.equal(audited, 0);
+});
+
+test("web url handler ensures serve, returns a 127.0.0.1 root url, and appends an intent audit entry", async () => {
+  const audit = [];
+  const executeOpenCodeWebUrl = createOpenCodeWebUrlHandler({
+    executionEnabled: async () => true,
+    ensureServer: async () => ({ baseUrl: "http://127.0.0.1:4231/session" }),
+    appendAuditEntry: async (entry) => audit.push(entry),
+  });
+
+  const result = await executeOpenCodeWebUrl({ body: { enableOpenCodeExecution: true } });
+
+  assert.deepEqual(result, { url: "http://127.0.0.1:4231/" });
+  assert.equal(audit.length, 1);
+  assert.equal(audit[0].addonId, "opencode");
+  assert.equal(audit[0].event, "webCockpitUrlIssued");
+  assert.equal(audit[0].url, "http://127.0.0.1:4231/");
+  assert.doesNotThrow(() => new Date(audit[0].at).toISOString());
 });

--- a/docs/augmentor-tester-runbook.md
+++ b/docs/augmentor-tester-runbook.md
@@ -94,6 +94,12 @@ install path for third-party add-ons in this build, and no uninstall flow
   the bridge by per-route capability tokens — they are not per-chip toggles.
   The one live control is each add-on's local CLI execution switch.
 
+OpenCode's full cockpit opens the native OpenCode UI in a separate browser tab.
+It is local and ungoverned: actions there bypass ResonantOS approvals, audit,
+and redaction, and the tab carries no ResonantOS banner. ResonantOS logs only
+that it issued the URL as `webCockpitUrlIssued`; cockpit actions themselves are
+not observable or audited by ResonantOS. Never expose the URL off-machine.
+
 ## 7. Recording evidence
 
 For each proof, capture: the check, expected vs. observed, and the build/commit.


### PR DESCRIPTION
Implements the red-team-approved 'Option A' from the hybrid-cockpit adjudication: surface the full native OpenCode cockpit as an honest convenience, without weakening the governed-surface story. Manolo's `opencode web` request, delivered truthfully.

## What it does
An "Open full cockpit (external, ungoverned)" button in the OpenCode workspace (hidden unless execution is enabled) → a pre-open interstitial warning the cockpit is **local and ungoverned** (bypasses ResonantOS approvals, redaction, audit) → on explicit confirm, opens the native cockpit in an **external browser tab**.

## Red-team non-negotiables (all verified, delta-reviewed CONFIRM by Cursor/Opus-4.8)
- **No iframe** — no frame→parent postMessage surface; tests assert no iframe is ever created.
- `window.open(url, _blank, noopener,noreferrer)` — exact string, tested.
- **Not an access gate** — honest button/interstitial/doc language; no false 'reachable only when enabled' claims.
- **Loopback-only** — `opencodeServeBaseUrl` throws on any non-loopback host, normalizes to 127.0.0.1, strips path/query/hash (no token/directory leak into the tab).
- **Intent-audit** — `webCockpitUrlIssued` (0600); docs state cockpit ACTIONS are unaudited/unobservable.
- Route requires `addon-runtime-control` + execution enablement; refusal proven non-vacuous (revert-test-restore).

## Companion beta.2 issues (the real boundary work)
- #320 — the always-on unauthenticated opencode server exposure.
- #321 — bridge-authenticated reverse proxy + session-scoped attributed event bus.

## Validation
983/983 suite · security pipeline · docs check · strict scope audit — all green. Reviewer note (accepted, consistent with 'not an access gate'): the execution gate honors a per-request enable flag as well as persisted settings, matching the system-wide pattern; the cockpit is directly reachable regardless per #320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)