### PR TITLE
build(release-scope): recognize packages/addon-sdk* and tsconfig.json as in-scope

### DIFF
--- a/scripts/browser-first-release-scope-audit.mjs
+++ b/scripts/browser-first-release-scope-audit.mjs
@@ -223,7 +223,7 @@ export function collectChangedPaths(options, runGit) {
   ];
 }
 
-function classify(changedPath, state) {
+export function classify(changedPath, state) {
   if (changedPath.startsWith("browser-first/")) {
     return {
       bucket: "include",
@@ -272,6 +272,12 @@ function classify(changedPath, state) {
       reason: "pure Node browser host support package",
     };
   }
+  if (changedPath.startsWith("packages/addon-sdk")) {
+    return {
+      bucket: "include",
+      reason: "add-on SDK package family (ADR-018/ADR-040), part of the browser-first extension release surface",
+    };
+  }
   if (
     changedPath.startsWith("src/") ||
     changedPath.startsWith("public/addons/") ||
@@ -290,7 +296,8 @@ function classify(changedPath, state) {
     changedPath === "SECURITY.md" ||
     changedPath === "LICENSE.txt" ||
     changedPath === "run-bridge-minimal.mjs" ||
-    changedPath === "vite.config.ts"
+    changedPath === "vite.config.ts" ||
+    changedPath === "tsconfig.json"
   ) {
     return {
       bucket: "include",

--- a/scripts/browser-first-release-scope-audit.test.mjs
+++ b/scripts/browser-first-release-scope-audit.test.mjs
@@ -342,3 +342,21 @@ test("known canonical, ADR, icon, and deleted documentation pass strict audit", 
   assert.match(stdout, /deleted\s+docs\/retired\/legacy-release-notes\.html/);
   assert.match(stdout, /deleted\s+CODEBASE-EVALUATION-OLD\.md/);
 });
+
+test("classify includes the add-on SDK package family and tsconfig in the browser-first release surface", () => {
+  const classify = requireExport("classify");
+  // packages/addon-sdk and packages/addon-sdk-testing must be in-scope (ADR-018/ADR-040)
+  // so strict release-scope audit does not reject SDK work — regression guard for the
+  // #327-#331 framework stack CI blocker.
+  for (const p of [
+    "packages/addon-sdk/src/contracts.ts",
+    "packages/addon-sdk/package.json",
+    "packages/addon-sdk-testing/test/trust-tier.test.ts",
+    "packages/addon-sdk-testing/src/failure-modes/f1-credential-exfiltration.ts",
+  ]) {
+    assert.equal(classify(p, "added").bucket, "include", `${p} must be in release scope`);
+  }
+  assert.equal(classify("tsconfig.json", "modified").bucket, "include", "tsconfig.json must be in release scope");
+  // negative control: an unrelated new top-level path still needs review
+  assert.notEqual(classify("packages/some-unrelated-tool/index.ts", "added").bucket, "include");
+});


### PR DESCRIPTION
Small maintainer infrastructure fix. The strict release-scope audit (`browser-first-release-scope-audit --committed --strict`) rejects the add-on SDK package family as "outside known browser-first release scope":
```
- added    packages/addon-sdk/src/contracts.ts   :: outside known browser-first release scope
- added    packages/addon-sdk-testing/test/...    :: outside known browser-first release scope
- modified tsconfig.json                          :: outside known browser-first release scope
Strict mode failed.
```
ADR-018/ADR-040 establish `packages/addon-sdk*` as the canonical SDK location, so it belongs in the browser-first release surface. This adds a `packages/addon-sdk` include rule and `tsconfig.json` to the metadata include list, exports `classify()`, and adds a regression test (with a negative control for unrelated top-level packages).

## Why now, standalone
This is a **prerequisite for any `packages/` SDK work to pass alpha-build**, independent of the #327–#331 framework stack's merge decision — so it lands on its own. It unblocks the alpha-build scope-audit step on #327/#328/#329/#331 without committing to merging the framework (which stays deferred to beta.2). Same class of fix as the docs/recipes allowlist in #304.

## Validation
- `node --test browser-first-release-scope-audit.test.mjs`: 11/11; new test proven red against the pre-fix classify (anti-false-green).
- Real stack paths now classify `include`; audit runs clean end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)