### PR TITLE
docs: add llms.txt — a machine-readable map of the repo for AI assistants

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -98,6 +98,7 @@ Related contributor references:
   [icon asset index](../public/icons/README.md)
 - [GitHub Action SHA-pinning policy](security-pipeline/sha-pin-policy.md)
 - [Committed private key material check](security-pipeline/committed-private-key-material.md)
+- [Machine-readable repo map for AI assistants](../llms.txt)
 - [Architecture templates, runbooks, and add-on skill contracts](architecture/README.md#contributor-contracts)
 
 ## Release The Alpha

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,17 @@
+# ResonantOS 2.0.0-alpha
+
+> The browser-first alpha of ResonantOS: the operating layer for cultivating a trusted AI strategist, then giving it a modular ecosystem of tools, memory, specialists, and community stewardship. Where a human and a trusted AI meet to think, work, and remember together.
+
+Docs:
+- [AGENTS.md](AGENTS.md): Agent operating contract — repository mission, runtime boundaries, evidence rules. Start of the five-file path.
+- [CONTRIBUTING.md](CONTRIBUTING.md): Contribution rules — run the alpha first, choose work from GitHub issues, feature branches target `dev`, PR titles prefixed by area.
+- [INSTALL.md](INSTALL.md): Supported runtime setup — npm install, `browser-first:bridge`, load the Chrome extension unpacked.
+- [docs/README.md](docs/README.md): Architecture and component references.
+
+Code:
+- [src/sdk/addons/](src/sdk/addons/): The add-on SDK and manifest validator — the modular specialist layer (add-ons declare a manifest, capabilities, and runtime type).
+- [browser-first/](browser-first/): The Chrome Manifest V3 side-panel extension and the authenticated local Node bridge (loopback by default).
+
+Project:
+- [Website](https://resonantos.com): Product overview, whitepaper, symbiotic licence.
+- [Economy research](https://github.com/ResonantOS/resonantos-economy-research): The governed research tower behind the contribution economy — "a research wind tunnel, not an economy factory."

--- a/llms.txt
+++ b/llms.txt
@@ -1,17 +1,17 @@
 # ResonantOS 2.0.0-alpha
 
-> The browser-first alpha of ResonantOS: the operating layer for cultivating a trusted AI strategist, then giving it a modular ecosystem of tools, memory, specialists, and community stewardship. Where a human and a trusted AI meet to think, work, and remember together.
+> ResonantOS 2.0.0 Alpha is a browser-first system composed of a Chrome Manifest V3 side-panel extension and an authenticated local Node.js bridge. The bridge provides host-mediated provider, memory, add-on, diagnostics, and browser-control services while privileged browser actions remain under explicit human control.
 
 Docs:
-- [AGENTS.md](AGENTS.md): Agent operating contract — repository mission, runtime boundaries, evidence rules. Start of the five-file path.
-- [CONTRIBUTING.md](CONTRIBUTING.md): Contribution rules — run the alpha first, choose work from GitHub issues, feature branches target `dev`, PR titles prefixed by area.
-- [INSTALL.md](INSTALL.md): Supported runtime setup — npm install, `browser-first:bridge`, load the Chrome extension unpacked.
-- [docs/README.md](docs/README.md): Architecture and component references.
+- [AGENTS.md](https://github.com/ResonantOS/2.0.0-alpha/blob/dev/AGENTS.md): Agent operating contract — repository mission, runtime boundaries, evidence rules. Start of the five-file path.
+- [CONTRIBUTING.md](https://github.com/ResonantOS/2.0.0-alpha/blob/dev/CONTRIBUTING.md): Contribution rules — run the alpha first, choose work from GitHub issues, feature branches target `dev`, PR titles prefixed by area.
+- [INSTALL.md](https://github.com/ResonantOS/2.0.0-alpha/blob/dev/INSTALL.md): Supported runtime setup — npm install, `browser-first:bridge`, load the Chrome extension unpacked.
+- [docs/README.md](https://github.com/ResonantOS/2.0.0-alpha/blob/dev/docs/README.md): Architecture and component references.
 
 Code:
-- [src/sdk/addons/](src/sdk/addons/): The add-on SDK and manifest validator — the modular specialist layer (add-ons declare a manifest, capabilities, and runtime type).
-- [browser-first/](browser-first/): The Chrome Manifest V3 side-panel extension and the authenticated local Node bridge (loopback by default).
+- [src/sdk/addons/](https://github.com/ResonantOS/2.0.0-alpha/tree/dev/src/sdk/addons): The add-on SDK and manifest validator — the modular specialist layer (add-ons declare a manifest, capabilities, and runtime type).
+- [browser-first/](https://github.com/ResonantOS/2.0.0-alpha/tree/dev/browser-first): The Chrome Manifest V3 side-panel extension and the authenticated local Node bridge (loopback by default).
 
 Project:
-- [Website](https://resonantos.com): Product overview, whitepaper, symbiotic licence.
+- [Website](https://resonantos.com): Product overview and whitepaper. MIT-licensed code; the website carries the symbiotic licence.
 - [Economy research](https://github.com/ResonantOS/resonantos-economy-research): The governed research tower behind the contribution economy — "a research wind tunnel, not an economy factory."

--- a/scripts/browser-first-release-scope-audit.mjs
+++ b/scripts/browser-first-release-scope-audit.mjs
@@ -18,6 +18,7 @@ const canonicalRootFiles = new Set([
   "CODE_OF_CONDUCT.md",
   "CONTRIBUTING.md",
   "INSTALL.md",
+  "llms.txt",
   "SUPPORT.md",
 ]);
 

--- a/scripts/browser-first-release-scope-audit.test.mjs
+++ b/scripts/browser-first-release-scope-audit.test.mjs
@@ -361,6 +361,16 @@ test("classify includes the add-on SDK package family and tsconfig in the browse
   assert.notEqual(classify("packages/some-unrelated-tool/index.ts", "added").bucket, "include");
 });
 
+test("the machine-readable repo map for AI assistants is an approved canonical root file", () => {
+  const classify = requireExport("classify");
+
+  assert.deepEqual(
+    classify("llms.txt", "added"),
+    { bucket: "include", reason: "canonical browser-first governance or release documentation" },
+    "llms.txt must be in release scope so strict audits do not reject the repo map",
+  );
+});
+
 test("security-pipeline documentation is approved release documentation", () => {
   const classify = requireExport("classify");
 


### PR DESCRIPTION
Adds an `llms.txt` at the repo root (the [llmstxt.org](https://llmstxt.org) convention): a short, curated, plain-text map of the project that AI assistants fetch before crawling. Everything in it is drawn from the repo's own files — the AGENTS.md operating contract, the install path, the add-on SDK, the browser-first runtime, and links to the website and the economy-research tower.

Why: AI assistants increasingly answer "what is ResonantOS / how do I build an add-on" questions; today they have to reconstruct the answer from raw file listings. This gives them the canonical entry points in the project's own words.

Part of a small coordinated set (one PR per repo): the same file for `resonantos-economy-research` and the website (plus `robots.txt`/`sitemap.xml` there). Happy to withdraw any of them.

One maintainer-only note from the same corner: this repo has no topics set. If useful: `ai-agents`, `browser-extension`, `local-first`, `operating-system`.


## Validation

Rebased onto current `dev` (6aa0bb6) and re-ran locally at head `20409ea`:

- `npm run repo:hygiene` — pass
- `npm run docs:check` — pass (llms.txt now reachable from docs/README.md)
- `npm run test:docs` — pass (includes the new release-scope-audit classify assertion)
- `node scripts/browser-first-release-scope-audit.mjs --committed --strict` — pass (llms.txt classified `include`)
- `npm run test:security-pipeline` — pass

Environment note: `npm run test:browser-host` requires a Playwright Chromium download that stalls on this machine; that step (and the rest of `verify:alpha` that depends on it) is left to CI on the clean runner. Everything above ran green locally.
