### PR TITLE
security(opencode): reaper matches opencode.exe wrappers; pid record has an owner; cockpit refusal never spawns (#343)

### DIFF
--- a/browser-first/host/addon-delegation-service.mjs
+++ b/browser-first/host/addon-delegation-service.mjs
@@ -9,7 +9,7 @@ import {
   parseDraftPacketMarkdown,
 } from "./addon-draft-connectors.mjs";
 import { dashboardProxyUrl } from "./bridge-server.mjs";
-import { ensureOpencodeServer } from "./opencode-client.mjs";
+import { ensureOpencodeServer, peekOpencodeServer } from "./opencode-client.mjs";
 import { createOpenCodeWebUrlHandler } from "./opencode-session-host-service.mjs";
 
 const DEFAULT_OPENCODE_MODEL = "openai/gpt-5.4-mini";
@@ -176,6 +176,7 @@ export function createAddonDelegationService(dependencies) {
     opencodeCommand,
     opencodeRuntimeDiagnostics,
     ensureOpenCodeServer = ensureOpencodeServer,
+    peekOpenCodeServer = peekOpencodeServer,
     platform = process.platform,
     redactPathForDiagnostics,
     readProviderSecrets = async () => ({}),
@@ -1256,6 +1257,9 @@ except BaseException as exc:
       port: process.env.RESONANTOS_OPENCODE_PORT ? Number(process.env.RESONANTOS_OPENCODE_PORT) : undefined,
       env: process.env,
     }),
+    // #343: never spawn a server just to refuse the cockpit handoff — peek the
+    // registered singleton first; only an already-running server yields a URL.
+    peekServer: () => peekOpenCodeServer({ command: opencodeCommand(), hostname: "127.0.0.1", env: process.env }),
     appendAuditEntry: appendAddonGovernanceAuditEntry,
   });
 

--- a/browser-first/host/opencode-client.mjs
+++ b/browser-first/host/opencode-client.mjs
@@ -21,6 +21,7 @@ const inflight = new Map();
 const children = new Set();
 let hooksInstalled = false;
 let stalePidCleanupDone = false;
+let stalePidSkipWrite = false;
 
 export function basicAuthHeader(username, password) {
   return "Basic " + Buffer.from(`${username}:${password}`, "utf8").toString("base64");
@@ -114,6 +115,7 @@ export function resetOpencodeServerSingletonForTests() {
   children.clear();
   hooksInstalled = false;
   stalePidCleanupDone = false;
+  stalePidSkipWrite = false;
 }
 
 export function forgetOpencodeServer(serverInfo) {
@@ -124,6 +126,16 @@ export function forgetOpencodeServer(serverInfo) {
   for (const [key, value] of inflight.entries()) {
     if (value === serverInfo || value?.serverInfo === serverInfo) inflight.delete(key);
   }
+}
+
+// Look up the registered singleton (if any) WITHOUT spawning. Returns the stored
+// server info, or null when nothing is registered (or a spawn is still in flight).
+export function peekOpencodeServer({ command, hostname = DEFAULT_HOST, cwd, env = process.env } = {}) {
+  const directory = resolveOpencodeCwd({ cwd, env });
+  const envPort = Number(env.RESONANTOS_OPENCODE_PORT);
+  const explicitPort = Number.isInteger(envPort) && envPort > 0 ? envPort : 0;
+  const key = `${command}|${hostname}|${directory}|${explicitPort}`;
+  return inflight.get(key)?.serverInfo ?? null;
 }
 
 export function createDefaultPidRecord(env = process.env) {
@@ -191,7 +203,8 @@ export async function ensureOpencodeServer({
   const key = `${command}|${hostname}|${directory}|${explicitPort}`;
   if (inflight.has(key)) {
     const info = await inflight.get(key);
-    if (await opencodeServerHealthy({ fetchImpl, baseUrl: info.baseUrl, headers: { Authorization: info.auth.header } })
+    if (info?.auth?.header
+      && await opencodeServerHealthy({ fetchImpl, baseUrl: info.baseUrl, headers: { Authorization: info.auth.header } })
       && await opencodeServerEnforcesAuth({ fetchImpl, baseUrl: info.baseUrl })) {
       return { ...info, spawned: false };
     }
@@ -249,7 +262,7 @@ async function startOpencodeServer({
     : randomBytes(32).toString("base64url");
   const header = basicAuthHeader(username, password);
 
-  await cleanupStalePidOnce(pidRecord, directory);
+  const skipWrite = await cleanupStalePidOnce(pidRecord, directory, processImpl);
   const spawnPort = explicitPort > 0 ? explicitPort : await pickEphemeralPort({ hostname });
 
   const startedAt = Date.now();
@@ -267,11 +280,19 @@ async function startOpencodeServer({
     // clobber a newer server registered under the same key (stop->start, stale-health respawn).
     const registered = inflight.get(key)?.serverInfo?.process;
     if (registered === child) inflight.delete(key);
-    // Likewise only clear the pid record when no newer server is registered under this key.
+    // Likewise only clear the pid record when no newer server is registered under this key,
+    // and only when THIS process owns the recorded server (a foreign bridge's record is left).
     if (registered === undefined || registered === child) {
-      try {
-        Promise.resolve(pidRecord.clear(directory)).catch(() => {});
-      } catch { /* noop */ }
+      (async () => {
+        try {
+          const record = await pidRecord.read(directory);
+          if (record?.owner === processImpl.pid) {
+            try {
+              await pidRecord.clear(directory);
+            } catch { /* noop */ }
+          }
+        } catch { /* noop */ }
+      })();
     }
   });
 
@@ -289,7 +310,9 @@ async function startOpencodeServer({
         throw new Error("OpenCode server does not enforce the bridge credential; refusing to adopt it.");
       }
       installShutdownHooks(processImpl);
-      await pidRecord.write(directory, { pid: child.pid, port: announcedPort, startedAt: Date.now() });
+      if (!skipWrite) {
+        await pidRecord.write(directory, { owner: processImpl.pid, pid: child.pid, port: announcedPort, startedAt: Date.now() });
+      }
       return { key, baseUrl, spawned: true, process: child, directory, auth: { username, password, header } };
     }
     if (Date.now() >= deadline) break;
@@ -325,13 +348,20 @@ function waitForAnnouncedPort(child, spawnPort, maxWaitMs) {
   });
 }
 
-async function cleanupStalePidOnce(pidRecord, directory) {
-  if (stalePidCleanupDone) return;
+async function cleanupStalePidOnce(pidRecord, directory, processImpl) {
+  if (stalePidCleanupDone) return stalePidSkipWrite;
   stalePidCleanupDone = true;
   const stale = await pidRecord.read(directory);
-  if (stale?.pid && pidRecord.isAlive(stale.pid) && /opencode\s+serve/.test(pidRecord.commandOf(stale.pid))) {
-    pidRecord.kill(stale.pid);
+  if (stale?.pid) {
+    const ownerAlive = stale.owner != null && pidRecord.isAlive(stale.owner);
+    if (ownerAlive && stale.owner !== processImpl.pid) {
+      // A LIVE other bridge/process owns this server: never kill it, never overwrite its record.
+      stalePidSkipWrite = true;
+    } else if (pidRecord.isAlive(stale.pid) && /\bopencode(?:\.exe|\.cmd)?\s+serve\b/i.test(pidRecord.commandOf(stale.pid))) {
+      pidRecord.kill(stale.pid);
+    }
   }
+  return stalePidSkipWrite;
 }
 
 function installShutdownHooks(processImpl) {

--- a/browser-first/host/opencode-session-host-service.mjs
+++ b/browser-first/host/opencode-session-host-service.mjs
@@ -6,7 +6,7 @@
 // /event bus; that streaming glue is bridge-server-specific and is registered
 // alongside these request/response routes.
 
-import { forgetOpencodeServer as defaultForgetOpencodeServer, opencodeServeBaseUrl } from "./opencode-client.mjs";
+import { forgetOpencodeServer as defaultForgetOpencodeServer, opencodeServeBaseUrl, peekOpencodeServer } from "./opencode-client.mjs";
 
 export function createOpenCodeWebUrlError(message) {
   const error = new Error(message);
@@ -16,7 +16,7 @@ export function createOpenCodeWebUrlError(message) {
   return error;
 }
 
-export function createOpenCodeWebUrlHandler({ executionEnabled, ensureServer, appendAuditEntry } = {}) {
+export function createOpenCodeWebUrlHandler({ executionEnabled, ensureServer, appendAuditEntry, peekServer, command, hostname, cwd, env } = {}) {
   if (typeof executionEnabled !== "function") {
     throw new Error("OpenCode web URL handler missing executionEnabled.");
   }
@@ -26,10 +26,26 @@ export function createOpenCodeWebUrlHandler({ executionEnabled, ensureServer, ap
   if (typeof appendAuditEntry !== "function") {
     throw new Error("OpenCode web URL handler missing appendAuditEntry.");
   }
+  // Peek (without spawning) whether a server is already registered. An explicit
+  // peekServer wins; otherwise, when enough context is available, peek the registered
+  // singleton directly. When no peek is possible (e.g. tests that stub ensureServer),
+  // fall back to the original ensure-then-serve behavior.
+  const peek = typeof peekServer === "function"
+    ? peekServer
+    : (command ? () => peekOpencodeServer({ command, hostname, cwd, env }) : null);
   return async function executeOpenCodeWebUrl(req) {
     const payload = req?.body ?? req ?? {};
     if (!(await executionEnabled(payload))) {
       throw createOpenCodeWebUrlError("OpenCode web cockpit URL issuance requires explicit OpenCode execution enablement.");
+    }
+    if (peek && !(await peek())) {
+      await appendAuditEntry({
+        at: new Date().toISOString(),
+        addonId: "opencode",
+        event: "webCockpitUrlIssued",
+        url: "",
+      });
+      return { url: "", requiresCredential: true };
     }
     const serverInfo = await ensureServer();
     const url = opencodeServeBaseUrl(serverInfo);

--- a/browser-first/test/addon-delegation-service-error-handling.test.mjs
+++ b/browser-first/test/addon-delegation-service-error-handling.test.mjs
@@ -40,6 +40,7 @@ function createService(root, overrides = {}) {
     opencodeCommand: overrides.opencodeCommand ?? (() => null),
     opencodeRuntimeDiagnostics: overrides.opencodeRuntimeDiagnostics ?? (() => ({ installed: false, command: null })),
     ensureOpenCodeServer: overrides.ensureOpenCodeServer,
+    peekOpenCodeServer: overrides.peekOpenCodeServer,
     redactPathForDiagnostics: (value) => String(value ?? "").replace(root, "<root>"),
     readProviderSecrets: overrides.readProviderSecrets ?? (async () => ({})),
     repoRoot: root,
@@ -197,6 +198,8 @@ test("OpenCode web cockpit URL issuance is execution-gated, loopback-only, and i
         ensured += 1;
         return { baseUrl: "http://127.0.0.1:4231/session?directory=%2Frepo" };
       },
+      // a server is already registered -> the handler may issue the URL (#343 peek)
+      peekOpenCodeServer: () => ({ baseUrl: "http://127.0.0.1:4231" }),
     });
     const auditPath = path.join(root, "BrowserFirst", "Settings", "addon-governance-audit.jsonl");
 
@@ -675,5 +678,25 @@ test("OpenCode provider matrix scopes explicit provider environment keys", async
         assert.ok(!envKeys.includes("RESONANTOS_PROVIDER_SECRETS_JSON"));
       }
     });
+  });
+});
+
+test("OpenCode web cockpit URL issuance does not spawn a server just to refuse (#343)", async () => {
+  await withTempService(async (_service, root) => {
+    let ensured = 0;
+    const service = createService(root, {
+      opencodeCommand: () => "/usr/local/bin/opencode",
+      opencodeRuntimeDiagnostics: () => ({ installed: true, command: "/usr/local/bin/opencode", commandRedacted: "<opencode>" }),
+      ensureOpenCodeServer: async () => { ensured += 1; return { baseUrl: "http://127.0.0.1:4231" }; },
+      peekOpenCodeServer: () => null, // nothing registered
+    });
+    const result = await service.executeOpenCodeWebUrl({ enableOpenCodeExecution: true });
+    assert.equal(ensured, 0);
+    assert.deepEqual(result, { url: "", requiresCredential: true });
+    const auditPath = path.join(root, "BrowserFirst", "Settings", "addon-governance-audit.jsonl");
+    const entries = (await readFile(auditPath, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].event, "webCockpitUrlIssued");
+    assert.equal(entries[0].url, "");
   });
 });

--- a/browser-first/test/opencode-client.test.mjs
+++ b/browser-first/test/opencode-client.test.mjs
@@ -18,6 +18,7 @@ import {
   pickFreeLoopbackPort,
   opencodeServeBaseUrl,
   opencodeServerHealthy,
+  peekOpencodeServer,
   resetOpencodeServerSingletonForTests
 } from "../host/opencode-client.mjs";
 
@@ -1044,4 +1045,198 @@ test("concurrent first API doc callers share one in-flight fetch before using pr
     "http://127.0.0.1:4096/session/s1/prompt_async",
     "http://127.0.0.1:4096/session/s1/prompt_async"
   ]);
+});
+
+test("the reaper matches the opencode.exe serve wrapper on the full command line", async () => {
+  resetOpencodeServerSingletonForTests();
+  const killed = [];
+  const env = { OPENCODE_SERVER_PASSWORD: "exe-wrapper-secret" };
+  await ensureTestOpencodeServer({
+    fetchImpl: authedFetch(basicAuthHeader("opencode", env.OPENCODE_SERVER_PASSWORD), []),
+    spawnImpl: () => fakeChild(),
+    command: "/bin/opencode",
+    env,
+    pidRecord: {
+      read: async () => ({ pid: 999 }),
+      write: async () => {},
+      clear: () => {},
+      isAlive: () => true,
+      commandOf: () => "/x/opencode-ai/bin/opencode.exe serve --hostname 127.0.0.1 --port 57979",
+      kill: (pid) => { killed.push(pid); }
+    },
+    processImpl: fakeProcess(),
+    sleep: immediateSleep,
+    pollMs: 1,
+    maxWaitMs: 100
+  });
+  assert.deepEqual(killed, [999]);
+});
+
+test("a pid record owned by a live other process is never killed or overwritten, and our server still starts", async () => {
+  resetOpencodeServerSingletonForTests();
+  const killed = [];
+  const writes = [];
+  const env = { OPENCODE_SERVER_PASSWORD: "foreign-owner-secret" };
+  const processImpl = fakeProcess();
+  processImpl.pid = 777;
+  const result = await ensureTestOpencodeServer({
+    fetchImpl: authedFetch(basicAuthHeader("opencode", env.OPENCODE_SERVER_PASSWORD), []),
+    spawnImpl: () => fakeChild(),
+    command: "/bin/opencode",
+    env,
+    pidRecord: {
+      read: async () => ({ owner: 888, pid: 999, port: 45123, startedAt: 0 }),
+      write: async (_directory, rec) => { writes.push(rec); },
+      clear: () => {},
+      isAlive: () => true,
+      commandOf: () => "/x/opencode-ai/bin/opencode serve --port 0",
+      kill: (pid) => { killed.push(pid); }
+    },
+    processImpl,
+    sleep: immediateSleep,
+    pollMs: 1,
+    maxWaitMs: 100
+  });
+  assert.equal(result.spawned, true);
+  assert.equal(result.baseUrl, "http://127.0.0.1:45123");
+  assert.deepEqual(killed, []);
+  assert.deepEqual(writes, []);
+});
+
+test("a pid record owned by a dead process with a matching serve command is killed and overwritten", async () => {
+  resetOpencodeServerSingletonForTests();
+  const killed = [];
+  const writes = [];
+  const env = { OPENCODE_SERVER_PASSWORD: "dead-owner-secret" };
+  const processImpl = fakeProcess();
+  processImpl.pid = 777;
+  const result = await ensureTestOpencodeServer({
+    fetchImpl: authedFetch(basicAuthHeader("opencode", env.OPENCODE_SERVER_PASSWORD), []),
+    spawnImpl: () => fakeChild(),
+    command: "/bin/opencode",
+    env,
+    pidRecord: {
+      read: async () => ({ owner: 888, pid: 999, port: 45123, startedAt: 0 }),
+      write: async (_directory, rec) => { writes.push(rec); },
+      clear: () => {},
+      isAlive: (pid) => pid === 999,
+      commandOf: () => "/x/opencode-ai/bin/opencode.exe serve --hostname 127.0.0.1 --port 57979",
+      kill: (pid) => { killed.push(pid); }
+    },
+    processImpl,
+    sleep: immediateSleep,
+    pollMs: 1,
+    maxWaitMs: 100
+  });
+  assert.equal(result.spawned, true);
+  assert.deepEqual(killed, [999]);
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0].owner, 777);
+  assert.equal(writes[0].pid, 4242);
+});
+
+test("child exit clears the pid record only when this process owns it", async () => {
+  const env = { OPENCODE_SERVER_PASSWORD: "owner-exit-secret" };
+  const expectedHeader = basicAuthHeader("opencode", env.OPENCODE_SERVER_PASSWORD);
+  const processImpl = fakeProcess();
+  processImpl.pid = 777;
+
+  // owner matches this process -> cleared
+  resetOpencodeServerSingletonForTests();
+  let clears = 0;
+  const child = fakeChild();
+  await ensureTestOpencodeServer({
+    fetchImpl: authedFetch(expectedHeader, []),
+    spawnImpl: () => child,
+    command: "/bin/opencode",
+    env,
+    pidRecord: {
+      read: async () => ({ owner: 777, pid: child.pid }),
+      write: async () => {},
+      clear: () => { clears += 1; },
+      isAlive: () => false,
+      commandOf: () => "",
+      kill: () => {}
+    },
+    processImpl,
+    sleep: immediateSleep,
+    pollMs: 1,
+    maxWaitMs: 100
+  });
+  child.emit("exit", 0);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(clears, 1);
+
+  // owner differs -> left alone
+  resetOpencodeServerSingletonForTests();
+  clears = 0;
+  const otherChild = fakeChild();
+  await ensureTestOpencodeServer({
+    fetchImpl: authedFetch(expectedHeader, []),
+    spawnImpl: () => otherChild,
+    command: "/bin/opencode",
+    env,
+    pidRecord: {
+      read: async () => ({ owner: 888, pid: otherChild.pid }),
+      write: async () => {},
+      clear: () => { clears += 1; },
+      isAlive: () => false,
+      commandOf: () => "",
+      kill: () => {}
+    },
+    processImpl,
+    sleep: immediateSleep,
+    pollMs: 1,
+    maxWaitMs: 100
+  });
+  otherChild.emit("exit", 0);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(clears, 0);
+});
+
+test("a registered singleton missing auth is treated as unhealthy and respawns", async () => {
+  resetOpencodeServerSingletonForTests();
+  let spawns = 0;
+  const env = { OPENCODE_SERVER_PASSWORD: "missing-auth-secret" };
+  const expectedHeader = basicAuthHeader("opencode", env.OPENCODE_SERVER_PASSWORD);
+  const ensure = () => ensureTestOpencodeServer({
+    fetchImpl: authedFetch(expectedHeader, []),
+    spawnImpl: () => { spawns += 1; return fakeChild(45123 + spawns); },
+    command: "/bin/opencode",
+    env,
+    pidRecord: noPid,
+    processImpl: fakeProcess(),
+    sleep: immediateSleep,
+    pollMs: 1,
+    maxWaitMs: 100
+  });
+  const first = await ensure();
+  assert.equal(spawns, 1);
+  first.auth = undefined; // simulate a singleton entry with no auth metadata
+  const second = await ensure();
+  assert.equal(spawns, 2);
+  assert.equal(second.spawned, true);
+});
+
+test("peekOpencodeServer returns the registered singleton without spawning, or null", async () => {
+  resetOpencodeServerSingletonForTests();
+  const env = { OPENCODE_SERVER_PASSWORD: "peek-secret" };
+  const expectedHeader = basicAuthHeader("opencode", env.OPENCODE_SERVER_PASSWORD);
+  assert.equal(peekOpencodeServer({ command: "/bin/opencode", hostname: "127.0.0.1", cwd: "/repo/root", env }), null);
+  const result = await ensureTestOpencodeServer({
+    fetchImpl: authedFetch(expectedHeader, []),
+    spawnImpl: () => fakeChild(),
+    command: "/bin/opencode",
+    hostname: "127.0.0.1",
+    cwd: "/repo/root",
+    env,
+    pidRecord: noPid,
+    processImpl: fakeProcess(),
+    sleep: immediateSleep,
+    pollMs: 1,
+    maxWaitMs: 100
+  });
+  const peeked = peekOpencodeServer({ command: "/bin/opencode", hostname: "127.0.0.1", cwd: "/repo/root", env });
+  assert.equal(peeked?.baseUrl, result.baseUrl);
+  assert.equal(peeked?.spawned, true);
 });

--- a/browser-first/test/opencode-session-host-service.test.mjs
+++ b/browser-first/test/opencode-session-host-service.test.mjs
@@ -332,3 +332,34 @@ test("web url handler returns requiresCredential and never leaks the credential"
   assert.equal(JSON.stringify(audit).includes("Basic x"), false);
   assert.equal(audit[0].url, "http://127.0.0.1:45123/");
 });
+
+test("web url handler peeks for a registered server and refuses without spawning when none is registered", async () => {
+  // No server registered -> refuse without calling ensureServer.
+  let ensured = 0;
+  const refuseAudit = [];
+  const refuseHandler = createOpenCodeWebUrlHandler({
+    executionEnabled: async () => true,
+    ensureServer: async () => { ensured += 1; return { baseUrl: "http://127.0.0.1:4231" }; },
+    appendAuditEntry: async (entry) => refuseAudit.push(entry),
+    peekServer: async () => null
+  });
+  const refused = await refuseHandler({ body: { enableOpenCodeExecution: true } });
+  assert.deepEqual(refused, { url: "", requiresCredential: true });
+  assert.equal(ensured, 0);
+  assert.equal(refuseAudit.length, 1);
+  assert.equal(refuseAudit[0].event, "webCockpitUrlIssued");
+  assert.equal(refuseAudit[0].url, "");
+
+  // A registered server -> existing behavior (ensure + serve URL, no credential leak).
+  const registeredAudit = [];
+  const registeredHandler = createOpenCodeWebUrlHandler({
+    executionEnabled: async () => true,
+    ensureServer: async () => ({ baseUrl: "http://127.0.0.1:45123/session", auth: { username: "opencode", password: "s3cret", header: "Basic x" } }),
+    appendAuditEntry: async (entry) => registeredAudit.push(entry),
+    peekServer: async () => ({ baseUrl: "http://127.0.0.1:45123" })
+  });
+  const issued = await registeredHandler({ body: { enableOpenCodeExecution: true } });
+  assert.deepEqual(issued, { url: "http://127.0.0.1:45123/", requiresCredential: true });
+  assert.equal(registeredAudit[0].url, "http://127.0.0.1:45123/");
+  assert.equal(JSON.stringify(registeredAudit).includes("s3cret"), false);
+});


### PR DESCRIPTION
Closes #343.

Found during the 2026-09-05 SDK regression run (live proofs against the deployed bridge) — pre-existing defects in the #339 seam.

**Changes (two commits, pi executor + review fix):**
- **Reaper regex** tolerates wrapper basenames: `/\bopencode(?:\.exe|\.cmd)?\s+serve\b/i` — the previous pattern never matched this machine's `opencode.exe serve` command line, so the orphan reaper was inert.
- **PID record ownership**: record is `{ owner, pid, port, startedAt }`; a record owned by a *live* other process is never killed or overwritten; only the owner clears it (a diagnostic process can no longer clobber the bridge's record).
- **Defensive reuse**: a singleton entry without an auth block is treated as unhealthy and respawned.
- **No spawn just to refuse**: `/opencode/web/url` peeks the registered singleton (injectable `peekOpenCodeServer`, default the real peek) and, with nothing registered, returns `{ url: "", requiresCredential: true }` without starting a server. Independent review (Opus 5) found the first version of this was inert in production (the call site passed neither `peekServer` nor `command`); fixed at the call site and re-confirmed RESOLVED.

**Evidence:** 82/82 across opencode-client, session-host-service and delegation-service error-handling suites; full `test:browser-first` **1092/1092**; anti-false-green mutations red (regex, live-owner guard, call-site peek); no port literal outside the annotated allowlist.

**Residuals (accepted, documented):** owner-pid reuse by an unrelated live process would make us skip reap/write (rare; server still runs); a non-integer `RESONANTOS_OPENCODE_PORT` desynchronizes peek/ensure keys (misconfiguration only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)