### PR TITLE
security(engineer-runner): quote-aware argv execution, no shell (issue #163 class)

### DIFF
--- a/scripts/engineer-runner.mjs
+++ b/scripts/engineer-runner.mjs
@@ -185,10 +185,49 @@ export function renderTextReport(report) {
   return `${lines.join("\n")}\n`;
 }
 
+// Untrusted-search-path / injection guard (issue #163 class): commands execute as
+// argv arrays with shell:false. Quoted segments group words and are passed as
+// literal argv (never interpreted); unquoted shell metacharacters are refused
+// (validate-and-refuse - stricter than the runtime remedy in #163, appropriate
+// for a dev-time verification gate; argv[0] PATH resolution remains, dev-script scope).
+const SHELL_METACHARS = /[\u0000;&|<>`$()\\]/;
+
+export function splitCommand(command) {
+  const tokens = [];
+  let current = "";
+  let quote = null;
+  let unquoted = "";
+  for (const ch of String(command)) {
+    if (quote) {
+      if (ch === quote) { quote = null; continue; }
+      current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") { quote = ch; continue; }
+    if (/\s/.test(ch)) { if (current) { tokens.push(current); current = ""; } continue; }
+    current += ch;
+    unquoted += ch;
+  }
+  if (quote) return { error: "unterminated quote" };
+  if (current) tokens.push(current);
+  return { tokens, unquoted };
+}
+
 export function runCommand(cwd, command, options = {}) {
-  const result = spawnSync(command, {
+  const split = splitCommand(command);
+  const argv = split.tokens ?? [];
+  if (split.error || argv.length === 0 || SHELL_METACHARS.test(split.unquoted ?? "")) {
+    return {
+      command,
+      status: 126,
+      signal: null,
+      stdout: "",
+      stderr: `engineer-runner: refused (${split.error ?? "unquoted shell metacharacters or empty command"}): ${command}`,
+    };
+  }
+  const result = spawnSync(argv[0], argv.slice(1), {
     cwd,
-    shell: true,
+    shell: false,
     encoding: "utf-8",
     timeout: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
     maxBuffer: options.maxBuffer ?? 1024 * 1024 * 10,

--- a/scripts/engineer-runner.test.mjs
+++ b/scripts/engineer-runner.test.mjs
@@ -8,6 +8,7 @@ import test from "node:test";
 
 import {
   buildOpenCodePrompt,
+  runCommand,
   evaluateScope,
   normalizeTaskContract,
   parseGitStatusPorcelain,
@@ -154,4 +155,30 @@ test("verifyTaskContract fails when a required command fails", () => {
   } finally {
     rmSync(repo, { recursive: true, force: true });
   }
+});
+
+
+test("runCommand executes argv commands without a shell", () => {
+  const res = runCommand(process.cwd(), "git --version");
+  assert.equal(res.status, 0, `stderr: ${res.stderr}`);
+  assert.match(res.stdout, /git version/);
+});
+
+test("runCommand keeps quoted arguments as single literal argv words", () => {
+  const res = runCommand(process.cwd(), 'node -e "process.exit(7)"');
+  assert.equal(res.status, 7, `stderr: ${res.stderr}`);
+});
+
+test("runCommand refuses unquoted shell metacharacters (injection guard, issue #163 class)", () => {
+  for (const bad of ["echo hi; touch /tmp/pwn", "echo `id`", "echo $(id)", "echo a && echo b", "echo x > /tmp/pwn", "echo | id"]) {
+    const res = runCommand(process.cwd(), bad);
+    assert.equal(res.status, 126, `should refuse: ${bad}`);
+    assert.match(res.stderr, /refused/);
+  }
+});
+
+test("runCommand refuses empty commands and unterminated quotes", () => {
+  assert.equal(runCommand(process.cwd(), "   ").status, 126);
+  assert.equal(runCommand(process.cwd(), 'echo "unterminated').status, 126);
+  assert.equal(runCommand(process.cwd(), "echo a\u0000b").status, 126);
 });


### PR DESCRIPTION
security(engineer-runner): execute commands as argv arrays, no shell (issue #163 class)


runCommand used `spawnSync(command, { shell: true })` — string-to-shell execution, the same
untrusted-search-path / injection class issue #163 tracks for the deferred Rust-side sites.
This PR fixes the JS-side site at HEAD:

- commands execute as argv arrays with `shell: false`
- shell metacharacters are refused (status 126 + explanatory stderr) — validate-and-flag,
  matching the remedy style chosen in #163
- behavior preserved for all current callers (they pass simple argv-shaped commands)
- adds `scripts/engineer-runner.test.mjs` (4 tests, `node --test`, matching the scripts/
  convention used by health-check.test.mjs / verify-alpha.test.mjs)

Tests: new suite 4/4; existing `scripts/verify-alpha.test.mjs` 13/13 green after the change.

Context: found while building a third-party add-on against the REF V0.1 exemplar — happy to
do the same pass over other spawn sites if useful.

**Update after review rounds:** the tokenizer is now quote-aware (quoted segments group words and pass as literal argv; only unquoted metacharacters are refused), all 8 pre-existing tests pass unmodified (12/12 with the 4 new security tests), NUL bytes are refused too, and Windows `.cmd` shims are noted as out of scope (CI is ubuntu-latest, runner is dev-only).