### PR TITLE
chore(docs): validate only git-visible Markdown so ignored scratch cannot fake findings (#344)

### DIFF
--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
-import { lstatSync, readFileSync, readdirSync, realpathSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync, readdirSync, realpathSync } from "node:fs";
 import { dirname, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { unified } from "unified";
@@ -134,9 +134,42 @@ function lineNumber(markdown, offset) {
   return line;
 }
 
+const SKIPPED_DIRECTORY_NAMES = new Set([".git", ".claude", "node_modules", "dist", "coverage"]);
+
+function isSkippedPath(relativePath) {
+  return relativePath.split("/").some((segment) => SKIPPED_DIRECTORY_NAMES.has(segment));
+}
+
+// In a git checkout, enumerate what git would publish or a contributor is about to
+// add: tracked files plus untracked files that are NOT ignored. Gitignored scratch
+// (rig artifacts, worktrees, executor copies) never reaches the validator, so the
+// local gate matches a clean checkout (#344). Falls back to a directory walk when
+// the root is not a git checkout or git is unavailable.
+function listGitVisibleFiles(root) {
+  if (!existsSync(resolve(root, ".git"))) return null;
+  try {
+    const output = execFileSync(
+      "git",
+      ["ls-files", "-z", "--cached", "--others", "--exclude-standard"],
+      { cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    );
+    return output
+      .split("\0")
+      .filter(Boolean)
+      .map((path) => path.split(sep).join("/"))
+      .filter((path) => !isSkippedPath(path) && existsSync(resolve(root, path)));
+  } catch {
+    return null;
+  }
+}
+
 function walkFiles(root, current = root, files = []) {
+  if (current === root) {
+    const visible = listGitVisibleFiles(root);
+    if (visible) return visible;
+  }
   for (const entry of readdirSync(current, { withFileTypes: true })) {
-    if ([".git", "node_modules", "dist", "coverage"].includes(entry.name)) continue;
+    if (SKIPPED_DIRECTORY_NAMES.has(entry.name)) continue;
     const path = resolve(current, entry.name);
     if (entry.isDirectory()) walkFiles(root, path, files);
     else if (entry.isFile()) files.push(toRelative(root, path));

--- a/scripts/validate-docs.test.mjs
+++ b/scripts/validate-docs.test.mjs
@@ -2385,3 +2385,27 @@ test("CLI scans cwd, prints actionable findings, and exits nonzero", () => {
     assert.match(result.stderr, /npm run missing-command/);
   });
 });
+
+test("gitignored and untracked-ignored Markdown is not validated in a git checkout (#344)", () => {
+  withRepository((root) => {
+    const git = (args) => spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+    git(["init", "--quiet"]);
+    git(["config", "user.email", "docs-test@example.invalid"]);
+    git(["config", "user.name", "Docs Test"]);
+    writeFixture(root, ".gitignore", ".resonant-rig/\nscratch-*/\n");
+    writeFixture(root, ".resonant-rig/review.md", "[broken](./missing-ignored-a.md)\n");
+    writeFixture(root, "scratch-copy/notes.md", "[broken](./missing-ignored-b.md)\n");
+    writeFixture(root, ".claude/worktrees/x/README.md", "[broken](./missing-ignored-c.md)\n");
+    writeFixture(root, "docs/untracked-new.md", "[broken](./missing-untracked.md)\n");
+    git(["add", "--all"]);
+    git(["commit", "--quiet", "-m", "fixture"]);
+    // docs/untracked-new.md is committed above; add a second, truly untracked doc after the commit
+    writeFixture(root, "docs/really-untracked.md", "[broken](./missing-really-untracked.md)\n");
+
+    const found = messages(validateRepositoryDocs(root).findings).join("\n");
+
+    assert.doesNotMatch(found, /missing-ignored-[abc]\.md/, "gitignored / .claude paths must not be validated");
+    assert.match(found, /missing-untracked\.md/, "tracked docs are validated");
+    assert.match(found, /missing-really-untracked\.md/, "untracked but not ignored docs are validated");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #344. `npm run docs:check` walked the entire working tree, so gitignored rig artifacts, worktree copies and executor scratch produced findings that a clean checkout never shows (100 false positives on the maintainer machine during the 2026-09-05 regression run). A misleading local gate can mask a real regression.

In a git checkout the validator now enumerates `git ls-files --cached --others --exclude-standard` — tracked files plus untracked files that are **not** ignored, honoring every `.gitignore` in the tree — and additionally skips `.claude/`. Outside a git checkout (or if `git` fails) it keeps the previous directory walk. Untracked-but-not-ignored docs are still validated, so a contributor sees link errors before `git add`.

## Evidence

- `node --test scripts/validate-docs.test.mjs`: **142 / 142** (new test: a temp git repo where gitignored and `.claude/` paths carrying broken links are **not** reported, while a tracked doc and an untracked non-ignored doc with broken links **are**).
- The patched validator run against the maintainer's main checkout, with `.resonant-rig/` and `.claude/worktrees/` artifacts present, now prints `Documentation contract validation passed.` — the same result CI gets on a clean checkout.
- Anti-false-green (rig-mutate, restored byte-identical): disabling the git-visible enumeration so the walk runs again turns the new test red.
- Process: Resonant-Rig micro tier (single script + its test) — deterministic gate + mutation proof, no external panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)