### PR TITLE
feat(browser-first): tab-mention-typeahead controller and surface polish (closes #252)

### DIFF
--- a/browser-first/host/augmentor-chat-contract.mjs
+++ b/browser-first/host/augmentor-chat-contract.mjs
@@ -17,6 +17,21 @@ export function augmentorSurfaceInstruction(surface = "side-panel") {
   return "You are running inside the ResonantOS browser side bar.";
 }
 
+// Browser tabs the user explicitly referenced with @tab mentions (#252). Each
+// block carries title/URL provenance so answers can cite which tab a claim
+// came from. Content is sanitized and budgeted by the extension; the host
+// re-slices defensively and caps the whole section.
+function referencedTabsContext(tabContexts) {
+  if (!Array.isArray(tabContexts) || !tabContexts.length) return "";
+  const blocks = tabContexts.slice(0, 8).map((tab, index) => {
+    const title = String(tab?.title ?? "").slice(0, 160) || "Untitled";
+    const url = String(tab?.url ?? "").slice(0, 400) || "unknown";
+    const text = String(tab?.text ?? "").slice(0, 4000);
+    return `--- Referenced tab ${index + 1}: ${title} — ${url} ---\n${text}`;
+  });
+  return `Browser tabs explicitly referenced by the user (scope the answer to these tabs; each block carries its tab provenance):\n${blocks.join("\n\n")}`.slice(0, 12000);
+}
+
 export function buildAugmentorSystemPrompt(payload = {}) {
   return [
     "You are Augmentor, the Strategist agent inside ResonantOS.",
@@ -34,6 +49,7 @@ export function buildAugmentorSystemPrompt(payload = {}) {
     "If browser page context is provided, use it as context but do not claim to mutate memory or execute tools unless the host explicitly returned that result.",
     payload.systemPrompt ? `Additional user-configured Augmentor system prompt:\n${String(payload.systemPrompt).slice(0, 8000)}` : "",
     payload.pageContext ? `Current browser page context:\n${String(payload.pageContext).slice(0, 8000)}` : "",
+    referencedTabsContext(payload.tabContexts),
     payload.runtimeContext ? `Current ResonantOS runtime context:\n${String(payload.runtimeContext).slice(0, 6000)}` : "",
   ].filter(Boolean).join("\n\n");
 }

--- a/browser-first/resonantos-side-panel-extension/src/lib/browser-page-actions.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/browser-page-actions.js
@@ -264,6 +264,26 @@ export function createBrowserPageActions(deps) {
     return responses.find((response) => response?.error) ?? { ok: false, error: "No frame handled this browser action." };
   }
 
+  const CONTENT_SCRIPT_FILES = [
+    "src/lib/resonant-context.js",
+    "src/lib/context-plugins.js",
+    "src/lib/resonator.js",
+    "src/lib/control-overlay.js",
+    "src/lib/content-field-safety.js",
+    "src/lib/content-inline-actions.js",
+    "src/lib/content-control-refs.js",
+    "src/content.js"
+  ];
+
+  async function injectContentScripts(tabId) {
+    if (!chrome.scripting?.executeScript) return false;
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      files: CONTENT_SCRIPT_FILES
+    }).catch(() => undefined);
+    return true;
+  }
+
   async function readSpecificTabPage(tab, { includeBlocked = false } = {}) {
     if (!tab?.id || !isReadableBrowserTab(tab)) {
       return { ok: false, tab, error: "Tab is not a readable web page." };
@@ -272,10 +292,19 @@ export function createBrowserPageActions(deps) {
     if (siteMode === "blocked" && !includeBlocked) {
       return { ok: false, tab, error: `Assistant is blocked on ${siteKeyForUrl(tab.url)}.` };
     }
-    const response = await sendContentActionToFrames(tab.id, {
+    const message = {
       channel: "resonantos.browser_first.content",
       type: "read_page"
-    });
+    };
+    let response = await sendContentActionToFrames(tab.id, message);
+    // A background tab may never have received the content script (e.g. it was
+    // open before the extension loaded). Inject and retry once — same recovery
+    // sendContentAction uses for the active tab.
+    if (!response?.ok && /receiving end|connection|No readable frame returned page context/i.test(response?.error ?? "")) {
+      if (await injectContentScripts(tab.id)) {
+        response = await sendContentActionToFrames(tab.id, message);
+      }
+    }
     return response?.ok
       ? { ok: true, tab, snapshot: response.snapshot }
       : { ok: false, tab, error: response?.error ?? "No readable page context returned." };
@@ -303,21 +332,7 @@ export function createBrowserPageActions(deps) {
     if (firstAttempt?.ok || !shouldInjectContentScript) {
       return firstAttempt;
     }
-    if (chrome.scripting?.executeScript) {
-      await chrome.scripting.executeScript({
-        target: { tabId: tab.id },
-        files: [
-          "src/lib/resonant-context.js",
-          "src/lib/context-plugins.js",
-          "src/lib/resonator.js",
-          "src/lib/control-overlay.js",
-          "src/lib/content-field-safety.js",
-          "src/lib/content-inline-actions.js",
-          "src/lib/content-control-refs.js",
-          "src/content.js"
-        ]
-      }).catch(() => undefined);
-    } else {
+    if (!await injectContentScripts(tab.id)) {
       await chrome.tabs.reload(tab.id);
       await sleep(1200);
     }
@@ -1040,6 +1055,7 @@ export function createBrowserPageActions(deps) {
     openBrowserUrl,
     prepareDaoWorkflowGuidance,
     readActivePage,
+    readSpecificTabPage,
     refreshTabContext,
     runResonatorCommand,
     scrollActivePage,

--- a/browser-first/resonantos-side-panel-extension/src/lib/chat-session-store.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/chat-session-store.js
@@ -317,7 +317,7 @@ export function createChatSessionStore({
     return messages.find((message) => message.id === id) ?? null;
   }
 
-  async function addMessage(role, content, { persist: shouldPersist = true, usage = null } = {}) {
+  async function addMessage(role, content, { persist: shouldPersist = true, usage = null, chips = null } = {}) {
     const text = String(content ?? "").trim();
     if (!text) return null;
     const message = {
@@ -325,6 +325,7 @@ export function createChatSessionStore({
       role,
       content: text,
       usage,
+      chips: Array.isArray(chips) && chips.length ? chips.map((chip) => ({ title: String(chip?.title ?? ""), url: String(chip?.url ?? "") })) : null,
       createdAt: now()
     };
     messages = [...messages, message];

--- a/browser-first/resonantos-side-panel-extension/src/lib/chat-turn-controller.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/chat-turn-controller.js
@@ -87,6 +87,22 @@ export function pageContextForSnapshot(snapshot) {
   ].filter(Boolean).join("\n\n");
 }
 
+// Budgeted, sanitized per-tab context blocks for explicitly scoped requests
+// (#252). The total budget is split evenly across referenced tabs (with a
+// floor) so N referenced tabs cannot crowd out conversation history; every
+// block carries title/URL provenance.
+export function tabContextsForScopedTabs(contexts, { totalBudget = 12000 } = {}) {
+  const list = Array.isArray(contexts) ? contexts.filter((context) => context && (context.text || context.title)) : [];
+  if (!list.length) return [];
+  const perTab = Math.max(1500, Math.floor(totalBudget / list.length));
+  return list.map((context) => ({
+    tabId: context.tabId ?? null,
+    title: safeContextText(context.title, 160),
+    url: safeContextUrl(context.url),
+    text: safeContextText(context.text, perTab)
+  }));
+}
+
 export function runtimeContextForAttachments(attachments) {
   return attachments.length
     ? `Composer attachments:\n${attachments.map((item) => `- ${item.name}: ${item.content ?? item.summary}`).join("\n")}`
@@ -107,7 +123,8 @@ export function createChatTurnController({
   chatSessionStore,
   clearActivitySoon,
   clearAttachments,
-  getLastSnapshot,
+    consumeScopedTabContexts = () => [],
+getLastSnapshot,
   getModel,
   getSurface = () => "side-panel",
   getSystemPrompt = () => "",
@@ -120,7 +137,7 @@ export function createChatTurnController({
   const bridge = () => (typeof getBridgeRequest === "function" ? getBridgeRequest() : bridgeRequest);
   let activeAbortController = null;
 
-  async function bridgeChat({ signal } = {}) {
+  async function bridgeChat({ signal, tabContexts = [] } = {}) {
     const attachments = chatSessionStore.getAttachments();
     return bridge()("/augmentor/chat", {
       method: "POST",
@@ -132,6 +149,7 @@ export function createChatTurnController({
         thinkingDepth: getThinkingDepth(),
         systemPrompt: getSystemPrompt(),
         pageContext: pageContextForSnapshot(getLastSnapshot()),
+        tabContexts,
         runtimeContext: runtimeContextForAttachments(attachments),
         messages: providerMessagesFromHistory(chatSessionStore.getMessages(), maxHistoryMessages)
       }
@@ -145,10 +163,14 @@ export function createChatTurnController({
     setStatus("Thinking");
     setActivity("thinking", "Thinking", "Calling the selected model route");
     try {
-      const result = await bridgeChat({ signal: activeAbortController.signal });
+      const tabContexts = tabContextsForScopedTabs(consumeScopedTabContexts());
+      const result = await bridgeChat({ signal: activeAbortController.signal, tabContexts });
       setStatus("Writing");
       setActivity("writing", "Writing response", result.model || getModel());
-      await addMessage("assistant", result.reply, { usage: result.usage ?? { providerId: result.providerId, model: result.model } });
+      await addMessage("assistant", result.reply, {
+        usage: result.usage ?? { providerId: result.providerId, model: result.model },
+        chips: tabContexts.map(({ title, url }) => ({ title, url }))
+      });
       // Make a route fallback visible: the preferred model was unavailable and a
       // different one answered. Surfaced as a system notice with recovery guidance
       // rather than silently swapping the user's route.

--- a/browser-first/resonantos-side-panel-extension/src/lib/side-panel-command-router.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/side-panel-command-router.js
@@ -14,18 +14,25 @@ import {
   parseSummarizePageIntent,
   parseTypeIntent
 } from "./browser-command-parser.js";
-import { isCompareIntent, parseTabMentions } from "./tab-comparison-resolver.js";
+import { isCompareIntent, parseTabMentionTokens } from "./tab-comparison-resolver.js";
 
 export function createSidePanelCommandRouter(handlers) {
   async function respondToCommand(value) {
-    // The cross-tab comparison path is gated on BOTH ≥2 mentions AND an explicit
-    // compare verb (compare/versus/vs/diff/between). This prevents ordinary
-    // prose containing two coincidental `@` symbols (e.g. an email address +
-    // handle) from being diverted into the comparison path on the strength of
-    // token count alone. The previous gate tripped on natural "@A and @B"
-    // phrasing and on email-handled text.
-    if (parseTabMentions(value).length >= 2 && isCompareIntent(value)) {
+    // Mention routing (three deliberate paths):
+    // 1. ≥2 mentions + compare verb → cross-tab comparison (#220). The verb
+    //    gate prevents prose with two coincidental `@` symbols (an email
+    //    address + a handle) from diverting on token count alone.
+    // 2. Any quoted @"…" mention → explicit tab scoping (#252). The quoted
+    //    form is what the composer typeahead inserts, so it signals a
+    //    deliberate reference: referenced tabs' content is captured and
+    //    attached to the request, and unresolved references fail loudly.
+    // 3. Otherwise → the legacy single-tab bind (bare single mention), which
+    //    stays silent when nothing resolves.
+    const mentionTokens = parseTabMentionTokens(value);
+    if (mentionTokens.length >= 2 && isCompareIntent(value)) {
       await handlers.resolveComparisonContext(value);
+    } else if (mentionTokens.some((token) => token.quoted)) {
+      await handlers.resolveScopedTabContext(value);
     } else {
       await handlers.bindMentionedTab(value);
     }

--- a/browser-first/resonantos-side-panel-extension/src/lib/side-panel-renderers.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/side-panel-renderers.js
@@ -159,7 +159,23 @@ export function createSidePanelRenderers({
       }
       actions.append(actionButton("delete", "Delete", "Delete this message", () => void onDeleteMessage(message.id)));
 
-      article.append(header, paragraph, actions);
+      // Referenced-tab provenance chips (#252): deterministic, request-side
+      // truth — they record which tabs were scoped into this message, never
+      // model-claimed citations.
+      if (Array.isArray(message.chips) && message.chips.length) {
+        const chipRow = document.createElement("div");
+        chipRow.className = "message-tab-chips";
+        for (const chip of message.chips) {
+          const element = document.createElement("span");
+          element.className = "tab-provenance-chip";
+          element.textContent = chip.title || chip.url || "referenced tab";
+          if (chip.url) element.title = chip.url;
+          chipRow.append(element);
+        }
+        article.append(header, chipRow, paragraph, actions);
+      } else {
+        article.append(header, paragraph, actions);
+      }
       transcript.append(article);
     });
     scrollTranscriptToBottom();

--- a/browser-first/resonantos-side-panel-extension/src/lib/tab-comparison-resolver.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/tab-comparison-resolver.js
@@ -30,12 +30,14 @@ export function isCompareIntent(message) {
   return COMPARE_VERB_PATTERN.test(String(message ?? ""));
 }
 
-// All unique @tab mentions in a message, in first-seen order, case-insensitively
-// de-duplicated. Multi-word quoted titles (@"Alpha Beta") are captured as a
-// single mention; unquoted multi-word forms are NOT (the token terminates at
-// whitespace). The two alternatives of the alternation keep the [quoted] vs
-// [unquoted] paths explicit.
-export function parseTabMentions(message) {
+// All unique @tab mention tokens in a message, in first-seen order,
+// case-insensitively de-duplicated by mention text. Each token carries how it
+// was written: `quoted` marks the deliberate `@"…"` form (what the composer
+// typeahead inserts — an explicit, intentional reference), and `tabRef` marks
+// the literal `@tab N` ranked form. #252 uses `quoted` to distinguish
+// deliberate references from prose: explicit references fail loudly, bare
+// mentions stay silent (#308 prose rule).
+export function parseTabMentionTokens(message) {
   const seen = new Set();
   const out = [];
   const text = String(message ?? "");
@@ -45,9 +47,18 @@ export function parseTabMentions(message) {
     const key = mention.toLowerCase();
     if (seen.has(key)) continue;
     seen.add(key);
-    out.push(mention);
+    out.push({ mention, quoted: match[2] != null, tabRef: match[1] != null });
   }
   return out;
+}
+
+// All unique @tab mentions in a message, in first-seen order, case-insensitively
+// de-duplicated. Multi-word quoted titles (@"Alpha Beta") are captured as a
+// single mention; unquoted multi-word forms are NOT (the token terminates at
+// whitespace). The two alternatives of the alternation keep the [quoted] vs
+// [unquoted] paths explicit.
+export function parseTabMentions(message) {
+  return parseTabMentionTokens(message).map((token) => token.mention);
 }
 
 function tabMatches(tab, needle) {
@@ -80,18 +91,19 @@ function resolveAmongReadable(mention, readableTabs) {
 //   ambiguous — mentions matching more than one readable tab, each
 //               { mention, candidates: [{ title, url }] } so the caller can ask
 //               for clarification or present candidate refs.
-export function resolveTabComparison(message, allTabs, isReadableBrowserTab) {
+// Shared resolution core. Entries carry the token's `quoted`/`tabRef` flags so
+// callers can distinguish deliberate references from bare prose mentions.
+function resolveMentionTokens(tokens, allTabs, isReadableBrowserTab) {
   const tabs = Array.isArray(allTabs) ? allTabs : [];
   const readable = tabs.filter(isReadableBrowserTab);
   const unreadable = tabs.filter((tab) => !isReadableBrowserTab(tab));
-  const mentions = parseTabMentions(message);
 
   const items = [];
   const skipped = [];
   const ambiguous = [];
   const seenIds = new Set();
 
-  for (const mention of mentions) {
+  for (const { mention, quoted, tabRef } of tokens) {
     const result = resolveAmongReadable(mention, readable);
     if (result.kind === "resolved") {
       const tab = result.tab;
@@ -101,11 +113,11 @@ export function resolveTabComparison(message, allTabs, isReadableBrowserTab) {
         if (seenIds.has(tab.id)) continue;
         seenIds.add(tab.id);
       }
-      items.push({ mention, tabId: tab.id ?? null, title: tab.title ?? "", url: tab.url ?? "" });
+      items.push({ mention, quoted, tabRef, tabId: tab.id ?? null, title: tab.title ?? "", url: tab.url ?? "" });
       continue;
     }
     if (result.kind === "ambiguous") {
-      ambiguous.push({ mention, candidates: result.candidates });
+      ambiguous.push({ mention, quoted, tabRef, candidates: result.candidates });
       continue;
     }
     // missing: did the mention name an unreadable/internal tab?
@@ -113,6 +125,8 @@ export function resolveTabComparison(message, allTabs, isReadableBrowserTab) {
     if (unreadableHit) {
       skipped.push({
         mention,
+        quoted,
+        tabRef,
         reason: `Skipped: "${unreadableHit.title || unreadableHit.url || "internal tab"}" is not a readable web page.`,
         title: unreadableHit.title ?? "",
         url: unreadableHit.url ?? ""
@@ -120,14 +134,36 @@ export function resolveTabComparison(message, allTabs, isReadableBrowserTab) {
     } else if (/^tab\s+\d+$/i.test(mention)) {
       skipped.push({
         mention,
+        quoted,
+        tabRef,
         reason: `Skipped: no readable tab at position ${Number(/\d+/.exec(mention)[0])}.`,
         title: "",
         url: ""
       });
     } else {
-      skipped.push({ mention, reason: "Skipped: no open tab matched this reference.", title: "", url: "" });
+      skipped.push({ mention, quoted, tabRef, reason: "Skipped: no open tab matched this reference.", title: "", url: "" });
     }
   }
 
   return { items, skipped, ambiguous };
+}
+
+// Resolve mentions for the comparison path (#220). The public entry shape is
+// preserved exactly — token flags stay internal to the scoped path.
+export function resolveTabComparison(message, allTabs, isReadableBrowserTab) {
+  const stripTokenFlags = ({ quoted, tabRef, ...entry }) => entry;
+  const { items, skipped, ambiguous } = resolveMentionTokens(parseTabMentionTokens(message), allTabs, isReadableBrowserTab);
+  return {
+    items: items.map(stripTokenFlags),
+    skipped: skipped.map(stripTokenFlags),
+    ambiguous: ambiguous.map(stripTokenFlags)
+  };
+}
+
+// Resolve mentions for explicit tab scoping (#252). Same resolution semantics
+// as the comparison path, but every entry keeps the token's `quoted`/`tabRef`
+// flags so the controller can fail loudly on deliberate references that no
+// longer resolve (closed/gone tab) without ever widening scope silently.
+export function resolveScopedTabs(message, allTabs, isReadableBrowserTab) {
+  return resolveMentionTokens(parseTabMentionTokens(message), allTabs, isReadableBrowserTab);
 }

--- a/browser-first/resonantos-side-panel-extension/src/lib/tab-context-controller.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/tab-context-controller.js
@@ -1,4 +1,8 @@
-import { resolveTabComparison } from "./tab-comparison-resolver.js";
+import { parseTabMentionTokens, resolveScopedTabs, resolveTabComparison } from "./tab-comparison-resolver.js";
+
+// Raw per-tab text cap at capture time; chat-turn-controller applies the
+// shared per-request budget and sanitization on top of this.
+const SCOPED_CAPTURE_TEXT_LIMIT = 12000;
 const INLINE_DRAFT_KEY = "augmentorInlineDraft";
 
 // Token grammar matches tab-comparison-resolver (Tom's review): no greedy
@@ -20,6 +24,7 @@ export function createTabContextController({
   chrome,
   getControlledTabId,
   isReadableBrowserTab,
+  readTabPage = async () => ({ ok: false, error: "Tab page capture unavailable." }),
   refreshTabContext,
   renderSitePermissionPanel,
   setContextMeter,
@@ -95,6 +100,74 @@ export function createTabContextController({
     const draft = await chrome.storage?.local?.get?.(INLINE_DRAFT_KEY).catch(() => ({}));
     await consumeInlineDraft(draft?.[INLINE_DRAFT_KEY]);
   };
+  // Scoped tab references (#252): contexts captured for the CURRENT composer
+  // submit only. The router resolves mentions before runChatTurn, and the
+  // chat-turn controller consumes (and clears) them when building the request
+  // payload, so a stale scope can never leak into a later turn.
+  let pendingScopedContexts = [];
+
+  const resolveScopedTabContext = async (message) => {
+    const allTabs = (await chrome.tabs.query({}).catch(() => []));
+    const scoped = resolveScopedTabs(message, allTabs, isReadableBrowserTab);
+    const { items, skipped, ambiguous } = scoped;
+    pendingScopedContexts = [];
+
+    // Explicit (quoted, typeahead-inserted) references that no longer resolve
+    // fail loudly and NEVER widen scope. Bare mentions keep the #308 prose
+    // rule: silent unless they named an unreadable/internal tab.
+    for (const entry of skipped) {
+      if (entry.quoted) {
+        await addMessage("system", `@"${entry.mention}" could not be resolved — the tab is closed or not readable in this session. The request scope was not widened.`);
+      } else if (entry.title || entry.url) {
+        await addMessage("system", entry.reason);
+      }
+    }
+
+    for (const entry of ambiguous) {
+      const candidates = entry.candidates
+        .map((candidate) => `"${candidate.title || candidate.url}"`)
+        .join(", ");
+      await addMessage("system", `@${entry.mention} matched ${entry.candidates.length} open tabs: ${candidates}. Specify which tab you mean (e.g. by full title or @tab N).`);
+    }
+
+    if (items.length === 0) return { ...scoped, contexts: [] };
+
+    const contexts = [];
+    for (const item of items) {
+      const read = await readTabPage({ id: item.tabId, title: item.title, url: item.url }).catch(() => null);
+      if (!read?.ok) {
+        await addMessage("system", `Skipped: could not read "${item.title || item.url || "referenced tab"}" (${read?.error ?? "no page context"}).`);
+        continue;
+      }
+      const snapshot = read.snapshot ?? {};
+      contexts.push({
+        tabId: item.tabId,
+        mention: item.mention,
+        title: snapshot.title || item.title,
+        url: snapshot.url || item.url,
+        text: String(snapshot.text ?? snapshot.page?.visibleText ?? "").slice(0, SCOPED_CAPTURE_TEXT_LIMIT)
+      });
+    }
+    pendingScopedContexts = contexts;
+
+    if (contexts.length > 0) {
+      const provenanceLines = contexts.map((context) =>
+        `- @${context.mention}: ${context.title || context.url || "(no title)"} — ${context.url || "(no url)"}`
+      );
+      await addMessage(
+        "system",
+        `Scoped to ${contexts.length} referenced tab${contexts.length === 1 ? "" : "s"} (content attached to this request; no tab activated):\n${provenanceLines.join("\n")}`,
+        { chips: contexts.map((context) => ({ title: context.title, url: context.url })) }
+      );
+    }
+    return { ...scoped, contexts };
+  };
+
+  const consumeScopedTabContexts = () => {
+    const contexts = pendingScopedContexts;
+    pendingScopedContexts = [];
+    return contexts;
+  };
   const resolveComparisonContext = async (message) => {
     const allTabs = (await chrome.tabs.query({}).catch(() => []));
     const comparison = resolveTabComparison(message, allTabs, isReadableBrowserTab);
@@ -149,10 +222,12 @@ export function createTabContextController({
     bindBrowserListeners,
     bindMentionedTab,
     consumeInlineDraft,
+    consumeScopedTabContexts,
     handleStorageChanged,
     handleTabUpdated,
     hydrateInitialContext,
     resolveComparisonContext,
+    resolveScopedTabContext,
     resolveTabMention
   };
 }

--- a/browser-first/resonantos-side-panel-extension/src/lib/tab-mention-typeahead.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/tab-mention-typeahead.js
@@ -1,0 +1,213 @@
+// Composer @tab mention typeahead (#252).
+//
+// Typing `@` in the composer opens a dropdown over the user's open, readable
+// (permitted) tabs; selecting one inserts the deliberate `@"quoted title"`
+// mention form, which the command router treats as an explicit tab scope:
+// referenced tabs' content is attached to the request, and a reference that
+// no longer resolves fails loudly instead of silently widening scope.
+//
+// Boundary (#252 non-goals): only tabs already open and readable in this
+// session are listed (the same set the mention resolver can address); no
+// navigation, activation, or automation authority is added.
+
+// Where is the caret inside an @mention token? Returns
+// { start, query, quoted } — start = index of the token's `@` — or null when
+// the caret is not inside a mention token. Email-style `bob@acme.com` never
+// matches because the `@` must follow a boundary character.
+export function mentionQueryAtCaret(text, caret) {
+  const value = String(text ?? "");
+  const position = Number.isInteger(caret) ? Math.max(0, Math.min(caret, value.length)) : value.length;
+  const before = value.slice(0, position);
+  const match = /(?:^|[\s,;!?([{])@("?)([a-z0-9][a-z0-9.:_ -]{0,80})?$/i.exec(before);
+  if (!match) return null;
+  const quoted = match[1] === '"';
+  const query = match[2] ?? "";
+  // An unquoted token terminates at whitespace: "@Alpha Be<caret>" means the
+  // mention ended and "Be" is new prose, not a longer query.
+  if (!quoted && /\s/.test(query)) return null;
+  const tokenStart = position - query.length - (quoted ? 2 : 1);
+  return { start: tokenStart, query, quoted };
+}
+
+function domainForUrl(url) {
+  try {
+    return new URL(String(url ?? "")).hostname || String(url ?? "");
+  } catch {
+    return String(url ?? "").slice(0, 60);
+  }
+}
+
+// Rank open tabs for a mention query. Only readable (permitted) tabs are
+// candidates, matching the resolver's addressable set exactly. Empty query
+// lists everything (ranked by tab order); otherwise title prefix beats title
+// substring beats URL/domain substring. `index` is the tab's 1-based position
+// among readable tabs so the list can hint the `@tab N` form.
+export function rankMentionCandidates(tabs, query, isReadableBrowserTab, { limit = 8 } = {}) {
+  const readable = (Array.isArray(tabs) ? tabs : []).filter(isReadableBrowserTab);
+  const needle = String(query ?? "").trim().toLowerCase();
+  const scored = [];
+  readable.forEach((tab, index) => {
+    const title = String(tab?.title ?? "").toLowerCase();
+    const url = String(tab?.url ?? "").toLowerCase();
+    let score = null;
+    if (!needle) score = 1;
+    else if (title.startsWith(needle)) score = 0;
+    else if (title.includes(needle)) score = 1;
+    else if (url.includes(needle)) score = 2;
+    if (score === null) return;
+    scored.push({ tab, index, score });
+  });
+  scored.sort((left, right) => left.score - right.score || left.index - right.index);
+  return scored.slice(0, limit).map(({ tab, index }) => ({
+    tabId: tab.id ?? null,
+    title: String(tab?.title ?? ""),
+    url: String(tab?.url ?? ""),
+    index: index + 1
+  }));
+}
+
+// The deliberate mention form inserted on selection: `@"Title"` (quotes and
+// line breaks stripped so the token grammar always parses it back), falling
+// back to the ranked `@tab N` form when the tab has no usable title.
+export function mentionInsertionForTab(candidate) {
+  const title = String(candidate?.title ?? "").replace(/["\r\n]+/g, " ").replace(/\s{2,}/g, " ").trim();
+  if (!title) return `@tab ${candidate?.index ?? 1} `;
+  return `@"${title}" `;
+}
+
+export function createTabMentionTypeahead({
+  input,
+  chrome,
+  isReadableBrowserTab = () => false,
+  doc = globalThis.document,
+  maxCandidates = 8,
+  queryTabs = null
+} = {}) {
+  if (!input) throw new Error("createTabMentionTypeahead requires an input element.");
+  if (!doc) throw new Error("createTabMentionTypeahead requires a document.");
+  const listTabs = typeof queryTabs === "function"
+    ? queryTabs
+    : async () => (await chrome?.tabs?.query?.({}).catch(() => [])) ?? [];
+  const keydownHost = input.form ?? input;
+
+  let container = null;
+  let candidates = [];
+  let activeIndex = -1;
+  let queryInfo = null;
+  let open = false;
+
+  const isOpen = () => open;
+
+  function close() {
+    open = false;
+    candidates = [];
+    activeIndex = -1;
+    queryInfo = null;
+    container?.remove();
+    container = null;
+  }
+
+  function renderList() {
+    if (!container) {
+      container = doc.createElement("div");
+      container.className = "tab-mention-typeahead";
+      container.setAttribute("role", "listbox");
+      container.setAttribute("aria-label", "Reference an open tab");
+      input.insertAdjacentElement("afterend", container);
+    }
+    container.replaceChildren();
+    candidates.forEach((candidate, position) => {
+      const option = doc.createElement("button");
+      option.type = "button";
+      option.className = `tab-mention-option${position === activeIndex ? " active" : ""}`;
+      option.setAttribute("role", "option");
+      option.setAttribute("aria-selected", position === activeIndex ? "true" : "false");
+      const title = doc.createElement("strong");
+      title.textContent = candidate.title || candidate.url || "(untitled tab)";
+      const domain = doc.createElement("span");
+      domain.textContent = `@tab ${candidate.index} · ${domainForUrl(candidate.url)}`;
+      option.append(title, domain);
+      // mousedown (not click) so selection lands before the input blur closes.
+      option.addEventListener("mousedown", (event) => {
+        event.preventDefault();
+        selectCandidate(position);
+      });
+      container.append(option);
+    });
+  }
+
+  async function refresh() {
+    const info = mentionQueryAtCaret(input.value, input.selectionStart);
+    if (!info) {
+      close();
+      return;
+    }
+    queryInfo = info;
+    const tabs = await listTabs();
+    if (queryInfo !== info) return; // a newer refresh superseded this one
+    candidates = rankMentionCandidates(tabs, info.query, isReadableBrowserTab, { limit: maxCandidates });
+    if (!candidates.length) {
+      close();
+      return;
+    }
+    open = true;
+    if (activeIndex < 0 || activeIndex >= candidates.length) activeIndex = 0;
+    renderList();
+  }
+
+  function selectCandidate(position) {
+    const candidate = candidates[position];
+    if (!candidate || !queryInfo) return;
+    const caret = input.selectionStart ?? input.value.length;
+    const insertion = mentionInsertionForTab(candidate);
+    input.value = input.value.slice(0, queryInfo.start) + insertion + input.value.slice(caret);
+    const nextCaret = queryInfo.start + insertion.length;
+    input.setSelectionRange?.(nextCaret, nextCaret);
+    close();
+    // Notify other composer listeners (undo stack, context meter) of the edit.
+    const view = input.ownerDocument?.defaultView;
+    input.dispatchEvent(new (view?.Event ?? Event)("input", { bubbles: true }));
+    input.focus?.();
+  }
+
+  // Capture phase on the form: runs before the composer controller's own
+  // keydown handler (Enter → submit), so an open dropdown wins the key.
+  function onKeydown(event) {
+    if (!open) return;
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      event.stopPropagation();
+      activeIndex = (activeIndex + 1) % candidates.length;
+      renderList();
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      event.stopPropagation();
+      activeIndex = (activeIndex - 1 + candidates.length) % candidates.length;
+      renderList();
+    } else if (event.key === "Enter" || event.key === "Tab") {
+      event.preventDefault();
+      event.stopPropagation();
+      selectCandidate(activeIndex);
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      close();
+    }
+  }
+
+  const onInput = () => void refresh();
+  const onBlur = () => close();
+
+  input.addEventListener("input", onInput);
+  input.addEventListener("blur", onBlur);
+  keydownHost.addEventListener("keydown", onKeydown, true);
+
+  function destroy() {
+    close();
+    input.removeEventListener("input", onInput);
+    input.removeEventListener("blur", onBlur);
+    keydownHost.removeEventListener("keydown", onKeydown, true);
+  }
+
+  return { close, destroy, isOpen };
+}

--- a/browser-first/resonantos-side-panel-extension/src/side-panel.js
+++ b/browser-first/resonantos-side-panel-extension/src/side-panel.js
@@ -54,6 +54,7 @@ import { createSidePanelUiController } from "./lib/side-panel-ui-controller.js";
 import { readPersonalizationSettings } from "./lib/personalization-settings.js";
 import { createSitePermissionStore } from "./lib/site-permission-store.js";
 import { createTabContextController } from "./lib/tab-context-controller.js";
+import { createTabMentionTypeahead } from "./lib/tab-mention-typeahead.js";
 import { createSessionSummaryController } from "./lib/session-summary-controller.js";
 import { createTaskConsentStore } from "./lib/task-consent-store.js";
 
@@ -266,6 +267,14 @@ const composerController = createComposerController({
   commandInput,
   forceClipboardFallback: true,
   navigator
+});
+// @tab mention typeahead (#252): typing `@` lists open, readable tabs;
+// selecting one inserts the deliberate @"…" mention form that the command
+// router treats as an explicit tab scope.
+createTabMentionTypeahead({
+  chrome,
+  input: commandInput,
+  isReadableBrowserTab
 });
 
 const chatInstanceId = `sidecar-${Math.random().toString(36).slice(2, 10)}`;
@@ -491,8 +500,8 @@ dockNewChat?.addEventListener("click", async () => {
   commandInput?.focus();
 });
 
-const addMessage = async (role, content, { persist = true, usage = null } = {}) => {
-  const message = await chatSessionStore.addMessage(role, content, { persist, usage });
+const addMessage = async (role, content, { persist = true, usage = null, chips = null } = {}) => {
+  const message = await chatSessionStore.addMessage(role, content, { persist, usage, chips });
   if (!message) return null;
   renderMessages();
   chatsTreeRenderer.render();
@@ -722,6 +731,7 @@ const tabContextController = createTabContextController({
   chrome,
   getControlledTabId: () => controlledTabId,
   isReadableBrowserTab,
+  readTabPage: (tab) => browserPageActions.readSpecificTabPage(tab),
   refreshTabContext,
   renderSitePermissionPanel,
   setContextMeter,
@@ -735,6 +745,8 @@ const tabContextController = createTabContextController({
 });
 const bindMentionedTab = tabContextController.bindMentionedTab;
 const resolveComparisonContext = tabContextController.resolveComparisonContext;
+const resolveScopedTabContext = tabContextController.resolveScopedTabContext;
+const consumeScopedTabContexts = tabContextController.consumeScopedTabContexts;
 const sessionSummaryController = createSessionSummaryController({
   chrome,
   isReadableBrowserTab,
@@ -1030,6 +1042,7 @@ const chatTurnController = createChatTurnController({
   chatSessionStore,
   clearActivitySoon,
   clearAttachments: () => messageActions.clearAttachments(),
+  consumeScopedTabContexts,
   getLastSnapshot: () => lastSnapshot,
   getModel: () => modelSelect.value,
   getThinkingDepth: () => thinkingDepthSelect.value,
@@ -1138,6 +1151,7 @@ const commandRouter = createSidePanelCommandRouter({
   allowControlPreflightOnceForTaskClass,
   bindMentionedTab,
   resolveComparisonContext,
+  resolveScopedTabContext,
   runSessionCommand,
   clickActivePageText,
   detectActivePageForms,

--- a/browser-first/resonantos-side-panel-extension/src/styles/side-panel/composer-context.css
+++ b/browser-first/resonantos-side-panel-extension/src/styles/side-panel/composer-context.css
@@ -403,3 +403,51 @@ textarea::placeholder {
   background: rgba(36, 209, 143, 0.12);
   box-shadow: 0 0 0 1px rgba(36, 209, 143, 0.28), 0 0 18px rgba(36, 209, 143, 0.16);
 }
+
+.tab-mention-typeahead {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 0 6px 8px;
+  max-height: 220px;
+  overflow-y: auto;
+  border: 1px solid rgba(36, 209, 143, 0.18);
+  border-radius: 12px;
+  background: rgba(10, 22, 17, 0.96);
+  padding: 4px;
+}
+
+.tab-mention-option {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: rgba(238, 247, 240, 0.82);
+  font-size: 0.72rem;
+  padding: 6px 8px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.tab-mention-option strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 600;
+}
+
+.tab-mention-option span {
+  flex-shrink: 0;
+  color: rgba(238, 247, 240, 0.45);
+  font-size: 0.62rem;
+}
+
+.tab-mention-option.active,
+.tab-mention-option:hover {
+  background: rgba(36, 209, 143, 0.14);
+  color: var(--text);
+}

--- a/browser-first/resonantos-side-panel-extension/src/styles/side-panel/messages.css
+++ b/browser-first/resonantos-side-panel-extension/src/styles/side-panel/messages.css
@@ -101,3 +101,25 @@
   stroke-linejoin: round;
   stroke-width: 1.8;
 }
+
+.message-tab-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin: 4px 0 6px;
+}
+
+.tab-provenance-chip {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border: 1px solid rgba(36, 209, 143, 0.18);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.055);
+  color: rgba(238, 247, 240, 0.78);
+  font-size: 0.66rem;
+  padding: 4px 7px;
+}

--- a/browser-first/test/augmentor-chat-contract.test.mjs
+++ b/browser-first/test/augmentor-chat-contract.test.mjs
@@ -71,3 +71,21 @@ test("Augmentor chat request messages require a human/assistant turn and prepend
     { role: "user", content: "can you delegate this to Hermes?" }
   ]);
 });
+test("Augmentor chat contract renders explicitly referenced tabs with provenance", () => {
+  const prompt = buildAugmentorSystemPrompt({
+    tabContexts: [
+      { title: "Alpha News", url: "https://alpha.test/", text: "Alpha visible text" },
+      { title: "Beta Report", url: "https://beta.test/", text: "Beta visible text" }
+    ]
+  });
+
+  assert.match(prompt, /Browser tabs explicitly referenced by the user/);
+  assert.match(prompt, /Referenced tab 1: Alpha News — https:\/\/alpha\.test\//);
+  assert.match(prompt, /Referenced tab 2: Beta Report — https:\/\/beta\.test\//);
+  assert.match(prompt, /Alpha visible text/);
+  assert.match(prompt, /scope the answer to these tabs/);
+
+  assert.doesNotMatch(buildAugmentorSystemPrompt({}), /explicitly referenced by the user/);
+  assert.doesNotMatch(buildAugmentorSystemPrompt({ tabContexts: [] }), /explicitly referenced by the user/);
+  assert.doesNotMatch(buildAugmentorSystemPrompt({ tabContexts: "not-an-array" }), /explicitly referenced by the user/);
+});

--- a/browser-first/test/chat-turn-controller.test.mjs
+++ b/browser-first/test/chat-turn-controller.test.mjs
@@ -5,7 +5,8 @@ import {
   createChatTurnController,
   pageContextForSnapshot,
   providerMessagesFromHistory,
-  runtimeContextForAttachments
+  runtimeContextForAttachments,
+  tabContextsForScopedTabs
 } from "../resonantos-side-panel-extension/src/lib/chat-turn-controller.js";
 
 test("chat turn controller builds compact page and runtime context", () => {
@@ -87,7 +88,7 @@ test("chat turn controller filters provider messages to recent user/assistant tu
   ]);
 });
 
-function createHarness({ fail = false, failureError = new Error("provider down"), systemPrompt = "" } = {}) {
+function createHarness({ fail = false, failureError = new Error("provider down"), systemPrompt = "", scopedContexts = [] } = {}) {
   const events = [];
   const attachments = [{ name: "notes.md", content: "notes" }];
   const messages = [
@@ -107,6 +108,7 @@ function createHarness({ fail = false, failureError = new Error("provider down")
     },
     clearActivitySoon: () => events.push(["clearActivitySoon"]),
     clearAttachments: async () => events.push(["clearAttachments"]),
+    consumeScopedTabContexts: () => scopedContexts,
     getLastSnapshot: () => ({ title: "Page", url: "https://example.com/", text: "Visible" }),
     getModel: () => "MiniMax-M3",
     getSystemPrompt: () => systemPrompt,
@@ -167,4 +169,57 @@ test("chat turn controller replaces raw fetch failures with bridge setup guidanc
   assert.match(message, /ResonantOS bridge is unreachable/);
   assert.match(message, /Settings > Bridge Target/);
   assert.doesNotMatch(message, /Failed to fetch/);
+});
+test("tabContextsForScopedTabs budgets and sanitizes per-tab context blocks", () => {
+  assert.deepEqual(tabContextsForScopedTabs(null), []);
+  assert.deepEqual(tabContextsForScopedTabs([]), []);
+  assert.deepEqual(tabContextsForScopedTabs([null, {}]), []);
+
+  const contexts = tabContextsForScopedTabs([
+    { tabId: 1, title: "Alpha", url: "https://alpha.test/", text: "alpha text" },
+    { tabId: 2, title: "Beta", url: "https://beta.test/", text: "B".repeat(9000) }
+  ]);
+  assert.equal(contexts.length, 2);
+  assert.equal(contexts[0].text, "alpha text");
+  assert.equal(contexts[1].text.length, 6000, "12000-char budget is split evenly across referenced tabs");
+
+  const single = tabContextsForScopedTabs([{ tabId: 1, title: "Alpha", url: "https://alpha.test/", text: "A".repeat(20000) }]);
+  assert.equal(single[0].text.length, 12000, "a single referenced tab gets the whole budget");
+});
+
+test("chat turn controller attaches tab contexts and provenance chips for scoped requests", async () => {
+  const skLive = ["sk", "live", "TABS", "ECRET"].join("-");
+  const harness = createHarness({
+    scopedContexts: [
+      { tabId: 1, mention: "Alpha News", title: "Alpha News", url: "https://alpha.test/", text: "Alpha visible text" },
+      { tabId: 2, mention: "Beta Report", title: "Beta Report", url: `https://beta.test/?token=${skLive}`, text: "Beta visible text" }
+    ]
+  });
+
+  await harness.controller.runChatTurn();
+
+  const bridgeEvent = harness.events.find((event) => event[0] === "bridge");
+  const tabContexts = bridgeEvent[2].body.tabContexts;
+  assert.equal(tabContexts.length, 2);
+  assert.equal(tabContexts[0].tabId, 1);
+  assert.equal(tabContexts[0].title, "Alpha News");
+  assert.match(tabContexts[0].text, /Alpha visible text/);
+  assert.doesNotMatch(tabContexts[1].url, /token=/, "referenced tab URLs are stripped of query secrets");
+
+  const assistant = harness.events.find((event) => event[0] === "message" && event[1] === "assistant");
+  assert.deepEqual(assistant[3]?.chips, [
+    { title: "Alpha News", url: "https://alpha.test/" },
+    { title: "Beta Report", url: "https://beta.test/" }
+  ], "assistant reply carries the request-side provenance chips");
+});
+
+test("chat turn controller sends no tab contexts for unscoped requests", async () => {
+  const harness = createHarness();
+
+  await harness.controller.runChatTurn();
+
+  const bridgeEvent = harness.events.find((event) => event[0] === "bridge");
+  assert.deepEqual(bridgeEvent[2].body.tabContexts, []);
+  const assistant = harness.events.find((event) => event[0] === "message" && event[1] === "assistant");
+  assert.deepEqual(assistant[3]?.chips, []);
 });

--- a/browser-first/test/side-panel-command-router.test.mjs
+++ b/browser-first/test/side-panel-command-router.test.mjs
@@ -13,6 +13,7 @@ function createHarness({ resumableControlRun = false } = {}) {
     allowControlPreflightOnceForTaskClass: handler("allow-control-once"),
     bindMentionedTab: handler("bind"),
     resolveComparisonContext: handler("compare"),
+    resolveScopedTabContext: handler("scoped"),
     cancelBrowserJob: handler("cancel"),
     approveControlPreflight: handler("approve-control"),
     continueBrowserJob: handler("continue"),
@@ -339,4 +340,32 @@ test("side panel command router treats email-handled prose as not having @tab me
   await harness.router.respondToCommand("email bob@acme.com, sue@corp.io re: plan");
   assert.equal(harness.calls.some((call) => call[0] === "compare"), false);
   assert.ok(harness.calls.some((call) => call[0] === "bind"));
+});
+test("side panel command router routes quoted mentions without a compare verb to explicit tab scoping", async () => {
+  const harness = createHarness();
+
+  // @"…" is the deliberate form the composer typeahead inserts (#252): quoted
+  // mentions scope the request to those tabs even with no compare verb.
+  await harness.router.respondToCommand('what do @"Alpha News" and @"Beta Report" say');
+  assert.ok(harness.calls.some((call) => call[0] === "scoped" && call[1] === 'what do @"Alpha News" and @"Beta Report" say'));
+  assert.equal(harness.calls.some((call) => call[0] === "compare"), false);
+  assert.equal(harness.calls.some((call) => call[0] === "bind" && call[1] === 'what do @"Alpha News" and @"Beta Report" say'), false);
+});
+
+test("side panel command router routes a single quoted mention to scoping, not the bare bind", async () => {
+  const harness = createHarness();
+
+  await harness.router.respondToCommand('summarize @"Alpha News"');
+  assert.ok(harness.calls.some((call) => call[0] === "scoped" && call[1] === 'summarize @"Alpha News"'));
+  assert.equal(harness.calls.some((call) => call[0] === "bind" && call[1] === 'summarize @"Alpha News"'), false);
+});
+
+test("side panel command router keeps the compare verb winning over quoted mentions", async () => {
+  const harness = createHarness();
+
+  // Explicit comparison intent keeps the #220 path exactly; scoping is the
+  // no-verb path only.
+  await harness.router.respondToCommand('compare @"Alpha News" and @"Beta Report"');
+  assert.ok(harness.calls.some((call) => call[0] === "compare" && call[1] === 'compare @"Alpha News" and @"Beta Report"'));
+  assert.equal(harness.calls.some((call) => call[0] === "scoped"), false);
 });

--- a/browser-first/test/tab-comparison-resolver.test.mjs
+++ b/browser-first/test/tab-comparison-resolver.test.mjs
@@ -3,7 +3,9 @@ import test from "node:test";
 
 import {
   isCompareIntent,
+  parseTabMentionTokens,
   parseTabMentions,
+  resolveScopedTabs,
   resolveTabComparison
 } from "../resonantos-side-panel-extension/src/lib/tab-comparison-resolver.js";
 
@@ -45,6 +47,30 @@ test("parseTabMentions returns empty for prose containing @ that is not a tab me
   // never tokens. The previous pattern counted them as two mentions.
   assert.deepEqual(parseTabMentions("email bob@acme.com, sue@corp.io re: plan"), []);
   assert.deepEqual(parseTabMentions("contact @someone on X"), ["someone"]);
+});
+
+test("parseTabMentionTokens marks quoted, bare, and @tab N forms", () => {
+  assert.deepEqual(parseTabMentionTokens('sum @"Alpha Beta" and @Beta and @tab 2'), [
+    { mention: "Alpha Beta", quoted: true, tabRef: false },
+    { mention: "Beta", quoted: false, tabRef: false },
+    { mention: "tab 2", quoted: false, tabRef: true }
+  ]);
+  assert.deepEqual(parseTabMentionTokens("email bob@acme.com"), []);
+});
+
+test("resolveScopedTabs keeps token flags; resolveTabComparison strips them", () => {
+  const scoped = resolveScopedTabs('sum @"Alpha News" and @"Gone Tab" and @Also Gone', twoPlusUnreadable, isReadable);
+  assert.equal(scoped.items.length, 1);
+  assert.equal(scoped.items[0].quoted, true, "resolved quoted mention keeps its flag");
+  assert.equal(scoped.items[0].tabId, 1);
+  const quotedSkip = scoped.skipped.find((entry) => entry.mention === "Gone Tab");
+  const bareSkip = scoped.skipped.find((entry) => entry.mention === "Also");
+  assert.equal(quotedSkip.quoted, true, "closed quoted reference is visibly explicit");
+  assert.equal(bareSkip.quoted, false, "bare mention stays a prose mention");
+
+  const comparison = resolveTabComparison('sum @"Alpha News" and @"Gone Tab"', twoPlusUnreadable, isReadable);
+  assert.deepEqual(Object.keys(comparison.items[0]).sort(), ["mention", "tabId", "title", "url"].sort());
+  assert.deepEqual(Object.keys(comparison.skipped[0]).sort(), ["mention", "reason", "title", "url"].sort());
 });
 
 test("isCompareIntent recognizes compare/versus/vs/diff/between (and nothing else)", () => {

--- a/browser-first/test/tab-context-controller.test.mjs
+++ b/browser-first/test/tab-context-controller.test.mjs
@@ -45,10 +45,15 @@ function createHarness(overrides = {}) {
     }
   };
   const controller = createTabContextController({
-    addMessage: async (role, content) => events.push(["message", role, content]),
+    addMessage: async (role, content, options) => events.push(options ? ["message", role, content, options] : ["message", role, content]),
     chrome,
     getControlledTabId: () => controlledTabId,
     isReadableBrowserTab: (tab) => /^https?:\/\//i.test(String(tab?.url ?? "")),
+    readTabPage: overrides.readTabPage ?? (async (tab) => ({
+      ok: true,
+      tab,
+      snapshot: { title: tab.title, url: tab.url, text: `Visible text of ${tab.title}` }
+    })),
     refreshTabContext: async () => events.push(["refresh"]),
     renderSitePermissionPanel: async (tab) => events.push(["render-site", tab?.id ?? null]),
     setContextMeter: (value) => events.push(["meter", value]),
@@ -197,4 +202,56 @@ test("tab context controller delegates a single unambiguous mention to the singl
   assert.equal(result?.id, 2);
   assert.equal(harness.getControlledTabId(), 2);
   assert.ok(harness.events.some((event) => event[0] === "message" && /Using @tab context:/.test(event[2])));
+});
+test("tab context controller scopes quoted mentions: captures content, posts provenance chips, consumes once", async () => {
+  const harness = createHarness();
+  const result = await harness.controller.resolveScopedTabContext('what do @"ResonantOS" and @"Manolo Booking" say');
+
+  assert.equal(result.contexts.length, 2);
+  assert.equal(result.contexts[0].tabId, 1);
+  assert.match(result.contexts[0].text, /Visible text of ResonantOS/);
+  assert.equal(result.contexts[1].tabId, 2);
+
+  const summary = harness.events.find((event) => event[0] === "message" && /Scoped to 2 referenced tabs/.test(event[2]));
+  assert.ok(summary, "provenance summary is posted");
+  assert.deepEqual(summary[3]?.chips, [
+    { title: "ResonantOS", url: "https://resonantos.com/" },
+    { title: "Manolo Booking", url: "https://manoloremiddi.com/booking" }
+  ]);
+  // Scoping never activates or binds a tab.
+  assert.equal(harness.getControlledTabId(), null);
+  assert.equal(harness.events.some((event) => event[0] === "tab-update"), false);
+
+  const consumed = harness.controller.consumeScopedTabContexts();
+  assert.equal(consumed.length, 2);
+  assert.deepEqual(harness.controller.consumeScopedTabContexts(), [], "scope is consumed once and cannot leak into a later turn");
+});
+
+test("tab context controller fails loudly on an unresolved quoted reference and never widens scope", async () => {
+  const harness = createHarness();
+  const result = await harness.controller.resolveScopedTabContext('summarize @"Closed Tab"');
+
+  assert.equal(result.contexts.length, 0);
+  assert.ok(harness.events.some((event) =>
+    event[0] === "message" && /"Closed Tab" could not be resolved/.test(event[2]) && /scope was not widened/.test(event[2])
+  ));
+  assert.equal(harness.controller.consumeScopedTabContexts().length, 0);
+});
+
+test("tab context controller keeps unresolved bare mentions silent in the scoped path", async () => {
+  const harness = createHarness();
+  await harness.controller.resolveScopedTabContext('sum @"ResonantOS" and @nothing-matches-this');
+
+  assert.equal(harness.events.some((event) => event[0] === "message" && /nothing-matches-this/.test(String(event[2]))), false);
+  assert.equal(harness.controller.consumeScopedTabContexts().length, 1);
+});
+
+test("tab context controller skips unreadable captures with a visible reason", async () => {
+  const harness = createHarness({
+    readTabPage: async (tab) => ({ ok: false, tab, error: "receiving end does not exist" })
+  });
+  const result = await harness.controller.resolveScopedTabContext('sum @"ResonantOS"');
+
+  assert.equal(result.contexts.length, 0);
+  assert.ok(harness.events.some((event) => event[0] === "message" && /could not read "ResonantOS"/.test(event[2])));
 });

--- a/browser-first/test/tab-mention-typeahead.test.mjs
+++ b/browser-first/test/tab-mention-typeahead.test.mjs
@@ -1,0 +1,131 @@
+// #252 — the composer typeahead lists only open, permitted tabs and inserts
+// the deliberate @"…" mention form that the router treats as an explicit scope.
+import assert from "node:assert/strict";
+import test from "node:test";
+import { JSDOM } from "jsdom";
+
+import {
+  createTabMentionTypeahead,
+  mentionInsertionForTab,
+  mentionQueryAtCaret,
+  rankMentionCandidates
+} from "../resonantos-side-panel-extension/src/lib/tab-mention-typeahead.js";
+
+const isReadable = (tab) => /^https?:\/\//i.test(String(tab?.url ?? ""));
+
+const openTabs = [
+  { id: 1, title: "Alpha News", url: "https://alpha.test/" },
+  { id: 2, title: "Beta Report", url: "https://beta.test/" },
+  { id: 3, title: "Internal Settings", url: "chrome://settings/" },
+  { id: 4, title: "Alpha Docs", url: "https://docs.alpha.test/" }
+];
+
+test("mentionQueryAtCaret detects mention tokens at the caret", () => {
+  assert.deepEqual(mentionQueryAtCaret("@", 1), { start: 0, query: "", quoted: false });
+  assert.deepEqual(mentionQueryAtCaret("sum @Al", 7), { start: 4, query: "Al", quoted: false });
+  assert.deepEqual(mentionQueryAtCaret('sum @"Alpha Be', 14), { start: 4, query: "Alpha Be", quoted: true });
+});
+
+test("mentionQueryAtCaret rejects prose, emails, and terminated tokens", () => {
+  assert.equal(mentionQueryAtCaret("bob@acme.com", 9), null);
+  assert.equal(mentionQueryAtCaret("no mention here", 15), null);
+  assert.equal(mentionQueryAtCaret("@Alpha Beta", 11), null, "unquoted token terminated at whitespace");
+  assert.equal(mentionQueryAtCaret('closed @"Done" already', 14), null);
+});
+
+test("rankMentionCandidates lists only readable tabs, prefix before substring before URL", () => {
+  const all = rankMentionCandidates(openTabs, "", isReadable);
+  assert.deepEqual(all.map((candidate) => candidate.title), ["Alpha News", "Beta Report", "Alpha Docs"], "chrome:// internal tab is never listed");
+  assert.deepEqual(all.map((candidate) => candidate.index), [1, 2, 3], "index is the position among readable tabs for @tab N");
+
+  const prefix = rankMentionCandidates(openTabs, "alpha", isReadable);
+  assert.deepEqual(prefix.map((candidate) => candidate.title), ["Alpha News", "Alpha Docs"]);
+
+  const substring = rankMentionCandidates(openTabs, "docs", isReadable);
+  assert.deepEqual(substring.map((candidate) => candidate.title), ["Alpha Docs"]);
+
+  assert.deepEqual(rankMentionCandidates(openTabs, "missing", isReadable), []);
+});
+
+test("mentionInsertionForTab inserts the deliberate quoted form and sanitizes titles", () => {
+  assert.equal(mentionInsertionForTab({ title: "Alpha News", index: 1 }), '@"Alpha News" ');
+  assert.equal(mentionInsertionForTab({ title: 'He said "hi"\nthere', index: 2 }), '@"He said hi there" ');
+  assert.equal(mentionInsertionForTab({ title: "", index: 3 }), "@tab 3 ", "untitled tab falls back to the ranked form");
+});
+
+function setupDom(tabs) {
+  const dom = new JSDOM('<form id="f"><textarea id="c"></textarea></form>', { url: "https://side-panel.test/" });
+  const doc = dom.window.document;
+  const input = doc.getElementById("c");
+  const typeahead = createTabMentionTypeahead({
+    doc,
+    input,
+    isReadableBrowserTab: isReadable,
+    queryTabs: async () => tabs
+  });
+  return { doc, dom, input, typeahead };
+}
+
+const keydown = (dom, key) => new dom.window.KeyboardEvent("keydown", { key, bubbles: true, cancelable: true });
+
+const typeAndRefresh = async (dom, input, value) => {
+  input.value = value;
+  input.setSelectionRange(value.length, value.length);
+  input.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+test("typeahead opens on @ over permitted tabs and inserts the quoted mention on Enter", async () => {
+  const { doc, dom, input, typeahead } = setupDom(openTabs);
+
+  await typeAndRefresh(dom, input, "sum @Al");
+  const list = doc.querySelector(".tab-mention-typeahead");
+  assert.ok(list, "dropdown renders");
+  assert.equal(typeahead.isOpen(), true);
+  const options = [...list.querySelectorAll(".tab-mention-option")];
+  assert.deepEqual(options.map((option) => option.querySelector("strong").textContent), ["Alpha News", "Alpha Docs"]);
+  assert.match(options[0].querySelector("span").textContent, /@tab 1 · alpha\.test/);
+
+  input.dispatchEvent(keydown(dom, "Enter"));
+  assert.equal(input.value, 'sum @"Alpha News" ');
+  assert.equal(typeahead.isOpen(), false);
+  assert.equal(doc.querySelector(".tab-mention-typeahead"), null);
+  assert.equal(input.selectionStart, input.value.length, "caret lands after the inserted mention");
+});
+
+test("typeahead arrow navigation selects a later candidate", async () => {
+  const { doc, dom, input, typeahead } = setupDom(openTabs);
+
+  await typeAndRefresh(dom, input, "@");
+  assert.equal(doc.querySelectorAll(".tab-mention-option").length, 3);
+
+  input.dispatchEvent(keydown(dom, "ArrowDown"));
+  assert.equal(doc.querySelector(".tab-mention-option.active strong").textContent, "Beta Report");
+  input.dispatchEvent(keydown(dom, "Enter"));
+  assert.equal(input.value, '@"Beta Report" ');
+  assert.equal(typeahead.isOpen(), false);
+});
+
+test("typeahead does not open for email prose and closes on Escape", async () => {
+  const { doc, dom, input, typeahead } = setupDom(openTabs);
+
+  await typeAndRefresh(dom, input, "mail bob@acme");
+  assert.equal(typeahead.isOpen(), false);
+  assert.equal(doc.querySelector(".tab-mention-typeahead"), null);
+
+  await typeAndRefresh(dom, input, "@");
+  assert.equal(typeahead.isOpen(), true);
+  input.dispatchEvent(keydown(dom, "Escape"));
+  assert.equal(typeahead.isOpen(), false);
+  assert.equal(input.value, "@", "Escape leaves the composer text untouched");
+});
+
+test("typeahead closes when the query stops matching any permitted tab", async () => {
+  const { doc, dom, input, typeahead } = setupDom(openTabs);
+
+  await typeAndRefresh(dom, input, "@Al");
+  assert.equal(typeahead.isOpen(), true);
+  await typeAndRefresh(dom, input, "@Alzzzz");
+  assert.equal(typeahead.isOpen(), false);
+  assert.equal(doc.querySelector(".tab-mention-typeahead"), null);
+});


### PR DESCRIPTION
Split from PR #327 (was bundled under the REF branch by accident).

**@tab tab-referencing feature**: the composer typeahead lists only open, permitted tabs; referenced-tab content scopes the response with provenance chips; an unavailable tab fails loudly and never widens scope.

- 18 browser-first files, 20 new tests (`test:browser-first` 1055/1055).
- Live-browser proof (Chrome 152 + local bridge, deterministic loopback stub): AC 1–3 confirmed — permitted-only typeahead, provenance chips with referenced-tab blocks flowing extension → bridge → model (no Authorization header), and closed-tab failure without scope widening.

Independent of the REF/SDK work; no docs/ADR changes.