### PR TITLE
security(extension): inline-action gate fails closed; single restricted-scheme source; denial path tested (#347)

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/content.js
+++ b/browser-first/resonantos-side-panel-extension/src/content.js
@@ -1216,7 +1216,7 @@ const runInlineAction = async (action) => {
   }
   const locationGate = inlineActionAllowedForLocationGate
     ? inlineActionAllowedForLocationGate(location.href)
-    : { allowed: true };
+    : { allowed: false, message: "Inline actions are unavailable: the surface gate did not load." };
   if (!locationGate.allowed) {
     result.textContent = locationGate.message;
     return;

--- a/browser-first/resonantos-side-panel-extension/src/lib/augmentor-shortcut-controller.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/augmentor-shortcut-controller.js
@@ -25,7 +25,7 @@
 (() => {
   if (globalThis.ResonantOSAugmentorShortcutController) return;
 
-  const RESTRICTED_SCHEMES = Object.freeze(["chrome:", "about:", "edge:", "devtools:"]);
+  const FALLBACK_RESTRICTED_SCHEMES = Object.freeze(["chrome:", "about:", "edge:", "devtools:"]);
   const EDITABLE_TAGS = new Set(["INPUT", "TEXTAREA", "SELECT"]);
 
   const isEditableTarget = (target) => {
@@ -41,7 +41,9 @@
     if (typeof href !== "string") return false;
     const lowered = href.trim().toLowerCase();
     if (!lowered) return false;
-    return RESTRICTED_SCHEMES.some((prefix) => lowered.startsWith(prefix));
+    const gateSchemes = globalThis.ResonantOSInlineActionSurfaceGate?.INLINE_RESTRICTED_SCHEMES;
+    const restrictedSchemes = Array.isArray(gateSchemes) ? gateSchemes : FALLBACK_RESTRICTED_SCHEMES;
+    return restrictedSchemes.some((prefix) => lowered.startsWith(String(prefix).toLowerCase()));
   };
 
   const hasAuxiliaryModifiers = (event) => Boolean(
@@ -112,7 +114,7 @@
   })();
 
   globalThis.ResonantOSAugmentorShortcutController = Object.freeze({
-    RESTRICTED_SCHEMES,
+    RESTRICTED_SCHEMES: FALLBACK_RESTRICTED_SCHEMES,
     classifyShortcut,
     createRequestToken,
     isSummaryContextStale

--- a/browser-first/resonantos-side-panel-extension/src/lib/content-inline-action-surface-gate.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/content-inline-action-surface-gate.js
@@ -1,8 +1,8 @@
 // Inline action surface gate: same restricted-scheme prefixes Agent Control
 // uses (see control-target-classification.js), kept in sync locally so the
 // content script need not import the runner. Order matters — the first match
-// wins. Loaded as a content-script file before content.js so the functions
-// are available on globalThis. Also importable as an ESM module for tests.
+// wins. Loaded as a classic content-script file before content.js so the
+// functions are available on globalThis without ESM syntax.
 
 (() => {
   if (globalThis.ResonantOSInlineActionSurfaceGate) return;

--- a/browser-first/test/alpha-browser-extension-scope.test.mjs
+++ b/browser-first/test/alpha-browser-extension-scope.test.mjs
@@ -83,12 +83,19 @@ test("2.0.0 alpha release scope is Chrome extension and bridge only", async () =
     /connect-src[^;]*https?:\/\/\*:\*/,
     "connect-src must permit the user's bridge host (remote LAN/Tailscale deployments)",
   );
-  assert.equal(manifest.content_scripts[0].js[0], "src/lib/resonant-context.js");
+  const contentScriptFiles = manifest.content_scripts[0].js;
+  assert.equal(contentScriptFiles[0], "src/lib/resonant-context.js");
   assert.deepEqual(
-    manifest.content_scripts[0].js.slice(0, 3),
+    contentScriptFiles.slice(0, 3),
     ["src/lib/resonant-context.js", "src/lib/context-plugins.js", "src/lib/resonator.js"],
   );
-  assert.ok(manifest.content_scripts[0].js.includes("src/lib/content-field-safety.js"));
+  assert.ok(contentScriptFiles.includes("src/lib/content-field-safety.js"));
+  assert.ok(contentScriptFiles.includes("src/lib/content-inline-action-surface-gate.js"));
+  assert.ok(
+    contentScriptFiles.indexOf("src/lib/content-inline-action-surface-gate.js") <
+      contentScriptFiles.indexOf("src/content.js"),
+    "inline-action surface gate must load before content.js",
+  );
 });
 
 test("2.0.0 alpha release scope excludes local credential artifacts", () => {

--- a/browser-first/test/content-inline-action-gate-enforcement.test.mjs
+++ b/browser-first/test/content-inline-action-gate-enforcement.test.mjs
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { JSDOM } from "jsdom";
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+const extensionSrcRoot = path.join(repoRoot, "browser-first", "resonantos-side-panel-extension", "src");
+const scriptPath = (...segments) => path.join(extensionSrcRoot, ...segments);
+
+const contentScriptPath = scriptPath("content.js");
+const controlOverlayScriptPath = scriptPath("lib", "control-overlay.js");
+const fieldSafetyScriptPath = scriptPath("lib", "content-field-safety.js");
+const inlineActionsScriptPath = scriptPath("lib", "content-inline-actions.js");
+const controlRefsScriptPath = scriptPath("lib", "content-control-refs.js");
+const inlineActionSurfaceGateScriptPath = scriptPath("lib", "content-inline-action-surface-gate.js");
+const augmentorShortcutControllerScriptPath = scriptPath("lib", "augmentor-shortcut-controller.js");
+
+async function evalScript(targetWindow, filePath) {
+  targetWindow.eval(await readFile(filePath, "utf8"));
+}
+
+async function loadContentScript({
+  loadGate = true,
+  url = "https://example.test/article",
+} = {}) {
+  const dom = new JSDOM("<!doctype html><main>Selected page text for the inline assistant.</main>", {
+    runScripts: "outside-only",
+    url,
+  });
+  const sentMessages = [];
+  let listener = null;
+  dom.window.chrome = {
+    runtime: {
+      onMessage: {
+        addListener(callback) {
+          listener = callback;
+        },
+      },
+      sendMessage(message) {
+        sentMessages.push(message);
+        return Promise.resolve({ ok: true, reply: "Provider reply should not run on denied surfaces." });
+      },
+    },
+    storage: {
+      local: {
+        get() {
+          return Promise.resolve({ augmentorSitePermissions: {} });
+        },
+        set() {
+          return Promise.resolve();
+        },
+      },
+      onChanged: {
+        addListener() {},
+      },
+    },
+  };
+  dom.window.HTMLElement.prototype.scrollIntoView = function scrollIntoView() {};
+  dom.window.__resonantosControlDwellMs = 0;
+
+  await evalScript(dom.window, controlOverlayScriptPath);
+  await evalScript(dom.window, fieldSafetyScriptPath);
+  await evalScript(dom.window, inlineActionsScriptPath);
+  await evalScript(dom.window, controlRefsScriptPath);
+  if (loadGate) {
+    await evalScript(dom.window, inlineActionSurfaceGateScriptPath);
+  }
+  await evalScript(dom.window, contentScriptPath);
+  assert.equal(typeof listener, "function");
+  return { dom, listener, sentMessages };
+}
+
+function showInlineAssistant(listener) {
+  listener({
+    channel: "resonantos.browser_first.content",
+    type: "show_inline_assistant_for_text",
+    text: "Selected page text for the inline assistant.",
+    rect: { bottom: 120, left: 24, top: 96, width: 320 },
+  }, {}, () => {});
+}
+
+async function runInlineSummarize({ loadGate, url }) {
+  const { dom, listener, sentMessages } = await loadContentScript({ loadGate, url });
+  showInlineAssistant(listener);
+  dom.window.document.querySelector("#resonantos-inline-button").click();
+  dom.window.document.querySelector('[data-action="summarize"]').click();
+  await new Promise((resolve) => dom.window.setTimeout(resolve, 0));
+  return {
+    result: dom.window.document.querySelector("#resonantos-inline-assistant .ros-inline-result")?.textContent ?? "",
+    sentMessages,
+  };
+}
+
+async function loadShortcutController({ loadGate }) {
+  const dom = new JSDOM("<!doctype html>", { runScripts: "outside-only" });
+  await evalScript(dom.window, augmentorShortcutControllerScriptPath);
+  if (loadGate) {
+    await evalScript(dom.window, inlineActionSurfaceGateScriptPath);
+  }
+  return dom.window.ResonantOSAugmentorShortcutController;
+}
+
+function makeShortcutEvent() {
+  return {
+    altKey: true,
+    code: "KeyA",
+    ctrlKey: false,
+    isComposing: false,
+    key: "a",
+    metaKey: false,
+    shiftKey: false,
+    target: { tagName: "BODY", isContentEditable: false },
+  };
+}
+
+test("inline action path denies restricted surfaces through the loaded gate (#347)", async () => {
+  const { result, sentMessages } = await runInlineSummarize({
+    loadGate: true,
+    url: "chrome://settings/",
+  });
+
+  assert.match(result, /Augmentor inline actions are disabled on this page \(chrome:\/\/\)/);
+  assert.equal(sentMessages.length, 0, "denied inline action must not reach the provider path");
+});
+
+test("inline action path denies when the surface gate did not load (#347)", async () => {
+  const { result, sentMessages } = await runInlineSummarize({
+    loadGate: false,
+    url: "https://example.test/article",
+  });
+
+  assert.equal(result, "Inline actions are unavailable: the surface gate did not load.");
+  assert.equal(sentMessages.length, 0, "missing gate must fail closed before running the action");
+});
+
+test("shortcut controller denies chrome pages with and without the gate global (#347)", async () => {
+  for (const loadGate of [true, false]) {
+    const controller = await loadShortcutController({ loadGate });
+    const result = controller.classifyShortcut(makeShortcutEvent(), { locationHref: "chrome://settings/" });
+    assert.equal(result.action, "none", `expected no shortcut action when loadGate=${loadGate}`);
+    assert.equal(result.conflict, "restricted", `expected restricted shortcut classification when loadGate=${loadGate}`);
+  }
+});
+
+test("shortcut controller reads the gate restricted schemes lazily at call time (#347)", async () => {
+  const controller = await loadShortcutController({ loadGate: true });
+  const result = controller.classifyShortcut(makeShortcutEvent(), { locationHref: "chrome-untrusted://terminal/" });
+
+  assert.equal(result.action, "none");
+  assert.equal(result.conflict, "restricted");
+});

--- a/browser-first/test/content-redaction.test.mjs
+++ b/browser-first/test/content-redaction.test.mjs
@@ -40,6 +40,14 @@ const inlineActionsScriptPath = path.join(
   "lib",
   "content-inline-actions.js",
 );
+const inlineActionSurfaceGateScriptPath = path.join(
+  repoRoot,
+  "browser-first",
+  "resonantos-side-panel-extension",
+  "src",
+  "lib",
+  "content-inline-action-surface-gate.js",
+);
 const controlRefsScriptPath = path.join(
   repoRoot,
   "browser-first",
@@ -129,6 +137,7 @@ async function loadContentScript(html, { asChildFrame = false, loadSdk = false, 
   targetWindow.eval(await readFile(fieldSafetyScriptPath, "utf8"));
   targetWindow.eval(await readFile(inlineActionsScriptPath, "utf8"));
   targetWindow.eval(await readFile(controlRefsScriptPath, "utf8"));
+  targetWindow.eval(await readFile(inlineActionSurfaceGateScriptPath, "utf8"));
   targetWindow.eval(await readFile(contentScriptPath, "utf8"));
   targetWindow.eval(await readFile(augmentorShortcutControllerScriptPath, "utf8"));
   assert.equal(typeof listener, "function");


### PR DESCRIPTION
Closes #347.

Found by the 2026-09-05 SDK regression panel (pre-existing, same class as #341/#342).

- `content.js` no longer falls back to `{ allowed: true }` when the inline-action surface gate is missing — it fails closed with an explicit message.
- `augmentor-shortcut-controller.js` reads the gate's `INLINE_RESTRICTED_SCHEMES` lazily at call time instead of keeping its own list (fail-closed fallback when the global is absent).
- Redaction test harness now loads the gate before `content.js`; new `content-inline-action-gate-enforcement.test.mjs` proves denial on a restricted location with the gate loaded and when it is absent, and that no action message is sent; scope test asserts the gate script precedes `content.js`; stale ESM header comment fixed.

**Evidence:** executor red→green (2/4 → 4/4), focused 46/46, full `test:browser-first` 1088/1088 unsandboxed; anti-false-green mutations red. Independent review (DeepSeek via pi, executing): CONFIRM — one non-blocking nit noted (the controller's *fallback* list, used only if the gate global is absent, is the 4-scheme subset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)