### PR TITLE
feat(augmentor): restart-safe session summary artifact (#222) — vonstegen, rebased to resolve conflict

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/lib/session-summary-artifact.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/session-summary-artifact.js
@@ -3,30 +3,44 @@
 // A bounded, reviewable, deletable artifact that preserves train-of-thought
 // across an extension reload WITHOUT persisting raw page content. The artifact
 // stores only tab provenance (title/url), skip reasons, and a redacted summary;
-// raw page text, form fields, and controls are never stored. Secrets (provider
-// keys, bearer tokens, api_key/token/secret/password assignments, wallet
-// private keys) are redacted from the summary AND from tab urls, titles, and
-// skip reasons before anything is persisted, so query-string secrets never
-// land in chrome.storage.local.
+// raw page text, form fields, and controls are never stored. Secrets are
+// redacted using the hardened trace redactor (`redactTraceText`) plus a
+// supplemental compound-name layer so `client_secret=`, `client_id=`, and
+// other `_`-joined names Tom's review flagged are caught. Percent-encoded
+// values, Bearer tokens, JSON-quoted secrets, and a wide range of provider
+// keys never reach chrome.storage.local. Tab query is scoped to the current
+// window only.
 
-const SECRET_PATTERNS = [
-  /sk-[a-z0-9_-]{16,}/gi,            // provider/api keys (OpenAI-style)
-  /\bbearer\s+[a-z0-9._-]+/gi,       // bearer tokens
-  /\bapi[_-]?key\s*[:=]\s*[^&\s]+/gi,     // api_key= / apiKey: (stops at &)
-  /\btoken\s*[:=]\s*[^&\s]+/gi,          // token= (stops at &)
-  /\bsecret\s*[:=]\s*[^&\s]+/gi,         // secret= (stops at &)
-  /\bpassword\s*[:=]\s*[^&\s]+/gi,       // password= (stops at &)
-  /\b0x[a-f0-9]{64}\b/gi,            // 32-byte wallet private keys
-  /\b(?:48|44)[a-z0-9]{86,}/gi       // ed25519 secret keys (base58, 88 chars)
-];
+import { redactTraceText } from "./trace-redaction.js";
+
+// Supplemental compound-name patterns that the trace redactor's alternation
+// does not yet cover. Matches assignments whose key starts with a known
+// compound prefix (client_, session_, id_, csrf_, jwt_) and value runs to
+// whitespace, &, #, or `"`/`'` so embedded JSON is also handled.
+const COMPOUND_NAME_PATTERN = /\b(?:client[_-]?(?:secret|id|token)|session[_-]?(?:id|token|key)|id[_-]?token|csrf[_-]?token|jwt[_-]?token)\s*["']?\s*[=:]\s*[^&\s#'`<>]+/gi;
+
 // Redact recognizable secret material from a free-text string before it is
 // persisted. Applied to the summary, tab urls, tab titles, and skip reasons.
+// Replace the value portion of a match (everything after the first `=` or `:`)
+// with `[redacted]`, preserving the key, separator, and any trailing quote so
+// JSON literals stay balanced.
+const replaceValue = (match) => {
+  const sepIndex = Math.max(match.indexOf("="), match.indexOf(":"));
+  if (sepIndex === -1) return match;
+  const prefix = match.slice(0, sepIndex + 1);
+  const trailing = match.endsWith('"') || match.endsWith("'") ? match.slice(-1) : "";
+  return prefix + "[redacted]" + trailing;
+};
+
+// Layer ordering: run the supplemental compound-name layer first so JSON-quoted
+// `client_secret` forms (which the trace redactor's alternation misses) are
+// caught, then feed the result to `redactTraceText` for the basic patterns
+// (token=, key=, secret=, password=, Bearer, sk-..., 32-byte hex, etc.).
 export function redactSecrets(text) {
-  let out = String(text ?? "");
-  for (const pattern of SECRET_PATTERNS) {
-    out = out.replace(pattern, "[redacted]");
-  }
-  return out;
+  if (typeof text !== "string") return "";
+  return redactTraceText(text.replace(COMPOUND_NAME_PATTERN, replaceValue))
+    .replace(/REDACTED/g, "[redacted]")
+    .replace(/\[REDACTED-TOKEN\]/g, "[redacted]");
 }
 
 // Build a reviewable session-summary artifact. `included` and `skipped` carry

--- a/browser-first/resonantos-side-panel-extension/src/lib/session-summary-artifact.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/session-summary-artifact.js
@@ -5,49 +5,83 @@
 // stores only tab provenance (title/url), skip reasons, and a redacted summary;
 // raw page text, form fields, and controls are never stored. Secrets are
 // redacted using the hardened trace redactor (`redactTraceText`) plus a
-// supplemental compound-name layer so `client_secret=`, `client_id=`, and
-// other `_`-joined names Tom's review flagged are caught. Percent-encoded
-// values, Bearer tokens, JSON-quoted secrets, and a wide range of provider
-// keys never reach chrome.storage.local. Tab query is scoped to the current
-// window only.
-
+// supplemental layer so `client_secret=`, bare `token` in JSON, multi-vendor
+// provider keys (Stripe, AWS, Google, GitHub, Slack), base58 wallet keys, and
+// the `[REDACTED-TOKEN]` hex sentinel all collapse to `[redacted]` before
+// persistence. Tab query is scoped to the current window only.
 import { redactTraceText } from "./trace-redaction.js";
 
-// Supplemental compound-name patterns that the trace redactor's alternation
-// does not yet cover. Matches assignments whose key starts with a known
-// compound prefix (client_, session_, id_, csrf_, jwt_) and value runs to
-// whitespace, &, #, or `"`/`'` so embedded JSON is also handled.
-const COMPOUND_NAME_PATTERN = /\b(?:client[_-]?(?:secret|id|token)|session[_-]?(?:id|token|key)|id[_-]?token|csrf[_-]?token|jwt[_-]?token)\s*["']?\s*[=:]\s*[^&\s#'`<>]+/gi;
+// Field-bound for per-tab title/url/reason. A page-controlled `document.title`
+// can be arbitrarily long, so we cap each piece of provenance at 300 chars
+// with an ellipsis to prevent an artifact-bombing tab from filling storage.
+const MAX_FIELD_LENGTH = 300;
+
+// Supplemental secret-name pattern that closes the gaps Tom's review flagged.
+// The trace redactor's basic alternation (token=/key=/secret=/password=) does
+// NOT cover:
+//   - JSON-quoted bare names: `{"token":"abc"}` — the `"` between name and `:`
+//     defeats the white-space prefix in the trace redactor's ASSIGNMENT_PATTERN.
+//   - Compound snake_case names: `client_secret`, `client_id`, `csrf_token`,
+//     `jwt_token`, `session_*`, `id_token` — Tom's blocker.
+//   - These extras are also covered here even when they appear in URL params,
+//     so the same pattern handles both contexts consistently.
+const SUPPLEMENTAL_NAME_PATTERN = /\b(?:client[_-]?(?:secret|id|token)|session[_-]?(?:id|token|key)|id[_-]?token|csrf[_-]?token|jwt[_-]?token|token|secret|password|api[_-]?key|access[_-]?token|refresh[_-]?token|key|otp|pin|auth[_-]?code|signature|code|sid|csrf)\s*["']?\s*[=:]\s*[^&\s#'`<>]+/gi;
+
+// Provider key prefixes — Tom listed Stripe `sk_live_`, AWS `AKIA…`, Google
+// `AIza…`, GitHub `ghp_…` / `gho_…`, Slack `xox…`. The trace redactor's `sk-`
+// rule catches OpenAI-style keys but not these. Length ranges use realistic
+// key-length windows so we don't accidentally match arbitrary short tokens.
+const PROVIDER_KEY_PREFIX_PATTERN = /\b(?:sk_live_[A-Za-z0-9]{8,}|AKIA[0-9A-Z]{16}|AIza[A-Za-z0-9_-]{25,39}|gh[pousr]_[A-Za-z0-9]{20,}|xox[abp]-[A-Za-z0-9-]{10,})\b/g;
+
+// Length-range base58 wallet-key class. Tom's note: the original `\b(?:48|44)
+// [a-z0-9]{86,}` pattern assumed a real-key prefix that actual keys don't
+// guarantee. A length-only base58 (\b[a-km-zA-HJ-NP-Z1-9]{40,90}\b) catches any
+// plausible wallet key without false-positives on common prose.
+const BASE58_HEURISTIC_PATTERN = /\b[A-HJ-NP-Za-hj-np-z1-9]{40,90}\b/g;
+
+// Replace the matched secret with `[redacted]`. For name+separator+value
+// assignments (token=abc), the key and separator are kept so the structure
+// (URL param, JSON key) is preserved; for prefix-bodied keys (sk_live_…,
+// AKIA…) the whole match is replaced since the value IS the match.
+const replaceValue = (match) => {
+  const sepIndex = Math.max(match.indexOf("="), match.indexOf(":"));
+  if (sepIndex === -1) return "[redacted]";
+  const prefix = match.slice(0, sepIndex + 1);
+  const trailing = match.endsWith("\u0022") || match.endsWith("\u0027") ? match.slice(-1) : "";
+  return prefix + "[redacted]" + trailing;
+};
+const boundField = (value) => {
+  const text = String(value ?? "");
+  return text.length > MAX_FIELD_LENGTH ? `${text.slice(0, MAX_FIELD_LENGTH)}…` : text;
+};
 
 // Redact recognizable secret material from a free-text string before it is
 // persisted. Applied to the summary, tab urls, tab titles, and skip reasons.
-// Replace the value portion of a match (everything after the first `=` or `:`)
-// with `[redacted]`, preserving the key, separator, and any trailing quote so
-// JSON literals stay balanced.
-const replaceValue = (match) => {
-  const sepIndex = Math.max(match.indexOf("="), match.indexOf(":"));
-  if (sepIndex === -1) return match;
-  const prefix = match.slice(0, sepIndex + 1);
-  const trailing = match.endsWith('"') || match.endsWith("'") ? match.slice(-1) : "";
-  return prefix + "[redacted]" + trailing;
-};
-
-// Layer ordering: run the supplemental compound-name layer first so JSON-quoted
-// `client_secret` forms (which the trace redactor's alternation misses) are
-// caught, then feed the result to `redactTraceText` for the basic patterns
-// (token=, key=, secret=, password=, Bearer, sk-..., 32-byte hex, etc.).
+// Order matters: the `[REDACTED-TOKEN]` sentinel collapse MUST run BEFORE the
+// generic `REDACTED` replacement, otherwise the `[` of `[REDACTED-TOKEN]` is
+// swallowed by the generic pass and the sentinel leaks as `[[redacted]-TOKEN]`.
 export function redactSecrets(text) {
   if (typeof text !== "string") return "";
-  return redactTraceText(text.replace(COMPOUND_NAME_PATTERN, replaceValue))
-    .replace(/REDACTED/g, "[redacted]")
-    .replace(/\[REDACTED-TOKEN\]/g, "[redacted]");
+  let redacted = text;
+  for (const pattern of [PROVIDER_KEY_PREFIX_PATTERN, SUPPLEMENTAL_NAME_PATTERN, BASE58_HEURISTIC_PATTERN]) {
+    redacted = redacted.replace(pattern, replaceValue);
+  }
+  return redactTraceText(redacted)
+    .replace(/\[REDACTED-TOKEN\]/g, "[redacted]")
+    // Sentinel collapse: the trace redactor emits `REDACTED` as a value
+    // placeholder. Anchor on the left `\b` (to avoid partial matches like
+    // `REDACTED-FOO` in custom scheme names) but allow the right side to
+    // abut non-word chars (e.g. `%3D` in percent-encoded URLs, a trailing
+    // quote, or end-of-string) so the sentinel is collapsed wherever the
+    // trace redactor emitted it.
+    .replace(/\bREDACTED(?![A-Za-z0-9])/g, "[redacted]");
 }
 
 // Build a reviewable session-summary artifact. `included` and `skipped` carry
-// tab provenance only (title/url/reason), with secrets redacted before
-// persistence so query-string secrets never reach chrome.storage.local. The
-// summary is also redacted and length-bounded. No raw text, fields, or
-// controls are stored.
+// tab provenance only (title/url/reason), with secrets redacted AND
+// per-field-bounded before persistence so query-string secrets AND
+// page-controlled long titles never reach chrome.storage.local. The summary is
+// also redacted and length-bounded. No raw text, fields, or controls are stored.
 export function buildSessionSummaryArtifact({
   included = [],
   skipped = [],
@@ -56,13 +90,13 @@ export function buildSessionSummaryArtifact({
   generatedAt = new Date().toISOString()
 } = {}) {
   const cleanIncluded = (Array.isArray(included) ? included : []).map((tab) => ({
-    title: redactSecrets(String(tab?.title ?? "")),
-    url: redactSecrets(String(tab?.url ?? ""))
+    title: boundField(redactSecrets(String(tab?.title ?? ""))),
+    url: boundField(redactSecrets(String(tab?.url ?? "")))
   }));
   const cleanSkipped = (Array.isArray(skipped) ? skipped : []).map((entry) => ({
-    title: redactSecrets(String(entry?.title ?? "")),
-    url: redactSecrets(String(entry?.url ?? "")),
-    reason: redactSecrets(String(entry?.reason ?? ""))
+    title: boundField(redactSecrets(String(entry?.title ?? ""))),
+    url: boundField(redactSecrets(String(entry?.url ?? ""))),
+    reason: boundField(redactSecrets(String(entry?.reason ?? "")))
   }));
   return Object.freeze({
     kind: "session-summary",

--- a/browser-first/resonantos-side-panel-extension/src/lib/session-summary-artifact.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/session-summary-artifact.js
@@ -1,0 +1,73 @@
+// Restart-safe session summary artifact for the Augmentor (#222).
+//
+// A bounded, reviewable, deletable artifact that preserves train-of-thought
+// across an extension reload WITHOUT persisting raw page content. The artifact
+// stores only tab provenance (title/url), skip reasons, and a redacted summary;
+// raw page text, form fields, and controls are never stored. Secrets (provider
+// keys, bearer tokens, api_key/token/secret/password assignments, wallet
+// private keys) are redacted from the summary AND from tab urls, titles, and
+// skip reasons before anything is persisted, so query-string secrets never
+// land in chrome.storage.local.
+
+const SECRET_PATTERNS = [
+  /sk-[a-z0-9_-]{16,}/gi,            // provider/api keys (OpenAI-style)
+  /\bbearer\s+[a-z0-9._-]+/gi,       // bearer tokens
+  /\bapi[_-]?key\s*[:=]\s*[^&\s]+/gi,     // api_key= / apiKey: (stops at &)
+  /\btoken\s*[:=]\s*[^&\s]+/gi,          // token= (stops at &)
+  /\bsecret\s*[:=]\s*[^&\s]+/gi,         // secret= (stops at &)
+  /\bpassword\s*[:=]\s*[^&\s]+/gi,       // password= (stops at &)
+  /\b0x[a-f0-9]{64}\b/gi,            // 32-byte wallet private keys
+  /\b(?:48|44)[a-z0-9]{86,}/gi       // ed25519 secret keys (base58, 88 chars)
+];
+// Redact recognizable secret material from a free-text string before it is
+// persisted. Applied to the summary, tab urls, tab titles, and skip reasons.
+export function redactSecrets(text) {
+  let out = String(text ?? "");
+  for (const pattern of SECRET_PATTERNS) {
+    out = out.replace(pattern, "[redacted]");
+  }
+  return out;
+}
+
+// Build a reviewable session-summary artifact. `included` and `skipped` carry
+// tab provenance only (title/url/reason), with secrets redacted before
+// persistence so query-string secrets never reach chrome.storage.local. The
+// summary is also redacted and length-bounded. No raw text, fields, or
+// controls are stored.
+export function buildSessionSummaryArtifact({
+  included = [],
+  skipped = [],
+  summary = "",
+  trigger = "explicit-command",
+  generatedAt = new Date().toISOString()
+} = {}) {
+  const cleanIncluded = (Array.isArray(included) ? included : []).map((tab) => ({
+    title: redactSecrets(String(tab?.title ?? "")),
+    url: redactSecrets(String(tab?.url ?? ""))
+  }));
+  const cleanSkipped = (Array.isArray(skipped) ? skipped : []).map((entry) => ({
+    title: redactSecrets(String(entry?.title ?? "")),
+    url: redactSecrets(String(entry?.url ?? "")),
+    reason: redactSecrets(String(entry?.reason ?? ""))
+  }));
+  return Object.freeze({
+    kind: "session-summary",
+    trigger,
+    generatedAt,
+    included: cleanIncluded,
+    skipped: cleanSkipped,
+    summary: redactSecrets(summary).slice(0, 4000)
+  });
+}
+
+// A short, reviewable context line restored from a persisted artifact on reload,
+// so the user sees prior session context was preserved (and can review/delete it).
+// Returns null when there is no valid artifact, so the caller can no-op cleanly.
+export function sessionSummaryRestoreLine(artifact) {
+  if (!artifact || artifact.kind !== "session-summary") return null;
+  const included = Array.isArray(artifact.included) ? artifact.included : [];
+  const skipped = Array.isArray(artifact.skipped) ? artifact.skipped : [];
+  const when = artifact.generatedAt || "unknown time";
+  const skippedNote = skipped.length ? `; ${skipped.length} skipped` : "";
+  return `Restored session context from ${when}: ${included.length} tab(s) included${skippedNote}. Review or delete it via /session clear.`;
+}

--- a/browser-first/resonantos-side-panel-extension/src/lib/session-summary-controller.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/session-summary-controller.js
@@ -2,9 +2,12 @@
 //
 // Pins the lifecycle trigger to an explicit command (/session) — no background
 // monitoring, no always-on personal memory (non-goal). The controller builds a
-// reviewable, deletable artifact from the open readable tabs, persists it via
-// chrome.storage.local (restart-safe), and restores a short context line on
-// hydrate so a reload preserves train-of-thought.
+// reviewable, deletable artifact from the open readable tabs in the current
+// window only (Tom's scope suggestion), persists it via chrome.storage.local
+// (restart-safe), and restores a short context line on hydrate so a reload
+// preserves train-of-thought. Storage failures are surfaced to the user via
+// `addMessage` so a quota error during /session is not a silent unhandled
+// rejection.
 
 import { buildSessionSummaryArtifact, sessionSummaryRestoreLine } from "./session-summary-artifact.js";
 import {
@@ -14,16 +17,41 @@ import {
 } from "./session-summary-store.js";
 
 export function createSessionSummaryController({ chrome, isReadableBrowserTab, addMessage, setStatus }) {
+  // Window scope: only the current window's open tabs are persisted. Tom's
+  // review flagged that `chrome.tabs.query({})` captures every open http(s)
+  // tab in the browser, so unrelated personal tabs in other windows would
+  // have their title/URL persisted merely for being open. Capping at the
+  // current window matches the user's mental model of "this session".
   const resolveOpenTabs = async () => {
-    const tabs = (await chrome.tabs.query({}).catch(() => [])).filter(isReadableBrowserTab);
+    const tabs = (await chrome.tabs.query({ currentWindow: true }).catch(() => [])).filter(isReadableBrowserTab);
     return tabs.slice(0, 12).map((tab) => ({ title: tab.title ?? "", url: tab.url ?? "" }));
+  };
+
+  // Storage try/catch helper. Wraps save/clear/load so a quota error or
+  // unreachable storage surfaces as a user-visible message instead of an
+  // unhandled rejection. The controller thread always returns an
+  // `{ok, ...}` shape so the caller can test the outcome.
+  const safeStorage = async (op, label) => {
+    try {
+      const result = await op();
+      return { ok: true, result };
+    } catch (error) {
+      const message = String(error?.message ?? error ?? "unknown storage error");
+      await addMessage("system", `Session summary ${label} failed: ${message}. The artifact may not survive a reload.`);
+      return { ok: false, error };
+    }
   };
 
   const runSessionCommand = async (body = "") => {
     const sub = String(body ?? "").trim().toLowerCase();
 
     if (sub === "clear" || sub === "delete") {
-      const removed = await deleteSessionSummaryArtifact(chrome);
+      const { ok, result } = await safeStorage(() => deleteSessionSummaryArtifact(chrome), "deletion");
+      if (!ok) {
+        setStatus?.("Session summary deletion failed");
+        return { ok: false, deleted: false };
+      }
+      const removed = result;
       await addMessage("system", removed ? "Session summary deleted. It will not reappear after reload." : "No session summary was stored to delete.");
       setStatus?.(removed ? "Session summary cleared" : "No session summary");
       return { ok: true, deleted: removed };
@@ -32,14 +60,19 @@ export function createSessionSummaryController({ chrome, isReadableBrowserTab, a
     // Default (and "summary"): build + persist the artifact now.
     const included = await resolveOpenTabs();
     const artifact = buildSessionSummaryArtifact({ included, skipped: [], summary: "", trigger: "explicit-command" });
-    await saveSessionSummaryArtifact(chrome, artifact);
+    const { ok } = await safeStorage(() => saveSessionSummaryArtifact(chrome, artifact), "save");
+    if (!ok) {
+      setStatus?.("Session summary save failed");
+      return { ok: false, artifact };
+    }
     await addMessage("system", `Session summary saved (${artifact.included.length} tab(s)). It is reviewable and survives reload; clear it with /session clear.`);
     setStatus?.("Session summary saved");
     return { ok: true, artifact };
   };
 
   const restoreSessionContext = async () => {
-    const artifact = await loadSessionSummaryArtifact(chrome);
+    const { ok, result } = await safeStorage(() => loadSessionSummaryArtifact(chrome), "load");
+    const artifact = ok ? result : null;
     const line = sessionSummaryRestoreLine(artifact);
     if (line) await addMessage("system", line);
     return artifact;

--- a/browser-first/resonantos-side-panel-extension/src/lib/session-summary-controller.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/session-summary-controller.js
@@ -1,0 +1,49 @@
+// Session-summary controller for the Augmentor (#222).
+//
+// Pins the lifecycle trigger to an explicit command (/session) — no background
+// monitoring, no always-on personal memory (non-goal). The controller builds a
+// reviewable, deletable artifact from the open readable tabs, persists it via
+// chrome.storage.local (restart-safe), and restores a short context line on
+// hydrate so a reload preserves train-of-thought.
+
+import { buildSessionSummaryArtifact, sessionSummaryRestoreLine } from "./session-summary-artifact.js";
+import {
+  deleteSessionSummaryArtifact,
+  loadSessionSummaryArtifact,
+  saveSessionSummaryArtifact
+} from "./session-summary-store.js";
+
+export function createSessionSummaryController({ chrome, isReadableBrowserTab, addMessage, setStatus }) {
+  const resolveOpenTabs = async () => {
+    const tabs = (await chrome.tabs.query({}).catch(() => [])).filter(isReadableBrowserTab);
+    return tabs.slice(0, 12).map((tab) => ({ title: tab.title ?? "", url: tab.url ?? "" }));
+  };
+
+  const runSessionCommand = async (body = "") => {
+    const sub = String(body ?? "").trim().toLowerCase();
+
+    if (sub === "clear" || sub === "delete") {
+      const removed = await deleteSessionSummaryArtifact(chrome);
+      await addMessage("system", removed ? "Session summary deleted. It will not reappear after reload." : "No session summary was stored to delete.");
+      setStatus?.(removed ? "Session summary cleared" : "No session summary");
+      return { ok: true, deleted: removed };
+    }
+
+    // Default (and "summary"): build + persist the artifact now.
+    const included = await resolveOpenTabs();
+    const artifact = buildSessionSummaryArtifact({ included, skipped: [], summary: "", trigger: "explicit-command" });
+    await saveSessionSummaryArtifact(chrome, artifact);
+    await addMessage("system", `Session summary saved (${artifact.included.length} tab(s)). It is reviewable and survives reload; clear it with /session clear.`);
+    setStatus?.("Session summary saved");
+    return { ok: true, artifact };
+  };
+
+  const restoreSessionContext = async () => {
+    const artifact = await loadSessionSummaryArtifact(chrome);
+    const line = sessionSummaryRestoreLine(artifact);
+    if (line) await addMessage("system", line);
+    return artifact;
+  };
+
+  return { runSessionCommand, restoreSessionContext };
+}

--- a/browser-first/resonantos-side-panel-extension/src/lib/session-summary-store.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/session-summary-store.js
@@ -1,0 +1,26 @@
+// Restart-safe persistence for the Augmentor session-summary artifact (#222).
+//
+// Uses chrome.storage.local so the artifact survives an extension reload; the
+// storage is the source of truth, so deletion is honored on restart. The
+// artifact is redacted by session-summary-artifact.js before it reaches here.
+
+export const SESSION_SUMMARY_ARTIFACT_KEY = "augmentorSessionSummaryArtifact";
+
+export async function saveSessionSummaryArtifact(chrome, artifact) {
+  if (!chrome?.storage?.local?.set) return false;
+  await chrome.storage.local.set({ [SESSION_SUMMARY_ARTIFACT_KEY]: artifact });
+  return true;
+}
+
+export async function loadSessionSummaryArtifact(chrome) {
+  if (!chrome?.storage?.local?.get) return null;
+  const result = await chrome.storage.local.get(SESSION_SUMMARY_ARTIFACT_KEY);
+  const artifact = result?.[SESSION_SUMMARY_ARTIFACT_KEY];
+  return artifact && artifact.kind === "session-summary" ? artifact : null;
+}
+
+export async function deleteSessionSummaryArtifact(chrome) {
+  if (!chrome?.storage?.local?.remove) return false;
+  await chrome.storage.local.remove(SESSION_SUMMARY_ARTIFACT_KEY);
+  return true;
+}

--- a/browser-first/resonantos-side-panel-extension/src/lib/side-panel-command-router.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/side-panel-command-router.js
@@ -65,6 +65,7 @@ export function createSidePanelCommandRouter(handlers) {
       if (name === "control") return handlers.runControlCommand(body);
       if (name === "save" || name === "archive" || name === "intake") return handlers.saveIntake(body);
       if (name === "trail" || name === "researchtrail") return handlers.saveIntake(`trail ${body}`.trim());
+      if (name === "session") return handlers.runSessionCommand(body);
       if (name === "dao" && /^audit\b/i.test(body)) {
         return handlers.saveWalletDaoAuditToArchive(body.replace(/^audit\b/i, "").trim());
       }

--- a/browser-first/resonantos-side-panel-extension/src/side-panel.js
+++ b/browser-first/resonantos-side-panel-extension/src/side-panel.js
@@ -54,6 +54,7 @@ import { createSidePanelUiController } from "./lib/side-panel-ui-controller.js";
 import { readPersonalizationSettings } from "./lib/personalization-settings.js";
 import { createSitePermissionStore } from "./lib/site-permission-store.js";
 import { createTabContextController } from "./lib/tab-context-controller.js";
+import { createSessionSummaryController } from "./lib/session-summary-controller.js";
 import { createTaskConsentStore } from "./lib/task-consent-store.js";
 
 const {
@@ -734,6 +735,13 @@ const tabContextController = createTabContextController({
 });
 const bindMentionedTab = tabContextController.bindMentionedTab;
 const resolveComparisonContext = tabContextController.resolveComparisonContext;
+const sessionSummaryController = createSessionSummaryController({
+  chrome,
+  isReadableBrowserTab,
+  addMessage,
+  setStatus
+});
+const runSessionCommand = sessionSummaryController.runSessionCommand;
 
 const controlPlanningService = createControlPlanningService({
   bridgeRequest: currentBridgeRequest,
@@ -1130,6 +1138,7 @@ const commandRouter = createSidePanelCommandRouter({
   allowControlPreflightOnceForTaskClass,
   bindMentionedTab,
   resolveComparisonContext,
+  runSessionCommand,
   clickActivePageText,
   detectActivePageForms,
   explainStructuredPageEditBoundary,
@@ -1297,6 +1306,7 @@ hydrateChatSettings().then(async () => {
   chatsTreeRenderer.render();
   await loadBrowserJobs();
   await tabContextController.hydrateInitialContext();
+  await sessionSummaryController.restoreSessionContext();
   await consumePendingSidebarPrompt();
 }).catch((error) => {
   setStatus("Context failed");

--- a/browser-first/test/session-summary-artifact.test.mjs
+++ b/browser-first/test/session-summary-artifact.test.mjs
@@ -36,35 +36,61 @@ test("buildSessionSummaryArtifact never persists raw page content (no text/field
   assert.equal("text" in artifact, false, "no raw page text on the artifact");
 });
 
-test("redactSecrets strips provider keys, tokens, api_key/token/secret/password, and wallet private keys", () => {
-  assert.equal(redactSecrets("key is sk-testtesttesttesttesttest here"), "key is [redacted] here");
-  assert.equal(redactSecrets("auth: bearer abc.def-ghi"), "auth: [redacted]");
-  assert.match(redactSecrets("api_key=abc123 secret=xyz token=t1 password=p1"), /\[redacted\].*\[redacted\].*\[redacted\].*\[redacted\]/);
-  assert.equal(redactSecrets("wallet 0x" + "a".repeat(64)), "wallet [redacted]");
-  // Non-secret text is preserved.
+test("redactSecrets redacts Authorization Bearer tokens", () => {
+  assert.equal(redactSecrets("Authorization: Bearer abc.def-ghi"), "Authorization: [redacted]");
   assert.equal(redactSecrets("plain notes with no secrets"), "plain notes with no secrets");
   assert.equal(redactSecrets(undefined), "");
 });
 
-test("buildSessionSummaryArtifact redacts secrets embedded in the summary before persistence", () => {
-  const artifact = buildSessionSummaryArtifact({ summary: "leaked sk-testtesttesttesttesttest key" });
-  assert.match(artifact.summary, /\[redacted\]/);
-  assert.equal(artifact.summary.includes("sk-testtesttesttesttesttest"), false);
+test("redactSecrets redacts simple URL parameter secrets (token/key/secret/password)", () => {
+  // These are in the trace-redaction alternation and are the core blocker
+  // resolution for #309. They produce the canonical REDACTED -> [redacted]
+  // mapping for the value while preserving the rest of the URL structure.
+  assert.equal(redactSecrets("https://idp/?token=ABC123XYZ"), "https://idp/?token=[redacted]");
+  assert.equal(redactSecrets("https://idp/?key=ABC123XYZ"), "https://idp/?key=[redacted]");
+  assert.equal(redactSecrets("https://idp/?secret=ABC123XYZ"), "https://idp/?secret=[redacted]");
+  assert.equal(redactSecrets("https://idp/?password=ABC123XYZ"), "https://idp/?password=[redacted]");
+  assert.equal(redactSecrets("https://idp/?api_key=ABC123XYZ&v=1"), "https://idp/?api_key=[redacted]&v=1");
+  assert.equal(redactSecrets("https://idp/?access_token=ABC123XYZ"), "https://idp/?access_token=[redacted]");
+  assert.equal(redactSecrets("https://idp/?refresh_token=ABC123XYZ"), "https://idp/?refresh_token=[redacted]");
 });
 
-test("buildSessionSummaryArtifact redacts query-string secrets in tab urls and titles before persistence", () => {
+test("redactSecrets redacts compound-name URL params the trace redactor missed (the blocker)", () => {
+  // Tom's review flagged these: the trace redactor's alternation does not
+  // include client_secret / client_id / csrf_token / jwt_token / session_*. The
+  // supplemental compound-name layer in session-summary-artifact catches them.
+  assert.equal(redactSecrets("https://idp/?client_secret=ABC123XYZ"), "https://idp/?client_secret=[redacted]");
+  assert.equal(redactSecrets("https://idp/?client_id=ABC123XYZ"), "https://idp/?client_id=[redacted]");
+  assert.equal(redactSecrets("https://idp/?csrf_token=ABC123XYZ"), "https://idp/?csrf_token=[redacted]");
+  assert.equal(redactSecrets("https://idp/?jwt_token=ABC123XYZ"), "https://idp/?jwt_token=[redacted]");
+  assert.equal(redactSecrets("https://idp/?session_id=ABC123XYZ"), "https://idp/?session_id=[redacted]");
+});
+
+test("redactSecrets redacts JSON-quoted compound-name secrets", () => {
+  // The supplemental pattern allows an optional `"` between the key and the
+  // separator so JSON literals like `{"client_secret":"abc"}` are also caught.
+  const out = redactSecrets('body={"client_secret":"abc123def456"}');
+  assert.equal(out.includes("abc123def456"), false);
+  assert.match(out, /client_secret.{0,3}\[redacted\]/);
+});
+
+test("redactSecrets redacts URL-param form of multi-vendor provider keys", () => {
+  assert.equal(redactSecrets("https://api/?key=AIzaSyA-EXAMPLE-key-1234567890"), "https://api/?key=[redacted]");
+});
+
+test("buildSessionSummaryArtifact redacts URL parameter secrets in tab urls and titles", () => {
   const artifact = buildSessionSummaryArtifact({
-    included: [{ title: "Doc api_key=LEAKED_TITLE", url: "https://x.test/p?token=sk-testtesttesttesttesttest&foo=bar" }],
-    skipped: [{ title: "T", url: "https://y.test/?api_key=TESTKEYZ&v=1", reason: "redirect with password=testpassword0" }]
+    included: [
+      { title: "OAuth", url: "https://idp.example/?access_token=ABC123XYZ&scope=read" },
+      { title: "Doc", url: "https://x.test/p?client_secret=ABC123XYZ&v=1" }
+    ],
+    skipped: [{ title: "T", url: "https://y.test/?v=1" }]
   });
-  assert.equal(artifact.included[0].url.includes("sk-testtesttesttesttesttest"), false);
-  assert.equal(artifact.included[0].url.includes("token="), false);
-  assert.equal(artifact.included[0].url.includes("foo=bar"), true);
-  assert.equal(artifact.included[0].title.includes("LEAKED_TITLE"), false);
-  assert.equal(artifact.included[0].title.includes("[redacted]"), true);
-  assert.equal(artifact.skipped[0].url.includes("api_key="), false);
+  assert.equal(artifact.included[0].url.includes("ABC123XYZ"), false);
+  assert.equal(artifact.included[0].url.includes("scope=read"), true);
+  assert.equal(artifact.included[1].url.includes("ABC123XYZ"), false);
+  assert.equal(artifact.included[1].url.includes("v=1"), true);
   assert.equal(artifact.skipped[0].url.includes("v=1"), true);
-  assert.equal(artifact.skipped[0].reason.includes("testpassword0"), false);
 });
 
 test("buildSessionSummaryArtifact is deterministic for identical input (modulo generatedAt)", () => {

--- a/browser-first/test/session-summary-artifact.test.mjs
+++ b/browser-first/test/session-summary-artifact.test.mjs
@@ -112,3 +112,90 @@ test("sessionSummaryRestoreLine returns null for a missing or invalid artifact",
   assert.equal(sessionSummaryRestoreLine({ kind: "other" }), null);
   assert.equal(sessionSummaryRestoreLine({}), null);
 });
+
+test("redactSecrets redacts JSON-quoted BARE secret names (not just compound)", () => {
+  // Tom's major #2: `"` between name and `:` defeats the trace redactor's
+  // ASSIGNMENT_PATTERN. The supplemental pattern must catch bare `token`,
+  // `csrf`, `secret`, `key`, `password` in JSON literals.
+  assert.equal(redactSecrets('{"token":"abc123def456"}').includes("abc123"), false);
+  assert.equal(redactSecrets('{"csrf":"abc123def456"}').includes("abc123"), false);
+  assert.equal(redactSecrets('{"api_key":"abc123def456"}').includes("abc123"), false);
+  assert.equal(redactSecrets('{"secret":"abc123def456"}').includes("abc123"), false);
+  assert.equal(redactSecrets('{"password":"abc123def456"}').includes("abc123"), false);
+  assert.equal(redactSecrets('{"refresh_token":"abc123def456"}').includes("abc123"), false);
+});
+
+test("redactSecrets redacts multi-vendor provider keys in bare form (Tom's major #1)", () => {
+  // Tom's list: Stripe sk_live_, AWS AKIA…, Google AIza…, GitHub ghp_…,
+  // Slack xox… — none of these are caught by the trace redactor's sk- rule.
+  // All provider keys are constructed at runtime so the literals do not
+  // trigger the credential scanner in repo:hygiene.
+  const awsKey = "AKIA" + "IOSFODNN7".padEnd(16, "X");
+  const fijiKey = "AIza" + "SyA-EXAMPLE-key-12345".padEnd(25, "6");
+  const ghKey = "ghp_" + "1234567890".padEnd(20, "a") + "bbbbbbbb";
+  const slackKey = "xoxb-" + "1234567890".padEnd(10, "1") + "-EXAMPLE-token";
+  assert.equal(redactSecrets("sk_live_ABCDEFGHIJ1234567890"), "[redacted]");
+  assert.equal(redactSecrets(awsKey), "[redacted]");
+  assert.equal(redactSecrets(fijiKey), "[redacted]");
+  assert.equal(redactSecrets(ghKey), "[redacted]");
+  assert.equal(redactSecrets(slackKey).includes(slackKey), false);
+});
+
+test("redactSecrets redacts percent-encoded URL params", () => {
+  // Tom's review: percent-encoded %3D/%3F/%26 separators inside a nested URL
+  // would leak the trace redactor's plain regex. The trace redactor handles
+  // this; verify the artifact-level pipeline still collapses the value to
+  // `[redacted]` (or the unconverted `REDACTED` placeholder) rather than
+  // leaking the secret fragment.
+  const out = redactSecrets("https://x.com/?next=https%3A%2F%2Fb.com%2F%3Ftoken%3Dabc123def456");
+  assert.equal(out.includes("abc123"), false, "secret value not leaked");
+  assert.match(out, /token(?:=|:|%3D)(?:\[redacted\]|REDACTED)/);
+});
+
+test("redactSecrets redacts length-range base58 wallet keys", () => {
+  // Tom's note: the original `\b(?:48|44)[a-z0-9]{86,}` pattern assumed a
+  // realistic prefix that real keys don't guarantee. Use a length-range
+  // heuristic: 40-90 character base58 — a plausible wallet-key window.
+  const walletKey = "5J3mBbAH58CpQ3Y5RNJpUKPE62Q5ttcFYjmwVdeC9YXSECYPeUm";
+  assert.equal(redactSecrets(walletKey), "[redacted]");
+  assert.equal(redactSecrets(`Solana key: ${walletKey}`).includes(walletKey), false);
+});
+
+test("redactSecrets redacts 32+ hex tokens (the [REDACTED-TOKEN] sentinel collapses cleanly)", () => {
+  // The trace redactor emits `[REDACTED-TOKEN]` for 32+ hex matches. The
+  // artifact-level pipeline must collapse this to `[redacted]` without
+  // leaving the sentinel's `]` corner-case exposed.
+  const out = redactSecrets("deadbeefdeadbeefdeadbeefdeadbeef");
+  assert.equal(out, "[redacted]");
+  const out2 = redactSecrets("Note: see token deadbeefdeadbeefdeadbeefdeadbeef in doc");
+  assert.equal(out2.includes("deadbeef"), false);
+  assert.equal(out2.includes("[[redacted]"), false, "no double-bracket leak");
+  assert.match(out2, /token \[redacted\]/);
+});
+
+test("buildSessionSummaryArtifact bounds per-tab title/url/reason to 300 chars (Tom's major #3)", () => {
+  // A page-controlled `document.title` can be arbitrarily long and would
+  // otherwise fill the bounded artifact. Each field is capped with an
+  // ellipsis so the artifact remains reviewable. The filler is a mix of
+  // letters and spaces so the trace redactor's 32+ hex/word heuristics
+  // don't collapse the title into a token replacement.
+  const filler = "Long title: " + "lorem ipsum dolor sit amet, consectetur adipiscing elit. ".repeat(20);
+  const longUrl = "https://x.com/" + "very-long-url-segment/".repeat(40);
+  const longReason = "Reason: " + "this is a long skip reason explaining why tab was not included. ".repeat(20);
+  const artifact = buildSessionSummaryArtifact({
+    included: [{ title: filler, url: longUrl }],
+    skipped: [{ title: filler, url: longUrl, reason: longReason }]
+  });
+  assert.ok(artifact.included[0].title.length <= 301, "title capped at 300 + ellipsis");
+  assert.match(artifact.included[0].title, /…$/, "ellipsis appended");
+  assert.ok(artifact.included[0].url.length <= 301, "url capped at 300 + ellipsis");
+  assert.ok(artifact.skipped[0].reason.length <= 301, "reason capped at 300 + ellipsis");
+});
+
+test("buildSessionSummaryArtifact does not double-redact when secrets already present in tab url", () => {
+  // The redaction should be a single pass; the value is gone after a build
+  // and a subsequent rebuild sees the same redacted value.
+  const a = buildSessionSummaryArtifact({ included: [{ title: "T", url: "https://x.com/?token=abc123def456" }] });
+  const b = buildSessionSummaryArtifact({ included: [{ title: "T", url: a.included[0].url }] });
+  assert.equal(b.included[0].url, a.included[0].url, "stable idempotent redaction");
+});

--- a/browser-first/test/session-summary-artifact.test.mjs
+++ b/browser-first/test/session-summary-artifact.test.mjs
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildSessionSummaryArtifact,
+  redactSecrets,
+  sessionSummaryRestoreLine
+} from "../resonantos-side-panel-extension/src/lib/session-summary-artifact.js";
+
+const included = [
+  { id: 1, title: "Alpha", url: "https://alpha.test/", text: "raw page text", controls: [{}, {}], fields: [{ value: "secret" }] },
+  { id: 2, title: "Beta", url: "https://beta.test/", text: "more raw text", fields: [{ value: "pw" }] }
+];
+const skipped = [{ title: "Internal", url: "chrome://settings/", reason: "not a readable web page" }];
+
+test("buildSessionSummaryArtifact lists included and skipped tabs with provenance only", () => {
+  const artifact = buildSessionSummaryArtifact({ included, skipped, summary: "notes" });
+
+  assert.equal(artifact.kind, "session-summary");
+  assert.equal(artifact.trigger, "explicit-command");
+  assert.equal(artifact.included.length, 2);
+  assert.equal(artifact.included[0].title, "Alpha");
+  assert.equal(artifact.included[0].url, "https://alpha.test/");
+  assert.equal(artifact.skipped.length, 1);
+  assert.equal(artifact.skipped[0].reason, "not a readable web page");
+  assert.equal(artifact.skipped[0].url, "chrome://settings/");
+});
+
+test("buildSessionSummaryArtifact never persists raw page content (no text/fields/controls)", () => {
+  const artifact = buildSessionSummaryArtifact({ included, summary: "notes" });
+  for (const tab of artifact.included) {
+    assert.equal("text" in tab, false, "no raw text stored");
+    assert.equal("controls" in tab, false, "no controls stored");
+    assert.equal("fields" in tab, false, "no form fields stored");
+  }
+  assert.equal("text" in artifact, false, "no raw page text on the artifact");
+});
+
+test("redactSecrets strips provider keys, tokens, api_key/token/secret/password, and wallet private keys", () => {
+  assert.equal(redactSecrets("key is sk-testtesttesttesttesttest here"), "key is [redacted] here");
+  assert.equal(redactSecrets("auth: bearer abc.def-ghi"), "auth: [redacted]");
+  assert.match(redactSecrets("api_key=abc123 secret=xyz token=t1 password=p1"), /\[redacted\].*\[redacted\].*\[redacted\].*\[redacted\]/);
+  assert.equal(redactSecrets("wallet 0x" + "a".repeat(64)), "wallet [redacted]");
+  // Non-secret text is preserved.
+  assert.equal(redactSecrets("plain notes with no secrets"), "plain notes with no secrets");
+  assert.equal(redactSecrets(undefined), "");
+});
+
+test("buildSessionSummaryArtifact redacts secrets embedded in the summary before persistence", () => {
+  const artifact = buildSessionSummaryArtifact({ summary: "leaked sk-testtesttesttesttesttest key" });
+  assert.match(artifact.summary, /\[redacted\]/);
+  assert.equal(artifact.summary.includes("sk-testtesttesttesttesttest"), false);
+});
+
+test("buildSessionSummaryArtifact redacts query-string secrets in tab urls and titles before persistence", () => {
+  const artifact = buildSessionSummaryArtifact({
+    included: [{ title: "Doc api_key=LEAKED_TITLE", url: "https://x.test/p?token=sk-testtesttesttesttesttest&foo=bar" }],
+    skipped: [{ title: "T", url: "https://y.test/?api_key=TESTKEYZ&v=1", reason: "redirect with password=testpassword0" }]
+  });
+  assert.equal(artifact.included[0].url.includes("sk-testtesttesttesttesttest"), false);
+  assert.equal(artifact.included[0].url.includes("token="), false);
+  assert.equal(artifact.included[0].url.includes("foo=bar"), true);
+  assert.equal(artifact.included[0].title.includes("LEAKED_TITLE"), false);
+  assert.equal(artifact.included[0].title.includes("[redacted]"), true);
+  assert.equal(artifact.skipped[0].url.includes("api_key="), false);
+  assert.equal(artifact.skipped[0].url.includes("v=1"), true);
+  assert.equal(artifact.skipped[0].reason.includes("testpassword0"), false);
+});
+
+test("buildSessionSummaryArtifact is deterministic for identical input (modulo generatedAt)", () => {
+  const a = buildSessionSummaryArtifact({ included, skipped, summary: "x", generatedAt: "T1" });
+  const b = buildSessionSummaryArtifact({ included, skipped, summary: "x", generatedAt: "T1" });
+  assert.deepEqual(a, b);
+});
+
+test("sessionSummaryRestoreLine restores a short context line from a valid artifact", () => {
+  const artifact = buildSessionSummaryArtifact({ included, skipped, generatedAt: "2026-08-19T12:00:00.000Z" });
+  const line = sessionSummaryRestoreLine(artifact);
+  assert.match(line, /Restored session context from 2026-08-19T12:00:00.000Z/);
+  assert.match(line, /2 tab\(s\) included/);
+  assert.match(line, /1 skipped/);
+});
+
+test("sessionSummaryRestoreLine returns null for a missing or invalid artifact", () => {
+  assert.equal(sessionSummaryRestoreLine(null), null);
+  assert.equal(sessionSummaryRestoreLine({ kind: "other" }), null);
+  assert.equal(sessionSummaryRestoreLine({}), null);
+});

--- a/browser-first/test/session-summary-controller.test.mjs
+++ b/browser-first/test/session-summary-controller.test.mjs
@@ -87,3 +87,70 @@ test("session summary controller deletes the artifact on /session clear and the 
   // Deletion honored across a reload (storage is the source of truth).
   assert.equal(await loadSessionSummaryArtifact(harness.chrome), null);
 });
+
+test("session summary controller queries the current window only (Tom's scope)", async () => {
+  // Tom's review: `chrome.tabs.query({})` captures every open http(s) tab in
+  // the browser, persisting unrelated personal tabs. The fix scopes to
+  // `currentWindow: true` so other windows' tabs are never captured.
+  const queryArgs = [];
+  const events = [];
+  const store = new Map();
+  const chrome = {
+    tabs: {
+      query: async (filter) => {
+        queryArgs.push(filter);
+        return [{ id: 1, title: "Alpha", url: "https://alpha.test/" }];
+      }
+    },
+    storage: {
+      local: {
+        get: async (key) => store.has(key) ? { [key]: store.get(key) } : {},
+        set: async (patch) => { for (const [k, v] of Object.entries(patch)) store.set(k, v); },
+        remove: async (key) => { store.delete(key); }
+      }
+    }
+  };
+  const controller = createSessionSummaryController({
+    chrome,
+    isReadableBrowserTab: (tab) => /^https?:\/\//i.test(String(tab?.url ?? "")),
+    addMessage: async (role, content) => events.push(["message", role, content]),
+    setStatus: () => {}
+  });
+  await controller.runSessionCommand("summary");
+  assert.equal(queryArgs.length, 1);
+  assert.equal(queryArgs[0].currentWindow, true, "currentWindow: true scoping applied");
+});
+
+test("session summary controller surfaces save failures as a user-visible message (Tom's major #4)", async () => {
+  const events = [];
+  const chrome = {
+    tabs: {
+      query: async () => [{ id: 1, title: "Alpha", url: "https://alpha.test/" }]
+    },
+    storage: {
+      local: {
+        get: async () => { throw new Error("quota exceeded"); },
+        set: async () => { throw new Error("quota exceeded"); },
+        remove: async () => { throw new Error("quota exceeded"); }
+      }
+    }
+  };
+  const controller = createSessionSummaryController({
+    chrome,
+    isReadableBrowserTab: (tab) => /^https?:\/\//i.test(String(tab?.url ?? "")),
+    addMessage: async (role, content) => events.push(["message", role, content]),
+    setStatus: () => {}
+  });
+
+  const saveResult = await controller.runSessionCommand("summary");
+  assert.equal(saveResult.ok, false, "save returns ok:false on storage failure");
+  assert.ok(events.some((e) => e[0] === "message" && /Session summary save failed/.test(e[2]) && /quota exceeded/.test(e[2])));
+
+  const restoreResult = await controller.restoreSessionContext();
+  assert.equal(restoreResult, null, "restore returns null on storage failure");
+  assert.ok(events.some((e) => e[0] === "message" && /Session summary load failed/.test(e[2])));
+
+  const clearResult = await controller.runSessionCommand("clear");
+  assert.equal(clearResult.ok, false, "clear returns ok:false on storage failure");
+  assert.ok(events.some((e) => e[0] === "message" && /Session summary deletion failed/.test(e[2])));
+});

--- a/browser-first/test/session-summary-controller.test.mjs
+++ b/browser-first/test/session-summary-controller.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createSessionSummaryController } from "../resonantos-side-panel-extension/src/lib/session-summary-controller.js";
+import { loadSessionSummaryArtifact } from "../resonantos-side-panel-extension/src/lib/session-summary-store.js";
+
+function createHarness(overrides = {}) {
+  const events = [];
+  const store = new Map();
+  const tabs = overrides.tabs ?? [
+    { id: 1, title: "Alpha", url: "https://alpha.test/" },
+    { id: 2, title: "Beta", url: "https://beta.test/" },
+    { id: 3, title: "Internal", url: "chrome://settings/" }
+  ];
+  const chrome = {
+    tabs: {
+      query: async () => tabs
+    },
+    storage: {
+      local: {
+        get: async (key) => store.has(key) ? { [key]: store.get(key) } : {},
+        set: async (patch) => { for (const [k, v] of Object.entries(patch)) store.set(k, v); },
+        remove: async (key) => { store.delete(key); }
+      }
+    }
+  };
+  const controller = createSessionSummaryController({
+    chrome,
+    isReadableBrowserTab: (tab) => /^https?:\/\//i.test(String(tab?.url ?? "")),
+    addMessage: async (role, content) => events.push(["message", role, content]),
+    setStatus: (status) => events.push(["status", status])
+  });
+  return { controller, events, chrome };
+}
+
+test("session summary controller saves a reviewable artifact from the open readable tabs on /session", async () => {
+  const harness = createHarness();
+
+  const result = await harness.controller.runSessionCommand("summary");
+
+  assert.equal(result.ok, true);
+  assert.equal(result.artifact.kind, "session-summary");
+  assert.equal(result.artifact.included.length, 2, "only readable tabs are included");
+  assert.equal(result.artifact.included[0].title, "Alpha");
+  assert.equal(result.artifact.included[1].url, "https://beta.test/");
+  assert.equal(result.artifact.included.some((t) => "text" in t), false, "no raw page content persisted");
+  assert.ok(harness.events.some((e) => e[0] === "message" && /Session summary saved \(2 tab/.test(e[2])));
+  assert.ok(harness.events.some((e) => e[0] === "status" && e[1] === "Session summary saved"));
+});
+
+test("session summary controller persists the artifact across a simulated reload", async () => {
+  const harness = createHarness();
+  await harness.controller.runSessionCommand("");
+
+  // A fresh load (simulating an extension reload) restores the artifact.
+  const restored = await loadSessionSummaryArtifact(harness.chrome);
+  assert.equal(restored.kind, "session-summary");
+  assert.equal(restored.included.length, 2);
+  assert.equal(restored.trigger, "explicit-command");
+});
+
+test("session summary controller restores a context line on hydrate when an artifact exists", async () => {
+  const harness = createHarness();
+  await harness.controller.runSessionCommand("summary");
+
+  const artifact = await harness.controller.restoreSessionContext();
+  assert.equal(artifact.kind, "session-summary");
+  assert.ok(harness.events.some((e) => e[0] === "message" && /Restored session context/.test(e[2]) && /2 tab/.test(e[2])));
+});
+
+test("session summary controller does not post a restore line when no artifact exists", async () => {
+  const harness = createHarness();
+  const artifact = await harness.controller.restoreSessionContext();
+  assert.equal(artifact, null);
+  assert.equal(harness.events.some((e) => e[0] === "message" && /Restored session context/.test(e[2])), false);
+});
+
+test("session summary controller deletes the artifact on /session clear and the deletion survives a reload", async () => {
+  const harness = createHarness();
+  await harness.controller.runSessionCommand("summary");
+  assert.ok(await loadSessionSummaryArtifact(harness.chrome));
+
+  const result = await harness.controller.runSessionCommand("clear");
+  assert.equal(result.ok, true);
+  assert.equal(result.deleted, true);
+  assert.ok(harness.events.some((e) => e[0] === "message" && /Session summary deleted/.test(e[2]) && /will not reappear after reload/.test(e[2])));
+  // Deletion honored across a reload (storage is the source of truth).
+  assert.equal(await loadSessionSummaryArtifact(harness.chrome), null);
+});

--- a/browser-first/test/session-summary-store.test.mjs
+++ b/browser-first/test/session-summary-store.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  SESSION_SUMMARY_ARTIFACT_KEY,
+  deleteSessionSummaryArtifact,
+  loadSessionSummaryArtifact,
+  saveSessionSummaryArtifact
+} from "../resonantos-side-panel-extension/src/lib/session-summary-store.js";
+import { buildSessionSummaryArtifact } from "../resonantos-side-panel-extension/src/lib/session-summary-artifact.js";
+
+// A chrome.storage.local mock backed by an in-memory map (the real API persists
+// across reloads; this mock proves the round-trip + deletion contract).
+function createChromeMock() {
+  const store = new Map();
+  return {
+    storage: {
+      local: {
+        async get(key) {
+          return store.has(key) ? { [key]: store.get(key) } : {};
+        },
+        async set(patch) {
+          for (const [key, value] of Object.entries(patch)) store.set(key, value);
+        },
+        async remove(key) {
+          store.delete(key);
+        }
+      }
+    },
+    _store: store
+  };
+}
+
+test("saveSessionSummaryArtifact persists the artifact under the canonical key", async () => {
+  const chrome = createChromeMock();
+  const artifact = buildSessionSummaryArtifact({ included: [{ title: "A", url: "https://a.test/" }], summary: "notes" });
+
+  const saved = await saveSessionSummaryArtifact(chrome, artifact);
+  assert.equal(saved, true);
+  assert.ok(chrome._store.has(SESSION_SUMMARY_ARTIFACT_KEY));
+});
+
+test("loadSessionSummaryArtifact restores a saved artifact (restart round-trip)", async () => {
+  const chrome = createChromeMock();
+  const artifact = buildSessionSummaryArtifact({
+    included: [{ title: "Alpha", url: "https://alpha.test/" }, { title: "Beta", url: "https://beta.test/" }],
+    skipped: [{ title: "Internal", url: "chrome://settings/", reason: "not a readable web page" }],
+    summary: "session notes",
+    generatedAt: "2026-08-19T12:00:00.000Z"
+  });
+  await saveSessionSummaryArtifact(chrome, artifact);
+
+  // A fresh load (simulating an extension reload) restores the same artifact.
+  const restored = await loadSessionSummaryArtifact(chrome);
+  assert.equal(restored.kind, "session-summary");
+  assert.equal(restored.included.length, 2);
+  assert.equal(restored.skipped.length, 1);
+  assert.equal(restored.generatedAt, "2026-08-19T12:00:00.000Z");
+});
+
+test("loadSessionSummaryArtifact returns null when nothing is stored or the kind is wrong", async () => {
+  const chrome = createChromeMock();
+  assert.equal(await loadSessionSummaryArtifact(chrome), null);
+  await chrome.storage.local.set({ [SESSION_SUMMARY_ARTIFACT_KEY]: { kind: "other" } });
+  assert.equal(await loadSessionSummaryArtifact(chrome), null);
+});
+
+test("deleteSessionSummaryArtifact removes the artifact and the deletion persists across a reload", async () => {
+  const chrome = createChromeMock();
+  const artifact = buildSessionSummaryArtifact({ included: [{ title: "A", url: "https://a.test/" }] });
+  await saveSessionSummaryArtifact(chrome, artifact);
+  assert.ok(await loadSessionSummaryArtifact(chrome));
+
+  const removed = await deleteSessionSummaryArtifact(chrome);
+  assert.equal(removed, true);
+  // A fresh load (simulating restart) honors the deletion — storage is the source of truth.
+  assert.equal(await loadSessionSummaryArtifact(chrome), null);
+});
+
+test("store functions degrade safely without chrome.storage.local", async () => {
+  assert.equal(await saveSessionSummaryArtifact({}, {}), false);
+  assert.equal(await loadSessionSummaryArtifact({}), null);
+  assert.equal(await deleteSessionSummaryArtifact({}), false);
+});

--- a/browser-first/test/side-panel-command-router.test.mjs
+++ b/browser-first/test/side-panel-command-router.test.mjs
@@ -49,7 +49,8 @@ function createHarness({ resumableControlRun = false } = {}) {
     searchBrowser: handler("search"),
     summarizeActivePage: handler("summarize-page"),
     summarizeSnapshot: handler("summary"),
-    typeIntoActivePage: handler("type")
+    typeIntoActivePage: handler("type"),
+    runSessionCommand: handler("session"),
   });
   return { calls, router };
 }
@@ -71,6 +72,9 @@ test("side panel command router dispatches slash commands", async () => {
   await harness.router.respondToCommand("/calendar Planning | body: Draft the event");
   await harness.router.respondToCommand("/save selection");
   await harness.router.respondToCommand("/trail dao research");
+  await harness.router.respondToCommand("/session");
+  await harness.router.respondToCommand("/session summary");
+  await harness.router.respondToCommand("/session clear");
 
   assert.deepEqual(harness.calls, [
     ["bind", "/goal build the app"],
@@ -100,7 +104,13 @@ test("side panel command router dispatches slash commands", async () => {
     ["bind", "/save selection"],
     ["save", "selection"],
     ["bind", "/trail dao research"],
-    ["save", "trail dao research"]
+    ["save", "trail dao research"],
+    ["bind", "/session"],
+    ["session", ""],
+    ["bind", "/session summary"],
+    ["session", "summary"],
+    ["bind", "/session clear"],
+    ["session", "clear"]
   ]);
 });
 

--- a/docs/reference/COMMANDS.md
+++ b/docs/reference/COMMANDS.md
@@ -63,6 +63,16 @@ approval boundaries, or human-only action limits.
 | `/dao <goal>` | Prepare read-only DAO workflow guidance. |
 | `/dao audit <goal>` | Save DAO evidence and a review request. |
 
+## Session Context
+
+| Command | Purpose |
+| --- | --- |
+| `/session [summary|clear]` | Save the current window's open readable tabs as a bounded, reviewable session summary that survives an extension reload. `/session clear` deletes the persisted summary. The summary never contains raw page content; tab titles, URLs, and skip reasons are redacted and length-bounded before persistence. |
+
+The summary is hosted in `chrome.storage.local` so the artifact is the source
+of truth across reloads. On hydrate the Augmentor posts a short context line
+naming the captured tab count so the user can review or delete it.
+
 ## Delegation And Draft Handoffs
 
 | Command | Purpose |


### PR DESCRIPTION
Lands @vonstegen's #309 (all four of their commits preserved, authorship intact) rebased onto dev after #308 merged. The only conflict was mechanical: both PRs wire a new handler into `side-panel.js`; resolved as a union (`resolveComparisonContext` from #308 + `sessionSummaryController`/`runSessionCommand` from #309).

Closes #222.

## Re-review (before rebase) — blocker and majors all resolved, verified by replaying the exact repros
- `access_token=` snake_case compound (**the blocker**) → `[redacted]` ✅
- `client_secret=`, JSON-quoted `{"token":"…"}`, Stripe `sk_live_`, AWS `AKIA…`, percent-encoded `token%3D…` → all redacted ✅
- Reuses the hardened `redactTraceText` (trace-redaction.js) as the base layer rather than a hand-rolled pattern list ✅
- Capture scope narrowed to `chrome.tabs.query({ currentWindow: true })` ✅

## Post-rebase verification
- Redaction repros re-run on the rebased code: all pass.
- Full suite **1033/1033** (both #308 and #309 test sets green together — proves the conflict resolution).

Minor follow-up for a future pass (not blocking): an encoded token inside a *non-secret-named* param without an encoded `?` context (e.g. `?next=token%3DSECRET`) isn't matched; realistic captured URLs with `%3F` are.

Credit: @vonstegen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)