### PR TITLE
fix(extension): inline-action surface gate content script fails to parse — restricted-surface gate was fail-open (#341)

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/lib/content-inline-action-surface-gate.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/content-inline-action-surface-gate.js
@@ -39,6 +39,6 @@
   });
 })();
 
-export const INLINE_RESTRICTED_SCHEMES = globalThis.ResonantOSInlineActionSurfaceGate.INLINE_RESTRICTED_SCHEMES;
-export const inlineActionRestrictedScheme = globalThis.ResonantOSInlineActionSurfaceGate.inlineActionRestrictedScheme;
-export const inlineActionAllowedForLocationGate = globalThis.ResonantOSInlineActionSurfaceGate.inlineActionAllowedForLocationGate;
+// Classic content script: the API is published on globalThis above. Do NOT add
+// `export` here — manifest content_scripts are not modules and a SyntaxError
+// silently disables this whole file on every page.

--- a/browser-first/test/content-inline-action-surface-gate.test.mjs
+++ b/browser-first/test/content-inline-action-surface-gate.test.mjs
@@ -1,11 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import {
+// The gate is a CLASSIC content script (see content-scripts-parse-as-classic.test.mjs):
+// import it for its side effect and read the API it publishes on globalThis.
+import "../resonantos-side-panel-extension/src/lib/content-inline-action-surface-gate.js";
+const {
   INLINE_RESTRICTED_SCHEMES,
   inlineActionRestrictedScheme,
   inlineActionAllowedForLocationGate
-} from "../resonantos-side-panel-extension/src/lib/content-inline-action-surface-gate.js";
+} = globalThis.ResonantOSInlineActionSurfaceGate;
 
 test("inline-action surface gate exposes the same restricted-scheme prefixes as control-target-classification (#219)", () => {
   // The two sources of truth must agree. control-target-classification.js

--- a/browser-first/test/content-scripts-parse-as-classic.test.mjs
+++ b/browser-first/test/content-scripts-parse-as-classic.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { Script } from "node:vm";
+
+// Content scripts declared in manifest.json are injected as CLASSIC scripts (no
+// `type: "module"` support for manifest content_scripts). Any ES-module syntax
+// (`export`, top-level `import`) makes Chrome abort parsing of the WHOLE file, so
+// nothing in it runs on the page — silently disabling whatever it guards (#219 gate).
+const root = new URL("../resonantos-side-panel-extension/", import.meta.url);
+const manifest = JSON.parse(readFileSync(new URL("manifest.json", root), "utf8"));
+
+test("manifest declares at least one classic content script", () => {
+  const scripts = (manifest.content_scripts ?? []).flatMap((cs) => cs.js ?? []);
+  assert.ok(scripts.length > 0);
+});
+
+for (const cs of manifest.content_scripts ?? []) {
+  for (const file of cs.js ?? []) {
+    test(`content script parses as a classic script: ${file}`, () => {
+      const source = readFileSync(new URL(file, root), "utf8");
+      assert.doesNotThrow(() => new Script(source, { filename: file }), `${file} must not use ES-module syntax (export/import) — it is injected as a classic content script`);
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Closes #341.

`src/lib/content-inline-action-surface-gate.js` is injected via `manifest.json` `content_scripts` as a **classic** script, but since c7c65d2 (#219) it ended with three `export const` statements. Chrome threw `Uncaught SyntaxError: Unexpected token 'export'` on every page and aborted the whole file, so `globalThis.ResonantOSInlineActionSurfaceGate` was never defined — and `content.js:1217-1219` fell back to `{ allowed: true }`. **The restricted-surface gate for inline actions has been fail-open on real pages since beta.1.**

## Changes
- Drop the trailing exports; the API stays published on `globalThis` exactly as before (IIFE unchanged).
- `content-inline-action-surface-gate.test.mjs`: import the file for its side effect and read the API from `globalThis` — every existing assertion intact.
- **New guard** `content-scripts-parse-as-classic.test.mjs`: every `manifest.json` `content_scripts[].js` file must parse as a classic script (`vm.Script`), so ES-module syntax can never silently disable a content script again.

## Evidence
- Red → green (guard failed against the old file, passes after); full `test:browser-first` **1084 / 1084**.
- Anti-false-green: re-adding an `export` turns the guard red; file restored byte-identical.
- All 10 declared content scripts parse; no other module imports the file.
- Independent review (DeepSeek via pi): CONFIRM on API preservation, test integrity, guard coverage.
- CI preflight: release-scope audit strict exit 0; `npm audit` 0 vulnerabilities.

Found while deploying #339 (Tom's `chrome://extensions` error panel); unrelated to #320 — no file in that range touches this. Deployed users need a pull + extension reload after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)