### PR TITLE
security(sdk): partial provenance never defaults to trusted — registry, installation defaults, and policies (#345)

### DIFF
--- a/src/core/defaults.ts
+++ b/src/core/defaults.ts
@@ -870,17 +870,18 @@ export const archiveAutomationPolicy: ArchiveAutomationPolicy = {
   aiMemoryBuilds: "off",
 };
 
-// P1-e: do not trust by omission. A bundled manifest with NO provenance is
-// marked dev/internal/unreviewed (sideloaded-unverified / unverified) rather than
-// silently defaulting to curated-signed / verified.
+// P1-e / #345: do not trust by omission. A bundled manifest with NO provenance,
+// or with a provenance block missing tier/verificationState, is marked
+// sideloaded-unverified / unverified rather than defaulting upward to
+// curated-signed / verified.
 const defaultProvenanceTier = (manifest: AddOnManifest, source: AddOnInstallation["source"]): AddOnInstallation["provenanceTier"] =>
-  source === "sideload" || !manifest.provenance ? "sideloaded-unverified" : (manifest.provenance.tier ?? "curated-signed");
+  source === "sideload" || !manifest.provenance ? "sideloaded-unverified" : (manifest.provenance.tier ?? "sideloaded-unverified");
 
 const defaultVerificationState = (
   manifest: AddOnManifest,
   source: AddOnInstallation["source"],
 ): AddOnInstallation["verificationState"] =>
-  source === "sideload" || !manifest.provenance ? "unverified" : (manifest.provenance.verificationState ?? "verified");
+  source === "sideload" || !manifest.provenance ? "unverified" : (manifest.provenance.verificationState ?? "unverified");
 
 export const createDefaultInstallation = (manifest: AddOnManifest, source: AddOnInstallation["source"]): AddOnInstallation => ({
   addonId: manifest.id,

--- a/src/core/policies.ts
+++ b/src/core/policies.ts
@@ -150,13 +150,13 @@ const defaultProvenanceTier = (
   manifest: AddOnManifest,
   source: AddOnInstallation["source"],
 ): AddOnInstallation["provenanceTier"] =>
-  source === "sideload" ? "sideloaded-unverified" : (manifest.provenance?.tier ?? "curated-signed");
+  source === "sideload" ? "sideloaded-unverified" : (manifest.provenance?.tier ?? "sideloaded-unverified");
 
 const defaultVerificationState = (
   manifest: AddOnManifest,
   source: AddOnInstallation["source"],
 ): AddOnInstallation["verificationState"] =>
-  source === "sideload" ? "unverified" : (manifest.provenance?.verificationState ?? "verified");
+  source === "sideload" ? "unverified" : (manifest.provenance?.verificationState ?? "unverified");
 
 const rankLocality = (
   node: ProviderRuntimeNode,

--- a/src/sdk/addons/registry.test.ts
+++ b/src/sdk/addons/registry.test.ts
@@ -73,6 +73,30 @@ describe("add-on registry snapshot", () => {
     expect(entry.reviewState).toBe("unreviewed");
   });
 
+  it("installation defaults never promote a partial provenance block (#345, defaults.ts path)", () => {
+    const tierOnly = createDefaultInstallation(manifest("addon.tier-only", { provenance: { tier: "curated-signed" } as never }), "bundled");
+    expect(tierOnly.provenanceTier).toBe("curated-signed");
+    expect(tierOnly.verificationState).toBe("unverified");
+    const stateOnly = createDefaultInstallation(manifest("addon.state-only", { provenance: { verificationState: "verified" } as never }), "bundled");
+    expect(stateOnly.provenanceTier).toBe("sideloaded-unverified");
+    expect(stateOnly.verificationState).toBe("verified");
+    const empty = createDefaultInstallation(manifest("addon.empty", { provenance: {} as never }), "bundled");
+    expect(empty.provenanceTier).toBe("sideloaded-unverified");
+    expect(empty.verificationState).toBe("unverified");
+  });
+
+  it("snapshot path keeps a partial provenance block least-trusted even with an installation record (#345)", () => {
+    const addon = manifest("addon.partial-snapshot", { provenance: { verificationState: "verified" } as never });
+    const snapshot = createAddOnRegistrySnapshot({
+      bundled: [addon],
+      sideloaded: [],
+      installations: { [addon.id]: createDefaultInstallation(addon, "bundled") },
+    });
+    const entry = snapshot.byId[addon.id];
+    expect(entry?.provenanceTier).toBe("sideloaded-unverified");
+    expect(entry?.reviewState).toBe("unreviewed");
+  });
+
   it("keeps an empty provenance block least-trusted and unreviewed", () => {
     const addon = manifest("addon.empty-provenance", {
       provenance: {} as never,

--- a/src/sdk/addons/registry.test.ts
+++ b/src/sdk/addons/registry.test.ts
@@ -73,6 +73,39 @@ describe("add-on registry snapshot", () => {
     expect(entry.reviewState).toBe("unreviewed");
   });
 
+  it("keeps an empty provenance block least-trusted and unreviewed", () => {
+    const addon = manifest("addon.empty-provenance", {
+      provenance: {} as never,
+    });
+    const entry = createAddOnRegistryEntry(addon, { registrySource: "bundled-catalog" });
+
+    expect(entry.provenanceTier).toBe("sideloaded-unverified");
+    expect(entry.verificationState).toBe("unverified");
+    expect(entry.reviewState).toBe("unreviewed");
+  });
+
+  it("does not promote a provenance block that only declares a tier", () => {
+    const addon = manifest("addon.tier-only", {
+      provenance: { tier: "curated-signed" } as never,
+    });
+    const entry = createAddOnRegistryEntry(addon, { registrySource: "bundled-catalog" });
+
+    expect(entry.provenanceTier).toBe("curated-signed");
+    expect(entry.verificationState).toBe("unverified");
+    expect(entry.reviewState).toBe("unreviewed");
+  });
+
+  it("does not promote a provenance block that only declares verification state", () => {
+    const addon = manifest("addon.verification-only", {
+      provenance: { verificationState: "verified" } as never,
+    });
+    const entry = createAddOnRegistryEntry(addon, { registrySource: "bundled-catalog" });
+
+    expect(entry.provenanceTier).toBe("sideloaded-unverified");
+    expect(entry.verificationState).toBe("verified");
+    expect(entry.reviewState).toBe("unreviewed");
+  });
+
   it("keeps a signed bundled manifest verified (P1-e)", () => {
     const addon = manifest("addon.signed", {
       provenance: {

--- a/src/sdk/addons/registry.ts
+++ b/src/sdk/addons/registry.ts
@@ -50,11 +50,6 @@ const sourceDefaults = (
     };
   }
 
-  // P1-e: a bundled-catalog manifest with NO provenance must NOT be trusted by
-  // omission. Previously an absent provenance silently defaulted to
-  // curated-signed/verified/reviewed. Instead, mark a manifest lacking any
-  // provenance metadata as dev/internal/unreviewed (sideloaded-unverified /
-  // unverified / unreviewed) so missing provenance is visible, never crashing.
   if (!manifest.provenance) {
     return {
       provenanceTier: "sideloaded-unverified",
@@ -64,9 +59,13 @@ const sourceDefaults = (
   }
 
   return {
-    provenanceTier: manifest.provenance.tier ?? "curated-signed",
-    verificationState: manifest.provenance.verificationState ?? "verified",
-    reviewState: "reviewed",
+    // Trust is never granted by omission (#345): a PRESENT but partial provenance
+    // block falls back to the least-trusted value for each missing field, and is
+    // only "reviewed" when both tier and verificationState are explicit. An ABSENT
+    // block is handled above (P1-e).
+    provenanceTier: manifest.provenance.tier ?? "sideloaded-unverified",
+    verificationState: manifest.provenance.verificationState ?? "unverified",
+    reviewState: manifest.provenance.tier && manifest.provenance.verificationState ? "reviewed" : "unreviewed",
   };
 };
 

--- a/src/sdk/addons/validation.test.ts
+++ b/src/sdk/addons/validation.test.ts
@@ -101,6 +101,37 @@ describe("add-on SDK manifest validation", () => {
     expect(result.valid).toBe(true);
   });
 
+  it("warns exactly once when provenance is present but incomplete", () => {
+    const result = validateAddOnManifest(
+      validManifest({
+        provenance: {} as never,
+      }),
+    );
+    const warnings = result.issues.filter((issue) => issue.code === "provenance-incomplete");
+
+    expect(result.valid).toBe(true);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatchObject({
+      severity: "warning",
+      path: "provenance",
+    });
+    expect(warnings[0]?.message).toContain("tier");
+    expect(warnings[0]?.message).toContain("verificationState");
+  });
+
+  it("does not warn about provenance when the provenance block is complete", () => {
+    const result = validateAddOnManifest(validManifest());
+
+    expect(result.issues.some((issue) => issue.code === "provenance-incomplete")).toBe(false);
+  });
+
+  it("does not warn about provenance when provenance is absent", () => {
+    const { provenance: _provenance, ...manifest } = validManifest();
+    const result = validateAddOnManifest(manifest);
+
+    expect(result.issues.some((issue) => issue.code === "provenance-incomplete")).toBe(false);
+  });
+
   it("accepts explicit workflow scaffolding contracts for packaged add-on work", () => {
     const result = validateAddOnManifest(
       validManifest({

--- a/src/sdk/addons/validation.ts
+++ b/src/sdk/addons/validation.ts
@@ -1146,6 +1146,22 @@ export const validateAddOnManifest = (
     }
   }
 
+  if (isRecord(candidate.provenance)) {
+    const provenance = candidate.provenance;
+    const missingProvenanceFields = (["tier", "verificationState"] as const).filter(
+      (field) => provenance[field] === undefined,
+    );
+    if (missingProvenanceFields.length > 0) {
+      pushIssue(
+        issues,
+        "warning",
+        "provenance-incomplete",
+        "provenance",
+        `provenance is incomplete; missing ${missingProvenanceFields.join(" and ")}.`,
+      );
+    }
+  }
+
   if (source === "sideload" && isRecord(candidate.provenance) && candidate.provenance.tier !== "sideloaded-unverified") {
     pushIssue(
       issues,


### PR DESCRIPTION
Closes #345.

Found by the 2026-09-05 SDK regression panel (security lens, DeepSeek via pi) — pre-existing trust-by-omission.

**Before:** a manifest whose `provenance` block was present but missing `tier` or `verificationState` was treated as `curated-signed` / `verified` / `reviewed`. The P1-e fix only covered an *absent* block.

**Now (two commits):**
1. `src/sdk/addons/registry.ts`: each missing field falls back to the least-trusted value; `reviewState` is `reviewed` only when both fields are explicit. `validation.ts` emits a `provenance-incomplete` warning naming the missing field(s).
2. Independent review (Opus 5) caught that the registry hardening was **bypassed on the production snapshot path** — entries prefer the installation's provenance, which `src/core/defaults.ts` and `src/core/policies.ts` still defaulted upward (policies had no absent-provenance guard at all). Both now fall back to least-trusted; tests cover `createDefaultInstallation` and the snapshot path with an installation record. Reviewer re-confirmed RESOLVED.

**Evidence:** TDD red→green; sdk+core 178/178; full vitest **434/434**; `tsc` 0 errors; anti-false-green mutations red for both the registry rule and the defaults rule; all 8 bundled + 2 example manifests carry both fields (unaffected).

**Residual (pre-existing, out of scope):** installation records persisted before this fix keep their previously-minted tier until re-derived (`registry.ts:110-111` trusts the persisted record). Tracked on #345.

🤖 Generated with [Claude Code](https://claude.com/claude-code)