### PR TITLE
security(ci): gate committed private key material in the security pipeline (#351)

### DIFF
--- a/.github/security-pipeline/checks.yml
+++ b/.github/security-pipeline/checks.yml
@@ -8,6 +8,10 @@
     "runtime-hardening": {
       "status": "active",
       "description": "Subprocess/runtime hardening: argv secrets, env scoping, pinned load roots, terminal command allowlist."
+    },
+    "secrets-hygiene": {
+      "status": "active",
+      "description": "Committed-content hygiene: private key material, signer files."
     }
   },
   "recordSets": {
@@ -1152,6 +1156,16 @@
         "package-lock.json",
         "npm-shrinkwrap.json"
       ]
+    },
+    {
+      "id": "committed-private-key-material",
+      "family": "secrets-hygiene",
+      "policy": "block",
+      "adapter": "committed-private-key-material",
+      "surfaces": [
+        "."
+      ],
+      "allowlist": []
     },
     {
       "id": "subprocess-no-argv-secret",

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,9 +1,8 @@
 # Security observe workflow.
 #
-# Runs the security-pipeline check registry in OBSERVE mode (non-gating): a
-# finding never fails the workflow and no job here is wired as a required
-# status check or branch-protection gate. Additive alongside alpha-build.yml,
-# which this workflow does not touch.
+# Runs the security-pipeline check registry in OBSERVE mode (non-gating) while
+# the committed-private-key-material job gates private key material. Additive
+# alongside alpha-build.yml, which this workflow does not touch.
 #
 # Action refs are pinned to full 40-char commit SHAs per
 # docs/security-pipeline/sha-pin-policy.md (lead by example).
@@ -42,3 +41,24 @@ jobs:
           node-version-file: .nvmrc
       - name: Run security-pipeline registry (observe, non-gating)
         run: node scripts/security-pipeline/run-check.mjs --config .github/security-pipeline/checks.yml
+
+  committed-private-key-material:
+    name: "committed private key material (gating)"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        # pin: full 40-char commit SHA per sha-pin-policy.md.
+        # NOTE: verify this SHA at the commit gate before merge.
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup Node.js
+        # pin: full 40-char commit SHA per sha-pin-policy.md.
+        # NOTE: verify this SHA at the commit gate before merge.
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version-file: .nvmrc
+      - name: Test committed private key material check
+        run: node --test scripts/security-pipeline/checks/committed-private-key-material.test.mjs
+      - name: Run committed private key material check
+        run: node scripts/security-pipeline/run-check.mjs --config .github/security-pipeline/checks.yml --check committed-private-key-material

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ public/addons/*.local-test-backup-*
 .env.*
 !.env.example
 *.signer.json
+*-signer.json
 *-private*.json
 *.jwk
 *.key

--- a/.gitignore
+++ b/.gitignore
@@ -28,11 +28,19 @@ public/addons/*.local-test-backup-*
 .env
 .env.*
 !.env.example
+*.signer.json
+*-private*.json
+*.jwk
 *.key
 *.pem
 *.p12
+*.pfx
 *.mobileprovision
 *.keystore
+id_rsa
+id_ed25519
+id_ecdsa
+id_dsa
 
 # Logs and caches
 logs/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ worker's changes.
 - Keep credentials and user data out of source, fixtures, logs, screenshots, and
   pull-request text.
 - Private key material (PEM blocks, JWKs with a private component,
-  `*.signer.json` / `*.pem` / `*.key` files) is blocked by the gating
+  `*.signer.json` / `*-signer.json` / `*.pem` / `*.key` files) is blocked by the gating
   `committed-private-key-material` check; a deliberately committed test fixture
   must be generated at test time instead, or, if it must be a file, listed in
   `.github/security-pipeline/checks.yml` under the check's `allowlist` with a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,13 @@ worker's changes.
 - Add focused tests for behavior changes.
 - Keep credentials and user data out of source, fixtures, logs, screenshots, and
   pull-request text.
+- Private key material (PEM blocks, JWKs with a private component,
+  `*.signer.json` / `*.pem` / `*.key` files) is blocked by the gating
+  `committed-private-key-material` check; a deliberately committed test fixture
+  must be generated at test time instead, or, if it must be a file, listed in
+  `.github/security-pipeline/checks.yml` under the check's `allowlist` with a
+  `reason`. See
+  [committed private key material](docs/security-pipeline/committed-private-key-material.md).
 - Do not claim runtime support, status, or release scope that is absent from
   code, tests, [current status](docs/STATUS.md), and Project 2.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,6 +96,7 @@ Related contributor references:
 - [Icon system decision](product/ICON-001-resonantos-svg-system.md) and
   [icon asset index](../public/icons/README.md)
 - [GitHub Action SHA-pinning policy](security-pipeline/sha-pin-policy.md)
+- [Committed private key material check](security-pipeline/committed-private-key-material.md)
 - [Architecture templates, runbooks, and add-on skill contracts](architecture/README.md#contributor-contracts)
 
 ## Release The Alpha

--- a/docs/security-pipeline/committed-private-key-material.md
+++ b/docs/security-pipeline/committed-private-key-material.md
@@ -8,16 +8,21 @@ committed to the repository. The adapter is registered in
 ## What It Detects
 
 - `private-key-filename`: paths matching signer and private-key file names:
-  `*.signer.json`, `*-private*.json`, `*.pem`, `*.key`, `*.p12`, `*.pfx`,
+  `*.signer.json`, `*-signer.json`, `*-private*.json`, `*.pem`, `*.key`, `*.p12`, `*.pfx`,
   `*.keystore`, `*.jwk`, and extensionless `id_rsa`, `id_ed25519`, `id_ecdsa`,
   or `id_dsa`.
 - `pem-private-key`: `-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----` headers followed
   by a body of at least 40 base64 characters; whitespace and literal JSON string
   `\n` / `\r` escapes are ignored for the count, and no `-----END` footer is
   required (a truncated block with a full body is still usable key material).
-- `jwk-private-component`: JSON objects with `kty` of `OKP`, `EC`, or `RSA` and
-  a string `d` private component of length at least 16; malformed JSON uses a
-  regex fallback when `kty` and `d` appear within 800 characters of each other.
+- `jwk-private-component`: JSON objects with `kty` of `OKP`, `EC`, or `RSA`
+  (matched case-insensitively, so a lowercased `kty` does not hide a key) and a
+  string `d` private component of length at least 16; malformed JSON and
+  non-JSON text use a regex fallback when `kty` and `d` appear within 800
+  characters of each other.
+
+Only standard base64 PEM bodies are matched; base64url-encoded bodies are
+non-standard and not detected.
 
 ## Scope
 
@@ -26,9 +31,12 @@ covers exactly what a commit would publish; untracked local files are not
 scanned. Outside a git checkout it walks the directory tree, skipping `.git`
 and `node_modules`. Filenames are checked for every path; contents are checked
 for text files up to 2 MiB (binary extensions such as images and archives are
-skipped). A tracked path that cannot be read is reported as `unreadable`
-evidence without failing the check. An allowlist entry covers every finding
-kind for that one path.
+skipped) up to 16 MiB, configurable per check with `maxContentBytes`. Larger
+files and tracked paths that cannot be read are reported as `oversized` /
+`unreadable` evidence so they stay visible without failing the check; a git
+submodule appears as one `unreadable` entry and its contents are not scanned.
+An allowlist entry covers every failing finding kind (filename, PEM, JWK) for
+that one path.
 
 ## Evidence
 

--- a/docs/security-pipeline/committed-private-key-material.md
+++ b/docs/security-pipeline/committed-private-key-material.md
@@ -1,0 +1,60 @@
+# Committed Private Key Material
+
+Issue #351 adds a blocking security-pipeline check for private key material
+committed to the repository. The adapter is registered in
+[checks.yml](../../.github/security-pipeline/checks.yml) as
+`committed-private-key-material`.
+
+## What It Detects
+
+- `private-key-filename`: paths matching signer and private-key file names:
+  `*.signer.json`, `*-private*.json`, `*.pem`, `*.key`, `*.p12`, `*.pfx`,
+  `*.keystore`, `*.jwk`, and extensionless `id_rsa`, `id_ed25519`, `id_ecdsa`,
+  or `id_dsa`.
+- `pem-private-key`: `-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----` headers followed
+  by a body of at least 40 base64 characters; whitespace and literal JSON string
+  `\n` / `\r` escapes are ignored for the count, and no `-----END` footer is
+  required (a truncated block with a full body is still usable key material).
+- `jwk-private-component`: JSON objects with `kty` of `OKP`, `EC`, or `RSA` and
+  a string `d` private component of length at least 16; malformed JSON uses a
+  regex fallback when `kty` and `d` appear within 800 characters of each other.
+
+## Scope
+
+In a git checkout the check scans every tracked path (`git ls-files`), so it
+covers exactly what a commit would publish; untracked local files are not
+scanned. Outside a git checkout it walks the directory tree, skipping `.git`
+and `node_modules`. Filenames are checked for every path; contents are checked
+for text files up to 2 MiB (binary extensions such as images and archives are
+skipped). A tracked path that cannot be read is reported as `unreadable`
+evidence without failing the check. An allowlist entry covers every finding
+kind for that one path.
+
+## Evidence
+
+Evidence reports path, line, kind, status, and a 12-hex-character SHA-256
+fingerprint of the matched material. It never prints PEM bodies, JWK `d` values,
+or other matched secret material, so logs can show where the problem is without
+disclosing the private key again.
+
+## Allowlisting
+
+Prefer generating test keys at test time. If a deliberate fixture must be
+committed, add its exact repo-relative path to the check's `allowlist` in
+[checks.yml](../../.github/security-pipeline/checks.yml) with a non-empty
+`reason`:
+
+```json
+{
+  "path": "test/fixtures/example.pem",
+  "reason": "documented redaction fixture"
+}
+```
+
+An allowlist entry without a reason fails the check.
+
+## Run Locally
+
+```bash
+node scripts/security-pipeline/run-check.mjs --check committed-private-key-material
+```

--- a/scripts/browser-first-release-scope-audit.mjs
+++ b/scripts/browser-first-release-scope-audit.mjs
@@ -254,6 +254,12 @@ export function classify(changedPath, state) {
       reason: "design-system reference documentation",
     };
   }
+  if (changedPath.startsWith("docs/security-pipeline/")) {
+    return {
+      bucket: "include",
+      reason: "security-pipeline policy and check documentation",
+    };
+  }
   if (canonicalRootFiles.has(changedPath) || changedPath === "public/icons/README.md") {
     return {
       bucket: "include",

--- a/scripts/browser-first-release-scope-audit.test.mjs
+++ b/scripts/browser-first-release-scope-audit.test.mjs
@@ -360,3 +360,17 @@ test("classify includes the add-on SDK package family and tsconfig in the browse
   // negative control: an unrelated new top-level path still needs review
   assert.notEqual(classify("packages/some-unrelated-tool/index.ts", "added").bucket, "include");
 });
+
+test("security-pipeline documentation is approved release documentation", () => {
+  const classify = requireExport("classify");
+
+  assert.deepEqual(classify("docs/security-pipeline/committed-private-key-material.md", "added"), {
+    bucket: "include",
+    reason: "security-pipeline policy and check documentation",
+  });
+  assert.deepEqual(classify("docs/security-pipeline/sha-pin-policy.md", "modified"), {
+    bucket: "include",
+    reason: "security-pipeline policy and check documentation",
+  });
+  assert.equal(classify("docs/unlisted/notes.md", "added").bucket, "review");
+});

--- a/scripts/security-pipeline/checks/committed-private-key-material.mjs
+++ b/scripts/security-pipeline/checks/committed-private-key-material.mjs
@@ -9,7 +9,9 @@ import {
   scanText,
 } from "./lib/private-key-material.mjs";
 
-const MAX_CONTENT_BYTES = 2 * 1024 * 1024;
+// Content scanning cap; larger tracked files are reported as `oversized` evidence (visible, non-failing)
+// rather than silently skipped. Override per check with `maxContentBytes`.
+const DEFAULT_MAX_CONTENT_BYTES = 16 * 1024 * 1024;
 
 export async function run({ check, repoRoot }) {
   const allowlist = Array.isArray(check.allowlist) ? check.allowlist : [];
@@ -23,6 +25,9 @@ export async function run({ check, repoRoot }) {
     ? check.surfaces
     : ["."];
   const scopedFiles = listCandidateFiles(repoRoot).filter((filePath) => isInSurfaces(filePath, surfaces));
+  const maxContentBytes = Number.isFinite(check.maxContentBytes) && check.maxContentBytes > 0
+    ? check.maxContentBytes
+    : DEFAULT_MAX_CONTENT_BYTES;
   const evidence = [];
 
   for (const filePath of scopedFiles) {
@@ -43,7 +48,14 @@ export async function run({ check, repoRoot }) {
     let text;
     try {
       const fileStat = await stat(absolutePath);
-      if (fileStat.size > MAX_CONTENT_BYTES) {
+      if (fileStat.size > maxContentBytes) {
+        evidence.push({
+          kind: "oversized",
+          path: filePath,
+          line: 1,
+          status: "oversized",
+          reason: `${fileStat.size} bytes exceeds the ${maxContentBytes}-byte content cap; filename rule still applied`,
+        });
         continue;
       }
       text = await readFile(absolutePath, "utf8");
@@ -67,6 +79,7 @@ export async function run({ check, repoRoot }) {
   const failedFindings = evidence.filter((finding) => finding.status === "fail");
   const allowlistedFindings = evidence.filter((finding) => finding.status === "allowlisted");
   const unreadable = evidence.filter((finding) => finding.status === "unreadable");
+  const oversized = evidence.filter((finding) => finding.status === "oversized");
   if (failedFindings.length > 0) {
     return {
       status: "fail",
@@ -77,7 +90,7 @@ export async function run({ check, repoRoot }) {
 
   return {
     status: "pass",
-    summary: `committed-private-key-material: clean, ${scopedFiles.length} file(s) scanned (${allowlistedFindings.length} allowlisted, ${unreadable.length} unreadable)`,
+    summary: `committed-private-key-material: clean, ${scopedFiles.length} file(s) scanned (${allowlistedFindings.length} allowlisted, ${unreadable.length} unreadable, ${oversized.length} oversized)`,
     evidence,
   };
 }

--- a/scripts/security-pipeline/checks/committed-private-key-material.mjs
+++ b/scripts/security-pipeline/checks/committed-private-key-material.mjs
@@ -1,0 +1,119 @@
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+
+import {
+  fingerprintMaterial,
+  isBinaryContentPath,
+  listCandidateFiles,
+  PRIVATE_KEY_FILENAME_PATTERN,
+  scanText,
+} from "./lib/private-key-material.mjs";
+
+const MAX_CONTENT_BYTES = 2 * 1024 * 1024;
+
+export async function run({ check, repoRoot }) {
+  const allowlist = Array.isArray(check.allowlist) ? check.allowlist : [];
+  const allowlistError = validateAllowlist(allowlist);
+  if (allowlistError) {
+    return allowlistError;
+  }
+
+  const allowlistedByPath = new Map(allowlist.map((entry) => [entry.path, entry.reason]));
+  const surfaces = Array.isArray(check.surfaces) && check.surfaces.length > 0
+    ? check.surfaces
+    : ["."];
+  const scopedFiles = listCandidateFiles(repoRoot).filter((filePath) => isInSurfaces(filePath, surfaces));
+  const evidence = [];
+
+  for (const filePath of scopedFiles) {
+    if (PRIVATE_KEY_FILENAME_PATTERN.test(filePath)) {
+      evidence.push(applyAllowlist({
+        kind: "private-key-filename",
+        path: filePath,
+        line: 1,
+        fingerprint: fingerprintMaterial(filePath),
+      }, allowlistedByPath));
+    }
+
+    if (isBinaryContentPath(filePath)) {
+      continue;
+    }
+
+    const absolutePath = path.join(repoRoot, filePath);
+    let text;
+    try {
+      const fileStat = await stat(absolutePath);
+      if (fileStat.size > MAX_CONTENT_BYTES) {
+        continue;
+      }
+      text = await readFile(absolutePath, "utf8");
+    } catch (error) {
+      // A tracked path that cannot be read (deleted in the working tree, dangling symlink,
+      // directory symlink) must not abort the scan of every other file. Reported, not failed.
+      evidence.push({
+        kind: "unreadable",
+        path: filePath,
+        line: 1,
+        status: "unreadable",
+        reason: error?.code ?? "read-error",
+      });
+      continue;
+    }
+    for (const finding of scanText({ path: filePath, text })) {
+      evidence.push(applyAllowlist(finding, allowlistedByPath));
+    }
+  }
+
+  const failedFindings = evidence.filter((finding) => finding.status === "fail");
+  const allowlistedFindings = evidence.filter((finding) => finding.status === "allowlisted");
+  const unreadable = evidence.filter((finding) => finding.status === "unreadable");
+  if (failedFindings.length > 0) {
+    return {
+      status: "fail",
+      summary: `committed-private-key-material: ${failedFindings.length} finding(s) in ${scopedFiles.length} file(s) scanned`,
+      evidence,
+    };
+  }
+
+  return {
+    status: "pass",
+    summary: `committed-private-key-material: clean, ${scopedFiles.length} file(s) scanned (${allowlistedFindings.length} allowlisted, ${unreadable.length} unreadable)`,
+    evidence,
+  };
+}
+
+function validateAllowlist(allowlist) {
+  for (const [index, entry] of allowlist.entries()) {
+    if (!entry || typeof entry.path !== "string" || entry.path.length === 0) {
+      return {
+        status: "fail",
+        summary: `committed-private-key-material: allowlist entry ${index} must include a path and reason`,
+        evidence: [],
+      };
+    }
+    if (typeof entry.reason !== "string" || entry.reason.trim().length === 0) {
+      return {
+        status: "fail",
+        summary: `committed-private-key-material: allowlist entry ${entry.path} must include a non-empty reason`,
+        evidence: [],
+      };
+    }
+  }
+  return null;
+}
+
+function applyAllowlist(finding, allowlistedByPath) {
+  const reason = allowlistedByPath.get(finding.path);
+  if (reason) {
+    return { ...finding, status: "allowlisted", reason };
+  }
+  return { ...finding, status: "fail" };
+}
+
+function isInSurfaces(filePath, surfaces) {
+  return surfaces.some((surface) => {
+    if (surface === ".") return true;
+    const prefix = surface.replace(/\/+$/u, "");
+    return filePath === prefix || filePath.startsWith(`${prefix}/`);
+  });
+}

--- a/scripts/security-pipeline/checks/committed-private-key-material.test.mjs
+++ b/scripts/security-pipeline/checks/committed-private-key-material.test.mjs
@@ -289,3 +289,51 @@ test("an unreadable path is reported without failing or aborting the scan", asyn
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("lowercase kty does not hide a JWK private component (parsed and fallback paths)", async () => {
+  const root = createFixture();
+  try {
+    const { jwk } = generateEd25519Material();
+    const lowered = { ...jwk, kty: jwk.kty.toLowerCase() };
+    writeFixture(root, "keys/lower.json", JSON.stringify(lowered));
+    writeFixture(root, "keys/lower.txt", `key = ${JSON.stringify(lowered)}`);
+
+    const result = await runFixture(root);
+
+    assert.equal(result.status, "fail");
+    assert.deepEqual(
+      result.evidence.map(({ kind, path: evidencePath }) => [kind, evidencePath]).sort(),
+      [
+        ["jwk-private-component", "keys/lower.json"],
+        ["jwk-private-component", "keys/lower.txt"],
+      ],
+    );
+    assert.equal(JSON.stringify(result).includes(jwk.d), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a file above the content cap is reported as oversized instead of silently skipped", async () => {
+  const root = createFixture();
+  try {
+    const { pem } = generateEd25519Material();
+    writeFixture(root, "big/blob.txt", `${pem}${"x".repeat(2048)}`);
+
+    const result = await runFixture(root, { surfaces: ["."], maxContentBytes: 1024 });
+
+    assert.equal(result.status, "pass");
+    assert.deepEqual(
+      result.evidence.map(({ kind, path: evidencePath, status }) => [kind, evidencePath, status]),
+      [["oversized", "big/blob.txt", "oversized"]],
+    );
+    assert.match(result.summary, /1 oversized/u);
+    assert.equal(JSON.stringify(result).includes(pem.split("\n")[1]), false);
+
+    const scanned = await runFixture(root);
+    assert.equal(scanned.status, "fail");
+    assert.equal(scanned.evidence[0].kind, "pem-private-key");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/security-pipeline/checks/committed-private-key-material.test.mjs
+++ b/scripts/security-pipeline/checks/committed-private-key-material.test.mjs
@@ -1,0 +1,291 @@
+import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { run } from "./committed-private-key-material.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+function createFixture() {
+  return mkdtempSync(path.join(os.tmpdir(), "private-key-material-"));
+}
+
+function writeFixture(root, relativePath, content = "") {
+  const absolutePath = path.join(root, relativePath);
+  mkdirSync(path.dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, content);
+}
+
+function generateEd25519Material() {
+  const { privateKey } = generateKeyPairSync("ed25519");
+  return {
+    pem: privateKey.export({ type: "pkcs8", format: "pem" }),
+    jwk: privateKey.export({ format: "jwk" }),
+  };
+}
+
+async function runFixture(root, check = { surfaces: ["."] }) {
+  return run({ check, repoRoot: root });
+}
+
+test("PEM private key in config text fails without leaking key material", async () => {
+  const root = createFixture();
+  try {
+    const { pem } = generateEd25519Material();
+    const bodyFirst40Chars = pem
+      .replace(/-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----/u, "")
+      .replace(/-----END [A-Z0-9 ]*PRIVATE KEY-----/u, "")
+      .replace(/\s+/gu, "")
+      .slice(0, 40);
+    writeFixture(root, "config/keys.txt", pem);
+
+    const result = await runFixture(root);
+
+    assert.equal(result.status, "fail");
+    assert.equal(result.evidence.length, 1);
+    assert.equal(result.evidence[0].kind, "pem-private-key");
+    assert.equal(result.evidence[0].path, "config/keys.txt");
+    assert.equal(JSON.stringify(result).includes(bodyFirst40Chars), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("one-line short PEM decoy is ignored", async () => {
+  const root = createFixture();
+  try {
+    writeFixture(root, "config/redacted.txt", "-----BEGIN PRIVATE KEY-----abc-----END PRIVATE KEY-----");
+
+    const result = await runFixture(root);
+
+    assert.equal(result.status, "pass");
+    assert.equal(result.evidence.length, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("PEM embedded in JSON string literal escapes fails", async () => {
+  const root = createFixture();
+  try {
+    const { pem } = generateEd25519Material();
+    writeFixture(root, "signer-config.json", JSON.stringify({ privateKeyPem: pem }));
+
+    const result = await runFixture(root);
+
+    assert.equal(result.status, "fail");
+    assert.equal(result.evidence.length, 1);
+    assert.equal(result.evidence[0].kind, "pem-private-key");
+    assert.equal(result.evidence[0].path, "signer-config.json");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("JWK private component fails without leaking d value", async () => {
+  const root = createFixture();
+  try {
+    const { jwk } = generateEd25519Material();
+    writeFixture(root, "test/fixtures/key.json", JSON.stringify(jwk, null, 2));
+
+    const result = await runFixture(root);
+
+    assert.equal(result.status, "fail");
+    assert.equal(result.evidence.length, 1);
+    assert.equal(result.evidence[0].kind, "jwk-private-component");
+    assert.equal(result.evidence[0].path, "test/fixtures/key.json");
+    assert.equal(JSON.stringify(result).includes(jwk.d), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("public JWK without private component passes", async () => {
+  const root = createFixture();
+  try {
+    const { jwk } = generateEd25519Material();
+    delete jwk.d;
+    writeFixture(root, "test/fixtures/key.json", JSON.stringify(jwk, null, 2));
+
+    const result = await runFixture(root);
+
+    assert.equal(result.status, "pass");
+    assert.equal(result.evidence.length, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("non-JSON text with nearby JWK kty and d fails", async () => {
+  const root = createFixture();
+  try {
+    const dValue = "abcdefghijklmnopqrstuvwxyz";
+    writeFixture(root, "notes/key.txt", `prefix "kty": "OKP", "d": "${dValue}" suffix`);
+
+    const result = await runFixture(root);
+
+    assert.equal(result.status, "fail");
+    assert.equal(result.evidence.length, 1);
+    assert.equal(result.evidence[0].kind, "jwk-private-component");
+    assert.equal(result.evidence[0].path, "notes/key.txt");
+    assert.equal(JSON.stringify(result).includes(dValue), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("private-key-like filenames fail even when empty", async () => {
+  const root = createFixture();
+  try {
+    writeFixture(root, "scripts/.bundled-test-signer.json");
+    writeFixture(root, "certs/server.pem");
+    writeFixture(root, "id_ed25519");
+
+    const result = await runFixture(root);
+
+    assert.equal(result.status, "fail");
+    assert.deepEqual(
+      result.evidence.map(({ kind, path: evidencePath }) => [kind, evidencePath]).sort(),
+      [
+        ["private-key-filename", "certs/server.pem"],
+        ["private-key-filename", "id_ed25519"],
+        ["private-key-filename", "scripts/.bundled-test-signer.json"],
+      ],
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("allowlisted PEM finding passes and records reason", async () => {
+  const root = createFixture();
+  try {
+    const { pem } = generateEd25519Material();
+    writeFixture(root, "config/keys.txt", pem);
+
+    const result = await runFixture(root, {
+      surfaces: ["."],
+      allowlist: [{ path: "config/keys.txt", reason: "documented redaction fixture" }],
+    });
+
+    assert.equal(result.status, "pass");
+    assert.equal(result.evidence.length, 1);
+    assert.equal(result.evidence[0].status, "allowlisted");
+    assert.equal(result.evidence[0].reason, "documented redaction fixture");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("allowlist entry without reason fails configuration", async () => {
+  const root = createFixture();
+  try {
+    writeFixture(root, "config/keys.txt", "");
+
+    const result = await runFixture(root, {
+      surfaces: ["."],
+      allowlist: [{ path: "config/keys.txt" }],
+    });
+
+    assert.equal(result.status, "fail");
+    assert.match(result.summary, /reason/u);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("real repository baseline is clean through git ls-files branch", async () => {
+  const result = await runFixture(path.resolve(HERE, "..", "..", ".."), { surfaces: ["."] });
+
+  assert.equal(result.status, "pass");
+});
+
+test("binary extension content is not scanned", async () => {
+  const root = createFixture();
+  try {
+    const { pem } = generateEd25519Material();
+    writeFixture(root, "images/key.png", pem);
+
+    const result = await runFixture(root);
+
+    assert.equal(result.status, "pass");
+    assert.equal(result.evidence.length, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("PEM body without an END footer still fails", async () => {
+  const root = createFixture();
+  try {
+    const { pem } = generateEd25519Material();
+    const truncated = pem.replace(/-----END [A-Z0-9 ]*PRIVATE KEY-----\s*$/u, "");
+    writeFixture(root, "notes/partial.txt", `${truncated}\n(rest of the file)`);
+
+    const result = await runFixture(root);
+
+    assert.equal(result.status, "fail");
+    assert.equal(result.evidence.length, 1);
+    assert.equal(result.evidence[0].kind, "pem-private-key");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("PEM embedded with literal CRLF escapes in a JSON string fails", async () => {
+  const root = createFixture();
+  try {
+    const { pem } = generateEd25519Material();
+    const crlfPem = pem.replace(/\n/gu, "\r\n");
+    writeFixture(root, "config/windows-settings.json", JSON.stringify({ key: crlfPem }));
+
+    const result = await runFixture(root);
+
+    assert.equal(result.status, "fail");
+    assert.equal(result.evidence.length, 1);
+    assert.equal(result.evidence[0].kind, "pem-private-key");
+    assert.equal(result.evidence[0].path, "config/windows-settings.json");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("surfaces match on path boundaries, not bare prefixes", async () => {
+  const root = createFixture();
+  try {
+    writeFixture(root, "src-legacy/server.pem");
+    writeFixture(root, "src/server.pem");
+
+    const outside = await runFixture(root, { surfaces: ["src"] });
+    assert.equal(outside.status, "fail");
+    assert.deepEqual(outside.evidence.map((finding) => finding.path), ["src/server.pem"]);
+
+    const legacyOnly = await runFixture(root, { surfaces: ["src-legacy/"] });
+    assert.deepEqual(legacyOnly.evidence.map((finding) => finding.path), ["src-legacy/server.pem"]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("an unreadable path is reported without failing or aborting the scan", async () => {
+  const root = createFixture();
+  try {
+    symlinkSync(path.join(root, "does-not-exist.txt"), path.join(root, "dangling.txt"));
+    writeFixture(root, "README.md", "clean");
+
+    const result = await runFixture(root);
+
+    assert.equal(result.status, "pass");
+    assert.deepEqual(
+      result.evidence.map(({ kind, path: evidencePath, status }) => [kind, evidencePath, status]),
+      [["unreadable", "dangling.txt", "unreadable"]],
+    );
+    assert.match(result.summary, /1 unreadable/u);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/security-pipeline/checks/lib/private-key-material.mjs
+++ b/scripts/security-pipeline/checks/lib/private-key-material.mjs
@@ -14,7 +14,7 @@ const JWK_PRIVATE_KTY = new Set(["OKP", "EC", "RSA"]);
 const PEM_PRIVATE_KEY_PATTERN =
   /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----(?<body>(?:[A-Za-z0-9+/=]|\s|\\[rn])+)/gu;
 const JWK_FALLBACK_PATTERN =
-  /(?:"kty"\s*:\s*"(OKP|EC|RSA)"[\s\S]{0,800}?"d"\s*:\s*"([A-Za-z0-9_\-+/=]{16,})"|"d"\s*:\s*"([A-Za-z0-9_\-+/=]{16,})"[\s\S]{0,800}?"kty"\s*:\s*"(OKP|EC|RSA)")/gu;
+  /(?:"kty"\s*:\s*"(?:[Oo][Kk][Pp]|[Ee][Cc]|[Rr][Ss][Aa])"[\s\S]{0,800}?"d"\s*:\s*"([A-Za-z0-9_\-+/=]{16,})"|"d"\s*:\s*"([A-Za-z0-9_\-+/=]{16,})"[\s\S]{0,800}?"kty"\s*:\s*"(?:[Oo][Kk][Pp]|[Ee][Cc]|[Rr][Ss][Aa])")/gu;
 
 export function scanText({ path: filePath, text }) {
   const findings = [];
@@ -87,7 +87,7 @@ function scanJwkPrivateComponents({ path: filePath, text }) {
 function scanJwkFallback({ path: filePath, text }) {
   const findings = [];
   for (const match of text.matchAll(JWK_FALLBACK_PATTERN)) {
-    const dValue = match[2] ?? match[3];
+    const dValue = match[1] ?? match[2];
     findings.push({
       kind: "jwk-private-component",
       path: filePath,
@@ -111,7 +111,7 @@ function walkJsonForJwk(value, onFinding) {
   }
 
   if (
-    JWK_PRIVATE_KTY.has(value.kty) &&
+    JWK_PRIVATE_KTY.has(String(value.kty ?? "").toUpperCase()) &&
     typeof value.d === "string" &&
     value.d.length >= 16
   ) {

--- a/scripts/security-pipeline/checks/lib/private-key-material.mjs
+++ b/scripts/security-pipeline/checks/lib/private-key-material.mjs
@@ -1,0 +1,162 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+export const PRIVATE_KEY_FILENAME_PATTERN =
+  /(^|[/\\])(?:[^/\\]*(?:\.|-)signer\.json|[^/\\]*-private[^/\\]*\.json|[^/\\]*\.(?:pem|key|p12|pfx|keystore|jwk)|id_(?:rsa|ed25519|ecdsa|dsa))$/iu;
+
+const BINARY_CONTENT_EXTENSION_PATTERN = /\.(?:png|jpe?g|gif|webp|ico|woff2?|ttf|otf|zip|gz|tgz|pdf|mp4|mov)$/iu;
+const JWK_PRIVATE_KTY = new Set(["OKP", "EC", "RSA"]);
+// The body is everything base64-ish after the header: base64 characters, whitespace, and the
+// literal two-character escapes \n / \r as they appear inside JSON strings. Deliberately NOT anchored
+// on an -----END----- footer: a truncated block with a full body is still usable key material.
+const PEM_PRIVATE_KEY_PATTERN =
+  /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----(?<body>(?:[A-Za-z0-9+/=]|\s|\\[rn])+)/gu;
+const JWK_FALLBACK_PATTERN =
+  /(?:"kty"\s*:\s*"(OKP|EC|RSA)"[\s\S]{0,800}?"d"\s*:\s*"([A-Za-z0-9_\-+/=]{16,})"|"d"\s*:\s*"([A-Za-z0-9_\-+/=]{16,})"[\s\S]{0,800}?"kty"\s*:\s*"(OKP|EC|RSA)")/gu;
+
+export function scanText({ path: filePath, text }) {
+  const findings = [];
+  findings.push(...scanPemPrivateKeys({ path: filePath, text }));
+  if (/\.json$/iu.test(filePath)) {
+    findings.push(...scanJwkPrivateComponents({ path: filePath, text }));
+  } else {
+    findings.push(...scanJwkFallback({ path: filePath, text }));
+  }
+  return findings;
+}
+
+export function listCandidateFiles(repoRoot) {
+  if (existsSync(path.join(repoRoot, ".git"))) {
+    const output = execFileSync("git", ["ls-files", "-z"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    });
+    return output.split("\0").filter(Boolean).map(toPosixPath).sort();
+  }
+
+  const files = [];
+  walkFiles(repoRoot, repoRoot, files);
+  return files.sort();
+}
+
+export function isBinaryContentPath(filePath) {
+  return BINARY_CONTENT_EXTENSION_PATTERN.test(filePath);
+}
+
+export function fingerprintMaterial(material) {
+  return createHash("sha256").update(material).digest("hex").slice(0, 12);
+}
+
+function scanPemPrivateKeys({ path: filePath, text }) {
+  const findings = [];
+  for (const match of text.matchAll(PEM_PRIVATE_KEY_PATTERN)) {
+    const normalizedBody = normalizePemBody(match.groups?.body ?? "");
+    if (normalizedBody.length < 40 || !/^[A-Za-z0-9+/=]+$/u.test(normalizedBody)) {
+      continue;
+    }
+    findings.push({
+      kind: "pem-private-key",
+      path: filePath,
+      line: lineForIndex(text, match.index ?? 0),
+      fingerprint: fingerprintMaterial(normalizedBody),
+    });
+  }
+  return findings;
+}
+
+function scanJwkPrivateComponents({ path: filePath, text }) {
+  const findings = [];
+  try {
+    const parsed = JSON.parse(text);
+    walkJsonForJwk(parsed, ({ d }) => {
+      findings.push({
+        kind: "jwk-private-component",
+        path: filePath,
+        line: lineForJsonDKey(text, d),
+        fingerprint: fingerprintMaterial(d),
+      });
+    });
+    return findings;
+  } catch {
+    return scanJwkFallback({ path: filePath, text });
+  }
+}
+
+function scanJwkFallback({ path: filePath, text }) {
+  const findings = [];
+  for (const match of text.matchAll(JWK_FALLBACK_PATTERN)) {
+    const dValue = match[2] ?? match[3];
+    findings.push({
+      kind: "jwk-private-component",
+      path: filePath,
+      line: lineForIndex(text, match.index ?? 0),
+      fingerprint: fingerprintMaterial(dValue),
+    });
+  }
+  return findings;
+}
+
+function walkJsonForJwk(value, onFinding) {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      walkJsonForJwk(item, onFinding);
+    }
+    return;
+  }
+
+  if (!value || typeof value !== "object") {
+    return;
+  }
+
+  if (
+    JWK_PRIVATE_KTY.has(value.kty) &&
+    typeof value.d === "string" &&
+    value.d.length >= 16
+  ) {
+    onFinding({ d: value.d });
+  }
+
+  for (const child of Object.values(value)) {
+    walkJsonForJwk(child, onFinding);
+  }
+}
+
+function lineForJsonDKey(text, dValue) {
+  const escaped = escapeRegExp(JSON.stringify(dValue).slice(1, -1));
+  const pattern = new RegExp(`"d"\\s*:\\s*"${escaped}"`, "u");
+  const match = pattern.exec(text);
+  return match ? lineForIndex(text, match.index) : 1;
+}
+
+function normalizePemBody(body) {
+  return body.replace(/\\[rn]/gu, "").replace(/\s+/gu, "");
+}
+
+function lineForIndex(text, index) {
+  return text.slice(0, index).split("\n").length;
+}
+
+function walkFiles(root, directory, files) {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (entry.name === ".git" || entry.name === "node_modules") {
+      continue;
+    }
+
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      walkFiles(root, absolutePath, files);
+    } else if (entry.isFile() || entry.isSymbolicLink()) {
+      files.push(toPosixPath(path.relative(root, absolutePath)));
+    }
+  }
+}
+
+function toPosixPath(filePath) {
+  return filePath.split(path.sep).join("/");
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}


### PR DESCRIPTION
## Summary

Closes #351. The security pipeline gains its first **blocking** secrets-hygiene check, `committed-private-key-material`, plus a **gating** CI job for it. Until now the pipeline covered lockfiles and subprocess hygiene but nothing scanned committed content for private key material; a contributor's disclosure of a test signing key committed in unmerged fork branches (never reachable from upstream, verified) exposed the gap.

- **What it detects** (tracked files only, i.e. exactly what a commit publishes):
  - `pem-private-key` — a `-----BEGIN … PRIVATE KEY-----` header followed by ≥ 40 base64 characters; whitespace and literal `\n` / `\r` escapes inside JSON strings are ignored for the count, and no `-----END` footer is required (a truncated block with a full body is still usable key material). The existing 3-character redaction decoy in `browser-first/test/context-plugins.test.mjs` is below the threshold by design.
  - `jwk-private-component` — a JWK with `kty` OKP/EC/RSA and a string `d` (≥ 16 chars); parsed for `.json`, proximity regex (800 chars) elsewhere and for malformed JSON.
  - `private-key-filename` — `*.signer.json`, `*-private*.json`, `*.pem`, `*.key`, `*.p12`, `*.pfx`, `*.keystore`, `*.jwk`, `id_rsa` / `id_ed25519` / `id_ecdsa` / `id_dsa`.
- **Evidence never carries material:** path, line, kind and a 12-hex sha256 fingerprint only.
- **Allowlist with a mandatory reason:** an entry without a documented `reason` fails the check (an undocumented allowlist is the loophole this closes). Entries are path-scoped.
- **Robust to a bad tree:** a tracked path that cannot be read (deleted in the working tree, dangling symlink) is reported as `unreadable` evidence without failing or aborting the scan.
- **CI:** new job `committed private key material (gating)` in `security.yml` — no `continue-on-error`, same SHA-pinned actions as the observe job, runs the check's tests and then the check. The existing observe job is untouched and stays non-gating.
- **Hygiene:** `.gitignore` gains signer/private-key patterns; CONTRIBUTING and a new `docs/security-pipeline/committed-private-key-material.md` document the rule, the thresholds, the allowlist procedure and how to run it locally.

## Evidence

- Focused suite **17 / 17**; full `test:security-pipeline` **46 / 46** (was 29 at base); `docs:check` clean on tracked docs.
- Deterministic gate **12 / 12**, including: a freshly generated Ed25519 key **staged in the index** makes `run-check --check committed-private-key-material` exit **1**, its evidence names the path, and **no key material appears anywhere in the output**; the same key left **untracked** is ignored (tracked-only semantics); the real tree passes (807 files); registry lists the check as `block`; both jobs use identical SHA pins.
- Anti-false-green: **12 / 12** guard mutations went red and were restored byte-identical — PEM threshold, CRLF-escape normalization, JWK `d` type check, fingerprint-instead-of-material, allowlist reason validation, filename rule, surface path boundary, unreadable-path handling, registry policy `block`, the gating job's absence of `continue-on-error`, case-insensitive JWK `kty`, and oversized-file evidence.
- Process: Resonant-Rig standard tier — fleet executor (Codex) built from a written spec; adjudicator review before commit fixed four issues (END-footer anchoring, literal `\r` escapes, `stat` throw aborting the scan, bare-prefix surface match) and added guard tests for each; independent cross-vendor review by DeepSeek v4-pro (via pi, with execution: ran the tests, an out-of-worktree key exercise, and proved the gate end-to-end) returned **CONFIRM** with one should-fix and five nits — four accepted and fixed in the second commit (case-insensitive `kty`; oversized files reported as evidence with a configurable 16 MiB cap; `*-signer.json` stated in docs and `.gitignore`; allowlist wording), two rejected with reasons recorded in the doc (base64url PEM is non-standard; submodule gitlinks are by design one non-failing `unreadable` entry).

## Notes for reviewers

- Semantics are **tracked-files-only** via `git ls-files` (directory walk outside a git checkout). That is the right surface for a commit gate; it deliberately does not police untracked local files.
- The pipeline's own unit tests (`test:security-pipeline`) still do not run in any CI workflow except the new job's focused test step — pre-existing, out of scope here.

Refs #345, #336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
