### PR TITLE
security(security-pipeline): gate the string-to-shell spawn pattern in CI

### DIFF
--- a/.github/security-pipeline/checks.yml
+++ b/.github/security-pipeline/checks.yml
@@ -1220,6 +1220,15 @@
         "browser-first/host",
         "src"
       ]
+    },
+    {
+      "id": "subprocess-no-shell-string",
+      "family": "runtime-hardening",
+      "policy": "block",
+      "adapter": "subprocess-no-shell-string",
+      "surfaces": [
+        "."
+      ]
     }
   ]
 }

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,8 +1,11 @@
 # Security observe workflow.
 #
 # Runs the security-pipeline check registry in OBSERVE mode (non-gating) while
-# the committed-private-key-material job gates private key material. Additive
-# alongside alpha-build.yml, which this workflow does not touch.
+# the committed-private-key-material and repository-hygiene jobs gate their
+# checks. One further gating exception: the subprocess-no-shell-string job
+# executes its registry check (policy "block") without continue-on-error, so
+# a new string-to-shell construction fails CI. Additive alongside
+# alpha-build.yml, which this workflow does not touch.
 #
 # Action refs are pinned to full 40-char commit SHAs per
 # docs/security-pipeline/sha-pin-policy.md (lead by example).
@@ -85,3 +88,27 @@ jobs:
         run: node --test scripts/check-repo-hygiene.test.mjs
       - name: Run repository hygiene guard
         run: npm run -s repo:hygiene
+
+  # Gating counterweight to the observe job above: one check, registered with
+  # policy "block", runs WITHOUT continue-on-error so a new instance of the
+  # pattern class fails CI. The registry stays the single source of truth.
+  subprocess-no-shell-string-gate:
+    name: "subprocess no shell-string (gate)"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        # pin: full 40-char commit SHA per sha-pin-policy.md.
+        # NOTE: verify this SHA at the commit gate before merge.
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup Node.js
+        # pin: full 40-char commit SHA per sha-pin-policy.md.
+        # NOTE: verify this SHA at the commit gate before merge.
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version-file: .nvmrc
+      - name: Test subprocess-no-shell-string check
+        run: node --test scripts/security-pipeline/checks/subprocess-no-shell-string.test.mjs
+      - name: Run subprocess-no-shell-string check (gating)
+        run: node scripts/security-pipeline/run-check.mjs --config .github/security-pipeline/checks.yml --check subprocess-no-shell-string

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,12 @@ worker's changes.
   `.github/security-pipeline/checks.yml` under the check's `allowlist` with a
   `reason`. See
   [committed private key material](docs/security-pipeline/committed-private-key-material.md).
+- Execute child processes as argv arrays (`spawn(file, [args], { shell: false })`),
+  never command strings or `shell: true` — the gating `subprocess-no-shell-string`
+  check flags `exec()`/`execSync()`, any non-false `shell:` option (string values and
+  the `{ shell }` shorthand included), template-literal commands, and unparseable call
+  spans. Known-safe sites need a data-flow rationale in the adapter's `ALLOWLIST`. See
+  [subprocess no shell-string](docs/security-pipeline/subprocess-no-shell-string.md).
 - Do not claim runtime support, status, or release scope that is absent from
   code, tests, [current status](docs/STATUS.md), and Project 2.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -98,6 +98,7 @@ Related contributor references:
   [icon asset index](../public/icons/README.md)
 - [GitHub Action SHA-pinning policy](security-pipeline/sha-pin-policy.md)
 - [Committed private key material check](security-pipeline/committed-private-key-material.md)
+- [Subprocess no shell-string check](security-pipeline/subprocess-no-shell-string.md)
 - [Machine-readable repo map for AI assistants](../llms.txt)
 - [Architecture templates, runbooks, and add-on skill contracts](architecture/README.md#contributor-contracts)
 

--- a/docs/security-pipeline/subprocess-no-shell-string.md
+++ b/docs/security-pipeline/subprocess-no-shell-string.md
@@ -1,0 +1,67 @@
+# Subprocess No Shell-String
+
+PR #338 adds a blocking security-pipeline check for the string-to-shell
+process-construction class fixed in PR #333 (the engineer-runner ran
+`spawnSync(command, { shell: true })` with contract-file strings). The adapter
+is registered in [checks.yml](../../.github/security-pipeline/checks.yml) as
+`subprocess-no-shell-string` (family `runtime-hardening`, policy `block`), and
+the `subprocess no shell-string (gate)` job in
+[security.yml](../../.github/workflows/security.yml) runs its own test file
+before the check so a broken adapter fails before a silent pass.
+
+## What It Detects
+
+- `exec-string-api`: `exec()` / `execSync()` calls — the command string is
+  shell-interpreted by design. Bare and member calls both match
+  (`execSync(...)`, `child_process.execSync(...)`); only `.exec(` is excluded,
+  because member `exec` is overwhelmingly `RegExp.prototype.exec` or a domain
+  method.
+- `shell-true-option`: spawn-family calls (`spawn`, `spawnSync`, `execFile`,
+  `execFileSync`) with a `shell:` option whose value is anything except
+  `false` — string values such as `shell: "bash"` and the shorthand
+  `{ shell }` form both flag.
+- `template-command-arg`: spawn-family calls whose command argument is a
+  template literal (dynamic command construction).
+- `unparseable-call-span`: a matched call whose span cannot be parsed within
+  8000 characters — a huge inline options object must not silently hide a
+  `shell: true`.
+
+The sanctioned pattern is argv form: `spawn(file, [args], { shell: false })`.
+
+## Masking
+
+String, template, comment, and regex-literal contents are masked before
+matching, so call-shaped text inside literals never flags. Quote state resets
+at newline for non-template strings, and regex literals are recognized
+positionally (after `( , = : ? ; ! [ { & |`, `return`, or start of file), so a
+quote inside `/["'()/` cannot open a phantom string and invert masking for the
+rest of the file. A `/` after an identifier, digit, `)`, or `]` stays division.
+This is a heuristic, not a JS parser — ambiguous constructs are rare in
+practice and err toward flagging.
+
+## Scope
+
+In a git checkout the check enumerates `git ls-files --cached --others
+--exclude-standard` (the pattern validate-docs adopted in #365), so it scans
+exactly tracked files plus visible untracked work: gitignored scratch and
+nested agent worktrees never reach the scan, and the local gate matches a
+clean checkout. Dot-directories are excluded on both enumeration paths.
+Outside a git checkout it walks the tree, skipping `node_modules`, `.git`,
+`dist`, and `coverage`.
+
+## Allowlisting
+
+Each entry pins file, rule, and the exact trimmed source line, so moved or
+edited code re-flags and forces a fresh look. Entries live in the adapter's
+`ALLOWLIST` in
+[subprocess-no-shell-string.mjs](../../scripts/security-pipeline/checks/subprocess-no-shell-string.mjs)
+and must carry the data-flow rationale for why the site is safe (for example:
+compile-time literal commands with no variable content). Known blind spots and
+the current allowlisted sites are documented in the adapter header.
+
+## Run Locally
+
+```bash
+node --test scripts/security-pipeline/checks/subprocess-no-shell-string.test.mjs
+node scripts/security-pipeline/run-check.mjs --check subprocess-no-shell-string
+```

--- a/docs/security-pipeline/subprocess-no-shell-string.md
+++ b/docs/security-pipeline/subprocess-no-shell-string.md
@@ -18,9 +18,15 @@ before the check so a broken adapter fails before a silent pass.
   method.
 - `shell-true-option`: spawn-family calls (`spawn`, `spawnSync`, `execFile`,
   `execFileSync`) with a `shell:` option whose value is anything except the
-  bare boolean `false` — string values such as `shell: "bash"` (and
-  `shell: "false"`, which names an executable, not the boolean) and the
-  shorthand `{ shell }` form all flag.
+  bare boolean `false` — exactly `false` terminated by `,` or `}`; `shell:
+  false || true` flags, string values such as `shell: "bash"` (and
+  `shell: "false"`, which names an executable, not the boolean), quoted keys
+  (`"shell": true`), and the shorthand `{ shell }` form all flag.
+- Aliased and module-bound calls are tracked: `const spawnImpl = spawn`,
+  `import { exec as runIt }`, and `const cp = require("node:child_process")`
+  all register, so `spawnImpl(...)`, `runIt(...)`, and `cp.exec(...)`
+  scan under their original semantics; member `.exec(` flags only on a
+  tracked child_process receiver (RegExp `exec` stays exempt).
 - `template-command-arg`: spawn-family calls whose command argument is a
   template literal (dynamic command construction).
 - `unparseable-call-span`: a matched call whose span cannot be parsed within
@@ -40,7 +46,12 @@ yield`, or start of file), so a quote inside
 `/["'()]/` cannot open a phantom string and invert masking for the rest of the
 file. A `/` after an identifier, digit, `)`, or `]` stays division. This is a
 heuristic, not a JS parser — ambiguous constructs are rare in practice and err
-toward flagging.
+toward flagging. Documented limits: an unterminated-looking template literal
+masks until its closing backtick (templates legitimately span lines; no
+instance in this repo), spread values are not resolved (so
+`{ shell: false, ...options }` can re-enable the shell invisibly), and
+provenance tracking is textual, so an import-shaped string literal could
+register a phantom alias in the over-matching direction.
 
 ## Scope
 

--- a/docs/security-pipeline/subprocess-no-shell-string.md
+++ b/docs/security-pipeline/subprocess-no-shell-string.md
@@ -13,9 +13,10 @@ before the check so a broken adapter fails before a silent pass.
 
 - `exec-string-api`: `exec()` / `execSync()` calls — the command string is
   shell-interpreted by design. Bare and member calls both match
-  (`execSync(...)`, `child_process.execSync(...)`); only `.exec(` is excluded,
-  because member `exec` is overwhelmingly `RegExp.prototype.exec` or a domain
-  method.
+  (`execSync(...)`, `child_process.execSync(...)`); member `.exec(` flags when
+  its receiver is a tracked child_process binding (a `require`d or imported
+  module object) and stays exempt otherwise — member `exec` is overwhelmingly
+  `RegExp.prototype.exec` or a domain method.
 - `shell-true-option`: spawn-family calls (`spawn`, `spawnSync`, `execFile`,
   `execFileSync`) with a `shell:` option whose value is anything except the
   bare boolean `false` — exactly `false` terminated by `,` or `}`; `shell:
@@ -66,8 +67,10 @@ repo's size) falls back to the plain walk — noted as a blind spot.
 
 ## Allowlisting
 
-Each entry pins file, rule, and the exact trimmed source line, so moved or
-edited code re-flags and forces a fresh look. Entries live in the adapter's
+Each entry pins file, rule, and the exact trimmed text of the whole call
+(multi-line calls included), so moved or edited code re-flags — including
+edits to later lines of a multi-line call — and forces a fresh look. Entries
+live in the adapter's
 `ALLOWLIST` in
 [subprocess-no-shell-string.mjs](../../scripts/security-pipeline/checks/subprocess-no-shell-string.mjs)
 and must carry the data-flow rationale for why the site is safe (for example:

--- a/docs/security-pipeline/subprocess-no-shell-string.md
+++ b/docs/security-pipeline/subprocess-no-shell-string.md
@@ -17,9 +17,10 @@ before the check so a broken adapter fails before a silent pass.
   because member `exec` is overwhelmingly `RegExp.prototype.exec` or a domain
   method.
 - `shell-true-option`: spawn-family calls (`spawn`, `spawnSync`, `execFile`,
-  `execFileSync`) with a `shell:` option whose value is anything except
-  `false` — string values such as `shell: "bash"` and the shorthand
-  `{ shell }` form both flag.
+  `execFileSync`) with a `shell:` option whose value is anything except the
+  bare boolean `false` — string values such as `shell: "bash"` (and
+  `shell: "false"`, which names an executable, not the boolean) and the
+  shorthand `{ shell }` form all flag.
 - `template-command-arg`: spawn-family calls whose command argument is a
   template literal (dynamic command construction).
 - `unparseable-call-span`: a matched call whose span cannot be parsed within
@@ -33,11 +34,13 @@ The sanctioned pattern is argv form: `spawn(file, [args], { shell: false })`.
 String, template, comment, and regex-literal contents are masked before
 matching, so call-shaped text inside literals never flags. Quote state resets
 at newline for non-template strings, and regex literals are recognized
-positionally (after `( , = : ? ; ! [ { & |`, `return`, or start of file), so a
-quote inside `/["'()/` cannot open a phantom string and invert masking for the
-rest of the file. A `/` after an identifier, digit, `)`, or `]` stays division.
-This is a heuristic, not a JS parser — ambiguous constructs are rare in
-practice and err toward flagging.
+positionally (after `( , = : ? ; ! [ { & | >` — the `>` covers arrow-body
+regexes — or the keywords `return case typeof in of new void delete await
+yield`, or start of file), so a quote inside
+`/["'()]/` cannot open a phantom string and invert masking for the rest of the
+file. A `/` after an identifier, digit, `)`, or `]` stays division. This is a
+heuristic, not a JS parser — ambiguous constructs are rare in practice and err
+toward flagging.
 
 ## Scope
 
@@ -46,8 +49,9 @@ In a git checkout the check enumerates `git ls-files --cached --others
 exactly tracked files plus visible untracked work: gitignored scratch and
 nested agent worktrees never reach the scan, and the local gate matches a
 clean checkout. Dot-directories are excluded on both enumeration paths.
-Outside a git checkout it walks the tree, skipping `node_modules`, `.git`,
-`dist`, and `coverage`.
+Outside a git checkout it walks the tree with the same exclusions. A git
+failure mid-scan (including a >32 MiB `ls-files` overflow, unreachable at this
+repo's size) falls back to the plain walk — noted as a blind spot.
 
 ## Allowlisting
 

--- a/scripts/security-pipeline/checks/runtime-hardening-registry.test.mjs
+++ b/scripts/security-pipeline/checks/runtime-hardening-registry.test.mjs
@@ -857,8 +857,17 @@ test("active runtime-hardening checks share production-derived spawn records", a
     check.family === "runtime-hardening" && check.policy !== "disabled"
   );
   assert.equal(registry.families["runtime-hardening"].status, "active");
-  assert.equal(runtimeChecks.length, 4);
-  for (const check of runtimeChecks) {
+  // Record-based checks observe the production spawn record set. The static
+  // source scanner (subprocess-no-shell-string) does not consume records; it
+  // must appear here explicitly so family membership stays reviewed.
+  const recordChecks = runtimeChecks.filter((check) => Array.isArray(check.recordSets));
+  const staticChecks = runtimeChecks.filter((check) => !Array.isArray(check.recordSets));
+  assert.equal(recordChecks.length, 4);
+  assert.deepEqual(
+    staticChecks.map((check) => check.id),
+    ["subprocess-no-shell-string"],
+  );
+  for (const check of recordChecks) {
     assert.deepEqual(check.recordSets, [RECORD_SET], `${check.id} must use the production record set`);
   }
 
@@ -945,6 +954,6 @@ test("production runtime-hardening records pass strict certification", () => {
   );
   assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
   const results = result.stdout.trim().split(/\n(?=\{)/).map((document) => JSON.parse(document));
-  assert.equal(results.length, 4, result.stdout);
-  assert.deepEqual(results.map(({ status }) => status), ["pass", "pass", "pass", "pass"]);
+  assert.equal(results.length, 5, result.stdout);
+  assert.deepEqual(results.map(({ status }) => status), ["pass", "pass", "pass", "pass", "pass"]);
 });

--- a/scripts/security-pipeline/checks/subprocess-no-shell-string.mjs
+++ b/scripts/security-pipeline/checks/subprocess-no-shell-string.mjs
@@ -32,7 +32,10 @@
 // Scope: in a git checkout the scan enumerates git-tracked and visible
 // untracked files (git ls-files --cached --others --exclude-standard), so
 // gitignored scratch and nested worktrees are never scanned; outside a git
-// checkout it walks the tree skipping node_modules/.git/dist/coverage.
+// checkout it walks the tree skipping dot-directories, node_modules, dist,
+// and coverage. Blind spot: a git invocation that fails mid-scan (including
+// a >32 MiB ls-files overflow, unreachable at this repo's size) falls back
+// to the plain walk, which does enter unignored scratch.
 //
 // Verdict mapping: clean -> pass, violation(s) -> fail, no sources -> skipped.
 
@@ -98,11 +101,13 @@ const CALL_PATTERN =
   /(?<![.\w$])(execFileSync|execFile|execSync|exec|spawnSync|spawn)\s*\(|(?<=\.)(execFileSync|execFile|execSync|spawnSync|spawn)\s*\(/g;
 const STRING_API_NAMES = new Set(["exec", "execSync"]);
 const SPAWN_FAMILY_NAMES = new Set(["spawn", "spawnSync", "execFile", "execFileSync"]);
-// R2 match: an options-object `shell:` whose value is anything except false
-// (including string values like "bash"), or the shorthand `{ shell }` form of
-// a variable that is not provably false.
+// R2 match: an options-object `shell:` whose value is anything except the
+// bare boolean false, or the shorthand `{ shell }` form of a variable that is
+// not provably false. On masked text only the bare `false` token can appear —
+// string contents are blanked — so every string-valued shell: (including
+// shell: "false", which is a truthy executable spec, not the boolean) flags.
 const SHELL_OPTION_PATTERN =
-  /(?:^|[{,(\s])(?:shell\s*:\s*(?!"false"|'false'|false\b)(?:"[^"]*"|'[^']*'|true\b|[^,})\s][^,})]*)|shell\s*(?=[},]))/;
+  /(?:^|[{,(\s])(?:shell\s*:\s*(?!false\b)(?:"[^"]*"|'[^']*'|true\b|[^,})\s][^,})]*)|shell\s*(?=[},]))/;
 
 function isSourceFile(fileName) {
   return SOURCE_EXTENSIONS.has(path.extname(fileName));
@@ -114,12 +119,15 @@ function isSourceFile(fileName) {
 // matching.
 //
 // Regex-literal handling is positional (not a JS parser): a `/` that follows
-// one of `( , = : ? ; ! [ { & |` or the keyword `return` (or the start of the
-// file) opens a regex literal whose body, character classes, and flags are
-// masked. A `/` after an identifier, `)`, `]`, or a digit stays division.
-// Single- and double-quote state resets at newline (non-template strings
-// cannot span lines), so a quote inside a regex or a truncated string can
-// only invert masking until the end of its line, never the rest of the file.
+// one of `( , = : ? ; ! [ { & | >` (the `>` covers arrow-body regexes) or a
+// keyword like `return` (or the start of the file) opens a regex literal
+// whose body, character classes, and flags are masked. A `/` after an
+// identifier, `)`, `]`, or a digit stays division. Single- and double-quote
+// state resets at newline (non-template strings cannot span lines), so a
+// quote inside a regex or a truncated string can only invert masking until
+// the end of its line, never the rest of the file. prevCode/prevWord are
+// deliberately stale across comment/string/regex spans — the last code
+// context before a literal is the relevant one for the next `/`.
 export function maskCode(text) {
   const out = text.split("");
   let quote = null;
@@ -199,11 +207,15 @@ export function maskCode(text) {
 
 // Positions after which a `/` unambiguously starts a regex literal (review
 // 2026-09-08: quotes inside regex literals used to open phantom strings and
-// invert masking for the rest of the file, hiding real violations).
-const REGEX_CONTEXT_CHARS = new Set(["(", ",", "=", ":", "?", ";", "!", "[", "{", "&", "|"]);
+// invert masking for the rest of the file, hiding real violations). `>` covers
+// arrow-body regexes (`(x) => /re/.test(x)`), this codebase's most common
+// regex position; division can never follow `>` directly because its left
+// operand (identifier, digit, `)`, `]`) is the immediately preceding char.
+const REGEX_CONTEXT_CHARS = new Set(["(", ",", "=", ":", "?", ";", "!", "[", "{", "&", "|", ">"]);
+const REGEX_CONTEXT_WORDS = new Set(["return", "case", "typeof", "in", "of", "new", "void", "delete", "await", "yield"]);
 
 function regexStartContext(prevCode, prevWord) {
-  return prevCode === "" || REGEX_CONTEXT_CHARS.has(prevCode) || prevWord === "return";
+  return prevCode === "" || REGEX_CONTEXT_CHARS.has(prevCode) || REGEX_CONTEXT_WORDS.has(prevWord);
 }
 
 // Tracked-sources enumeration (review 2026-09-08, the #365 pattern from
@@ -238,7 +250,7 @@ export async function listSourceFiles(rootDir, current = rootDir) {
   const files = [];
   for (const entry of entries) {
     if (entry.isDirectory()) {
-      if (SKIPPED_DIRECTORIES.has(entry.name)) continue;
+      if (SKIPPED_DIRECTORIES.has(entry.name) || entry.name.startsWith(".")) continue;
       files.push(...await listSourceFiles(rootDir, path.join(current, entry.name)));
     } else if (entry.isFile() && isSourceFile(entry.name)) {
       files.push(path.relative(rootDir, path.join(current, entry.name)));

--- a/scripts/security-pipeline/checks/subprocess-no-shell-string.mjs
+++ b/scripts/security-pipeline/checks/subprocess-no-shell-string.mjs
@@ -4,24 +4,45 @@
 // PR #333 (engineer-runner runCommand used spawnSync(command, {shell:true})
 // with contract-file strings). Flags, in tracked JS/TS sources:
 //   R1 exec-string-api         exec()/execSync() calls (shell-interpreted by design)
-//   R2 shell-true-option       spawn-family calls with a shell: option that is not false
+//   R2 shell-true-option       spawn-family calls with a shell: option that is not
+//                              false — string values (shell: "bash") and the
+//                              shorthand form ({ shell }) both flag
 //   R3 template-command-arg    spawn-family calls whose command argument is a
 //                              template literal (dynamic command construction)
-// Argv-form spawns (array args, shell:false or default) are the sanctioned pattern
-// and pass. Allowlist entries below carry the data-flow rationale for each
-// known-safe site. Wraps into the run-check.mjs contract:
+//   R4 unparseable-call-span   a matched call whose span cannot be parsed within
+//                              MAX_CALL_SPAN_CHARS (a huge inline options object
+//                              must not silently hide a shell: true)
+// Bare and member calls both match (cp.spawnSync, child_process.execSync);
+// only `.exec(` is excluded — member exec is RegExp.prototype.exec or a
+// domain method, not the child_process string API. Argv-form spawns (array
+// args, shell:false or default) are the sanctioned pattern and pass.
+// Allowlist entries below carry the data-flow rationale for each known-safe
+// site. Wraps into the run-check.mjs contract:
 //   run({ check, repoRoot }) -> { status, summary, evidence[] }
 //
 // Known blind spots (by design, documented): string- and comment-literal
 // contents are masked before matching, so call-shaped text inside strings or
 // comments never flags (and code inside template ${...} interpolation is
-// masked with the template); a shell: option whose value is a string literal
-// (e.g. shell: "bash") is masked with the string and not flagged.
+// masked with the template). Regex literals are masked positionally (see
+// maskCode), so a quote inside /.../ does not open a phantom string; a quote
+// state opened by other malformed input resets at the next newline. The
+// shorthand { shell } flags even when the variable is false — allowlist it
+// with a reason if the data flow is provably safe.
+//
+// Scope: in a git checkout the scan enumerates git-tracked and visible
+// untracked files (git ls-files --cached --others --exclude-standard), so
+// gitignored scratch and nested worktrees are never scanned; outside a git
+// checkout it walks the tree skipping node_modules/.git/dist/coverage.
 //
 // Verdict mapping: clean -> pass, violation(s) -> fail, no sources -> skipped.
 
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 
 const SOURCE_EXTENSIONS = new Set([".mjs", ".js", ".ts", ".tsx", ".jsx"]);
 const SKIPPED_DIRECTORIES = new Set(["node_modules", ".git", "dist", "coverage"]);
@@ -68,24 +89,46 @@ const ALLOWLIST = [
   },
 ];
 
-// Longest names first so execFileSync is not matched as exec.
-const CALL_PATTERN = /(?<![.\w$])(execFileSync|execFile|execSync|exec|spawnSync|spawn)\s*\(/g;
+// Two alternatives (review 2026-09-08): bare calls of any name, plus member
+// calls such as cp.spawnSync(...) or child_process.execSync(...) — only
+// `.exec(` stays excluded, because member exec is overwhelmingly
+// RegExp.prototype.exec or a domain method, not the child_process string API.
+// Longest names first within each group so execFileSync is not matched as exec.
+const CALL_PATTERN =
+  /(?<![.\w$])(execFileSync|execFile|execSync|exec|spawnSync|spawn)\s*\(|(?<=\.)(execFileSync|execFile|execSync|spawnSync|spawn)\s*\(/g;
 const STRING_API_NAMES = new Set(["exec", "execSync"]);
 const SPAWN_FAMILY_NAMES = new Set(["spawn", "spawnSync", "execFile", "execFileSync"]);
-const SHELL_OPTION_PATTERN = /(?:^|[{,(\s])shell\s*:\s*(?!"false"|'false'|false\b)(?:"[^"]*"|'[^']*'|true\b|[^,})\s][^,})]*)/;
+// R2 match: an options-object `shell:` whose value is anything except false
+// (including string values like "bash"), or the shorthand `{ shell }` form of
+// a variable that is not provably false.
+const SHELL_OPTION_PATTERN =
+  /(?:^|[{,(\s])(?:shell\s*:\s*(?!"false"|'false'|false\b)(?:"[^"]*"|'[^']*'|true\b|[^,})\s][^,})]*)|shell\s*(?=[},]))/;
 
 function isSourceFile(fileName) {
   return SOURCE_EXTENSIONS.has(path.extname(fileName));
 }
 
-// Replace comment and string/template-literal contents with spaces (newlines
-// preserved) so the result has identical length and line structure to the
-// input, but only real code positions remain for call matching.
+// Replace comment and string/template-literal/regex-literal contents with
+// spaces (newlines preserved) so the result has identical length and line
+// structure to the input, but only real code positions remain for call
+// matching.
+//
+// Regex-literal handling is positional (not a JS parser): a `/` that follows
+// one of `( , = : ? ; ! [ { & |` or the keyword `return` (or the start of the
+// file) opens a regex literal whose body, character classes, and flags are
+// masked. A `/` after an identifier, `)`, `]`, or a digit stays division.
+// Single- and double-quote state resets at newline (non-template strings
+// cannot span lines), so a quote inside a regex or a truncated string can
+// only invert masking until the end of its line, never the rest of the file.
 export function maskCode(text) {
   const out = text.split("");
   let quote = null;
   let lineComment = false;
   let blockComment = false;
+  let regex = false;
+  let regexClass = false;
+  let prevCode = "";
+  let prevWord = "";
   for (let index = 0; index < text.length; index += 1) {
     const ch = text[index];
     const next = text[index + 1];
@@ -99,9 +142,33 @@ export function maskCode(text) {
       else if (ch !== "\n") out[index] = " ";
       continue;
     }
+    if (regex) {
+      if (ch === "\\") { out[index] = " "; out[index + 1] = " "; index += 1; continue; }
+      if (ch === "\n") { regex = false; regexClass = false; continue; }
+      if (regexClass) {
+        if (ch === "]") regexClass = false;
+        out[index] = " ";
+        continue;
+      }
+      if (ch === "[") { regexClass = true; out[index] = " "; continue; }
+      if (ch === "/") {
+        regex = false;
+        out[index] = " ";
+        let flagsEnd = index + 1;
+        while (flagsEnd < text.length && /[a-z]/i.test(text[flagsEnd])) { out[flagsEnd] = " "; flagsEnd += 1; }
+        index = flagsEnd - 1;
+        continue;
+      }
+      out[index] = " ";
+      continue;
+    }
     if (quote) {
       if (ch === "\\") { out[index] = " "; out[index + 1] = " "; index += 1; continue; }
       if (ch === quote) {
+        quote = null;
+        continue;
+      }
+      if (ch === "\n" && quote !== "`") {
         quote = null;
         continue;
       }
@@ -110,12 +177,63 @@ export function maskCode(text) {
     }
     if (ch === "/" && next === "/") { out[index] = " "; out[index + 1] = " "; lineComment = true; index += 1; continue; }
     if (ch === "/" && next === "*") { out[index] = " "; out[index + 1] = " "; blockComment = true; index += 1; continue; }
-    if (ch === "'" || ch === '"' || ch === "`") { quote = ch; continue; }
+    if (ch === "/" && regexStartContext(prevCode, prevWord)) {
+      regex = true;
+      out[index] = " ";
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === "`") {
+      quote = ch;
+      prevCode = ch;
+      prevWord = "";
+      continue;
+    }
+    if (/\S/.test(ch)) {
+      prevCode = ch;
+      if (/[A-Za-z0-9_$]/.test(ch)) prevWord += ch;
+      else prevWord = "";
+    }
   }
   return out.join("");
 }
 
+// Positions after which a `/` unambiguously starts a regex literal (review
+// 2026-09-08: quotes inside regex literals used to open phantom strings and
+// invert masking for the rest of the file, hiding real violations).
+const REGEX_CONTEXT_CHARS = new Set(["(", ",", "=", ":", "?", ";", "!", "[", "{", "&", "|"]);
+
+function regexStartContext(prevCode, prevWord) {
+  return prevCode === "" || REGEX_CONTEXT_CHARS.has(prevCode) || prevWord === "return";
+}
+
+// Tracked-sources enumeration (review 2026-09-08, the #365 pattern from
+// validate-docs): in a git checkout, `git ls-files --cached --others
+// --exclude-standard` covers exactly tracked files plus visible untracked
+// work, and never enters gitignored scratch or nested worktrees — a plain
+// filesystem walk scanned both and could fail a clean checkout. The argv
+// form (no shell) is the pattern this check mandates. Outside a git checkout
+// the walk fallback applies.
+async function listGitVisibleFiles(rootDir) {
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["-C", rootDir, "ls-files", "-z", "--cached", "--others", "--exclude-standard"],
+      { maxBuffer: 32 * 1024 * 1024 },
+    );
+    return stdout
+      .split("\0")
+      .filter(Boolean)
+      .map((file) => file.split(path.sep).join("/"))
+      .filter((file) => !file.split("/").some((segment) => segment.startsWith(".") || SKIPPED_DIRECTORIES.has(segment)))
+      .filter((file) => isSourceFile(file) && existsSync(path.join(rootDir, file)));
+  } catch {
+    return null;
+  }
+}
+
 export async function listSourceFiles(rootDir, current = rootDir) {
+  const gitFiles = await listGitVisibleFiles(rootDir);
+  if (gitFiles) return gitFiles.sort();
   const entries = await readdir(current, { withFileTypes: true });
   const files = [];
   for (const entry of entries) {
@@ -182,10 +300,18 @@ export function scanSource(fileName, source) {
   CALL_PATTERN.lastIndex = 0;
   let match;
   while ((match = CALL_PATTERN.exec(masked)) !== null) {
-    const name = match[1];
+    const name = match[1] ?? match[2];
     const openParenIndex = match.index + match[0].length - 1;
     const closeParenIndex = findCallSpanEnd(masked, openParenIndex);
-    if (closeParenIndex === -1) continue;
+    if (closeParenIndex === -1) {
+      // Review 2026-09-08: a call span past MAX_CALL_SPAN_CHARS used to be
+      // skipped silently, so a huge inline options object could hide a
+      // `shell: true`. Unparseable spans surface as findings instead.
+      const lineNumber = masked.slice(0, match.index).split("\n").length;
+      const snippet = (lines[lineNumber - 1] ?? "").trim();
+      findings.push({ file: fileName, line: lineNumber, rule: "unparseable-call-span", snippet });
+      continue;
+    }
     const span = masked.slice(openParenIndex, closeParenIndex + 1);
     const lineNumber = masked.slice(0, match.index).split("\n").length;
     const snippet = (lines[lineNumber - 1] ?? "").trim();

--- a/scripts/security-pipeline/checks/subprocess-no-shell-string.mjs
+++ b/scripts/security-pipeline/checks/subprocess-no-shell-string.mjs
@@ -1,0 +1,265 @@
+// subprocess-no-shell-string adapter.
+//
+// Static scanner for the string-to-shell process-construction class fixed in
+// PR #333 (engineer-runner runCommand used spawnSync(command, {shell:true})
+// with contract-file strings). Flags, in tracked JS/TS sources:
+//   R1 exec-string-api         exec()/execSync() calls (shell-interpreted by design)
+//   R2 shell-true-option       spawn-family calls with a shell: option that is not false
+//   R3 template-command-arg    spawn-family calls whose command argument is a
+//                              template literal (dynamic command construction)
+// Argv-form spawns (array args, shell:false or default) are the sanctioned pattern
+// and pass. Allowlist entries below carry the data-flow rationale for each
+// known-safe site. Wraps into the run-check.mjs contract:
+//   run({ check, repoRoot }) -> { status, summary, evidence[] }
+//
+// Known blind spots (by design, documented): string- and comment-literal
+// contents are masked before matching, so call-shaped text inside strings or
+// comments never flags (and code inside template ${...} interpolation is
+// masked with the template); a shell: option whose value is a string literal
+// (e.g. shell: "bash") is masked with the string and not flagged.
+//
+// Verdict mapping: clean -> pass, violation(s) -> fail, no sources -> skipped.
+
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+const SOURCE_EXTENSIONS = new Set([".mjs", ".js", ".ts", ".tsx", ".jsx"]);
+const SKIPPED_DIRECTORIES = new Set(["node_modules", ".git", "dist", "coverage"]);
+const MAX_CALL_SPAN_CHARS = 8000;
+
+// Known-safe call sites. Each entry pins file + rule + exact trimmed source
+// line, so moved or edited code re-flags and forces a fresh look.
+// Why each is safe (data flow):
+//  - engineer-runner.test.mjs: node:test fixtures whose command strings are
+//    compile-time literals ("git init", ...) with no variable content.
+//  - ensure-dev-server.mjs: argv elements are compile-time constants ("npm",
+//    "run", "dev"); no stored/request content reaches the shell. Public
+//    follow-up of the PR #333 fix (same shape as the engineer-runner site).
+const ALLOWLIST = [
+  {
+    file: "scripts/engineer-runner.test.mjs",
+    rule: "shell-true-option",
+    snippet: `spawnSync("git init", { cwd: repo, shell: true, stdio: "ignore" });`,
+    reason: "test fixture, literal command, no variable content",
+  },
+  {
+    file: "scripts/engineer-runner.test.mjs",
+    rule: "shell-true-option",
+    snippet: `spawnSync("git config user.email test@example.com", { cwd: repo, shell: true, stdio: "ignore" });`,
+    reason: "test fixture, literal command, no variable content",
+  },
+  {
+    file: "scripts/engineer-runner.test.mjs",
+    rule: "shell-true-option",
+    snippet: `spawnSync("git config user.name Test", { cwd: repo, shell: true, stdio: "ignore" });`,
+    reason: "test fixture, literal command, no variable content",
+  },
+  {
+    file: "scripts/engineer-runner.test.mjs",
+    rule: "shell-true-option",
+    snippet: `spawnSync("git add . && git commit -m initial", { cwd: repo, shell: true, stdio: "ignore" });`,
+    reason: "test fixture, literal command, no variable content",
+  },
+  {
+    file: "scripts/ensure-dev-server.mjs",
+    rule: "shell-true-option",
+    snippet: `const child = spawn("npm", ["run", "dev"], {`,
+    reason: "constant argv (\"npm\", [\"run\", \"dev\"]); no untrusted content; known follow-up of PR #333",
+  },
+];
+
+// Longest names first so execFileSync is not matched as exec.
+const CALL_PATTERN = /(?<![.\w$])(execFileSync|execFile|execSync|exec|spawnSync|spawn)\s*\(/g;
+const STRING_API_NAMES = new Set(["exec", "execSync"]);
+const SPAWN_FAMILY_NAMES = new Set(["spawn", "spawnSync", "execFile", "execFileSync"]);
+const SHELL_OPTION_PATTERN = /(?:^|[{,(\s])shell\s*:\s*(?!"false"|'false'|false\b)(?:"[^"]*"|'[^']*'|true\b|[^,})\s][^,})]*)/;
+
+function isSourceFile(fileName) {
+  return SOURCE_EXTENSIONS.has(path.extname(fileName));
+}
+
+// Replace comment and string/template-literal contents with spaces (newlines
+// preserved) so the result has identical length and line structure to the
+// input, but only real code positions remain for call matching.
+export function maskCode(text) {
+  const out = text.split("");
+  let quote = null;
+  let lineComment = false;
+  let blockComment = false;
+  for (let index = 0; index < text.length; index += 1) {
+    const ch = text[index];
+    const next = text[index + 1];
+    if (lineComment) {
+      if (ch === "\n") lineComment = false;
+      else out[index] = " ";
+      continue;
+    }
+    if (blockComment) {
+      if (ch === "*" && next === "/") { out[index] = " "; out[index + 1] = " "; blockComment = false; index += 1; }
+      else if (ch !== "\n") out[index] = " ";
+      continue;
+    }
+    if (quote) {
+      if (ch === "\\") { out[index] = " "; out[index + 1] = " "; index += 1; continue; }
+      if (ch === quote) {
+        quote = null;
+        continue;
+      }
+      out[index] = ch === "\n" ? "\n" : " ";
+      continue;
+    }
+    if (ch === "/" && next === "/") { out[index] = " "; out[index + 1] = " "; lineComment = true; index += 1; continue; }
+    if (ch === "/" && next === "*") { out[index] = " "; out[index + 1] = " "; blockComment = true; index += 1; continue; }
+    if (ch === "'" || ch === '"' || ch === "`") { quote = ch; continue; }
+  }
+  return out.join("");
+}
+
+export async function listSourceFiles(rootDir, current = rootDir) {
+  const entries = await readdir(current, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (SKIPPED_DIRECTORIES.has(entry.name)) continue;
+      files.push(...await listSourceFiles(rootDir, path.join(current, entry.name)));
+    } else if (entry.isFile() && isSourceFile(entry.name)) {
+      files.push(path.relative(rootDir, path.join(current, entry.name)));
+    }
+  }
+  return files.sort();
+}
+
+// Index of the ')' matching the '(' at openParenIndex, quote-aware.
+export function findCallSpanEnd(text, openParenIndex) {
+  let depth = 0;
+  let quote = null;
+  for (let index = openParenIndex; index < text.length; index += 1) {
+    if (index - openParenIndex > MAX_CALL_SPAN_CHARS) return -1;
+    const ch = text[index];
+    if (quote) {
+      if (ch === "\\") { index += 1; continue; }
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === "`") { quote = ch; continue; }
+    if (ch === "(") depth += 1;
+    if (ch === ")") {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  }
+  return -1;
+}
+
+// Text of the first argument (after `(`), up to the first top-level comma.
+export function firstArgumentText(text, openParenIndex, closeParenIndex) {
+  let depth = 0;
+  let quote = null;
+  for (let index = openParenIndex + 1; index < closeParenIndex; index += 1) {
+    const ch = text[index];
+    if (quote) {
+      if (ch === "\\") { index += 1; continue; }
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === "`") { quote = ch; continue; }
+    if (ch === "(" || ch === "[" || ch === "{") depth += 1;
+    if (ch === ")" || ch === "]" || ch === "}") {
+      if (depth === 0) return text.slice(openParenIndex + 1, index).trim();
+      depth -= 1;
+    }
+    if (ch === "," && depth === 0) {
+      return text.slice(openParenIndex + 1, index).trim();
+    }
+  }
+  return text.slice(openParenIndex + 1, closeParenIndex).trim();
+}
+
+export function scanSource(fileName, source) {
+  const masked = maskCode(source);
+  const lines = source.split("\n");
+  const findings = [];
+  CALL_PATTERN.lastIndex = 0;
+  let match;
+  while ((match = CALL_PATTERN.exec(masked)) !== null) {
+    const name = match[1];
+    const openParenIndex = match.index + match[0].length - 1;
+    const closeParenIndex = findCallSpanEnd(masked, openParenIndex);
+    if (closeParenIndex === -1) continue;
+    const span = masked.slice(openParenIndex, closeParenIndex + 1);
+    const lineNumber = masked.slice(0, match.index).split("\n").length;
+    const snippet = (lines[lineNumber - 1] ?? "").trim();
+
+    if (STRING_API_NAMES.has(name)) {
+      findings.push({ file: fileName, line: lineNumber, rule: "exec-string-api", snippet });
+      continue;
+    }
+    if (!SPAWN_FAMILY_NAMES.has(name)) continue;
+
+    if (SHELL_OPTION_PATTERN.test(span)) {
+      findings.push({ file: fileName, line: lineNumber, rule: "shell-true-option", snippet });
+      continue;
+    }
+    const firstArgument = firstArgumentText(masked, openParenIndex, closeParenIndex);
+    if (firstArgument.startsWith("`")) {
+      findings.push({ file: fileName, line: lineNumber, rule: "template-command-arg", snippet });
+    }
+  }
+  return findings;
+}
+
+function allowlisted(finding) {
+  return ALLOWLIST.some((entry) =>
+    entry.file === finding.file &&
+    entry.rule === finding.rule &&
+    entry.snippet === finding.snippet
+  );
+}
+
+export async function run({ check, repoRoot }) {
+  const files = await listSourceFiles(repoRoot);
+  if (files.length === 0) {
+    return {
+      status: "skipped",
+      summary: "subprocess-no-shell-string: no JS/TS sources found; nothing to scan.",
+      evidence: [],
+    };
+  }
+
+  const violations = [];
+  let allowlistedCount = 0;
+  for (const file of files) {
+    const source = await readFile(path.join(repoRoot, file), "utf8");
+    for (const finding of scanSource(file, source)) {
+      if (allowlisted(finding)) {
+        allowlistedCount += 1;
+        continue;
+      }
+      violations.push(finding);
+    }
+  }
+
+  if (violations.length > 0) {
+    return {
+      status: "fail",
+      summary:
+        `subprocess-no-shell-string: ${violations.length} string-to-shell construction(s) found ` +
+        `(${allowlistedCount} allowlisted site(s) skipped). ` +
+        "Execute commands as argv arrays with shell:false (see PR #333).",
+      evidence: violations.map((violation) => ({
+        path: violation.file,
+        line: violation.line,
+        rule: violation.rule,
+        snippet: violation.snippet,
+      })),
+    };
+  }
+
+  return {
+    status: "pass",
+    summary:
+      `subprocess-no-shell-string: no string-to-shell constructions in ${files.length} source file(s) ` +
+      `(${allowlistedCount} allowlisted site(s), data-flow safe).`,
+    evidence: [],
+  };
+}

--- a/scripts/security-pipeline/checks/subprocess-no-shell-string.mjs
+++ b/scripts/security-pipeline/checks/subprocess-no-shell-string.mjs
@@ -27,7 +27,14 @@
 // maskCode), so a quote inside /.../ does not open a phantom string; a quote
 // state opened by other malformed input resets at the next newline. The
 // shorthand { shell } flags even when the variable is false — allowlist it
-// with a reason if the data flow is provably safe.
+// with a reason if the data flow is provably safe. A template literal's
+// backtick state legitimately spans lines, so an unterminated-looking
+// template can mask later lines until its closing backtick (no instance in
+// this repo). Spread overrides after a literal `shell: false` (e.g.
+// { shell: false, ...options }) can re-enable the shell invisibly — spread
+// values are not resolved. Provenance tracking is textual: an import-shaped
+// string literal could register a phantom alias (over-matching direction;
+// allowlist relief applies).
 //
 // Scope: in a git checkout the scan enumerates git-tracked and visible
 // untracked files (git ls-files --cached --others --exclude-standard), so
@@ -87,27 +94,102 @@ const ALLOWLIST = [
   {
     file: "scripts/ensure-dev-server.mjs",
     rule: "shell-true-option",
-    snippet: `const child = spawn("npm", ["run", "dev"], {`,
+    snippet: `const child = spawn("npm", ["run", "dev"], {
+  cwd: process.cwd(),
+  stdio: "ignore",
+  detached: true,
+  shell: true,
+});`,
     reason: "constant argv (\"npm\", [\"run\", \"dev\"]); no untrusted content; known follow-up of PR #333",
   },
 ];
 
-// Two alternatives (review 2026-09-08): bare calls of any name, plus member
-// calls such as cp.spawnSync(...) or child_process.execSync(...) — only
-// `.exec(` stays excluded, because member exec is overwhelmingly
-// RegExp.prototype.exec or a domain method, not the child_process string API.
-// Longest names first within each group so execFileSync is not matched as exec.
-const CALL_PATTERN =
-  /(?<![.\w$])(execFileSync|execFile|execSync|exec|spawnSync|spawn)\s*\(|(?<=\.)(execFileSync|execFile|execSync|spawnSync|spawn)\s*\(/g;
+// Three alternatives (review 2026-09-11): bare calls of any name — including
+// per-file ALIAS names, injected into the alternation by buildCallPattern,
+// because `spawnImpl = spawn` call sites are otherwise invisible; member
+// calls such as cp.spawnSync(...); and receiver-qualified member calls with
+// the receiver captured, so `.exec(` flags only when the receiver is a known
+// child_process binding (member exec is overwhelmingly RegExp.prototype.exec
+// or a domain method otherwise). Longest names first within each group so
+// execFileSync is not matched as exec.
+const CALL_NAMES = ["execFileSync", "execFile", "execSync", "exec", "spawnSync", "spawn"];
+
+function buildCallPattern(extraNames = []) {
+  const bareNames = [...new Set([...extraNames, ...CALL_NAMES])];
+  const memberNames = CALL_NAMES.filter((name) => name !== "exec");
+  return new RegExp(
+    `(?<![.\\w$])(${bareNames.join("|")})\\s*\\(` +
+      `|(?<=\\.)(${memberNames.join("|")})\\s*\\(` +
+      `|([A-Za-z_$][\\w$]*)\\.(${CALL_NAMES.join("|")})\\s*\\(`,
+    "g",
+  );
+}
 const STRING_API_NAMES = new Set(["exec", "execSync"]);
 const SPAWN_FAMILY_NAMES = new Set(["spawn", "spawnSync", "execFile", "execFileSync"]);
 // R2 match: an options-object `shell:` whose value is anything except the
-// bare boolean false, or the shorthand `{ shell }` form of a variable that is
-// not provably false. On masked text only the bare `false` token can appear —
-// string contents are blanked — so every string-valued shell: (including
-// shell: "false", which is a truthy executable spec, not the boolean) flags.
+// bare boolean false — EXACTLY false, terminated by `,` or `}` (review
+// 2026-09-11: `shell: false || true` used to pass as a prefix match) — or the
+// shorthand `{ shell }` form of a variable that is not provably false. On
+// masked text only bare tokens can appear — string contents are blanked — so
+// every string-valued shell: (including shell: "false", which is a truthy
+// executable spec, not the boolean) flags. Quoted keys ("shell": true) are
+// invisible on masked text (the key blanks with its string) and are detected
+// on the raw span by QUOTED_SHELL_KEY below.
 const SHELL_OPTION_PATTERN =
-  /(?:^|[{,(\s])(?:shell\s*:\s*(?!false\b)(?:"[^"]*"|'[^']*'|true\b|[^,})\s][^,})]*)|shell\s*(?=[},]))/;
+  /(?:^|[{,(\s])(?:shell\s*:\s*(?!\s*false\s*[,}])(?:"[^"]*"|'[^']*'|true\b|[^,})\s][^,})]*)|shell\s*(?=[},]))/;
+const QUOTED_SHELL_KEY = /["']shell["']\s*:\s*(?!\s*false\s*[,}])/;
+
+// Provenance tracking (review 2026-09-11 blocker 2): this repo aliases the
+// child_process APIs (`spawnImpl = spawn`, bridge-tls.mjs) and binds the
+// module itself (`require("node:child_process")`), and those call sites were
+// invisible to the bare/member patterns. Collected from RAW source (module
+// names live inside strings, which masking blanks):
+//   aliases:  import { exec as runIt } / const { spawn: s } = require(...) /
+//             const spawnImpl = spawn           -> bare calls of the alias match
+//   receivers: import cp from / import * as cp / const cp = require(...)
+//             -> member calls receiver.exec(...) flag
+// Known limit: provenance is textual — a string literal containing an
+// import-shaped text could register a phantom alias (over-matching,
+// allowlist relief applies).
+const CHILD_PROCESS_API_NAMES = [...STRING_API_NAMES, ...SPAWN_FAMILY_NAMES].join("|");
+const PROVENANCE_PATTERNS = [
+  // import { a, b as c } from "node:child_process"
+  [/import\s*\{([^}]+)\}\s*from\s*["']node:child_process["']/g, "names"],
+  // const { a, b as c } = require("node:child_process")
+  [/const\s*\{([^}]+)\}\s*=\s*require\(\s*["']node:child_process["']\s*\)/g, "names"],
+  // const x = spawn  (bare alias of a tracked API)
+  [new RegExp(`(?:const|let|var)\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*(${CHILD_PROCESS_API_NAMES})\\b`, "g"), "alias"],
+  // import cp from / import * as cp from / const cp = require(...)
+  [/import\s+([A-Za-z_$][\w$]*)\s+from\s*["']node:child_process["']/g, "receiver"],
+  [/import\s*\*\s*as\s+([A-Za-z_$][\w$]*)\s+from\s*["']node:child_process["']/g, "receiver"],
+  [/const\s+([A-Za-z_$][\w$]*)\s*=\s*require\(\s*["']node:child_process["']\s*\)/g, "receiver"],
+];
+
+function collectProvenance(rawSource) {
+  const aliases = new Map();
+  const receivers = new Set();
+  for (const [pattern, kind] of PROVENANCE_PATTERNS) {
+    pattern.lastIndex = 0;
+    let match;
+    while ((match = pattern.exec(rawSource)) !== null) {
+      if (kind === "names") {
+        for (const piece of match[1].split(",")) {
+          const binding = piece.trim().split(/\s+as\s+/);
+          const original = binding[0]?.trim();
+          const bound = (binding[1] ?? binding[0])?.trim();
+          if (original && bound && CHILD_PROCESS_API_NAMES.includes(original)) {
+            aliases.set(bound, original);
+          }
+        }
+      } else if (kind === "alias") {
+        aliases.set(match[1], match[2]);
+      } else {
+        receivers.add(match[1]);
+      }
+    }
+  }
+  return { aliases, receivers };
+}
 
 function isSourceFile(fileName) {
   return SOURCE_EXTENSIONS.has(path.extname(fileName));
@@ -308,25 +390,42 @@ export function firstArgumentText(text, openParenIndex, closeParenIndex) {
 export function scanSource(fileName, source) {
   const masked = maskCode(source);
   const lines = source.split("\n");
+  const { aliases, receivers } = collectProvenance(source);
   const findings = [];
-  CALL_PATTERN.lastIndex = 0;
+  const callPattern = buildCallPattern([...aliases.keys()]);
   let match;
-  while ((match = CALL_PATTERN.exec(masked)) !== null) {
-    const name = match[1] ?? match[2];
+  while ((match = callPattern.exec(masked)) !== null) {
+    const bareName = match[1];
+    const memberName = match[2] ?? match[4];
+    const receiver = match[3];
+    let name = bareName ?? memberName;
+    if (bareName) {
+      name = aliases.get(bareName) ?? bareName;
+    } else if (memberName === "exec" && !receivers.has(receiver)) {
+      // Member .exec( flags only on a tracked child_process receiver;
+      // RegExp.prototype.exec and domain .exec methods stay exempt.
+      continue;
+    }
     const openParenIndex = match.index + match[0].length - 1;
     const closeParenIndex = findCallSpanEnd(masked, openParenIndex);
+    const lineNumber = masked.slice(0, match.index).split("\n").length;
     if (closeParenIndex === -1) {
       // Review 2026-09-08: a call span past MAX_CALL_SPAN_CHARS used to be
       // skipped silently, so a huge inline options object could hide a
       // `shell: true`. Unparseable spans surface as findings instead.
-      const lineNumber = masked.slice(0, match.index).split("\n").length;
       const snippet = (lines[lineNumber - 1] ?? "").trim();
       findings.push({ file: fileName, line: lineNumber, rule: "unparseable-call-span", snippet });
       continue;
     }
     const span = masked.slice(openParenIndex, closeParenIndex + 1);
-    const lineNumber = masked.slice(0, match.index).split("\n").length;
-    const snippet = (lines[lineNumber - 1] ?? "").trim();
+    // Review 2026-09-11: fingerprint the whole call (multi-line included), so
+    // an allowlisted site re-flags when ANY of its later lines is edited, not
+    // just the opening one.
+    const spanLines = source.slice(
+      source.lastIndexOf("\n", match.index) + 1,
+      source.indexOf("\n", closeParenIndex) === -1 ? source.length : source.indexOf("\n", closeParenIndex),
+    ).trim();
+    const snippet = spanLines;
 
     if (STRING_API_NAMES.has(name)) {
       findings.push({ file: fileName, line: lineNumber, rule: "exec-string-api", snippet });
@@ -334,7 +433,7 @@ export function scanSource(fileName, source) {
     }
     if (!SPAWN_FAMILY_NAMES.has(name)) continue;
 
-    if (SHELL_OPTION_PATTERN.test(span)) {
+    if (SHELL_OPTION_PATTERN.test(span) || QUOTED_SHELL_KEY.test(source.slice(match.index, closeParenIndex + 1))) {
       findings.push({ file: fileName, line: lineNumber, rule: "shell-true-option", snippet });
       continue;
     }
@@ -355,7 +454,16 @@ function allowlisted(finding) {
 }
 
 export async function run({ check, repoRoot }) {
-  const files = await listSourceFiles(repoRoot);
+  const registrySurfaces = Array.isArray(check?.surfaces) ? check.surfaces : null;
+  const registryAllowlist = Array.isArray(check?.allowlist) ? check.allowlist : [];
+  let files = await listSourceFiles(repoRoot);
+  if (registrySurfaces) {
+    // Registry `surfaces` scopes the scan (the convention the other checks
+    // follow — review 2026-09-11 minor): a surface is a repo-relative prefix.
+    files = files.filter((file) =>
+      registrySurfaces.some((surface) => surface === "." || file === surface || file.startsWith(`${surface}/`)),
+    );
+  }
   if (files.length === 0) {
     return {
       status: "skipped",
@@ -370,6 +478,13 @@ export async function run({ check, repoRoot }) {
     const source = await readFile(path.join(repoRoot, file), "utf8");
     for (const finding of scanSource(file, source)) {
       if (allowlisted(finding)) {
+        allowlistedCount += 1;
+        continue;
+      }
+      // Registry allowlist (checks.yml `allowlist: [{path, reason}]`) — the
+      // exception convention the other checks use; internal ALLOWLIST entries
+      // stay the primary, fingerprinted mechanism.
+      if (registryAllowlist.some((entry) => entry.path === finding.file && entry.reason)) {
         allowlistedCount += 1;
         continue;
       }

--- a/scripts/security-pipeline/checks/subprocess-no-shell-string.mjs
+++ b/scripts/security-pipeline/checks/subprocess-no-shell-string.mjs
@@ -137,7 +137,23 @@ const SPAWN_FAMILY_NAMES = new Set(["spawn", "spawnSync", "execFile", "execFileS
 // on the raw span by QUOTED_SHELL_KEY below.
 const SHELL_OPTION_PATTERN =
   /(?:^|[{,(\s])(?:shell\s*:\s*(?!\s*false\s*[,}])(?:"[^"]*"|'[^']*'|true\b|[^,})\s][^,})]*)|shell\s*(?=[},]))/;
-const QUOTED_SHELL_KEY = /["']shell["']\s*:\s*(?!\s*false\s*[,}])/;
+// Quoted-key detection runs in two stages so string ARGUMENTS cannot fake a
+// key (review 2026-09-11 minor b): match the key SHAPE on masked text —
+// string interiors are blanked there, so `spawn("printf", ['{"shell": true}'],
+// { shell: false })` shows no key shape — then verify the raw text at the
+// same offset (masking preserves length) actually names "shell".
+const QUOTED_KEY_SHAPE = /[{,]\s*\[?\s*("[^"\n]*"|'[^'\n]*'|`[^`\n]*`)\s*\]?\s*:\s*(?!\s*false\s*[,}])/g;
+
+function quotedShellKey(maskedSpan, rawSpan) {
+  QUOTED_KEY_SHAPE.lastIndex = 0;
+  let match;
+  while ((match = QUOTED_KEY_SHAPE.exec(maskedSpan)) !== null) {
+    const keyStart = match.index + match[0].indexOf(match[1].charAt(0));
+    const rawKey = rawSpan.slice(keyStart, keyStart + match[1].length);
+    if (rawKey === "\"shell\"" || rawKey === "'shell'" || rawKey === "`shell`") return true;
+  }
+  return false;
+}
 
 // Provenance tracking (review 2026-09-11 blocker 2): this repo aliases the
 // child_process APIs (`spawnImpl = spawn`, bridge-tls.mjs) and binds the
@@ -151,41 +167,116 @@ const QUOTED_SHELL_KEY = /["']shell["']\s*:\s*(?!\s*false\s*[,}])/;
 // Known limit: provenance is textual — a string literal containing an
 // import-shaped text could register a phantom alias (over-matching,
 // allowlist relief applies).
-const CHILD_PROCESS_API_NAMES = [...STRING_API_NAMES, ...SPAWN_FAMILY_NAMES].join("|");
-const PROVENANCE_PATTERNS = [
-  // import { a, b as c } from "node:child_process"
-  [/import\s*\{([^}]+)\}\s*from\s*["']node:child_process["']/g, "names"],
-  // const { a, b as c } = require("node:child_process")
-  [/const\s*\{([^}]+)\}\s*=\s*require\(\s*["']node:child_process["']\s*\)/g, "names"],
-  // const x = spawn  (bare alias of a tracked API)
-  [new RegExp(`(?:const|let|var)\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*(${CHILD_PROCESS_API_NAMES})\\b`, "g"), "alias"],
-  // import cp from / import * as cp from / const cp = require(...)
-  [/import\s+([A-Za-z_$][\w$]*)\s+from\s*["']node:child_process["']/g, "receiver"],
-  [/import\s*\*\s*as\s+([A-Za-z_$][\w$]*)\s+from\s*["']node:child_process["']/g, "receiver"],
-  [/const\s+([A-Za-z_$][\w$]*)\s*=\s*require\(\s*["']node:child_process["']\s*\)/g, "receiver"],
+const CHILD_PROCESS_API_NAMES = [...STRING_API_NAMES, ...SPAWN_FAMILY_NAMES];
+// Import/require patterns reference the module name inside a string, so they
+// run on RAW source; first-wins registration means a later phantom match (a
+// doc-text import inside a string literal) can never overwrite a real import
+// binding (review 2026-09-11: a comment-shaped alias used to overwrite one).
+// Provenance patterns run on the FULL MASK (comments, strings, and regex
+// literals blanked — the mask is the one lexer that gets all three right, a
+// lesson this file taught itself twice). Module specifiers are strings, so
+// they blank too: each pattern captures the blanked string as a placeholder
+// and the raw text at the same offset (masking preserves length) must name
+// child_process — comment text, doc strings, and this file's own pattern
+// literals all fail that check and register nothing.
+const MODULE_SPEC_PATTERNS = new Set([
+  '"node:child_process"', "'node:child_process'",
+  '"child_process"', "'child_process'",
+]);
+const PROVENANCE_MASKED_PATTERNS = [
+  [/import\s*\{([^}]+)\}\s*from\s*("[^"\n]*"|'[^'\n]*')/g, "names", 2],
+  [/const\s*\{([^}]+)\}\s*=\s*require\(\s*("[^"\n]*"|'[^'\n]*')\s*\)/g, "names", 2],
+  [/const\s*\{([^}]+)\}\s*=\s*await\s+import\(\s*("[^"\n]*"|'[^'\n]*')\s*\)/g, "names", 2],
+  [/import\s+([A-Za-z_$][\w$]*)\s*,\s*\{([^}]+)\}\s*from\s*("[^"\n]*"|'[^'\n]*')/g, "mixed", 3],
+  [/import\s+([A-Za-z_$][\w$]*)\s+from\s*("[^"\n]*"|'[^'\n]*')/g, "receiver", 2],
+  [/import\s*\*\s*as\s+([A-Za-z_$][\w$]*)\s+from\s*("[^"\n]*"|'[^'\n]*')/g, "receiver", 2],
+  [/const\s+([A-Za-z_$][\w$]*)\s*=\s*require\(\s*("[^"\n]*"|'[^'\n]*')\s*\)/g, "receiver", 2],
 ];
 
-function collectProvenance(rawSource) {
+// Bare bindings (name = identifier) run on the MASKED text: comments are
+// blanked there, so a comment cannot register or overwrite anything, and the
+// pattern covers const/let/var assignments AND parameter defaults /
+// destructured parameters — the bridge-tls.mjs shape (review 2026-09-11
+// blocker). Identifier-to-identifier bindings form a graph resolved below,
+// so alias chains (const a = spawn; const b = a;) reach the original API.
+// Last-wins per name: a later rebinding to an API must register (comorbidity
+// probe: `let s = argv; s = spawn; s(cmd, { shell: true })` was a false
+// negative under first-wins).
+const BARE_BINDING_PATTERN = /([A-Za-z_$][\w$]*)\s*=\s*([A-Za-z_$][\w$]*)/g;
+
+function rawSpecifierIsModule(maskedText, rawText, match, specGroupIndex) {
+  const group = match[specGroupIndex];
+  const offset = match.index + match[0].indexOf(group);
+  return MODULE_SPEC_PATTERNS.has(rawText.slice(offset, offset + group.length));
+}
+
+function parseBraceBindings(clause, aliases, receivers = null) {
+  for (const piece of clause.split(",")) {
+    // "exec", "spawn as s", "spawn: s" — rename via `as` (import) or
+    // `:` (destructuring).
+    const binding = piece.trim().split(/\s+(?:as)\s+|\s*:\s*/);
+    const original = binding[0]?.trim();
+    const bound = (binding[1] ?? binding[0])?.trim();
+    if (original === "default" && receivers && /^[A-Za-z_$][\w$]*$/.test(bound ?? "")) {
+      receivers.add(bound);
+      continue;
+    }
+    if (
+      original && bound &&
+      /^[A-Za-z_$][\w$]*$/.test(bound) &&
+      CHILD_PROCESS_API_NAMES.includes(original) && !aliases.has(bound)
+    ) {
+      aliases.set(bound, original);
+    }
+  }
+}
+
+function collectProvenance(rawSource, maskedSource) {
   const aliases = new Map();
   const receivers = new Set();
-  for (const [pattern, kind] of PROVENANCE_PATTERNS) {
+  for (const [pattern, kind, specGroup] of PROVENANCE_MASKED_PATTERNS) {
     pattern.lastIndex = 0;
     let match;
-    while ((match = pattern.exec(rawSource)) !== null) {
+    while ((match = pattern.exec(maskedSource)) !== null) {
+      if (!rawSpecifierIsModule(maskedSource, rawSource, match, specGroup)) continue;
       if (kind === "names") {
-        for (const piece of match[1].split(",")) {
-          const binding = piece.trim().split(/\s+as\s+/);
-          const original = binding[0]?.trim();
-          const bound = (binding[1] ?? binding[0])?.trim();
-          if (original && bound && CHILD_PROCESS_API_NAMES.includes(original)) {
-            aliases.set(bound, original);
-          }
-        }
-      } else if (kind === "alias") {
-        aliases.set(match[1], match[2]);
+        parseBraceBindings(match[1], aliases);
+      } else if (kind === "mixed") {
+        receivers.add(match[1]);
+        parseBraceBindings(match[2], aliases);
       } else {
         receivers.add(match[1]);
       }
+    }
+  }
+  BARE_BINDING_PATTERN.lastIndex = 0;
+  const bindings = new Map();
+  let match;
+  while ((match = BARE_BINDING_PATTERN.exec(maskedSource)) !== null) {
+    // Last-wins: a later rebinding to an API must register even when the name
+    // was first bound to something safe (comorbidity probe 2026-09-11:
+    // `let s = argv; s = spawn; s(cmd, { shell: true })` was a false negative
+    // under first-wins). Over-match direction for rebind-away-from-API.
+    if (match[1] !== match[2]) {
+      bindings.set(match[1], match[2]);
+    }
+  }
+  // Resolve binding chains: a name aliases the child_process API its binding
+  // graph reaches (alias-of-alias included); cycles and dead ends register
+  // nothing.
+  for (const bound of bindings.keys()) {
+    let target = bindings.get(bound);
+    const seen = new Set([bound]);
+    while (target && !seen.has(target)) {
+      seen.add(target);
+      if (CHILD_PROCESS_API_NAMES.includes(target) && !aliases.has(bound)) {
+        // First-wins vs import-derived bindings: a property assignment like
+        // `adapters.exec = execFileSync` parses as a bare binding and must
+        // not overwrite what a real import registered (pre-push review F1).
+        aliases.set(bound, target);
+        break;
+      }
+      target = bindings.get(target);
     }
   }
   return { aliases, receivers };
@@ -218,6 +309,7 @@ export function maskCode(text) {
   let regex = false;
   let regexClass = false;
   let prevCode = "";
+  let prevPrevCode = "";
   let prevWord = "";
   for (let index = 0; index < text.length; index += 1) {
     const ch = text[index];
@@ -267,7 +359,7 @@ export function maskCode(text) {
     }
     if (ch === "/" && next === "/") { out[index] = " "; out[index + 1] = " "; lineComment = true; index += 1; continue; }
     if (ch === "/" && next === "*") { out[index] = " "; out[index + 1] = " "; blockComment = true; index += 1; continue; }
-    if (ch === "/" && regexStartContext(prevCode, prevWord)) {
+    if (ch === "/" && regexStartContext(prevCode, prevWord, prevPrevCode)) {
       regex = true;
       out[index] = " ";
       continue;
@@ -279,7 +371,14 @@ export function maskCode(text) {
       continue;
     }
     if (/\S/.test(ch)) {
-      prevCode = ch;
+      if (!(ch === "+" || ch === "-") || prevCode !== ch) {
+        // collapse ++/-- to a single context char so the operand-position
+        // guard in regexStartContext sees them as one token
+        prevPrevCode = prevCode;
+        prevCode = ch;
+      } else {
+        prevPrevCode = prevCode;
+      }
       if (/[A-Za-z0-9_$]/.test(ch)) prevWord += ch;
       else prevWord = "";
     }
@@ -293,11 +392,17 @@ export function maskCode(text) {
 // arrow-body regexes (`(x) => /re/.test(x)`), this codebase's most common
 // regex position; division can never follow `>` directly because its left
 // operand (identifier, digit, `)`, `]`) is the immediately preceding char.
-const REGEX_CONTEXT_CHARS = new Set(["(", ",", "=", ":", "?", ";", "!", "[", "{", "&", "|", ">"]);
+const REGEX_CONTEXT_CHARS = new Set(["(", ",", "=", ":", "?", ";", "!", "[", "{", "&", "|", ">", "*", "%", "~", "^", "<", "+", "-"]);
 const REGEX_CONTEXT_WORDS = new Set(["return", "case", "typeof", "in", "of", "new", "void", "delete", "await", "yield"]);
 
-function regexStartContext(prevCode, prevWord) {
-  return prevCode === "" || REGEX_CONTEXT_CHARS.has(prevCode) || REGEX_CONTEXT_WORDS.has(prevWord);
+function regexStartContext(prevCode, prevWord, prevPrevCode = "") {
+  if (prevCode === "" || REGEX_CONTEXT_CHARS.has(prevCode) || REGEX_CONTEXT_WORDS.has(prevWord)) {
+    // `+`/`-` only count as operand positions when not part of ++/--
+    // (pre-push review F3: `a++ / 2` is division, `a + /re/` is a regex).
+    if (prevCode === "+" || prevCode === "-") return prevPrevCode !== prevCode;
+    return true;
+  }
+  return false;
 }
 
 // Tracked-sources enumeration (review 2026-09-08, the #365 pattern from
@@ -390,7 +495,7 @@ export function firstArgumentText(text, openParenIndex, closeParenIndex) {
 export function scanSource(fileName, source) {
   const masked = maskCode(source);
   const lines = source.split("\n");
-  const { aliases, receivers } = collectProvenance(source);
+  const { aliases, receivers } = collectProvenance(source, masked);
   const findings = [];
   const callPattern = buildCallPattern([...aliases.keys()]);
   let match;
@@ -424,7 +529,7 @@ export function scanSource(fileName, source) {
     const spanLines = source.slice(
       source.lastIndexOf("\n", match.index) + 1,
       source.indexOf("\n", closeParenIndex) === -1 ? source.length : source.indexOf("\n", closeParenIndex),
-    ).trim();
+    ).trim().replace(/\r\n/g, "\n");
     const snippet = spanLines;
 
     if (STRING_API_NAMES.has(name)) {
@@ -433,7 +538,7 @@ export function scanSource(fileName, source) {
     }
     if (!SPAWN_FAMILY_NAMES.has(name)) continue;
 
-    if (SHELL_OPTION_PATTERN.test(span) || QUOTED_SHELL_KEY.test(source.slice(match.index, closeParenIndex + 1))) {
+    if (SHELL_OPTION_PATTERN.test(span) || quotedShellKey(span, source.slice(openParenIndex, closeParenIndex + 1))) {
       findings.push({ file: fileName, line: lineNumber, rule: "shell-true-option", snippet });
       continue;
     }
@@ -459,12 +564,25 @@ export async function run({ check, repoRoot }) {
   let files = await listSourceFiles(repoRoot);
   if (registrySurfaces) {
     // Registry `surfaces` scopes the scan (the convention the other checks
-    // follow — review 2026-09-11 minor): a surface is a repo-relative prefix.
+    // follow — review 2026-09-11 minor): a surface is a repo-relative prefix;
+    // trailing slashes are normalized so "scripts/" does not become "scripts//".
     files = files.filter((file) =>
-      registrySurfaces.some((surface) => surface === "." || file === surface || file.startsWith(`${surface}/`)),
+      registrySurfaces.some((surface) => {
+        const prefix = surface === "." ? "" : surface.replace(/^\.\//, "").replace(/\/+$/, "");
+        return prefix === "" || file === prefix || file.startsWith(`${prefix}/`);
+      }),
     );
   }
   if (files.length === 0) {
+    if (registrySurfaces) {
+      // A configured surface that scopes to zero files is a config typo that
+      // would silently disarm the gate (pre-push review F7) — fail loudly.
+      return {
+        status: "fail",
+        summary: `subprocess-no-shell-string: registry surfaces ${JSON.stringify(registrySurfaces)} matched no source files; fix the paths.`,
+        evidence: [],
+      };
+    }
     return {
       status: "skipped",
       summary: "subprocess-no-shell-string: no JS/TS sources found; nothing to scan.",

--- a/scripts/security-pipeline/checks/subprocess-no-shell-string.test.mjs
+++ b/scripts/security-pipeline/checks/subprocess-no-shell-string.test.mjs
@@ -1,0 +1,168 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  findCallSpanEnd,
+  firstArgumentText,
+  run,
+  scanSource,
+} from "./subprocess-no-shell-string.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "..", "..", "..");
+
+// The real gate: current dev must be clean (only allowlisted sites may exist).
+test("repo scan passes on the checkout", async () => {
+  const result = await run({ check: {}, repoRoot: REPO_ROOT });
+  assert.equal(result.status, "pass");
+});
+
+test("exec() string API -> exec-string-api", () => {
+  const findings = scanSource(
+    "fixture.mjs",
+    `import { exec } from "node:child_process";\nexec(\`ls \${dir}\`, () => {});\n`
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].rule, "exec-string-api");
+  assert.equal(findings[0].line, 2);
+});
+
+test("execSync() literal -> exec-string-api", () => {
+  const findings = scanSource("fixture.mjs", `execSync("git status");\n`);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].rule, "exec-string-api");
+});
+
+test("shell: true in a multi-line spawn call -> shell-true-option", () => {
+  const findings = scanSource(
+    "fixture.mjs",
+    [
+      "const child = spawn(\"npm\", [\"run\", \"dev\"], {",
+      "  cwd: process.cwd(),",
+      "  shell: true,",
+      "});",
+    ].join("\n")
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].rule, "shell-true-option");
+});
+
+test("shell: false spawn -> no findings", () => {
+  const findings = scanSource(
+    "fixture.mjs",
+    `spawnSync(argv[0], argv.slice(1), { shell: false, encoding: "utf-8" });\n`
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("default-shell spawn (argv form) -> no findings", () => {
+  const findings = scanSource(
+    "fixture.mjs",
+    `const child = spawnImpl(command, args, { stdio: ["ignore", "pipe", "pipe"] });\n`
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("template-literal command argument -> template-command-arg", () => {
+  const findings = scanSource(
+    "fixture.mjs",
+    "const child = spawn(`/usr/bin/${tool} --scan`, { cwd });\n"
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].rule, "template-command-arg");
+});
+
+test("call-shaped text inside strings and comments is masked out", () => {
+  const findings = scanSource(
+    "fixture.mjs",
+    [
+      "// spawn(\"x\", { shell: true }) in a comment",
+      "const doc = `use spawnSync(cmd, { shell: true }) here`;",
+      'const note = "exec(formatCommand(input))";',
+      "spawn(process.execPath, files);",
+    ].join("\n")
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("RegExp .exec() is not a child_process call", () => {
+  const findings = scanSource(
+    "fixture.mjs",
+    `const match = /^#\\s+(.+)$/m.exec(content);\nconst other = text.exec(value);\n`
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("execFileAsync wrapper name is not matched", () => {
+  const findings = scanSource(
+    "fixture.mjs",
+    `const { stdout } = await execFileAsync("git", ["ls-files"]);\n`
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("shell option nested in a call argument is found within the call span", () => {
+  const findings = scanSource(
+    "fixture.mjs",
+    `wrap(spawn("npm", ["run", "dev"], { shell: true }), opts);\n`
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].rule, "shell-true-option");
+});
+
+test("allowlisted constant-argv site passes (ensure-dev-server shape)", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "spnssh-allowlist-"));
+  try {
+    const dir = path.join(root, "scripts");
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      path.join(dir, "ensure-dev-server.mjs"),
+      [
+        "const child = spawn(\"npm\", [\"run\", \"dev\"], {",
+        "  cwd: process.cwd(),",
+        "  shell: true,",
+        "});",
+        "",
+      ].join("\n")
+    );
+    const result = await run({ check: {}, repoRoot: root });
+    assert.equal(result.status, "pass");
+    assert.match(result.summary, /1 allowlisted site/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("edited allowlisted site re-flags", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "spnssh-edited-"));
+  try {
+    const dir = path.join(root, "scripts");
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      path.join(dir, "ensure-dev-server.mjs"),
+      [
+        "const command = readConfig();",
+        "const child = spawn(command, [\"run\", \"dev\"], {",
+        "  shell: true,",
+        "});",
+        "",
+      ].join("\n")
+    );
+    const result = await run({ check: {}, repoRoot: root });
+    assert.equal(result.status, "fail");
+    assert.equal(result.evidence.length, 1);
+    assert.equal(result.evidence[0].rule, "shell-true-option");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("unbalanced call span is skipped without throwing", () => {
+  assert.equal(findCallSpanEnd("spawn(\"a\", { shell: true }", 5), -1);
+  const text = "spawn(process.execPath, files)";
+  assert.equal(findCallSpanEnd(text, 5), text.length - 1);
+  assert.equal(firstArgumentText(text, 5, text.length - 1), "process.execPath");
+});

--- a/scripts/security-pipeline/checks/subprocess-no-shell-string.test.mjs
+++ b/scripts/security-pipeline/checks/subprocess-no-shell-string.test.mjs
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -7,6 +8,7 @@ import { fileURLToPath } from "node:url";
 import {
   findCallSpanEnd,
   firstArgumentText,
+  maskCode,
   run,
   scanSource,
 } from "./subprocess-no-shell-string.mjs";
@@ -165,4 +167,143 @@ test("unbalanced call span is skipped without throwing", () => {
   const text = "spawn(process.execPath, files)";
   assert.equal(findCallSpanEnd(text, 5), text.length - 1);
   assert.equal(firstArgumentText(text, 5, text.length - 1), "process.execPath");
+});
+
+// Review 2026-09-08 hardening: a quote inside a regex literal used to open a
+// phantom string and invert masking for the rest of the file, hiding real
+// violations that followed.
+test("quote characters inside regex literals do not invert masking", () => {
+  const masked = maskCode('const parts = text.split(/["\'();\\n]/);\n');
+  // the regex body must be masked (spaces), the split( call must stay code
+  assert.match(masked, /split\(\s+\)/);
+  assert.doesNotMatch(masked, /\["\'/);
+
+  const findings = scanSource(
+    "fixture.mjs",
+    [
+      'const parts = text.split(/["\'();\\n]/);',
+      'const child = spawnSync(userInput, { shell: true });',
+    ].join("\n")
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].rule, "shell-true-option");
+  assert.equal(findings[0].line, 2);
+});
+
+test("regex literals after return and in argument positions are masked", () => {
+  const masked = maskCode(
+    ['return /["\\\\]/.test(line);', 'wrap(/["x]/, value);', 'const map = { key: /[\'y]/ };'].join("\n")
+  );
+  // no quote state may survive any of the three regex literals
+  assert.equal(masked.match(/"/g), null);
+  assert.equal(masked.match(/'/g), null);
+});
+
+test("division after identifiers, digits, and parens stays code", () => {
+  const masked = maskCode("const rate = total / count / 2;\nconst w = (a + b) / c;\n");
+  assert.match(masked, /total \/ count \/ 2/);
+  assert.match(masked, /\(a \+ b\) \/ c/);
+});
+
+// Review 2026-09-08 hardening: member calls (cp.spawnSync, child_process
+// .execSync) were never scanned because the lookbehind excluded every
+// member call; only `.exec(` keeps the carve-out.
+test("member spawn-family calls are scanned", () => {
+  const findings = scanSource(
+    "fixture.mjs",
+    [
+      'import cp from "node:child_process";',
+      "cp.spawnSync(userInput, { shell: true });",
+      'child_process.execSync("ls -la " + dir);',
+      "cp.spawn(argv[0], argv.slice(1), { stdio: 'ignore' });",
+    ].join("\n")
+  );
+  assert.equal(findings.length, 2);
+  assert.equal(findings[0].rule, "shell-true-option");
+  assert.equal(findings[0].line, 2);
+  assert.equal(findings[1].rule, "exec-string-api");
+  assert.equal(findings[1].line, 3);
+});
+
+test("member .exec( keeps the RegExp carve-out", () => {
+  const findings = scanSource(
+    "fixture.mjs",
+    [
+      "const m = /^#\\s+(.+)$/m.exec(content);",
+      "const other = registry.exec(record);",
+    ].join("\n")
+  );
+  assert.deepEqual(findings, []);
+});
+
+// Review 2026-09-08 hardening: the shorthand `{ shell }` options form was
+// not matched by the shell: pattern.
+test("shorthand { shell } option flags", () => {
+  const findings = scanSource(
+    "fixture.mjs",
+    ["const shell = true;", "spawn(command, args, { shell });"].join("\n")
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].rule, "shell-true-option");
+});
+
+test("unrelated shorthand identifiers do not flag", () => {
+  const findings = scanSource(
+    "fixture.mjs",
+    'spawn(command, args, { cwd, env: pick(["PATH"]) });\n'
+  );
+  assert.deepEqual(findings, []);
+});
+
+// Review 2026-09-08 hardening: an over-long call span was skipped silently;
+// now it surfaces as a finding instead of hiding a possible shell: true.
+test("call spans beyond MAX_CALL_SPAN_CHARS report as unparseable", () => {
+  const padding = "x".repeat(9000);
+  const findings = scanSource(
+    "fixture.mjs",
+    `spawn("cmd", { padding: "${padding}" });\n`
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].rule, "unparseable-call-span");
+});
+
+// Review 2026-09-08 hardening (#365 pattern): enumeration must use
+// git-tracked + visible untracked files, never a plain filesystem walk, so
+// gitignored scratch never reaches the scan.
+test("listSourceFiles excludes gitignored scratch but keeps visible untracked work", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "spnssh-gitvisible-"));
+  const git = (args) =>
+    execFileSync("git", ["-C", root, ...args], { stdio: ["ignore", "pipe", "ignore"] });
+  try {
+    git(["init", "--quiet"]);
+    git(["config", "user.email", "test@example.invalid"]);
+    git(["config", "user.name", "Subprocess Check Test"]);
+    await mkdir(path.join(root, "scripts"), { recursive: true });
+    await writeFile(path.join(root, ".gitignore"), "scratch-rig/\n");
+    await writeFile(
+      path.join(root, "scripts", "tracked.mjs"),
+      'import { spawn } from "node:child_process";\nspawn(argv[0], argv.slice(1));\n'
+    );
+    await writeFile(
+      path.join(root, "scripts", "untracked-visible.mjs"),
+      'spawn(command, args, { shell: true });\n'
+    );
+    await mkdir(path.join(root, "scratch-rig"), { recursive: true });
+    await writeFile(
+      path.join(root, "scratch-rig", "live.mjs"),
+      'execSync("ls");\n'
+    );
+    git(["add", ".gitignore", "scripts/tracked.mjs"]);
+    git(["commit", "--quiet", "-m", "base"]);
+
+    const result = await run({ check: {}, repoRoot: root });
+    assert.equal(result.status, "fail");
+    assert.equal(result.evidence.length, 1);
+    assert.equal(result.evidence[0].path, "scripts/untracked-visible.mjs");
+    assert.equal(result.evidence[0].rule, "shell-true-option");
+    // gitignored scratch-rig/live.mjs must not appear anywhere in evidence
+    assert.ok(!result.evidence.some((item) => item.path.includes("scratch-rig")));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });

--- a/scripts/security-pipeline/checks/subprocess-no-shell-string.test.mjs
+++ b/scripts/security-pipeline/checks/subprocess-no-shell-string.test.mjs
@@ -205,6 +205,68 @@ test("division after identifiers, digits, and parens stays code", () => {
   assert.match(masked, /\(a \+ b\) \/ c/);
 });
 
+// Arrow-body regexes are this codebase's most common regex position, and one
+// tracked file has an apostrophe inside one — the combination that used to
+// walk the phantom-string path (code review finding, 2026-09-10).
+test("arrow-body regex with an apostrophe does not invert masking", () => {
+  const masked = maskCode('const keep = msgs.filter((m) => /\\b(ok|don\'t)\\b/i.test(m));\n');
+  // the regex body is masked; no quote state survives the line
+  assert.doesNotMatch(masked, /don/);
+
+  const findings = scanSource(
+    "fixture.mjs",
+    [
+      'const keep = msgs.filter((m) => /\\b(ok|don\'t)\\b/i.test(m));',
+      'spawnSync(userCmd, { shell: true });',
+    ].join("\n")
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].rule, "shell-true-option");
+  assert.equal(findings[0].line, 2);
+});
+
+test("arrow-body regex followed by a violation on the same line still flags", () => {
+  const findings = scanSource(
+    "fixture.mjs",
+    'const bad = (s) => /don\'t/.test(s) || spawnSync(cmd, { shell: true });\n'
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].rule, "shell-true-option");
+});
+
+test("division after a greater-than comparison stays code", () => {
+  const masked = maskCode("const half = a > b ? total / 2 : total / count;\n");
+  assert.match(masked, /total \/ 2/);
+  assert.match(masked, /total \/ count/);
+});
+
+// The newline quote reset is one of the maintainer's explicit asks; pin it
+// directly, including the backtick exception.
+test("unterminated quote resets at newline; backtick templates span lines", () => {
+  const masked = maskCode("const s = it's;\nexec(real);\nconst t = `a\nb`;\nexec(next);\n");
+  // line 2's exec( survives as code despite the apostrophe on line 1
+  assert.match(masked.slice(0, masked.indexOf("\n", masked.indexOf("exec(real)"))), /exec\(real\)/);
+  // the template body across lines 3-4 is masked, the call after it is code
+  const afterTemplate = masked.slice(masked.indexOf("`"));
+  assert.match(afterTemplate, /exec\(next\)/);
+  assert.doesNotMatch(masked, /`a\nb`/);
+});
+
+// R2 headline claims, previously untested: string-valued shell: flags, and
+// shell: "false" is a truthy executable spec (not the boolean exemption).
+test("string-valued shell options flag, including shell: \"false\"", () => {
+  const bashFindings = scanSource("fixture.mjs", 'spawn(cmd, args, { shell: "bash" });\n');
+  assert.equal(bashFindings.length, 1);
+  assert.equal(bashFindings[0].rule, "shell-true-option");
+
+  const falseStringFindings = scanSource("fixture.mjs", 'spawn(cmd, args, { shell: "false" });\n');
+  assert.equal(falseStringFindings.length, 1);
+  assert.equal(falseStringFindings[0].rule, "shell-true-option");
+
+  const bareFalse = scanSource("fixture.mjs", "spawn(cmd, args, { shell: false });\n");
+  assert.deepEqual(bareFalse, []);
+});
+
 // Review 2026-09-08 hardening: member calls (cp.spawnSync, child_process
 // .execSync) were never scanned because the lookbehind excluded every
 // member call; only `.exec(` keeps the carve-out.

--- a/scripts/security-pipeline/checks/subprocess-no-shell-string.test.mjs
+++ b/scripts/security-pipeline/checks/subprocess-no-shell-string.test.mjs
@@ -125,6 +125,8 @@ test("allowlisted constant-argv site passes (ensure-dev-server shape)", async ()
       [
         "const child = spawn(\"npm\", [\"run\", \"dev\"], {",
         "  cwd: process.cwd(),",
+        "  stdio: \"ignore\",",
+        "  detached: true,",
         "  shell: true,",
         "});",
         "",
@@ -157,6 +159,83 @@ test("edited allowlisted site re-flags", async () => {
     assert.equal(result.status, "fail");
     assert.equal(result.evidence.length, 1);
     assert.equal(result.evidence[0].rule, "shell-true-option");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+// Review 2026-09-11 blockers: the safe shell value must be EXACTLY false,
+// quoted keys must flag, and aliased/module-bound call sites must scan.
+test("shell: false || true flags (exactly-false requirement)", () => {
+  const findings = scanSource("fixture.mjs", "spawn(cmd, args, { shell: false || true });\n");
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].rule, "shell-true-option");
+});
+
+test("bare shell: false stays safe at value and object end", () => {
+  assert.deepEqual(scanSource("fixture.mjs", "spawn(cmd, args, { shell: false });\n"), []);
+  assert.deepEqual(scanSource("fixture.mjs", "spawn(cmd, args, { shell: false, cwd });\n"), []);
+});
+
+test("quoted shell keys flag when truthy and pass when exactly false", () => {
+  const truthy = scanSource("fixture.mjs", 'spawn(cmd, args, { "shell": true });\n');
+  assert.equal(truthy.length, 1);
+  assert.equal(truthy[0].rule, "shell-true-option");
+  assert.deepEqual(scanSource("fixture.mjs", "spawn(cmd, args, { 'shell': false });\n"), []);
+});
+
+test("injected alias of spawn scans under spawn semantics", () => {
+  const flagged = scanSource(
+    "fixture.mjs",
+    'import { spawn as spawnImpl } from "node:child_process";\nspawnImpl(userCmd, { shell: true });\n'
+  );
+  assert.equal(flagged.length, 1);
+  assert.equal(flagged[0].rule, "shell-true-option");
+
+  const clean = scanSource(
+    "fixture.mjs",
+    'const spawnImpl = spawn;\nspawnImpl(command, args, { stdio: ["ignore"] });\n'
+  );
+  assert.deepEqual(clean, []);
+});
+
+test("renamed exec import scans as the string API", () => {
+  const findings = scanSource(
+    "fixture.mjs",
+    'import { exec as runShell } from "node:child_process";\nrunShell(command);\n'
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].rule, "exec-string-api");
+});
+
+test("member .exec( flags on a tracked child_process receiver only", () => {
+  const tracked = scanSource(
+    "fixture.mjs",
+    'const cp = require("node:child_process");\ncp.exec(command);\n'
+  );
+  assert.equal(tracked.length, 1);
+  assert.equal(tracked[0].rule, "exec-string-api");
+
+  assert.deepEqual(scanSource("fixture.mjs", 'const m = /^#(.+)$/m;\nm.exec(content);\n'), []);
+});
+
+test("registry surfaces scope the scan and registry allowlist exempts paths", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "spnssh-registry-"));
+  try {
+    await mkdir(path.join(root, "scripts"), { recursive: true });
+    await mkdir(path.join(root, "browser-first"), { recursive: true });
+    await writeFile(path.join(root, "scripts", "a.mjs"), "execSync('ls');\n");
+    await writeFile(path.join(root, "browser-first", "b.mjs"), "execSync('ls');\n");
+    const scoped = await run({ check: { surfaces: ["browser-first"] }, repoRoot: root });
+    assert.equal(scoped.status, "fail");
+    assert.deepEqual(scoped.evidence.map((item) => item.path), ["browser-first/b.mjs"]);
+
+    const exempt = await run({
+      check: { allowlist: [{ path: "browser-first/b.mjs", reason: "documented fixture" }] },
+      repoRoot: root,
+    });
+    assert.equal(exempt.status, "fail");
+    assert.deepEqual(exempt.evidence.map((item) => item.path), ["scripts/a.mjs"]);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/scripts/security-pipeline/checks/subprocess-no-shell-string.test.mjs
+++ b/scripts/security-pipeline/checks/subprocess-no-shell-string.test.mjs
@@ -230,6 +230,11 @@ test("registry surfaces scope the scan and registry allowlist exempts paths", as
     assert.equal(scoped.status, "fail");
     assert.deepEqual(scoped.evidence.map((item) => item.path), ["browser-first/b.mjs"]);
 
+    // trailing slashes must not turn the prefix into "scripts//"
+    const slashScoped = await run({ check: { surfaces: ["scripts/"] }, repoRoot: root });
+    assert.equal(slashScoped.status, "fail");
+    assert.deepEqual(slashScoped.evidence.map((item) => item.path), ["scripts/a.mjs"]);
+
     const exempt = await run({
       check: { allowlist: [{ path: "browser-first/b.mjs", reason: "documented fixture" }] },
       repoRoot: root,
@@ -239,6 +244,89 @@ test("registry surfaces scope the scan and registry allowlist exempts paths", as
   } finally {
     await rm(root, { recursive: true, force: true });
   }
+});
+
+// Review 2026-09-11 round 3: the cited alias sites are parameter defaults,
+// not const declarations.
+test("parameter-default alias of spawn scans (bridge-tls shape)", () => {
+  const findings = scanSource(
+    "fixture.mjs",
+    [
+      'import { spawn } from "node:child_process";',
+      "async function run(cmd, args, opts = {}, spawnImpl = spawn) {",
+      "  const child = spawnImpl(cmd, { shell: true });",
+      "}",
+    ].join("\n")
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].rule, "shell-true-option");
+});
+
+// Review 2026-09-11 round 3 major: a comment must not be able to overwrite a
+// real import mapping and flip the scan to a false negative.
+test("comment-shaped alias cannot overwrite an import binding", () => {
+  const findings = scanSource(
+    "fixture.mjs",
+    [
+      'import { exec } from "node:child_process";',
+      "// const exec = spawn;",
+      "exec(command);",
+    ].join("\n")
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].rule, "exec-string-api");
+});
+
+// Review 2026-09-11 round 3 minor b: string ARGUMENTS must not fake a quoted
+// shell key.
+test("quoted shell-like text inside a string argument does not flag", () => {
+  const findings = scanSource(
+    "fixture.mjs",
+    'spawn("printf", [\'{"shell": true}\'], { shell: false });\n'
+  );
+  assert.deepEqual(findings, []);
+});
+
+// Review 2026-09-11 round 3 minor a: destructuring renames use `:`, not `as`.
+test("colon-rename destructured require registers the alias", () => {
+  const findings = scanSource(
+    "fixture.mjs",
+    [
+      'const { spawn: s } = require("node:child_process");',
+      "s(userCmd, { shell: true });",
+    ].join("\n")
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].rule, "shell-true-option");
+});
+
+// Same hostile classes, self-found before submission: alias chains and
+// template-literal keys.
+test("alias-of-alias chains resolve to the original API", () => {
+  const findings = scanSource(
+    "fixture.mjs",
+    'import { spawn } from "node:child_process";\nconst a = spawn;\nconst b = a;\nb(cmd, { shell: true });\n'
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].rule, "shell-true-option");
+});
+
+test("template-literal shell key flags", () => {
+  const findings = scanSource("fixture.mjs", "spawn(cmd, args, { `shell`: true });\n");
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].rule, "shell-true-option");
+});
+
+// Comorbidity sweep 2026-09-11 (predicted from the first-wins mechanism,
+// confirmed by probe): rebinding a name to a child_process API later in the
+// file must register.
+test("late rebinding to spawn scans", () => {
+  const findings = scanSource(
+    "fixture.mjs",
+    "let s = argv;\ns = spawn;\ns(cmd, { shell: true });\n"
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].rule, "shell-true-option");
 });
 
 test("unbalanced call span is skipped without throwing", () => {
@@ -444,6 +532,100 @@ test("listSourceFiles excludes gitignored scratch but keeps visible untracked wo
     assert.equal(result.evidence[0].rule, "shell-true-option");
     // gitignored scratch-rig/live.mjs must not appear anywhere in evidence
     assert.ok(!result.evidence.some((item) => item.path.includes("scratch-rig")));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+// Pre-push adversarial review round (2026-09-11) — every finding pinned.
+test("property assignment cannot overwrite an import binding (F1)", () => {
+  const findings = scanSource(
+    "fixture.mjs",
+    [
+      'import { exec, execFileSync } from "node:child_process";',
+      "const adapters = {};",
+      "adapters.exec = execFileSync;",
+      "exec(userInput);",
+    ].join("\n")
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].rule, "exec-string-api");
+});
+
+test("unprefixed child_process registers renamed imports and receivers (F2)", () => {
+  const renamed = scanSource(
+    "fixture.mjs",
+    'import { exec as run } from "child_process";\nrun(userInput);\n'
+  );
+  assert.equal(renamed.length, 1);
+  assert.equal(renamed[0].rule, "exec-string-api");
+
+  const receiver = scanSource(
+    "fixture.mjs",
+    'const cp = require("child_process");\ncp.exec(userInput);\n'
+  );
+  assert.equal(receiver.length, 1);
+  assert.equal(receiver[0].rule, "exec-string-api");
+});
+
+test("quote-bearing regex after an operator does not hide a same-line violation (F3)", () => {
+  const findings = scanSource(
+    "fixture.mjs",
+    'const parts = a + /["\']/g.test(s); spawn(cmd, { shell: true });\n'
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].rule, "shell-true-option");
+
+  // ++/-- stay division contexts
+  assert.deepEqual(
+    scanSource("fixture.mjs", "i++; const r = total / count; spawn(f, a);\n"),
+    []
+  );
+});
+
+test("computed quoted key flags (F4)", () => {
+  const findings = scanSource("fixture.mjs", 'spawn(cmd, args, { ["shell"]: true });\n');
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].rule, "shell-true-option");
+});
+
+test("mixed default+named import and await import() renames register (F6)", () => {
+  const mixed = scanSource(
+    "fixture.mjs",
+    'import cp, { exec } from "node:child_process";\ncp.exec(cmd);\n'
+  );
+  assert.equal(mixed.length, 1);
+  assert.equal(mixed[0].rule, "exec-string-api");
+
+  const dynamic = scanSource(
+    "fixture.mjs",
+    'const { exec: run } = await import("node:child_process");\nrun(cmd);\n'
+  );
+  assert.equal(dynamic.length, 1);
+  assert.equal(dynamic[0].rule, "exec-string-api");
+});
+
+test("comment-shaped provenance registers nothing (self-scan catch)", () => {
+  assert.deepEqual(
+    scanSource(
+      "fixture.mjs",
+      '// const { exec: run } = await import("child_process");\nrun(cmd, args);\n'
+    ),
+    []
+  );
+});
+
+test("surfaces scoped to zero files fails loudly; leading ./ is stripped (F7)", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "spnssh-zero-"));
+  try {
+    await mkdir(path.join(root, "scripts"), { recursive: true });
+    await writeFile(path.join(root, "scripts", "a.mjs"), "spawn(f, a);\n");
+    const typo = await run({ check: { surfaces: ["./docs"] }, repoRoot: root });
+    assert.equal(typo.status, "fail");
+    assert.match(typo.summary, /matched no source files/);
+
+    const stripped = await run({ check: { surfaces: ["./scripts"] }, repoRoot: root });
+    assert.equal(stripped.status, "pass");
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
Adds a static security-pipeline check for the command-construction class fixed in PR #333 (engineer-runner `runCommand` executed contract strings with `shell:true`). The check scans tracked JS/TS sources and fails CI on: `exec()`/`execSync()` calls; spawn-family calls with a `shell:` option that is not `false`; spawn-family calls whose command argument is a template literal. Argv-form execution (array args, `shell:false` or default) is the sanctioned pattern and passes.

Comment/string contents are masked before matching, so call-shaped text in comments and string literals never flags (documented blind spot: code inside template `${...}` interpolation. A string-valued `shell:` option — e.g. `shell: "bash"` — is caught by the non-false check.).

Five known-safe sites are allowlisted with per-site data-flow rationales: four `engineer-runner.test.mjs` fixtures (literal git commands, test-only) and `scripts/ensure-dev-server.mjs` (constant argv; the follow-up site named in the PR #333 commit message). Any edit to an allowlisted line re-flags and forces a fresh look.

Wiring: registered as `subprocess-no-shell-string` in the security-pipeline registry (family `runtime-hardening`, policy `block`); a new gating job in `security.yml` runs it without `continue-on-error` so a new instance of the pattern class fails CI; the existing observe job and `alpha-build.yml` are untouched; action pins reuse the reviewed SHAs. `runtime-hardening-registry.test.mjs` updated for the fifth family member.

Checks run: `node --test scripts/security-pipeline/checks/subprocess-no-shell-string.test.mjs` (14/14) · `npm run test:security-pipeline` (43/43) · `node scripts/security-pipeline/run-check.mjs --check subprocess-no-shell-string` (pass, exit 0) · `npm run docs:check` (pass) · `npm run test:docs` (229/229) · synthetic-instance proof in a scratch copy: injected `spawnSync(string, {shell:true})` + `exec()` fail the gate (exit 1) and pass once removed. Known unrelated baseline: `npm run verify:alpha`'s browser-host step requires a locally installed Playwright chromium binary and fails without it (reproduced on unmodified `dev`).



## Validation

Rebased onto current `dev` (55adb22, post #337/#404 merges; the one-line `docs/README.md` conflict with #337's llms.txt entry resolved keeping both) and re-ran locally at head `a651004`:

- `node --test scripts/security-pipeline/checks/subprocess-no-shell-string.test.mjs` — pass (28 tests)
- `npm run repo:hygiene`, `docs:check`, `test:docs` — pass
- `npm run build`, `npm test -- --run`, `test:browser-first` — pass
- `npm run test:security-pipeline`, `run-check --certify` — pass
- `npm run pre-release:scan`, strict committed release-scope audit — pass
- security.yml job set verified equal to dev's live job set plus `subprocess-no-shell-string-gate`

`test:browser-host` requires a Playwright Chromium download that stalls on this machine; that step is left to CI on the clean runner (everything else above ran green locally).
