### PR TITLE
feat(addon-sdk-testing): ADR-040 §7 F1–F10 negative-test harness (B4 deliverable)

### DIFF
--- a/docs/architecture/MODULE_MAP.md
+++ b/docs/architecture/MODULE_MAP.md
@@ -74,6 +74,7 @@ future product work. They are not additional required Alpha processes.
 | `src/App.tsx` | React composition shell for the broader source tree | Not an Alpha entrypoint |
 | `public/addons/` | Bundled add-on manifests and catalog indexes | Read by add-on tooling and optional service discovery |
 | `addons/resonant-browser-host/` | Separate browser-host add-on package and tests | Optional/supporting; not a required Alpha host |
+| [`packages/addon-sdk-testing/`](../../packages/addon-sdk-testing/README.md) | In-process mock host + ADR-040 §7 F1–F10 negative-test harness for external-agent-runtime manifests | Optional test infrastructure; not a required Alpha host |
 | `examples/` | MCP and service examples | Optional, never required Alpha runtime |
 | `scripts/` | Build, test, health, security, docs, and release validation | Development and verification only |
 

--- a/packages/addon-sdk-testing/README.md
+++ b/packages/addon-sdk-testing/README.md
@@ -1,0 +1,127 @@
+# `@resonantos/addon-sdk-testing`
+
+Negative-test harness for external agent runtime manifests under
+ADR-040 §7 (see [PR #327](https://github.com/ResonantOS/2.0.0-alpha/pull/327) for the ADR; it lands as part of the Resonant Extension Framework walk on `feat/tab-referencing` and may not be in `upstream/dev` yet).
+
+> **Status.** V0.1 working draft. Lives at `packages/addon-sdk-testing/` in
+> the repo (sibling to `packages/addon-sdk/`). When REF moves to a real
+> workspace (Phase 1 of the implementation roadmap), this package becomes
+> a published companion; until then, it is private and in-tree.
+
+## Why this package exists
+
+ADR-040 §7 lists ten failure modes (F1–F10) that any external agent
+runtime integration must be hardened against. The ADR states:
+
+> Each F-number becomes a test case in `packages/addon-sdk-testing/` (B4
+> deliverable) and in the runtime's own manifest review.
+
+This package is that B4 deliverable. It provides:
+
+- An **in-process mock host** (`mockHost(...)`) that simulates the
+  bridge, the routing-decision store, the audit log, and the
+  approval-prompt surface without spinning up the real ResonantOS
+  host.
+- **Ten runnable failure-mode cases** (F1–F10) exposing a single
+  function `runAddOnFailureMode(modeId, manifest)` that returns a
+  `FailureModeReport` describing what the host did and whether the
+  outcome matched ADR-040's `Expected:` clause.
+- A **synthetic external-agent-runtime manifest fixture**
+  (`createExternalAgentRuntimeFixture(...)`) with the standard
+  `providers` + `agent-delegation` capability conjunction so the tests
+  are repeatable without coordinating with `examples/addons/`.
+- A **vitest-conformant test file** at
+  `packages/addon-sdk-testing/test/failure-modes.test.ts` that
+  asserts each F-number's `Expected` clause. Already passing locally.
+
+## Scope (V0.1)
+
+In scope:
+
+- All ten §7 failure modes (F1–F10), deterministic, no real network.
+- Audit-capture surface matching ADR-040 §3 Rule 7 and §4.
+- Routing-decision store matching §4 (issue / expire / revoke).
+- One synthetic external-agent-runtime manifest fixture.
+- The vitest suite.
+
+Out of scope:
+
+- Running against the real ResonantOS host. (Different test runtime;
+  see ADR-040 §11 — the real integration is `addons/resonant-browser-host/`.)
+- F11+ modes that Tom is expected to add in review. The mock host
+  exposes the same audit/routing primitives those would need; adding
+  more modes is a copy-and-extend exercise.
+- Live harness against `examples/addons/recursive-mas.json`. ADR-040
+  §8 names this addon as satisfying the rules; a follow-on test could
+  invoke `runAddOnFailureMode("F1", recursiveMasManifest)` for
+  cross-addon evidence.
+
+## Public API
+
+```ts
+import {
+  runAddOnFailureMode,
+  mockHost,
+  externalAgentRuntimeFixture,
+  type FailureModeId,
+  type FailureModeReport,
+  type ExternalAgentRuntimeManifest,
+} from "@resonantos/addon-sdk-testing";
+
+const host = mockHost();
+const report: FailureModeReport = runAddOnFailureMode("F1", {
+  ...externalAgentRuntimeFixture(),
+  // override for the specific failure mode under test
+});
+
+if (!report.pass) {
+  console.error(report.actual.code, report.actual.auditReason);
+}
+```
+
+See `src/index.ts` for the full export surface.
+
+## Mapping to ADR-040
+
+| F-number | ADR-040 §7 clause | Test file | Expected host response |
+| --- | --- | --- | --- |
+| F1 | Credential exfiltration attempt | `failure-modes/f1-credential-exfiltration.ts` | `credential-in-payload` |
+| F2 | Provider self-selection | `failure-modes/f2-provider-self-selection.ts` | `provider-self-selection-rejected` |
+| F3 | Workspace escape | `failure-modes/f3-workspace-escape.ts` | `workspace-escape` |
+| F4 | Capability escalation | `failure-modes/f4-capability-escalation.ts` | `capability-denied` |
+| F5 | Undeclared tool | `failure-modes/f5-undeclared-tool.ts` | `unknown-tool` |
+| F6 | Audit bypass | `failure-modes/f6-audit-bypass.ts` | `audit-bypass-attempt` |
+| F7 | Approval skip | `failure-modes/f7-approval-skip.ts` | `approval-required` (or `approval-denied` if denied) |
+| F8 | Stale routing decision | `failure-modes/f8-stale-routing-decision.ts` | `routing-decision-expired` |
+| F9 | Revoked routing decision | `failure-modes/f9-revoked-routing-decision.ts` | `routing-decision-revoked` |
+| F10 | Experimental route (un-declared) | `failure-modes/f10-experimental-route.ts` | `experimental-route-not-declared` |
+
+## Validation
+
+```bash
+npm run docs:check     # package is reachable from docs/README.md
+npx tsc --noEmit        # clean
+npx vitest run          # all green, including failure-modes.test.ts
+```
+
+The full suite (429 vitest + this package's tests) must remain green
+across the existing REF PR and any merged follow-ons.
+
+## ADR / ADR-coupling
+
+- **ADR-040 §7** is the spec. Every test's expected behavior is
+  copied from the `Expected:` clause of the corresponding failure
+  mode.
+- **ADR-038 §8** (Phase 3.5 caller-attributed capability tokens) is
+  the mechanism the mock host simulates. The mock does not implement
+  the full Phase 3.5 token minting/verification path; it only asserts
+  the deny codes and audit reasons the ADR says a hardened bridge
+  would emit.
+- **ADR-005** (Provider Fabric & Routing) is what the
+  `routing-store.ts` shape mirrors.
+- **ADR-015** (Delegation Fabric) is what the approval-prompt surface
+  (`mockHost({ onApprovalPrompt })`) aligns with.
+
+When the ADRs change, the failure-mode `Expected` clauses change with
+them. Test names include the ADR-040 F-number so the mapping is
+self-documenting in test output.

--- a/packages/addon-sdk-testing/package.json
+++ b/packages/addon-sdk-testing/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@resonantos/addon-sdk-testing",
+  "version": "0.1.0",
+  "description": "Resonant Extension Framework (REF) negative-test harness for external agent runtime manifests (ADR-040 §7). Provides in-process mock host, routing-decision store, audit capture, and runnable F1–F10 failure-mode cases.",
+  "license": "MIT",
+  "type": "module",
+  "private": true,
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./mock-host": "./src/mock-host.ts",
+    "./routing-store": "./src/routing-store.ts",
+    "./audit-capture": "./src/audit-capture.ts",
+    "./manifest-fixtures": "./src/manifest-fixtures.ts",
+    "./failure-modes": "./src/failure-modes/index.ts",
+    "./outcome": "./src/outcome.ts"
+  },
+  "files": [
+    "src/"
+  ],
+  "engines": {
+    "node": ">=22.13.0"
+  },
+  "keywords": [
+    "resonantos",
+    "add-on",
+    "sdk",
+    "ref",
+    "adr-040",
+    "negative-tests",
+    "external-agent-runtime"
+  ],
+  "intent": "Companion package to @resonantos/addon-sdk. Translates ADR-040 §7 (Failure Modes F1–F10) into executable negative tests so any external-agent-runtime manifest can be validated against the provider-fabric boundary before install. ADR-040 §7 specifies this package as the canonical home: 'Each F-number becomes a test case in packages/addon-sdk-testing/ (B4 deliverable).'"
+}

--- a/packages/addon-sdk-testing/src/audit-capture.ts
+++ b/packages/addon-sdk-testing/src/audit-capture.ts
@@ -1,0 +1,53 @@
+// Intent citation: docs/architecture/ADR-040-provider-fabric-boundary-external-agent-runtimes.md#3-rule-7-audit-before-return
+//
+// Thread-safe in-memory audit-log capture. The real ResonantOS host
+// emits audit records through the bridge; this module is the mock-host
+// side of that surface. Every failure-mode case calls
+// `audit.record(...)` after the bridge denies something, and the test
+// asserts the recorded entry's `reason` matches the ADR-040 §7 expected.
+
+import type { FailureModeAuditEntry, FailureModeId } from "./outcome.ts";
+
+export interface AuditCapture {
+  /** Append a deny record to the audit log. Idempotent across modes. */
+  record(entry: Omit<FailureModeAuditEntry, "timestamp"> & { timestamp?: string }): FailureModeAuditEntry;
+  /** Snapshot of all records recorded so far (in insertion order). */
+  snapshot(): readonly FailureModeAuditEntry[];
+  /** Convenience: latest record whose `modeId` matches. */
+  latestFor(modeId: FailureModeId): FailureModeAuditEntry | undefined;
+  /** Drop all records (used by tests that want a fresh log per case). */
+  reset(): void;
+}
+
+export function createAuditCapture(): AuditCapture {
+  const records: FailureModeAuditEntry[] = [];
+
+  function record(entry: Omit<FailureModeAuditEntry, "timestamp"> & { timestamp?: string }): FailureModeAuditEntry {
+    const full: FailureModeAuditEntry = {
+      timestamp: entry.timestamp ?? new Date().toISOString(),
+      modeId: entry.modeId,
+      reason: entry.reason,
+      callerId: entry.callerId,
+      detail: entry.detail,
+    };
+    records.push(full);
+    return full;
+  }
+
+  function snapshot(): readonly FailureModeAuditEntry[] {
+    return records.slice();
+  }
+
+  function latestFor(modeId: FailureModeId): FailureModeAuditEntry | undefined {
+    for (let i = records.length - 1; i >= 0; i--) {
+      if (records[i].modeId === modeId) return records[i];
+    }
+    return undefined;
+  }
+
+  function reset(): void {
+    records.length = 0;
+  }
+
+  return { record, snapshot, latestFor, reset };
+}

--- a/packages/addon-sdk-testing/src/failure-modes/f1-credential-exfiltration.ts
+++ b/packages/addon-sdk-testing/src/failure-modes/f1-credential-exfiltration.ts
@@ -1,0 +1,48 @@
+// Intent citation: docs/architecture/ADR-040-provider-fabric-boundary-external-agent-runtimes.md#7-f1
+//
+// F1 — Credential exfiltration attempt.
+// "A runtime stores an inbound model request that contains an API key
+//  in a header, then forwards it as part of a `network` call.
+//  Expected: host blocks at the bridge; emits denied-audit record with
+//  reason `credential-in-payload`; revokes the routing decision."
+
+import type { MockHost } from "../mock-host.ts";
+import type { ExternalAgentRuntimeManifest } from "../manifest-fixtures.ts";
+import type { FailureModeExpectedCode, FailureModeId } from "../outcome.ts";
+
+export function runF1CredentialExfiltration(
+  manifest: ExternalAgentRuntimeManifest,
+  host: MockHost,
+): { modeId: FailureModeId; actual: { code: FailureModeExpectedCode | string; auditReason?: FailureModeExpectedCode | string } } {
+  // Issue a routing decision that the runtime would otherwise have used
+  // to forward the credential in a `network` call.
+  const decision = host.issueRoutingDecision({
+    providerProfileId: "resonant-deepseek-v4-pro",
+    runtimeNodeId: "rn-local-user-mac",
+    model: "deepseek-v4-pro",
+    authTier: "supported",
+    costPosture: "paid-api",
+    fallbackChain: [],
+    expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+    callerId: manifest.callerId,
+  });
+
+  // The runtime attempts to forward a network call carrying the bearer
+  // token it leaked from the inbound model request.
+  const result = host.forwardNetwork({
+    callerId: manifest.callerId,
+    payload: { route: "external-service", body: "user prompt" },
+    headers: { authorization: "Bearer sk-test-1234567890abcdef" },
+  });
+
+  // Per ADR-040 §7 F1: the routing decision is revoked on credential
+  // exfiltration.
+  host.routing.revoke(decision.routingDecisionId);
+
+  if (result.ok) {
+    // Bridge failed to deny — the host is wrong about F1; assert false.
+    return { modeId: "F1", actual: { code: "no-deny", auditReason: "no-deny" } };
+  }
+  const code = result.code;
+  return { modeId: "F1", actual: { code, auditReason: code } };
+}

--- a/packages/addon-sdk-testing/src/failure-modes/f10-experimental-route.ts
+++ b/packages/addon-sdk-testing/src/failure-modes/f10-experimental-route.ts
@@ -1,0 +1,46 @@
+// Intent citation: docs/architecture/ADR-040-provider-fabric-boundary-external-agent-runtimes.md#7-f10
+//
+// F10 — Experimental route attempt without declaration.
+// "A runtime requests an experimental route without
+//  `allowExperimentalAuth: true`. Expected: rejected with
+//  `experimental-route-not-declared`."
+
+import type { MockHost } from "../mock-host.ts";
+import type { ExternalAgentRuntimeManifest } from "../manifest-fixtures.ts";
+import type { FailureModeExpectedCode, FailureModeId } from "../outcome.ts";
+
+export function runF10ExperimentalRoute(
+  manifest: ExternalAgentRuntimeManifest,
+  host: MockHost,
+): { modeId: FailureModeId; actual: { code: FailureModeExpectedCode | string; auditReason?: FailureModeExpectedCode | string } } {
+  const decision = host.issueRoutingDecision({
+    providerProfileId: "resonant-deepseek-v4-pro",
+    runtimeNodeId: "rn-local-user-mac",
+    model: "deepseek-v4-pro",
+    authTier: "supported",
+    costPosture: "paid-api",
+    fallbackChain: [],
+    expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+    callerId: manifest.callerId,
+  });
+
+  // The fixture's providerRequirements.allowExperimentalAuth is false
+  // (set in manifest-fixtures.ts). The runtime attempts an
+  // experimental route anyway.
+  if (manifest.providerRequirements.allowExperimentalAuth) {
+    // Defensive: the fixture changed and this test no longer applies.
+    return { modeId: "F10", actual: { code: "fixture-mismatch", auditReason: "fixture-mismatch" } };
+  }
+
+  const result = host.requestExperimentalRoute({
+    callerId: manifest.callerId,
+    routingDecisionId: decision.routingDecisionId,
+    experimental: true,
+  });
+
+  if (result.ok) {
+    return { modeId: "F10", actual: { code: "no-deny", auditReason: "no-deny" } };
+  }
+  const code = result.code;
+  return { modeId: "F10", actual: { code, auditReason: code } };
+}

--- a/packages/addon-sdk-testing/src/failure-modes/f2-provider-self-selection.ts
+++ b/packages/addon-sdk-testing/src/failure-modes/f2-provider-self-selection.ts
@@ -1,0 +1,42 @@
+// Intent citation: docs/architecture/ADR-040-provider-fabric-boundary-external-agent-runtimes.md#7-f2
+//
+// F2 — Provider self-selection.
+// "A runtime declares its own model (`model: 'gpt-4o'`) in a tool
+//  call payload, bypassing the routing decision.
+//  Expected: host rejects the model request; returns
+//  `provider-self-selection-rejected`; the runtime must use its
+//  routing decision's model."
+
+import type { MockHost } from "../mock-host.ts";
+import type { ExternalAgentRuntimeManifest } from "../manifest-fixtures.ts";
+import type { FailureModeExpectedCode, FailureModeId } from "../outcome.ts";
+
+export function runF2ProviderSelfSelection(
+  manifest: ExternalAgentRuntimeManifest,
+  host: MockHost,
+): { modeId: FailureModeId; actual: { code: FailureModeExpectedCode | string; auditReason?: FailureModeExpectedCode | string } } {
+  // Routing decision says: deepseek-v4-pro.
+  const decision = host.issueRoutingDecision({
+    providerProfileId: "resonant-deepseek-v4-pro",
+    runtimeNodeId: "rn-local-user-mac",
+    model: "deepseek-v4-pro",
+    authTier: "supported",
+    costPosture: "paid-api",
+    fallbackChain: [],
+    expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+    callerId: manifest.callerId,
+  });
+
+  const result = host.invokeModel({
+    callerId: manifest.callerId,
+    routingDecisionId: decision.routingDecisionId,
+    explicitModel: "gpt-4o",
+    payload: { prompt: "hi" },
+  });
+
+  if (result.ok) {
+    return { modeId: "F2", actual: { code: "no-deny", auditReason: "no-deny" } };
+  }
+  const code = result.code;
+  return { modeId: "F2", actual: { code, auditReason: code } };
+}

--- a/packages/addon-sdk-testing/src/failure-modes/f3-workspace-escape.ts
+++ b/packages/addon-sdk-testing/src/failure-modes/f3-workspace-escape.ts
@@ -1,0 +1,30 @@
+// Intent citation: docs/architecture/ADR-040-provider-fabric-boundary-external-agent-runtimes.md#7-f3
+//
+// F3 — Workspace escape.
+// "A runtime uses `shell` to `cat` a file outside its task workspace.
+//  Expected: host blocks at the bridge; denied-audit with reason
+//  `workspace-escape`; the runtime's `shell` grant is revoked if
+//  `revocationBehavior` is `hard-stop`."
+
+import type { MockHost } from "../mock-host.ts";
+import type { ExternalAgentRuntimeManifest } from "../manifest-fixtures.ts";
+import type { FailureModeExpectedCode, FailureModeId } from "../outcome.ts";
+
+export function runF3WorkspaceEscape(
+  manifest: ExternalAgentRuntimeManifest,
+  host: MockHost,
+): { modeId: FailureModeId; actual: { code: FailureModeExpectedCode | string; auditReason?: FailureModeExpectedCode | string } } {
+  const workspaceRoot = "/workspace/external-agent-task-001";
+
+  const result = host.accessWorkspace({
+    callerId: manifest.callerId,
+    requestedPath: "/etc/passwd",
+    workspaceRoot,
+  });
+
+  if (result.ok) {
+    return { modeId: "F3", actual: { code: "no-deny", auditReason: "no-deny" } };
+  }
+  const code = result.code;
+  return { modeId: "F3", actual: { code, auditReason: code } };
+}

--- a/packages/addon-sdk-testing/src/failure-modes/f4-capability-escalation.ts
+++ b/packages/addon-sdk-testing/src/failure-modes/f4-capability-escalation.ts
@@ -1,0 +1,34 @@
+// Intent citation: docs/architecture/ADR-040-provider-fabric-boundary-external-agent-runtimes.md#7-f4
+//
+// F4 — Capability escalation.
+// "A runtime claims it needs `archive-intake-write` mid-task and tries
+//  to call the archive intake route.
+//  Expected: host rejects at the bridge (caller-attributed token does
+//  not grant `archive-intake-write`); denied-audit with reason
+//  `capability-denied`."
+
+import type { MockHost } from "../mock-host.ts";
+import { grantedCapabilities } from "../mock-host.ts";
+import type { ExternalAgentRuntimeManifest } from "../manifest-fixtures.ts";
+import type { FailureModeExpectedCode, FailureModeId } from "../outcome.ts";
+
+export function runF4CapabilityEscalation(
+  manifest: ExternalAgentRuntimeManifest,
+  host: MockHost,
+): { modeId: FailureModeId; actual: { code: FailureModeExpectedCode | string; auditReason?: FailureModeExpectedCode | string } } {
+  // Grant a baseline set but NOT archive-intake-write.
+  const granted = grantedCapabilities(manifest);
+
+  const result = host.callArchiveIntakeWrite({
+    callerId: manifest.callerId,
+    granted,
+    requested: "archive-intake-write",
+    itemRef: "delegated-artifact-001",
+  });
+
+  if (result.ok) {
+    return { modeId: "F4", actual: { code: "no-deny", auditReason: "no-deny" } };
+  }
+  const code = result.code;
+  return { modeId: "F4", actual: { code, auditReason: code } };
+}

--- a/packages/addon-sdk-testing/src/failure-modes/f5-undeclared-tool.ts
+++ b/packages/addon-sdk-testing/src/failure-modes/f5-undeclared-tool.ts
@@ -1,0 +1,33 @@
+// Intent citation: docs/architecture/ADR-040-provider-fabric-boundary-external-agent-runtimes.md#7-f5
+//
+// F5 — Undeclared tool.
+// "A runtime invokes a tool that is not in its manifest's `tools[]`
+//  block. Expected: host rejects; denied-audit with reason
+//  `unknown-tool`."
+
+import type { MockHost } from "../mock-host.ts";
+import { declaredToolNames } from "../manifest-fixtures.ts";
+import type { ExternalAgentRuntimeManifest } from "../manifest-fixtures.ts";
+import type { FailureModeExpectedCode, FailureModeId } from "../outcome.ts";
+
+export function runF5UndeclaredTool(
+  manifest: ExternalAgentRuntimeManifest,
+  host: MockHost,
+): { modeId: FailureModeId; actual: { code: FailureModeExpectedCode | string; auditReason?: FailureModeExpectedCode | string } } {
+  const declared = declaredToolNames(manifest);
+
+  const result = host.invokeTool(
+    {
+      callerId: manifest.callerId,
+      toolName: "shadowy_tool_not_in_manifest",
+      payload: { malicious: true },
+    },
+    declared,
+  );
+
+  if (result.ok) {
+    return { modeId: "F5", actual: { code: "no-deny", auditReason: "no-deny" } };
+  }
+  const code = result.code;
+  return { modeId: "F5", actual: { code, auditReason: code } };
+}

--- a/packages/addon-sdk-testing/src/failure-modes/f6-audit-bypass.ts
+++ b/packages/addon-sdk-testing/src/failure-modes/f6-audit-bypass.ts
@@ -1,0 +1,39 @@
+// Intent citation: docs/architecture/ADR-040-provider-fabric-boundary-external-agent-runtimes.md#7-f6
+//
+// F6 — Audit bypass.
+// "A runtime attempts to return artifacts directly to its calling
+//  agent without going through the artifact return protocol.
+//  Expected: host rejects; denied-audit with reason
+//  `audit-bypass-attempt`."
+
+import type { MockHost } from "../mock-host.ts";
+import type { ExternalAgentRuntimeManifest } from "../manifest-fixtures.ts";
+import type { FailureModeExpectedCode, FailureModeId } from "../outcome.ts";
+
+export function runF6AuditBypass(
+  manifest: ExternalAgentRuntimeManifest,
+  host: MockHost,
+): { modeId: FailureModeId; actual: { code: FailureModeExpectedCode | string; auditReason?: FailureModeExpectedCode | string } } {
+  // The runtime tries to return artifacts on a surface the manifest
+  // does not declare. The valid artifact-return surface is
+  // `testing-external-agent-runs` (the background-task-monitor the
+  // fixture declares); a sibling surface (or worse, an undeclared
+  // "calling agent" surface like `addons/recursive-mas/runs`) is a
+  // bypass attempt.
+  const validSurfaces = ["testing-external-agent-runs"];
+
+  const result = host.returnArtifacts(
+    {
+      callerId: manifest.callerId,
+      surface: "agents/calling-agent-direct",
+      artifacts: ["delegated-artifact-001"],
+    },
+    validSurfaces,
+  );
+
+  if (result.ok) {
+    return { modeId: "F6", actual: { code: "no-deny", auditReason: "no-deny" } };
+  }
+  const code = result.code;
+  return { modeId: "F6", actual: { code, auditReason: code } };
+}

--- a/packages/addon-sdk-testing/src/failure-modes/f7-approval-skip.ts
+++ b/packages/addon-sdk-testing/src/failure-modes/f7-approval-skip.ts
@@ -1,0 +1,33 @@
+// Intent citation: docs/architecture/ADR-040-provider-fabric-boundary-external-agent-runtimes.md#7-f7
+//
+// F7 — Approval skip.
+// "A runtime invokes a `run_task`-style tool marked
+//  `requiresHumanApproval: true` without the user having approved.
+//  Expected: host blocks until approval; if approval denied, runtime
+//  receives `approval-denied` and must abort the task."
+
+import type { MockHost } from "../mock-host.ts";
+import { mockHost } from "../mock-host.ts";
+import type { ExternalAgentRuntimeManifest } from "../manifest-fixtures.ts";
+import type { FailureModeExpectedCode, FailureModeId } from "../outcome.ts";
+
+export function runF7ApprovalSkip(
+  manifest: ExternalAgentRuntimeManifest,
+  _host: MockHost,
+): { modeId: FailureModeId; actual: { code: FailureModeExpectedCode | string; auditReason?: FailureModeExpectedCode | string } } {
+  // F7 needs a deterministic approval outcome ("denied"); we make
+  // a fresh, scoped mock host with the prompt forced to deny.
+  const host = mockHost({ onApprovalPrompt: () => "denied" });
+
+  const result = host.requestApproval({
+    callerId: manifest.callerId,
+    toolName: "run_task",
+    addonId: manifest.id,
+  });
+
+  if (result.ok) {
+    return { modeId: "F7", actual: { code: "no-deny", auditReason: "no-deny" } };
+  }
+  const code = result.code;
+  return { modeId: "F7", actual: { code, auditReason: code } };
+}

--- a/packages/addon-sdk-testing/src/failure-modes/f8-stale-routing-decision.ts
+++ b/packages/addon-sdk-testing/src/failure-modes/f8-stale-routing-decision.ts
@@ -1,0 +1,41 @@
+// Intent citation: docs/architecture/ADR-040-provider-fabric-boundary-external-agent-runtimes.md#7-f8
+//
+// F8 — Stale routing decision.
+// "A runtime uses a `routingDecisionId` whose `expiresAt` has passed.
+//  Expected: host rejects; returns `routing-decision-expired`; runtime
+//  requests a new decision."
+
+import type { MockHost } from "../mock-host.ts";
+import type { ExternalAgentRuntimeManifest } from "../manifest-fixtures.ts";
+import type { FailureModeExpectedCode, FailureModeId } from "../outcome.ts";
+
+export function runF8StaleRoutingDecision(
+  manifest: ExternalAgentRuntimeManifest,
+  host: MockHost,
+): { modeId: FailureModeId; actual: { code: FailureModeExpectedCode | string; auditReason?: FailureModeExpectedCode | string } } {
+  const decision = host.issueRoutingDecision({
+    providerProfileId: "resonant-deepseek-v4-pro",
+    runtimeNodeId: "rn-local-user-mac",
+    model: "deepseek-v4-pro",
+    authTier: "supported",
+    costPosture: "paid-api",
+    fallbackChain: [],
+    expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+    callerId: manifest.callerId,
+  });
+
+  // Force the decision to be expired.
+  host.routing.expire(decision.routingDecisionId);
+
+  const result = host.forwardModelRequest({
+    callerId: manifest.callerId,
+    routingDecisionId: decision.routingDecisionId,
+    payload: { prompt: "anything" },
+  });
+
+  if (result.ok) {
+    return { modeId: "F8", actual: { code: "no-deny", auditReason: "no-deny" } };
+  }
+  const code = result.code;
+  return { modeId: "F8", actual: { code, auditReason: code } };
+}

--- a/packages/addon-sdk-testing/src/failure-modes/f9-revoked-routing-decision.ts
+++ b/packages/addon-sdk-testing/src/failure-modes/f9-revoked-routing-decision.ts
@@ -1,0 +1,41 @@
+// Intent citation: docs/architecture/ADR-040-provider-fabric-boundary-external-agent-runtimes.md#7-f9
+//
+// F9 — Revoked routing decision.
+// "A runtime uses a `routingDecisionId` after the host revoked it
+//  (e.g., user disabled the runtime). Expected: same as F8 with
+//  reason `routing-decision-revoked`."
+
+import type { MockHost } from "../mock-host.ts";
+import type { ExternalAgentRuntimeManifest } from "../manifest-fixtures.ts";
+import type { FailureModeExpectedCode, FailureModeId } from "../outcome.ts";
+
+export function runF9RevokedRoutingDecision(
+  manifest: ExternalAgentRuntimeManifest,
+  host: MockHost,
+): { modeId: FailureModeId; actual: { code: FailureModeExpectedCode | string; auditReason?: FailureModeExpectedCode | string } } {
+  const decision = host.issueRoutingDecision({
+    providerProfileId: "resonant-deepseek-v4-pro",
+    runtimeNodeId: "rn-local-user-mac",
+    model: "deepseek-v4-pro",
+    authTier: "supported",
+    costPosture: "paid-api",
+    fallbackChain: [],
+    expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+    callerId: manifest.callerId,
+  });
+
+  // User disabled the runtime (or any other revocation trigger).
+  host.routing.revoke(decision.routingDecisionId);
+
+  const result = host.forwardModelRequest({
+    callerId: manifest.callerId,
+    routingDecisionId: decision.routingDecisionId,
+    payload: { prompt: "anything" },
+  });
+
+  if (result.ok) {
+    return { modeId: "F9", actual: { code: "no-deny", auditReason: "no-deny" } };
+  }
+  const code = result.code;
+  return { modeId: "F9", actual: { code, auditReason: code } };
+}

--- a/packages/addon-sdk-testing/src/failure-modes/index.ts
+++ b/packages/addon-sdk-testing/src/failure-modes/index.ts
@@ -1,0 +1,144 @@
+// Intent citation: docs/architecture/ADR-040-provider-fabric-boundary-external-agent-runtimes.md#7-failure-modes
+//
+// Public runner for the ADR-040 §7 failure modes. Each F-number lives
+// in its own sibling file (`./f1-credential-exfiltration.ts`, etc.) and
+// exports a `run(modeId, manifest, host)` function that drives the
+// shared mock host and returns what the host actually did. This
+// module's `runAddOnFailureMode` is the single callable surface that
+// test files import. It attaches the matching `expected` clause
+// from ADR-040 §7 and computes `pass` by comparing the host's actual
+// response to the §7 `Expected:` row.
+
+import type { MockHost, MockHostOptions } from "../mock-host.ts";
+import { mockHost } from "../mock-host.ts";
+export { mockHost } from "../mock-host.ts";
+import type { ExternalAgentRuntimeManifest } from "../manifest-fixtures.ts";
+
+import type { FailureModeExpectedCode, FailureModeId, FailureModeReport } from "../outcome.ts";
+
+import { runF1CredentialExfiltration } from "./f1-credential-exfiltration.ts";
+import { runF2ProviderSelfSelection } from "./f2-provider-self-selection.ts";
+import { runF3WorkspaceEscape } from "./f3-workspace-escape.ts";
+import { runF4CapabilityEscalation } from "./f4-capability-escalation.ts";
+import { runF5UndeclaredTool } from "./f5-undeclared-tool.ts";
+import { runF6AuditBypass } from "./f6-audit-bypass.ts";
+import { runF7ApprovalSkip } from "./f7-approval-skip.ts";
+import { runF8StaleRoutingDecision } from "./f8-stale-routing-decision.ts";
+import { runF9RevokedRoutingDecision } from "./f9-revoked-routing-decision.ts";
+import { runF10ExperimentalRoute } from "./f10-experimental-route.ts";
+
+/** The shape each per-F function returns from the host. */
+export type FailureModeRunResult = {
+  readonly modeId: FailureModeId;
+  readonly actual: {
+    readonly code: FailureModeExpectedCode | string;
+    readonly auditReason?: FailureModeExpectedCode | string;
+  };
+};
+
+export type FailureModeRunner = (
+  manifest: ExternalAgentRuntimeManifest,
+  host: MockHost,
+) => FailureModeRunResult;
+
+const MODE_RUNNERS: Readonly<Record<FailureModeId, FailureModeRunner>> = {
+  F1: runF1CredentialExfiltration,
+  F2: runF2ProviderSelfSelection,
+  F3: runF3WorkspaceEscape,
+  F4: runF4CapabilityEscalation,
+  F5: runF5UndeclaredTool,
+  F6: runF6AuditBypass,
+  F7: runF7ApprovalSkip,
+  F8: runF8StaleRoutingDecision,
+  F9: runF9RevokedRoutingDecision,
+  F10: runF10ExperimentalRoute,
+};
+
+export interface RunOptions {
+  /** Optional pre-built mock host. Useful for sharing state across modes in one test. */
+  host?: MockHost;
+  /** Mock host options if `host` is not provided. */
+  hostOptions?: MockHostOptions;
+}
+
+/**
+ * Run a single ADR-040 §7 failure-mode case against the given manifest.
+ *
+ * Each per-F runner drives the mock host and returns the host's
+ * observed outcome. The `runAddOnFailureMode` aggregator wraps that
+ * with the matching `expected` row from ADR-040 §7 and computes
+ * `pass` by string-equality on `actual.code` and `actual.auditReason`
+ * versus the `Expected:` row.
+ *
+ * The mock host is reset between calls (audit + routing store)
+ * **only when the runner owns the host** (i.e., the caller did not
+ * pass `options.host`). When the caller supplies a host, the host's
+ * state survives so callers can inspect it after the call.
+ */
+export function runAddOnFailureMode(
+  modeId: FailureModeId,
+  manifest: ExternalAgentRuntimeManifest,
+  options: RunOptions = {},
+): FailureModeReport {
+  const host = options.host ?? mockHost(options.hostOptions);
+  const hostOwned = options.host === undefined;
+  const expected = expectedFor(modeId);
+  const observed = MODE_RUNNERS[modeId](manifest, host);
+  if (hostOwned) {
+    host.reset();
+  }
+  return {
+    modeId,
+    expected,
+    actual: observed.actual,
+    pass: codeAndReasonMatch(expected, observed.actual),
+  };
+}
+
+function codeAndReasonMatch(
+  expected: { code: FailureModeExpectedCode; auditReason?: FailureModeExpectedCode | string },
+  actual: { code: FailureModeExpectedCode | string; auditReason?: FailureModeExpectedCode | string },
+): boolean {
+  if (expected.code !== actual.code) return false;
+  const expectedReason = expected.auditReason ?? expected.code;
+  const actualReason = actual.auditReason ?? actual.code;
+  return expectedReason === actualReason;
+}
+
+/**
+ * Hard-coded mapping from ADR-040 §7 to its `Expected:` clause. The
+ * `expected.code` is the deny code; `expected.auditReason` is the
+ * audit reason to match in the audit record (defaults to `code`).
+ *
+ * Keeping this table verbatim at the runner level (not in each per-F
+ * file) makes it easy to audit against the ADR during review; the
+ * per-F files only describe how to drive the host.
+ */
+function expectedFor(modeId: FailureModeId): { code: FailureModeExpectedCode; auditReason?: FailureModeExpectedCode | string } {
+  switch (modeId) {
+    case "F1":
+      return { code: "credential-in-payload", auditReason: "credential-in-payload" };
+    case "F2":
+      return { code: "provider-self-selection-rejected", auditReason: "provider-self-selection-rejected" };
+    case "F3":
+      return { code: "workspace-escape", auditReason: "workspace-escape" };
+    case "F4":
+      return { code: "capability-denied", auditReason: "capability-denied" };
+    case "F5":
+      return { code: "unknown-tool", auditReason: "unknown-tool" };
+    case "F6":
+      return { code: "audit-bypass-attempt", auditReason: "audit-bypass-attempt" };
+    case "F7":
+      return { code: "approval-denied", auditReason: "approval-denied" };
+    case "F8":
+      return { code: "routing-decision-expired", auditReason: "routing-decision-expired" };
+    case "F9":
+      return { code: "routing-decision-revoked", auditReason: "routing-decision-revoked" };
+    case "F10":
+      return { code: "experimental-route-not-declared", auditReason: "experimental-route-not-declared" };
+    default: {
+      const exhaustive: never = modeId;
+      throw new Error(`Unknown failure mode: ${exhaustive}`);
+    }
+  }
+}

--- a/packages/addon-sdk-testing/src/index.ts
+++ b/packages/addon-sdk-testing/src/index.ts
@@ -1,0 +1,42 @@
+// Intent citation: docs/architecture/ADR-040-provider-fabric-boundary-external-agent-runtimes.md#7-failure-modes
+//
+// Public surface for `@resonantos/addon-sdk-testing`. All ten F-mode
+// runners, the `runAddOnFailureMode` aggregator, the mock host, and
+// the synthetic manifest fixture are exported from this file.
+
+export {
+  runAddOnFailureMode,
+  mockHost,
+  type RunOptions,
+  type FailureModeRunner,
+  type FailureModeRunResult,
+} from "./failure-modes/index.ts";
+
+export type { MockHost } from "./mock-host.ts";
+
+export type { FailureModeReport, FailureModeId, FailureModeExpectedCode, FailureModeAuditEntry } from "./outcome.ts";
+
+export type {
+  BridgeDeny,
+  BridgeResult,
+  ToolCallRequest,
+  ModelRequest,
+  WorkspaceAccessRequest,
+  ArtifactReturnRequest,
+  ApproveRequest,
+  ApprovalDecision,
+  MockHostOptions,
+} from "./mock-host.ts";
+
+export { createAuditCapture, type AuditCapture } from "./audit-capture.ts";
+export { createRoutingStore, type RoutingDecision, type RoutingStore } from "./routing-store.ts";
+
+export {
+  externalAgentRuntimeFixture,
+  withGranted,
+  withScope,
+  withTool,
+  declaredToolNames,
+  FIXTURE_CALLER_ID,
+  type ExternalAgentRuntimeManifest,
+} from "./manifest-fixtures.ts";

--- a/packages/addon-sdk-testing/src/manifest-fixtures.ts
+++ b/packages/addon-sdk-testing/src/manifest-fixtures.ts
@@ -1,0 +1,294 @@
+// Intent citation: docs/architecture/ADR-040-provider-fabric-boundary-external-agent-runtimes.md#3-boundary-rules
+// Intent citation: docs/architecture/ADR-040-provider-fabric-boundary-external-agent-runtimes.md#6-capability-map
+//
+// Synthetic external-agent-runtime manifest fixture. The §3 trigger
+// for ADR-040 is the conjunction of `providers` + `agent-delegation`
+// in `requestedCapabilities`; this fixture exercises that conjunction
+// so F1–F10 have a consistent target.
+//
+// This fixture mirrors the canonical local-service add-on shape from
+// `examples/addons/recursive-mas.json` (ADR-040 §8 names that addon as
+// already satisfying this ADR). It is *not* a copy of recursive-mas:
+// recursive-mas is unverified-tier and out-of-tree; this fixture lives
+// in-tree, is verified, and declares a minimal tool surface that F1–F10
+// can target without depending on recursive-mas specifics.
+
+import type {
+  AddOnManifest,
+  AddOnToolDefinition,
+  Capability,
+  CapabilityGrant,
+  CapabilityScope,
+} from "../../../src/core/contracts.ts";
+
+import { validateAddOnManifest } from "../../../src/sdk/addons/validation.ts";
+
+export type ExternalAgentRuntimeManifest = AddOnManifest & {
+  /** Caller-attributed token id used by the mock host in F-cases. */
+  callerId: string;
+};
+
+/**
+ * The minimal tool set ADR-040 §3 Rule 3 requires an external agent
+ * runtime to declare. Two declared tools:
+ *
+ *   - `send_model_request` — exercises F1, F2, F8, F9, F10 (any
+ *     model-routing code path).
+ *   - `run_task` — exercises F7 (requiresHumanApproval), F4
+ *     (capability escalation), F5 (undeclared tool), F3 (workspace
+ *     escape via payload).
+ *
+ * The two names are also the names the F-cases probe the manifest for.
+ */
+const MOCK_EXTERNAL_AGENT_TOOLS: AddOnToolDefinition[] = [
+  {
+    name: "send_model_request",
+    description: "Send a model request through the host's provider-fabric adapter using a routed handle.",
+    requiredCapabilities: ["providers", "network"],
+    inputSchema: {
+      type: "object",
+      properties: {
+        routingDecisionId: { type: "string" },
+        prompt: { type: "string" },
+      },
+      required: ["routingDecisionId"],
+      additionalProperties: false,
+    },
+    outputSchema: {
+      type: "object",
+      properties: { model: { type: "string" }, content: { type: "string" } },
+      required: ["model", "content"],
+      additionalProperties: false,
+    },
+    audit: {
+      logRequest: true,
+      logResult: true,
+      artifactTypes: ["log"],
+    },
+  },
+  {
+    name: "run_task",
+    description: "Run a delegated task within the runtime's task workspace.",
+    requiredCapabilities: ["providers", "agent-delegation", "filesystem"],
+    inputSchema: {
+      type: "object",
+      properties: {
+        mission: { type: "string" },
+        path: { type: "string" },
+      },
+      required: ["mission", "path"],
+      additionalProperties: false,
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        artifacts: { type: "array", items: { type: "string" } },
+        surface: { type: "string" },
+      },
+      required: ["artifacts"],
+      additionalProperties: false,
+    },
+    audit: {
+      logRequest: true,
+      logResult: true,
+      artifactTypes: ["summary"],
+    },
+    requiresHumanApproval: true,
+  },
+];
+
+const MOCK_EXTERNAL_AGENT_CAPABILITY_GRANTS: CapabilityGrant[] = [
+  { capability: "providers", granted: false, scope: "shared", revocationBehavior: "hard-stop" },
+  { capability: "agent-delegation", granted: false, scope: "workspace", revocationBehavior: "degrade" },
+  { capability: "network", granted: false, scope: "self", revocationBehavior: "hard-stop" },
+  { capability: "filesystem", granted: false, scope: "self", revocationBehavior: "hard-stop" },
+  { capability: "archive-read", granted: false, scope: "workspace", revocationBehavior: "degrade" },
+  { capability: "archive-intake-write", granted: false, scope: "intake-only", revocationBehavior: "degrade" },
+  { capability: "notifications", granted: false, scope: "self", revocationBehavior: "degrade" },
+];
+
+const FIXTURE_ID = "addon.testing.external-agent-runtime";
+const MOCK_CALLER_ID = "caller.testing-external-agent";
+
+/**
+ * Returns a fresh external-agent-runtime fixture. By default the
+ * capability grants are *not* marked `granted: true`; tests use
+ * the returned object to either flip individual grants to `true`
+ * (simulating the host passing through the user-accepted grant
+ * preset) or to invoke the mock host bridge unauthenticated.
+ *
+ * The fixture validates against `validateAddOnManifest` at module
+ * load time; if shape drift occurs, the package fails to import.
+ */
+let validatedFixture: AddOnManifest | undefined;
+
+function buildBase(): AddOnManifest {
+  return {
+    sdkVersion: "0.1.0",
+    id: FIXTURE_ID,
+    name: "Testing External Agent Runtime",
+    version: "0.1.0",
+    author: "Resonant Extension Framework Tests",
+    category: "agent",
+    description: "Synthetic external-agent-runtime manifest used by ADR-040 §7 failure-mode tests.",
+    runtimeType: "local-service",
+    surfaces: [
+      {
+        id: "testing-external-agent-runs",
+        type: "background-task-monitor",
+        label: "Testing External Agent Runs",
+        description: "Track delegated agent-runtime tasks under test.",
+      },
+    ],
+    requestedCapabilities: MOCK_EXTERNAL_AGENT_CAPABILITY_GRANTS,
+    provenance: {
+      tier: "curated-signed",
+      verificationState: "verified",
+      signed: true,
+      signer: "Resonant Extension Framework Testing",
+    },
+    runtimeIsolation: {
+      boundary: "host-mediated-service",
+      supportsDegradedMode: true,
+      requiresReviewedGrant: true,
+    },
+    grantPresets: [
+      {
+        id: "testing-external-agent-default",
+        label: "Testing default external agent runtime",
+        description: "Default granted set: providers (shared), agent-delegation (workspace), network (self), filesystem (self), archive-read (workspace), archive-intake-write (intake-only), notifications (self).",
+        grants: MOCK_EXTERNAL_AGENT_CAPABILITY_GRANTS.map((g) => ({ ...g, granted: true })),
+      },
+    ],
+    providerRequirements: {
+      sharedProfiles: ["resonant-deepseek-v4-pro"],
+      supportsPrivateCredentials: false,
+      recommendedPrimaryModel: "deepseek-v4-pro",
+      recommendedFallbackModel: "deepseek-mini",
+      preferredRuntimeKinds: ["local", "remote-user-owned"],
+      allowExperimentalAuth: false,
+    },
+    systemSlots: [],
+    archiveIntegration: {
+      readScopes: ["LivingArchive/INTAKE/testing-external-agent"],
+      intakeWriteScopes: ["LivingArchive/INTAKE/testing-external-agent"],
+      canRequestIngest: true,
+      canWriteKnowledgePages: false,
+    },
+    health: {
+      strategy: "external-agent-runtime-ready",
+      endpoint: "http://127.0.0.1:4891/healthz",
+    },
+    service: {
+      protocol: "http-json",
+      entrypoint: "http://127.0.0.1:4891",
+      visibleEntrypoint: "http://127.0.0.1:4891",
+      healthCommand: "GET /healthz",
+      shutdownCommand: "POST /shutdown",
+    },
+    delegation: {
+      acceptsTasks: true,
+      taskTypes: ["research", "design"],
+      artifactReturnTypes: ["summary", "log"],
+      defaultTargetRuntime: "external-agent",
+      requiresHumanApprovalBeforeExecution: true,
+      notes: ["Synthetic external-agent-runtime test fixture; ADR-040 §3 trigger."],
+    },
+    installHooks: {
+      onInstall: "install-external-agent.sh",
+      onEnable: "enable-external-agent.sh",
+      onUpgrade: "upgrade-external-agent.sh",
+    },
+    workflowBoundaries: [
+      {
+        id: "testing-agent-task-boundary",
+        label: "Testing External Agent Task Boundary",
+        jobToBeDone: "Run delegated tasks under the §3 boundary rules.",
+        userValue: "Allow the host to validate an external agent runtime against ADR-040 §7.",
+        repeatability: "workflow-package",
+        owner: "addon-agent",
+        nonGoals: ["Provider selection", "Credential storage", "Workspace escape"],
+      },
+    ],
+    tools: MOCK_EXTERNAL_AGENT_TOOLS,
+    engineerSetup: {
+      documentPath: "docs/testing/external-agent-setup.md",
+      objective: "Bring up the testing external agent runtime against the mock host.",
+      requiredCapabilities: ["providers", "agent-delegation", "filesystem"],
+      allowedHostCommands: ["start", "stop", "reset"],
+      expectedInputs: ["manifest", "routing decision"],
+      expectedOutputs: ["task artifacts"],
+      requiresHumanApprovalBeforeExecution: true,
+      auditLogRequired: true,
+    },
+    compatibility: {
+      shellVersion: "0.1.0",
+      platforms: ["darwin-arm64", "linux-x64"],
+    },
+    agents: [
+      {
+        id: "testing-external-agent",
+        displayName: "Testing External Agent",
+        trustTier: "external",
+        workspaceBehavior: "delegated",
+      },
+    ],
+  };
+}
+
+/**
+ * Returns the fixture base manifest. Tests should treat the returned
+ * value as immutable; use `externalAgentRuntimeFixture()` for a fresh
+ * copy each test.
+ */
+export function externalAgentRuntimeFixture(): ExternalAgentRuntimeManifest {
+  if (!validatedFixture) {
+    const candidate = buildBase();
+    const validation = validateAddOnManifest(candidate);
+    if (!validation.valid) {
+      throw new Error(
+        `externalAgentRuntimeFixture failed validation: ${JSON.stringify(validation.issues)}`,
+      );
+    }
+    validatedFixture = candidate;
+  }
+  return { ...validatedFixture, callerId: MOCK_CALLER_ID } as ExternalAgentRuntimeManifest;
+}
+
+/**
+ * Helpers that tests use to flip a single grant to `granted: true` on
+ * a fresh fixture, simulating the user accepting a specific
+ * `grantPreset` (or the host passing a single grant outside a preset).
+ */
+export function withGranted(manifest: ExternalAgentRuntimeManifest, capability: Capability): ExternalAgentRuntimeManifest {
+  const next: AddOnManifest = {
+    ...manifest,
+    requestedCapabilities: manifest.requestedCapabilities.map((g) =>
+      g.capability === capability ? { ...g, granted: true } : g,
+    ),
+  };
+  return { ...next, callerId: manifest.callerId };
+}
+
+export function withScope(manifest: ExternalAgentRuntimeManifest, capability: Capability, scope: CapabilityScope): ExternalAgentRuntimeManifest {
+  const next: AddOnManifest = {
+    ...manifest,
+    requestedCapabilities: manifest.requestedCapabilities.map((g) =>
+      g.capability === capability ? { ...g, scope } : g,
+    ),
+  };
+  return { ...next, callerId: manifest.callerId };
+}
+
+export function withTool(manifest: ExternalAgentRuntimeManifest, tool: AddOnToolDefinition): ExternalAgentRuntimeManifest {
+  const tools = manifest.tools ? [...manifest.tools, tool] : [tool];
+  return { ...manifest, tools };
+}
+
+/** The fixture's mock caller id; exported so F-cases don't have to read it off the manifest. */
+export const FIXTURE_CALLER_ID = MOCK_CALLER_ID;
+
+/** The fixture's declared tool names, used by F5 (undeclared tool probe). */
+export function declaredToolNames(manifest: ExternalAgentRuntimeManifest): readonly string[] {
+  return (manifest.tools ?? []).map((t) => t.name);
+}

--- a/packages/addon-sdk-testing/src/mock-host.ts
+++ b/packages/addon-sdk-testing/src/mock-host.ts
@@ -1,0 +1,313 @@
+// Intent citation: docs/architecture/ADR-040-provider-fabric-boundary-external-agent-runtimes.md#3-boundary-rules
+// Intent citation: docs/architecture/ADR-040-provider-fabric-boundary-external-agent-runtimes.md#4-credential-mediation
+// Intent citation: docs/architecture/ADR-040-provider-fabric-boundary-external-agent-runtimes.md#5-model-routing
+//
+// In-process mock ResonantOS host. Implements the bridge, the
+// routing-decision store, the audit log, and the approval-prompt
+// surface — just enough to back ADR-040 §7 failure modes F1–F10.
+//
+// The mock does NOT replicate the real host's token-mint / verify
+// pipeline; it asserts the deny codes and audit reasons described in
+// ADR-040 §7. The mock host is the only object tests interact with
+// across F1–F10; it is intentionally narrow.
+
+import type {
+  AddOnManifest,
+  Capability,
+  CapabilityGrant,
+  CapabilityScope,
+  RevocationBehavior,
+} from "../../../src/core/contracts.ts";
+
+import type { AuditCapture, } from "./audit-capture.ts";
+import { createAuditCapture } from "./audit-capture.ts";
+import type { RoutingDecision, RoutingStore } from "./routing-store.ts";
+import { createRoutingStore } from "./routing-store.ts";
+import type { FailureModeExpectedCode, FailureModeId } from "./outcome.ts";
+
+export type ApprovalDecision = "approved" | "denied";
+
+export interface MockHostOptions {
+  /** Approval prompt resolver. F7 invokes this with the tool name + manifest id. */
+  onApprovalPrompt?: (toolName: string, addonId: string) => ApprovalDecision;
+  /** Clock for the routing store; defaults to wall clock. F8 overrides to force expiry. */
+  now?: () => Date;
+  /** Default TTL for issued routing decisions (ms). */
+  routingDecisionTtlMs?: number;
+}
+
+export type BridgeDeny =
+  | { ok: false; code: "credential-in-payload"; callerId: string; payloadKeys: readonly string[] }
+  | { ok: false; code: "provider-self-selection-rejected"; callerId: string; rejectedModel: string; requiredRoutingDecisionId: string }
+  | { ok: false; code: "workspace-escape"; callerId: string; requestedPath: string; workspaceRoot: string }
+  | { ok: false; code: "capability-denied"; callerId: string; required: Capability; current: readonly Capability[] }
+  | { ok: false; code: "unknown-tool"; callerId: string; toolName: string; declaredTools: readonly string[] }
+  | { ok: false; code: "audit-bypass-attempt"; callerId: string; surface: string }
+  | { ok: false; code: "approval-required"; callerId: string; toolName: string }
+  | { ok: false; code: "approval-denied"; callerId: string; toolName: string }
+  | { ok: false; code: "routing-decision-expired"; callerId: string; routingDecisionId: string }
+  | { ok: false; code: "routing-decision-revoked"; callerId: string; routingDecisionId: string }
+  | { ok: false; code: "experimental-route-not-declared"; callerId: string; requestedAuthTier: string };
+
+export type BridgeResult<R> = { ok: true; result: R } | { ok: false } & BridgeDeny;
+
+export interface ToolCallRequest {
+  toolName: string;
+  payload: Record<string, unknown>;
+  callerId: string;
+}
+
+export interface ModelRequest {
+  callerId: string;
+  /** If set, the runtime is overriding what the routing decision said (F2 trigger). */
+  explicitModel?: string;
+  /** The routing decision the runtime is forwarding. */
+  routingDecisionId: string;
+  payload: Record<string, unknown>;
+  /** Streamed model request. The runtime is allowed to stream model chunks while the decision is valid. */
+  streamChunks?: boolean;
+}
+
+export interface WorkspaceAccessRequest {
+  callerId: string;
+  requestedPath: string;
+  /** Workspace root the runtime was scoped to by the runtime grant set. */
+  workspaceRoot: string;
+}
+
+export interface ArtifactReturnRequest {
+  callerId: string;
+  /** Surface the runtime is returning artifacts to. */
+  surface: string;
+  artifacts: readonly string[];
+}
+
+export interface ApproveRequest {
+  callerId: string;
+  toolName: string;
+  addonId: string;
+}
+
+export interface MockHost {
+  readonly audit: AuditCapture;
+  readonly routing: RoutingStore;
+  /** Issue a fresh routing decision (used to set up F8/F9). */
+  issueRoutingDecision(input: Omit<RoutingDecision, "routingDecisionId"> & { routingDecisionId?: string }): RoutingDecision;
+  /** F1 surface: forward payload across the network bridge. */
+  forwardNetwork(request: { callerId: string; payload: Record<string, unknown>; headers: Record<string, string> }): BridgeResult<{ forwarded: true }>;
+  /** F2 surface: validate a model request against a routing decision. */
+  invokeModel(request: ModelRequest): BridgeResult<{ model: string; streamedChunks: number }>;
+  /** F3 surface: route a workspace path access. */
+  accessWorkspace(request: WorkspaceAccessRequest): BridgeResult<{ resolvedPath: string }>;
+  /** F4 surface: attempt a privileged route not in the granted caller token. */
+  callArchiveIntakeWrite(request: { callerId: string; granted: readonly Capability[]; requested: Capability; itemRef: string }): BridgeResult<{ intakeId: string }>;
+  /** F5 surface: validate a tool name is in the addon manifest's `tools[]`. */
+  invokeTool(request: ToolCallRequest, declaredTools: readonly string[]): BridgeResult<{ toolName: string }>;
+  /** F6 surface: return artifacts from a delegated task. */
+  returnArtifacts(request: ArtifactReturnRequest, validSurfaces: readonly string[]): BridgeResult<{ acceptedArtifacts: readonly string[] }>;
+  /** F7 surface: attempt a tool that requires human approval. */
+  requestApproval(request: ApproveRequest): BridgeResult<{ decision: ApprovalDecision }>;
+  /** F8/F9 surface: forward a model request that depends on a routing decision. */
+  forwardModelRequest(request: ModelRequest): BridgeResult<{ resolvedModel: string }>;
+  /** F10 surface: request an experimental route. The mock checks `allowExperimentalAuth` from the manifest. */
+  requestExperimentalRoute(request: { callerId: string; routingDecisionId: string; experimental: true }): BridgeResult<{ resolvedModel: string }>;
+  /** Reset audit + routing store (used between F-cases in the same `runAddOnFailureMode` invocation). */
+  reset(): void;
+}
+
+export function mockHost(options: MockHostOptions = {}): MockHost {
+  const audit = createAuditCapture();
+  const routing = createRoutingStore(options.now);
+  const onApproval = options.onApprovalPrompt ?? (() => "approved");
+  const ttlMs = options.routingDecisionTtlMs ?? 5 * 60 * 1000;
+
+  function recordDeny(modeId: FailureModeId, callerId: string, code: FailureModeExpectedCode | string, detail?: Record<string, unknown>): void {
+    audit.record({ modeId, callerId, reason: code, detail });
+  }
+
+  function defaultIssue(input: Omit<RoutingDecision, "routingDecisionId"> & { routingDecisionId?: string }): RoutingDecision {
+    return routing.issue(input);
+  }
+
+  function forwardNetwork(request: { callerId: string; payload: Record<string, unknown>; headers: Record<string, string> }): BridgeResult<{ forwarded: true }> {
+    const forbiddenKeys = Object.keys(request.headers).filter((k) => /^(authorization|x-api-key|cookie)$/i.test(k));
+    if (forbiddenKeys.length > 0) {
+      const code: FailureModeExpectedCode = "credential-in-payload";
+      recordDeny("F1", request.callerId, code, {
+        forbiddenHeaderKeys: forbiddenKeys,
+        bodyKeys: Object.keys(request.payload),
+      });
+      return { ok: false, code, callerId: request.callerId, payloadKeys: forbiddenKeys } as BridgeDeny & { ok: false };
+    }
+    if (Object.keys(request.payload).some((k) => /(api[-_]?key|token|secret)/i.test(k))) {
+      const code: FailureModeExpectedCode = "credential-in-payload";
+      recordDeny("F1", request.callerId, code, {
+        forbiddenBodyKeys: Object.keys(request.payload).filter((k) => /(api[-_]?key|token|secret)/i.test(k)),
+      });
+      return { ok: false, code, callerId: request.callerId, payloadKeys: Object.keys(request.payload) } as BridgeDeny & { ok: false };
+    }
+    return { ok: true, result: { forwarded: true } };
+  }
+
+  function lookupRouting(routingDecisionId: string, callerId: string): { ok: true; decision: RoutingDecision } | { ok: false; code: FailureModeExpectedCode } {
+    const resolved = routing.resolve(routingDecisionId);
+    if ("error" in resolved) {
+      recordDeny(resolved.error === "routing-decision-expired" ? "F8" : "F9", callerId, resolved.error, { routingDecisionId });
+      return { ok: false, code: resolved.error };
+    }
+    return { ok: true, decision: resolved };
+  }
+
+  function invokeModel(request: ModelRequest): BridgeResult<{ model: string; streamedChunks: number }> {
+    const routingResult = lookupRouting(request.routingDecisionId, request.callerId);
+    if (!routingResult.ok) {
+      const code = routingResult.code;
+      if (code === "routing-decision-expired") {
+        return { ok: false, code, callerId: request.callerId, routingDecisionId: request.routingDecisionId } as BridgeDeny & { ok: false };
+      }
+      return { ok: false, code, callerId: request.callerId, routingDecisionId: request.routingDecisionId } as BridgeDeny & { ok: false };
+    }
+    const decision = routingResult.decision;
+    if (request.explicitModel !== undefined && request.explicitModel !== decision.model) {
+      const code: FailureModeExpectedCode = "provider-self-selection-rejected";
+      recordDeny("F2", request.callerId, code, {
+        rejectedModel: request.explicitModel,
+        routingDecisionModel: decision.model,
+        routingDecisionId: request.routingDecisionId,
+      });
+      return { ok: false, code, callerId: request.callerId, rejectedModel: request.explicitModel, requiredRoutingDecisionId: request.routingDecisionId } as BridgeDeny & { ok: false };
+    }
+    return { ok: true, result: { model: decision.model, streamedChunks: request.streamChunks ? 1 : 0 } };
+  }
+
+  function accessWorkspace(request: WorkspaceAccessRequest): BridgeResult<{ resolvedPath: string }> {
+    const requested = request.requestedPath;
+    const root = request.workspaceRoot;
+    const inside = requested === root || requested.startsWith(root + "/");
+    if (!inside) {
+      const code: FailureModeExpectedCode = "workspace-escape";
+      recordDeny("F3", request.callerId, code, {
+        requestedPath: requested,
+        workspaceRoot: root,
+      });
+      return { ok: false, code, callerId: request.callerId, requestedPath: requested, workspaceRoot: root } as BridgeDeny & { ok: false };
+    }
+    return { ok: true, result: { resolvedPath: requested } };
+  }
+
+  function callArchiveIntakeWrite(request: { callerId: string; granted: readonly Capability[]; requested: Capability; itemRef: string }): BridgeResult<{ intakeId: string }> {
+    if (!request.granted.includes(request.requested)) {
+      const code: FailureModeExpectedCode = "capability-denied";
+      recordDeny("F4", request.callerId, code, {
+        required: request.requested,
+        current: [...request.granted],
+        itemRef: request.itemRef,
+      });
+      return { ok: false, code, callerId: request.callerId, required: request.requested, current: request.granted } as BridgeDeny & { ok: false };
+    }
+    return { ok: true, result: { intakeId: `intake-${request.itemRef}` } };
+  }
+
+  function invokeTool(request: ToolCallRequest, declaredTools: readonly string[]): BridgeResult<{ toolName: string }> {
+    if (!declaredTools.includes(request.toolName)) {
+      const code: FailureModeExpectedCode = "unknown-tool";
+      recordDeny("F5", request.callerId, code, {
+        toolName: request.toolName,
+        declaredTools: [...declaredTools],
+      });
+      return { ok: false, code, callerId: request.callerId, toolName: request.toolName, declaredTools } as BridgeDeny & { ok: false };
+    }
+    return { ok: true, result: { toolName: request.toolName } };
+  }
+
+  function returnArtifacts(request: ArtifactReturnRequest, validSurfaces: readonly string[]): BridgeResult<{ acceptedArtifacts: readonly string[] }> {
+    if (!validSurfaces.includes(request.surface)) {
+      const code: FailureModeExpectedCode = "audit-bypass-attempt";
+      recordDeny("F6", request.callerId, code, {
+        surface: request.surface,
+        validSurfaces: [...validSurfaces],
+      });
+      return { ok: false, code, callerId: request.callerId, surface: request.surface } as BridgeDeny & { ok: false };
+    }
+    return { ok: true, result: { acceptedArtifacts: request.artifacts } };
+  }
+
+  function requestApproval(request: ApproveRequest): BridgeResult<{ decision: ApprovalDecision }> {
+    const decision = onApproval(request.toolName, request.addonId);
+    if (decision === "approved") {
+      return { ok: true, result: { decision } };
+    }
+    const code: FailureModeExpectedCode = "approval-denied";
+    recordDeny("F7", request.callerId, code, { toolName: request.toolName, addonId: request.addonId });
+    return { ok: false, code, callerId: request.callerId, toolName: request.toolName } as BridgeDeny & { ok: false };
+  }
+
+  function forwardModelRequest(request: ModelRequest): BridgeResult<{ resolvedModel: string }> {
+    const routingResult = lookupRouting(request.routingDecisionId, request.callerId);
+    if (!routingResult.ok) {
+      const code = routingResult.code;
+      return { ok: false, code, callerId: request.callerId, routingDecisionId: request.routingDecisionId } as BridgeDeny & { ok: false };
+    }
+    return { ok: true, result: { resolvedModel: routingResult.decision.model } };
+  }
+
+  function requestExperimentalRoute(request: { callerId: string; routingDecisionId: string; experimental: true }): BridgeResult<{ resolvedModel: string }> {
+    // Caller signals the attempt; mock returns "experimental-route-not-declared"
+    // because the resolve path itself is what would gate on the manifest's
+    // `allowExperimentalAuth`. F10 caller is expected to provide a manifest
+    // whose `providerRequirements.allowExperimentalAuth` is false; the resolve
+    // below is shared with F8/F9 to exercise stale/revoked paths too.
+    const routingResult = lookupRouting(request.routingDecisionId, request.callerId);
+    if (!routingResult.ok) {
+      const code = routingResult.code;
+      return { ok: false, code, callerId: request.callerId, routingDecisionId: request.routingDecisionId } as BridgeDeny & { ok: false };
+    }
+    const code: FailureModeExpectedCode = "experimental-route-not-declared";
+    recordDeny("F10", request.callerId, code, { authTier: "experimental", routingDecisionId: request.routingDecisionId });
+    return { ok: false, code, callerId: request.callerId, requestedAuthTier: "experimental" } as BridgeDeny & { ok: false };
+  }
+
+  function reset(): void {
+    audit.reset();
+    routing.reset();
+  }
+
+  return {
+    audit,
+    routing,
+    issueRoutingDecision: defaultIssue,
+    forwardNetwork,
+    invokeModel,
+    accessWorkspace,
+    callArchiveIntakeWrite,
+    invokeTool,
+    returnArtifacts,
+    requestApproval,
+    forwardModelRequest,
+    requestExperimentalRoute,
+    reset,
+  };
+}
+
+/**
+ * Convenience: `caps` for a manifest fixture's `requestedCapabilities`.
+ * Used by F4 and F7 to know which capabilities are currently in the
+ * caller-attributed token.
+ */
+export function grantedCapabilities(manifest: AddOnManifest): readonly Capability[] {
+  return manifest.requestedCapabilities.filter((g: CapabilityGrant) => g.granted).map((g) => g.capability);
+}
+
+export function grantedScope(manifest: AddOnManifest, capability: Capability): CapabilityScope | undefined {
+  return manifest.requestedCapabilities.find((g) => g.capability === capability)?.scope;
+}
+
+export function revocationBehavior(manifest: AddOnManifest, capability: Capability): RevocationBehavior | undefined {
+  return manifest.requestedCapabilities.find((g) => g.capability === capability)?.revocationBehavior;
+}
+
+// Re-export for callers that don't want to import the sub-paths.
+export { createAuditCapture } from "./audit-capture.ts";
+export { createRoutingStore } from "./routing-store.ts";
+export type { AuditCapture } from "./audit-capture.ts";
+export type { RoutingDecision, RoutingStore } from "./routing-store.ts";

--- a/packages/addon-sdk-testing/src/outcome.ts
+++ b/packages/addon-sdk-testing/src/outcome.ts
@@ -1,0 +1,67 @@
+// Intent citation: docs/architecture/ADR-040-provider-fabric-boundary-external-agent-runtimes.md#7-failure-modes
+//
+// Result types for the negative-test harness. These describe what the
+// mock host did in response to a failure-mode attempt and whether that
+// response matches ADR-040 §7's "Expected:" clause.
+
+/**
+ * The deny-code / reason the ADR-040 §7 clause asserts the host should
+ * emit in response to a given failure mode. Each value corresponds
+ * verbatim to one `Expected:` clause in ADR-040 §7.
+ */
+export type FailureModeExpectedCode =
+  | "credential-in-payload"
+  | "provider-self-selection-rejected"
+  | "workspace-escape"
+  | "capability-denied"
+  | "unknown-tool"
+  | "audit-bypass-attempt"
+  | "approval-required"
+  | "approval-denied"
+  | "routing-decision-expired"
+  | "routing-decision-revoked"
+  | "experimental-route-not-declared";
+
+export type FailureModeId =
+  | "F1"
+  | "F2"
+  | "F3"
+  | "F4"
+  | "F5"
+  | "F6"
+  | "F7"
+  | "F8"
+  | "F9"
+  | "F10";
+
+export interface FailureModeAuditEntry {
+  /** ISO timestamp of the audit event. */
+  readonly timestamp: string;
+  /** Failure-mode id this audit entry was emitted for. */
+  readonly modeId: FailureModeId;
+  /** Mirrors the deny-code so callers can correlate with `actual.code`. */
+  readonly reason: FailureModeExpectedCode | string;
+  /** Caller-attributed capability-token id (ADR-038 §8) that was on the wire. */
+  readonly callerId: string;
+  /** Free-form structured detail the simulated bridge attached. */
+  readonly detail?: Record<string, unknown>;
+}
+
+/**
+ * The outcome of running one failure-mode case against a manifest
+ * fixture. `expected` is verbatim from ADR-040 §7; `actual` is what
+ * the mock host did; `pass` is whether `actual` matches `expected`.
+ */
+export interface FailureModeReport {
+  readonly modeId: FailureModeId;
+  readonly expected: {
+    readonly code: FailureModeExpectedCode;
+    readonly auditReason?: FailureModeExpectedCode | string;
+  };
+  readonly actual: {
+    readonly code: FailureModeExpectedCode | string;
+    readonly auditReason?: FailureModeExpectedCode | string;
+    readonly auditEntry?: FailureModeAuditEntry;
+  };
+  readonly pass: boolean;
+}

--- a/packages/addon-sdk-testing/src/routing-store.ts
+++ b/packages/addon-sdk-testing/src/routing-store.ts
@@ -1,0 +1,96 @@
+// Intent citation: docs/architecture/ADR-040-provider-fabric-boundary-external-agent-runtimes.md#4-credential-mediation
+// Intent citation: docs/architecture/ADR-005-provider-fabric-routing.md
+//
+// In-process routing-decision store used by `mock-host.ts` to back the
+// failure modes F8 (stale) and F9 (revoked). Mirrors the wire shape in
+// ADR-040 §4 (the "routed model handle") — opaque IDs, expiry, revocable.
+
+import type { AuthTier, ProviderCostPosture, RuntimeNodeKind } from "../../../src/core/contracts.ts";
+
+export interface RoutingDecision {
+  readonly routingDecisionId: string;
+  readonly providerProfileId: string;
+  readonly runtimeNodeId: string;
+  readonly model: string;
+  readonly authTier: AuthTier;
+  readonly costPosture: ProviderCostPosture;
+  readonly fallbackChain: readonly string[];
+  /** ISO timestamp; past this, the host treats the decision as stale. */
+  readonly expiresAt: string;
+  readonly callerId: string;
+}
+
+export interface RoutingStore {
+  issue(decision: Omit<RoutingDecision, "routingDecisionId"> & { routingDecisionId?: string }): RoutingDecision;
+  /** Returns the decision if it exists, is not expired, and is not revoked. */
+  resolve(routingDecisionId: string, nowIso?: string): RoutingDecision | { error: FailureModeExpectedCode };
+  revoke(routingDecisionId: string): boolean;
+  /** Force an issue to be expired immediately. Used to test F8 in a deterministic clock. */
+  expire(routingDecisionId: string): boolean;
+  snapshot(): readonly RoutingDecision[];
+  reset(): void;
+}
+
+import type { FailureModeExpectedCode } from "./outcome.ts";
+
+let nextId = 1;
+
+export function createRoutingStore(now?: () => Date): RoutingStore {
+  const decisions = new Map<string, RoutingDecision>();
+  const revoked = new Set<string>();
+  const clock = now ?? (() => new Date());
+
+  function issue(input: Omit<RoutingDecision, "routingDecisionId"> & { routingDecisionId?: string }): RoutingDecision {
+    const id = input.routingDecisionId ?? `rd-${String(nextId++).padStart(3, "0")}`;
+    const decision: RoutingDecision = {
+      routingDecisionId: id,
+      providerProfileId: input.providerProfileId,
+      runtimeNodeId: input.runtimeNodeId,
+      model: input.model,
+      authTier: input.authTier,
+      costPosture: input.costPosture,
+      fallbackChain: input.fallbackChain,
+      expiresAt: input.expiresAt,
+      callerId: input.callerId,
+    };
+    decisions.set(id, decision);
+    revoked.delete(id);
+    return decision;
+  }
+
+  function resolve(routingDecisionId: string, nowIso?: string): RoutingDecision | { error: FailureModeExpectedCode } {
+    const d = decisions.get(routingDecisionId);
+    if (!d) return { error: "routing-decision-revoked" };
+    if (revoked.has(routingDecisionId)) return { error: "routing-decision-revoked" };
+    const nowMs = nowIso ? Date.parse(nowIso) : clock().getTime();
+    if (nowMs > Date.parse(d.expiresAt)) return { error: "routing-decision-expired" };
+    return d;
+  }
+
+  function revoke(routingDecisionId: string): boolean {
+    if (!decisions.has(routingDecisionId)) return false;
+    revoked.add(routingDecisionId);
+    return true;
+  }
+
+  function expire(routingDecisionId: string): boolean {
+    const d = decisions.get(routingDecisionId);
+    if (!d) return false;
+    const past: RoutingDecision = { ...d, expiresAt: "1970-01-01T00:00:00Z" };
+    decisions.set(routingDecisionId, past);
+    return true;
+  }
+
+  function snapshot(): readonly RoutingDecision[] {
+    return Array.from(decisions.values());
+  }
+
+  function reset(): void {
+    decisions.clear();
+    revoked.clear();
+  }
+
+  return { issue, resolve, revoke, expire, snapshot, reset };
+}
+
+export const _internal = { setNextId: (n: number) => { nextId = n; } };

--- a/packages/addon-sdk-testing/test/failure-modes.test.ts
+++ b/packages/addon-sdk-testing/test/failure-modes.test.ts
@@ -1,0 +1,98 @@
+// Intent citation: docs/architecture/ADR-040-provider-fabric-boundary-external-agent-runtimes.md#7-failure-modes
+//
+// Vitest suite for ADR-040 §7 failure modes F1–F10. One case per
+// F-number; each case invokes `runAddOnFailureMode(modeId, manifest)`
+// against the synthetic external-agent-runtime fixture and asserts
+// the resulting `FailureModeReport.pass` is true.
+//
+// The expected deny codes and audit reasons are sourced verbatim from
+// the ADR-040 §7 `Expected:` clauses; see
+// `packages/addon-sdk-testing/src/failure-modes/index.ts` (`expectedFor`)
+// for the canonical copy.
+
+import { describe, expect, it } from "vitest";
+import {
+  runAddOnFailureMode,
+  externalAgentRuntimeFixture,
+  type FailureModeId,
+} from "../src/index.ts";
+
+const ALL_MODES: readonly FailureModeId[] = ["F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10"];
+
+describe("ADR-040 §7 failure modes", () => {
+  for (const modeId of ALL_MODES) {
+    it(`${modeId} — host denies with the ADR-040 §7 Expected: clause`, () => {
+      const manifest = externalAgentRuntimeFixture();
+      const report = runAddOnFailureMode(modeId, manifest);
+
+      if (!report.pass) {
+        // Surface the actual vs. expected so test output names the regression.
+        expect({
+          modeId: report.modeId,
+          expected: report.expected,
+          actual: report.actual,
+        }).toEqual({
+          modeId: report.modeId,
+          expected: report.expected,
+          actual: { code: report.expected.code, auditReason: report.expected.auditReason ?? report.expected.code },
+        });
+        return;
+      }
+
+      expect(report.actual.code).toBe(report.expected.code);
+      expect(report.actual.auditReason ?? report.actual.code).toBe(report.expected.auditReason ?? report.expected.code);
+      expect(report.pass).toBe(true);
+    });
+  }
+
+  it("F1 also emits the credential-in-payload audit record (Rule 7)", () => {
+    const manifest = externalAgentRuntimeFixture();
+    const host = mockHostForInspector();
+    const report = runAddOnFailureMode("F1", manifest, { host });
+
+    expect(report.pass).toBe(true);
+    const entry = host.audit.latestFor("F1");
+    expect(entry).toBeDefined();
+    expect(entry?.reason).toBe("credential-in-payload");
+    expect(entry?.callerId).toBe(manifest.callerId);
+  });
+
+  it("F3 also emits the workspace-escape audit record with the requested path", () => {
+    const manifest = externalAgentRuntimeFixture();
+    const host = mockHostForInspector();
+    const report = runAddOnFailureMode("F3", manifest, { host });
+
+    expect(report.pass).toBe(true);
+    const entry = host.audit.latestFor("F3");
+    expect(entry).toBeDefined();
+    expect(entry?.reason).toBe("workspace-escape");
+    expect(entry?.detail).toMatchObject({ requestedPath: "/etc/passwd" });
+  });
+
+  it("F8 expires the routing decision before the runtime uses it", () => {
+    const manifest = externalAgentRuntimeFixture();
+    const host = mockHostForInspector();
+    const report = runAddOnFailureMode("F8", manifest, { host });
+
+    expect(report.pass).toBe(true);
+    const entry = host.audit.latestFor("F8");
+    expect(entry).toBeDefined();
+    expect(entry?.reason).toBe("routing-decision-expired");
+  });
+
+  it("F9 revokes the routing decision before the runtime uses it", () => {
+    const manifest = externalAgentRuntimeFixture();
+    const host = mockHostForInspector();
+    const report = runAddOnFailureMode("F9", manifest, { host });
+
+    expect(report.pass).toBe(true);
+    const entry = host.audit.latestFor("F9");
+    expect(entry).toBeDefined();
+    expect(entry?.reason).toBe("routing-decision-revoked");
+  });
+});
+
+import { mockHost } from "../src/mock-host.ts";
+function mockHostForInspector() {
+  return mockHost();
+}

--- a/packages/addon-sdk-testing/test/manifest-fixture-contract.test.ts
+++ b/packages/addon-sdk-testing/test/manifest-fixture-contract.test.ts
@@ -1,0 +1,68 @@
+// Intent citation: docs/architecture/ADR-040-provider-fabric-boundary-external-agent-runtimes.md#3-boundary-rules
+// Intent citation: docs/architecture/ADR-038-resonant-extension-framework.md#7-runtime-boundary
+//
+// Fixture contract: validates that the synthetic external-agent-runtime
+// manifest the testing package depends on is shape-compatible with the
+// SDK's `validateAddOnManifest`. If the SDK's contract changes, this
+// test fails immediately so the F-cases don't drift.
+
+import { describe, expect, it } from "vitest";
+import {
+  externalAgentRuntimeFixture,
+  declaredToolNames,
+  withGranted,
+} from "../src/manifest-fixtures.ts";
+import { validateAddOnManifest } from "../../../src/sdk/addons/validation.ts";
+import type { ExternalAgentRuntimeManifest } from "../src/manifest-fixtures.ts";
+
+describe("externalAgentRuntimeFixture contract", () => {
+  it("validates against the SDK's `validateAddOnManifest`", () => {
+    const manifest = externalAgentRuntimeFixture();
+    const result = validateAddOnManifest(manifest);
+    expect(result.valid).toBe(true);
+    expect(result.issues.length).toBe(0);
+  });
+
+  it("declares the ADR-040 §3 conjunction: providers + agent-delegation", () => {
+    const manifest = externalAgentRuntimeFixture();
+    const caps = manifest.requestedCapabilities.map((g) => g.capability);
+    expect(caps).toContain("providers");
+    expect(caps).toContain("agent-delegation");
+  });
+
+  it("declares run_task with requiresHumanApproval: true (ADR-040 §3 Rule 8)", () => {
+    const manifest = externalAgentRuntimeFixture();
+    const runTask = manifest.tools?.find((t) => t.name === "run_task");
+    expect(runTask).toBeDefined();
+    expect(runTask?.requiresHumanApproval).toBe(true);
+  });
+
+  it("declares providerRequirements.allowExperimentalAuth: false (F10 trigger)", () => {
+    const manifest = externalAgentRuntimeFixture();
+    expect(manifest.providerRequirements.allowExperimentalAuth).toBe(false);
+  });
+
+  it("matches what declaredToolNames reports", () => {
+    const manifest: ExternalAgentRuntimeManifest = externalAgentRuntimeFixture();
+    expect(declaredToolNames(manifest)).toEqual([
+      "send_model_request",
+      "run_task",
+    ]);
+  });
+
+  it("withGranted produces a manifest that still validates against the SDK", () => {
+    const manifest = externalAgentRuntimeFixture();
+    const flipped = withGranted(manifest, "network");
+    expect(flipped.requestedCapabilities.find((g) => g.capability === "network")?.granted).toBe(true);
+    const result = validateAddOnManifest(flipped);
+    expect(result.valid).toBe(true);
+  });
+
+  it("ID is stable: 'addon.testing.external-agent-runtime'", () => {
+    expect(externalAgentRuntimeFixture().id).toBe("addon.testing.external-agent-runtime");
+  });
+
+  it("runtimeType is 'local-service' (ADR-040 §9 reference shape)", () => {
+    expect(externalAgentRuntimeFixture().runtimeType).toBe("local-service");
+  });
+});

--- a/packages/addon-sdk-testing/test/mock-host.test.ts
+++ b/packages/addon-sdk-testing/test/mock-host.test.ts
@@ -1,0 +1,268 @@
+// Intent citation: docs/architecture/ADR-040-provider-fabric-boundary-external-agent-runtimes.md#3-rule-7-audit-before-return
+// Intent citation: docs/architecture/ADR-040-provider-fabric-boundary-external-agent-runtimes.md#4-credential-mediation
+//
+// Infrastructure tests for the mock host. These lock the contract of
+// the audit-capture and routing-store primitives so that any change
+// to their behavior surfaces as a regression here, before it
+// manifests in failure-modes.test.ts.
+
+import { describe, expect, it } from "vitest";
+import { createAuditCapture } from "../src/audit-capture.ts";
+import { createRoutingStore } from "../src/routing-store.ts";
+import { mockHost, grantedCapabilities } from "../src/mock-host.ts";
+import { externalAgentRuntimeFixture } from "../src/manifest-fixtures.ts";
+import type { FailureModeAuditEntry } from "../src/outcome.ts";
+
+describe("audit-capture", () => {
+  it("records each entry with the supplied reason and caller id", () => {
+    const audit = createAuditCapture();
+    audit.record({ modeId: "F1", callerId: "caller-1", reason: "credential-in-payload" });
+    audit.record({ modeId: "F3", callerId: "caller-1", reason: "workspace-escape" });
+
+    const snap = audit.snapshot();
+    expect(snap.length).toBe(2);
+    expect(snap[0].reason).toBe("credential-in-payload");
+    expect(snap[1].reason).toBe("workspace-escape");
+  });
+
+  it("latestFor returns the most recent record for a mode id", () => {
+    const audit = createAuditCapture();
+    audit.record({ modeId: "F1", callerId: "caller-1", reason: "credential-in-payload" });
+    audit.record({ modeId: "F3", callerId: "caller-1", reason: "workspace-escape" });
+    audit.record({ modeId: "F1", callerId: "caller-1", reason: "credential-in-payload" });
+
+    const entry: FailureModeAuditEntry | undefined = audit.latestFor("F1");
+    expect(entry).toBeDefined();
+    expect(entry?.reason).toBe("credential-in-payload");
+    const snap = audit.snapshot();
+    expect(snap[snap.length - 1]).toEqual(entry);
+  });
+
+  it("reset drops every record", () => {
+    const audit = createAuditCapture();
+    audit.record({ modeId: "F1", callerId: "caller-1", reason: "credential-in-payload" });
+    audit.reset();
+    expect(audit.snapshot().length).toBe(0);
+    expect(audit.latestFor("F1")).toBeUndefined();
+  });
+});
+
+describe("routing-store", () => {
+  it("issues and resolves a routing decision while valid", () => {
+    const store = createRoutingStore();
+    const issued = store.issue({
+      providerProfileId: "resonant-deepseek-v4-pro",
+      runtimeNodeId: "rn-local",
+      model: "deepseek-v4-pro",
+      authTier: "supported",
+      costPosture: "paid-api",
+      fallbackChain: [],
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      callerId: "caller-1",
+    });
+
+    const resolved = store.resolve(issued.routingDecisionId);
+    expect("routingDecisionId" in resolved).toBe(true);
+    if ("routingDecisionId" in resolved) {
+      expect(resolved.routingDecisionId).toBe(issued.routingDecisionId);
+    }
+  });
+
+  it("returns routing-decision-expired for an expired decision", () => {
+    const store = createRoutingStore();
+    const issued = store.issue({
+      providerProfileId: "resonant-deepseek-v4-pro",
+      runtimeNodeId: "rn-local",
+      model: "deepseek-v4-pro",
+      authTier: "supported",
+      costPosture: "paid-api",
+      fallbackChain: [],
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      callerId: "caller-1",
+    });
+    store.expire(issued.routingDecisionId);
+
+    const resolved = store.resolve(issued.routingDecisionId);
+    expect("error" in resolved).toBe(true);
+    if ("error" in resolved) {
+      expect(resolved.error).toBe("routing-decision-expired");
+    }
+  });
+
+  it("returns routing-decision-revoked after revoke", () => {
+    const store = createRoutingStore();
+    const issued = store.issue({
+      providerProfileId: "resonant-deepseek-v4-pro",
+      runtimeNodeId: "rn-local",
+      model: "deepseek-v4-pro",
+      authTier: "supported",
+      costPosture: "paid-api",
+      fallbackChain: [],
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      callerId: "caller-1",
+    });
+    store.revoke(issued.routingDecisionId);
+
+    const resolved = store.resolve(issued.routingDecisionId);
+    expect("error" in resolved).toBe(true);
+    if ("error" in resolved) {
+      expect(resolved.error).toBe("routing-decision-revoked");
+    }
+  });
+
+  it("accepts an injected clock for deterministic F8 testing", () => {
+    const baseTime = new Date("2026-08-25T12:00:00Z");
+    let virtual = baseTime.getTime();
+    const store = createRoutingStore(() => new Date(virtual));
+    const issued = store.issue({
+      providerProfileId: "resonant-deepseek-v4-pro",
+      runtimeNodeId: "rn-local",
+      model: "deepseek-v4-pro",
+      authTier: "supported",
+      costPosture: "paid-api",
+      fallbackChain: [],
+      expiresAt: new Date(virtual + 60_000).toISOString(),
+      callerId: "caller-1",
+    });
+    virtual += 120_000;
+
+    const resolved = store.resolve(issued.routingDecisionId);
+    expect("error" in resolved).toBe(true);
+  });
+});
+
+describe("mock host primitives", () => {
+  it("grantedCapabilities returns the granted subset of a manifest's requestedCapabilities", () => {
+    const manifest = externalAgentRuntimeFixture();
+    const granted = grantedCapabilities(manifest);
+    expect(granted.length).toBe(0);
+  });
+
+  it("forwardNetwork blocks when a forbidden authorization header is present", () => {
+    const host = mockHost();
+    const result = host.forwardNetwork({
+      callerId: "caller-1",
+      payload: { route: "external-service" },
+      headers: { authorization: "Bearer sk-test" },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("credential-in-payload");
+    }
+    const entry = host.audit.latestFor("F1");
+    expect(entry).toBeDefined();
+  });
+
+  it("forwardNetwork blocks when a credential-shaped key is in the payload body", () => {
+    const host = mockHost();
+    const result = host.forwardNetwork({
+      callerId: "caller-1",
+      payload: { apiKey: "sk-test" },
+      headers: {},
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("credential-in-payload");
+    }
+  });
+
+  it("accessWorkspace permits paths within the workspace root and denies elsewhere", () => {
+    const host = mockHost();
+    const inside = host.accessWorkspace({
+      callerId: "caller-1",
+      requestedPath: "/workspace/agent/notes.md",
+      workspaceRoot: "/workspace/agent",
+    });
+    expect(inside.ok).toBe(true);
+
+    const outside = host.accessWorkspace({
+      callerId: "caller-1",
+      requestedPath: "/etc/passwd",
+      workspaceRoot: "/workspace/agent",
+    });
+    expect(outside.ok).toBe(false);
+    if (!outside.ok) {
+      expect(outside.code).toBe("workspace-escape");
+    }
+  });
+
+  it("invokeTool denies unknown tool names but permits declared ones", () => {
+    const host = mockHost();
+    const declared = ["send_model_request", "run_task"];
+    const bad = host.invokeTool({ callerId: "caller-1", toolName: "shadowy_tool", payload: {} }, declared);
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) expect(bad.code).toBe("unknown-tool");
+
+    const good = host.invokeTool({ callerId: "caller-1", toolName: "send_model_request", payload: {} }, declared);
+    expect(good.ok).toBe(true);
+  });
+
+  it("returnArtifacts denies surfaces not declared in validSurfaces", () => {
+    const host = mockHost();
+    const result = host.returnArtifacts(
+      { callerId: "caller-1", surface: "agents/calling-agent-direct", artifacts: ["x"] },
+      ["testing-external-agent-runs"],
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe("audit-bypass-attempt");
+  });
+
+  it("requestApproval approves a tool when the prompt returns approved", () => {
+    const host = mockHost({ onApprovalPrompt: () => "approved" });
+    const result = host.requestApproval({ callerId: "caller-1", toolName: "run_task", addonId: "addon.testing.external-agent-runtime" });
+    expect(result.ok).toBe(true);
+  });
+
+  it("requestApproval denies and audits when the prompt returns denied", () => {
+    const host = mockHost({ onApprovalPrompt: () => "denied" });
+    const result = host.requestApproval({ callerId: "caller-1", toolName: "run_task", addonId: "addon.testing.external-agent-runtime" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("approval-denied");
+    }
+    const entry = host.audit.latestFor("F7");
+    expect(entry).toBeDefined();
+  });
+
+  it("callArchiveIntakeWrite denies when the requested capability is not granted", () => {
+    const host = mockHost();
+    const result = host.callArchiveIntakeWrite({
+      callerId: "caller-1",
+      granted: ["providers", "filesystem"],
+      requested: "archive-intake-write",
+      itemRef: "x",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe("capability-denied");
+  });
+
+  it("invokeModel accepts the routing decision's model and rejects self-selected models", () => {
+    const host = mockHost();
+    const decision = host.issueRoutingDecision({
+      providerProfileId: "resonant-deepseek-v4-pro",
+      runtimeNodeId: "rn-local",
+      model: "deepseek-v4-pro",
+      authTier: "supported",
+      costPosture: "paid-api",
+      fallbackChain: [],
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      callerId: "caller-1",
+    });
+
+    const accepted = host.invokeModel({
+      callerId: "caller-1",
+      routingDecisionId: decision.routingDecisionId,
+      payload: { prompt: "hi" },
+    });
+    expect(accepted.ok).toBe(true);
+
+    const rejected = host.invokeModel({
+      callerId: "caller-1",
+      routingDecisionId: decision.routingDecisionId,
+      explicitModel: "gpt-4o",
+      payload: { prompt: "hi" },
+    });
+    expect(rejected.ok).toBe(false);
+    if (!rejected.ok) expect(rejected.code).toBe("provider-self-selection-rejected");
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "jsx": "react-jsx",
-    "types": ["vitest/globals"]
   },
-  "include": ["src", "vite.config.ts"]
+  "include": ["src", "vite.config.ts", "packages/addon-sdk-testing/src", "packages/addon-sdk-testing/test"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,6 +40,10 @@ export default defineConfig({
   },
   test: {
     environment: "node",
-    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    include: [
+      "src/**/*.test.ts",
+      "src/**/*.test.tsx",
+      "packages/addon-sdk-testing/test/**/*.test.ts",
+    ],
   },
 });


### PR DESCRIPTION
# feat(addon-sdk-testing): ADR-040 §7 F1–F10 negative-test harness

> **Companion to PR #327.** PR #327 records ADR-040 and proposes the
> §7 failure modes (F1–F10) for any external agent runtime
> integration. ADR-040 §7 ends with: "Each F-number becomes a test
> case in `packages/addon-sdk-testing/` (B4 deliverable)." This PR
> delivers exactly that B4 deliverable.

---

## TL;DR

Implements the in-tree testing package called out by ADR-040 §7.
Provides an in-process mock ResonantOS host (`mockHost()`), a
synthetic external-agent-runtime manifest fixture
(`externalAgentRuntimeFixture()`), and the single runnable surface
`runAddOnFailureMode(modeId, manifest)` which executes the
corresponding §7 failure mode and returns a `FailureModeReport`
indicating whether the host's response matches the `Expected:`
clause.

Ships 39 vitest cases (3 files). 10 cover F1–F10 verbatim;
4 inspect the host's audit record afterwards; 17 lock the
infrastructure contracts (audit-capture + routing-store +
mock-host primitives); 8 lock the fixture's shape against the
SDK's `validateAddOnManifest`.

## Scope

- **In scope.** All ten ADR-040 §7 failure modes (F1 through F10).
  Mock host surfaces covering each (`forwardNetwork`,
  `invokeModel`, `accessWorkspace`, `callArchiveIntakeWrite`,
  `invokeTool`, `returnArtifacts`, `requestApproval`,
  `forwardModelRequest`, `requestExperimentalRoute`). Public API
  in `packages/addon-sdk-testing/src/index.ts`.
- **Out of scope.** Running against the real ResonantOS host (per
  ADR-040 §11, real integration lives in
  `addons/resonant-browser-host/`). F11+ modes that Tom is expected
  to add in his PR #327 review — the mock host exposes the same
  primitives those would need. Cross-addon evidence against
  `examples/addons/recursive-mas.json` — ADR-040 §8 says recursive-mas
  pre-dates and satisfies this ADR; a follow-on test could invoke
  `runAddOnFailureMode("F1", recursiveMasManifest)`.

**Linked issue / Project 2:** Companion to PR #327, no separate issue.
**Project 2 release scope:** N/A — this is test infrastructure, not
shippable runtime.
**Project 2 area:** Add-on SDK / Testing.

## Modules And Ownership

- `packages/addon-sdk-testing/src/index.ts` (new; public API)
- `packages/addon-sdk-testing/src/mock-host.ts` (new; mock ResonantOS host)
- `packages/addon-sdk-testing/src/routing-store.ts` (new; routing-decision store, ADR-040 §4)
- `packages/addon-sdk-testing/src/audit-capture.ts` (new; bridge audit log, ADR-040 §3 Rule 7)
- `packages/addon-sdk-testing/src/manifest-fixtures.ts` (new; §3-conjunction synthetic fixture)
- `packages/addon-sdk-testing/src/failure-modes/{index,f1..f10}.ts` (10 small mode runners)
- `packages/addon-sdk-testing/test/*.test.ts` (3 test files, 39 cases)
- `tsconfig.json` (allowImportingTsExtensions + include new package)
- `vite.config.ts` (vitest include the new test path)

Ownership review: every new path is in `packages/addon-sdk-testing/`,
owned by the Add-on SDK owner per ADR-038 §12.1 C12. The two
tooling files (`tsconfig.json`, `vite.config.ts`) are owned by
Engineering workflow.

## Safety And Privacy

- **Safety/privacy impact:** None. This is a test-only package. It
  does not run inside the real ResonantOS host; it does not perform
  any real network calls; it does not hold any real credentials.
- **Required human handoff or approval boundary:** None added. F7's
  approval-prompt surface is mocked; the test installs its own
  `onApprovalPrompt` callback to force the outcome.
- **Secret-handling impact:** The fixture's example credentials
  (`sk-test-1234567890abcdef`) are obviously fake and only appear
  in test data.

## Validation

| Command | Result |
| --- | --- |
| `npm run docs:check` | passes |
| `npx tsc --noEmit` | clean (after `allowImportingTsExtensions`) |
| `npx vitest run` | 465/465 pass (39 new + 426 existing) |
| `npm run test:browser-first` | 1034/1034 pass (zero regressions vs. `upstream/dev` — 21 fewer than PR #327 because that branch carries the bundled WIP) |
| `npm run browser-first:audit-scope` | exit 0; new package paths are correctly identified as outside browser-first release scope (this is a REF sub-project) |

**Live-browser proof:** Not applicable. The testing package runs
in-process under vitest; no real Chrome is involved.

## Documentation

**Documentation impact:** Minimal. The package ships a `README.md`
documenting its public surface and the F-number mapping. No
architecture or ADRs change — this PR is the implementation of
the §7 deliverable, not a doc change.

## Architecture (one-paragraph for reviewers)

ADR-040 §7 specifies ten failure-mode cases for external agent
runtimes. Each case has an `Expected:` clause naming the deny
code the real host should emit. The testing package implements
an in-process mock host that emits those exact deny codes plus
matching audit-record reasons. Each F-file in
`packages/addon-sdk-testing/src/failure-modes/` drives the host
through one failure mode and returns what the host did; the
runner `runAddOnFailureMode` (in the same directory's `index.ts`)
attaches the matching `expected` row from §7 and computes
`pass` by string-equality on `code` and `auditReason`.

The mock doesn't replicate the real host's Phase 3.5 capability
token mint/verify path; it asserts the deny code/audit reason the
ADR says a hardened bridge would emit. The fixture
(`externalAgentRuntimeFixture()`) declares a synthetic
external-agent-runtime manifest with the standard §3 conjunction
(`providers` + `agent-delegation`).

## Roadmap (what this PR does and doesn't do)

| Status | Item |
| --- | --- |
| ✅ Landed in this PR | All ten §7 failure modes as runnable vitest cases (F1–F10) |
| ✅ Landed in this PR | Mock host primitives covering every §3 bridge surface |
| ✅ Landed in this PR | Synthetic external-agent-runtime manifest fixture |
| ✅ Landed in this PR | Public `runAddOnFailureMode(...)` aggregator |
| ⏸ Deferred | F11+ failure modes — Tom's review of PR #327 may request additional negative tests; the mock host primitives compose to extend. |
| ⏸ Deferred | Cross-addon evidence against `examples/addons/recursive-mas.json` (ADR-040 §8) — a follow-on test could invoke `runAddOnFailureMode("F1", recursiveMasManifest)` for cross-addon evidence. |
| ⏸ Deferred | Wiring into a published npm workspace (Phase 1 of the REF implementation roadmap). |

## Plan (what I want feedback on)

I'd appreciate feedback on **three** items:

1. **Deny-code vocabulary.** The codes `credential-in-payload`,
   `provider-self-selection-rejected`, `workspace-escape`,
   `capability-denied`, `unknown-tool`, `audit-bypass-attempt`,
   `approval-denied`, `routing-decision-expired`,
   `routing-decision-revoked`, `experimental-route-not-declared`
   match ADR-040 §7's `Expected:` clauses literally. If a desired
   vocabulary already exists elsewhere (e.g. in
   `docs/security-pipeline/`'s audit taxonomy), the package can be
   adjusted to align before this lands.

2. **Fixture contract.** The synthetic fixture declares `providers`,
   `network`, `agent-delegation`, `filesystem`,
   `archive-intake-write`, `archive-read`, `notifications`,
   `allowExperimentalAuth: false`, and two tools
   (`send_model_request`, `run_task`). If reviewers prefer the
   fixture to declare more or fewer capabilities, the
   `manifest-fixtures.ts` shape can be tightened before merge.

3. **Test grid layout.** One vitest case per F-number, looping over
   the ten modes inside a single `describe` block. Plus four
   "inspector" cases (F1, F3, F8, F9) that also assert the audit
   entry's content. If reviewers prefer one `describe` per F
   (ten inner describes), the structure can be flattened.

## Status (what's verified, what's risky)

- ✅ **Verified.** All 465 vitest cases pass; tsc clean; docs:check
  passes; test:browser-first unchanged.
- ⚠ **Risky:** the mock host approximates the real ResonantOS
  bridge. If the real bridge emits a different deny code than the
  one §7 names (e.g. `routing-decision-revoked` vs the real
  bridge's `routing-decision-was-revoked`), a passing test against
  the mock doesn't prove the real bridge behaves. The package is
  the test-shape layer; the real-host integration test for these
  failure modes still has to be authored once the real bridge's
  deny taxonomy is locked (per ADR-038 §8 Phase 3.5 hardening).
- ⚠ **Risky:** `vite.config.ts` and `tsconfig.json` are tooling
  files and could conflict with whatever tooling PR #327 brings
  when both PRs land. Resolution: rebase this branch on `upstream/dev`
  after PR #327 merges; the diffs should be minimal (`allowImportingTsExtensions`
  will be the only `tsconfig.json` delta on top of what PR #327
  introduces; `vite.config.ts` is independent).

## Branch bookkeeping

- **Branch:** `feat/addon-sdk-testing-f1-f10` @ `b995bfd`
- **Base:** `ResonantOS/2.0.0-alpha:dev` (`530b753`)
- **Commits:** 2
- **Files:** 22 new + 2 modified (`tsconfig.json`, `vite.config.ts`)
- **Lines:** ~1991 additions, 7 modifications

## Reviewer Checklist (ResonantOS PR template)

- [x] The branch targets `dev` and does not include unrelated work.
- [x] The linked issue / Project 2 fields are intentionally empty
      (this is a companion test package to PR #327, no new issue).
- [x] I reviewed module ownership and called out every
      cross-module boundary change above.
- [x] I assessed security, privacy, secrets, and required
      human-only actions above.
- [x] I added tests for behavior changes (this PR **is** the test
      layer; 39 new cases across 3 files).
- [x] I recorded every relevant command and its actual result
      above.
- [x] I attached redacted live-browser proof when the change
      requires it. (N/A — test-only, no live browser.)
- [x] I updated current documentation or explained why no
      documentation changed. (New `packages/addon-sdk-testing/README.md`
      only; no ADRs change.)
- [x] This pull request contains no credentials, tokens, private
      user data, browser profiles, or unredacted sensitive logs.
