### PR TITLE
docs: post-#339 accuracy follow-ups — cockpit wording, ADR-006 amendment, MEMORY_SERVICE_TOKEN (#348)

### DIFF
--- a/docs/architecture/ADR-006-addon-runtime-sdk.md
+++ b/docs/architecture/ADR-006-addon-runtime-sdk.md
@@ -173,3 +173,18 @@ Augmentor may use the skill to guide high-level human collaboration with the add
 - The SDK must document both manifest shape and grant semantics.
 - A signing and registry model becomes part of the product, not just build tooling.
 - Contracts in `src/core/` should evolve to express provenance tier and verification state directly.
+
+## Amendment 2026-09 — credential-protected OpenCode server (#320, #339)
+
+The OpenCode add-on runtime's local server (`opencode serve`) is spawned by the
+bridge on a **bridge-picked ephemeral loopback port** (never 4096/4231) under a
+**bridge-minted Basic-auth credential** (`OPENCODE_SERVER_PASSWORD`). Readiness is
+fail-closed: the server must answer 200 with the credential and 401 without it
+before it is adopted. Consumers forward the credential; the side panel receives
+it as `eventAuthorization` in session start/list responses (only when the server
+is credential-protected) and sends it on its `/event` stream. `/opencode/web/url`
+returns `requiresCredential: true` and the panel disables the direct cockpit
+handoff until a governed proxy exists (#321). The same seam is used by both bridge
+layouts (session handlers and the cockpit-URL handler) via one per-process
+singleton. Residuals tracked: credential visible in the child environment (#326),
+orphan on SIGKILL until the next bridge start reaps it (#343).

--- a/docs/architecture/ADR-029-living-archive-mcp-bridge.md
+++ b/docs/architecture/ADR-029-living-archive-mcp-bridge.md
@@ -361,3 +361,13 @@ npm run test:living-archive-memory-service
 npm test -- src/App.test.tsx -t "Living Archive memory bridge"
 cargo test memory_service --manifest-path src-tauri/Cargo.toml
 ```
+
+## Memory service write token
+
+`RESONANTOS_MEMORY_SERVICE_TOKEN` gates **write** operations on the HTTP-JSON
+memory provider (`src/core/memory-provider.ts`) and the reference
+`examples/living-archive-memory-service.mjs`. Set the same value in the bridge
+environment and in the memory service's environment; requests without a matching
+`Authorization: Bearer <token>` are rejected for writes (reads are unaffected).
+Treat it like any other secret: read it from your key store at launch, never
+commit it, never print it.

--- a/docs/augmentor-tester-runbook.md
+++ b/docs/augmentor-tester-runbook.md
@@ -96,16 +96,17 @@ install path for third-party add-ons in this build, and no uninstall flow
   The one live control is each add-on's local CLI execution switch.
 
 The OpenCode server the bridge runs is now credential-protected and bound to
-an ephemeral loopback port instead of the old fixed port 4231. While that
-protection is in place, the **cockpit handoff button is disabled** — the panel
-shows "OpenCode cockpit handoff is disabled while the server is
-credential-protected" instead of opening a tab. Governed cockpit access (a
-proxied handoff that carries the credential) is tracked in #321. The governed
-OpenCode workspace inside the side panel keeps working unaffected. Testers
-should verify that opening `http://127.0.0.1:4231/` directly fails to connect,
-and that no OpenCode URL is ever shown in the panel. ResonantOS still logs
-that it issued the URL as `webCockpitUrlIssued`; the event is still emitted
-with the plain URL even though the panel no longer surfaces it.
+an ephemeral loopback port instead of the old fixed port 4231. The cockpit
+button stays visible; clicking it opens the confirmation step, and while the
+server is credential-protected the panel then shows "OpenCode cockpit handoff
+is disabled while the server is credential-protected (restored by #321)" and
+opens no tab. Governed cockpit access (a proxied handoff that carries the
+credential) is tracked in #321. The governed OpenCode workspace inside the
+side panel keeps working unaffected. Testers should verify that opening
+`http://127.0.0.1:4231/` directly fails to connect and that no OpenCode URL is
+ever shown in the panel. ResonantOS still logs that it issued the URL as
+`webCockpitUrlIssued`; the event is still emitted with the plain URL even
+though the panel no longer surfaces it.
 
 ## 7. Recording evidence
 


### PR DESCRIPTION
Closes #348. Documentation only (micro tier: `validate-docs` clean on tracked docs).

- Tester runbook §6: cockpit handoff wording now matches the real UX (button visible → confirmation step → credential-protected notice, no tab).
- ADR-006: dated amendment describing the credential-protected OpenCode server, `eventAuthorization` / `requiresCredential`, and the #321 handoff gate.
- `RESONANTOS_MEMORY_SERVICE_TOKEN` documented (memory-write bearer auth) in ADR-029 (living-archive MCP bridge), the doc that already covers the memory service.

Found by the 2026-09-05 SDK regression panel (gemini docs lens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)