### PR TITLE
extension: preserve appearance when saving preferences fails

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/lib/settings/appearance-section.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/settings/appearance-section.js
@@ -1,4 +1,4 @@
-import { noteCard, setStatus, settingsHeader } from "./settings-common.js";
+import { noteCard, safeErrorMessage, setStatus, settingsHeader } from "./settings-common.js";
 
 const defaults = {
   density: "comfortable",
@@ -43,6 +43,7 @@ export function renderAppearanceSection(container, { storage, storageKeys = {} }
   const key = storageKeys.appearance;
   const statusNode = document.createElement("p");
   statusNode.className = "settings-status";
+  statusNode.setAttribute("role", "status");
   statusNode.textContent = "Loading appearance settings...";
   const form = document.createElement("form");
   form.className = "settings-appearance-form";
@@ -77,7 +78,8 @@ export function renderAppearanceSection(container, { storage, storageKeys = {} }
     labelledControl("Density", "Choose compact desktop spacing or larger touch-friendly controls.", density),
     labelledControl("Text size", "Adjust chat, navigation, and settings text without changing workflows.", fontScale),
     labelledControl("Motion", "Reduce motion when animation should be calmer or less distracting.", motion),
-    save
+    save,
+    statusNode
   );
 
   container.replaceChildren(
@@ -86,7 +88,6 @@ export function renderAppearanceSection(container, { storage, storageKeys = {} }
       title: "Interface Preferences",
       body: "Tune the workspace for desktop focus or touch-friendly use. These settings change presentation only, not agent behavior."
     }),
-    statusNode,
     noteCard({
       title: "Recommended default",
       body: "Use Comfortable + Standard + Full motion for the normal desktop experience. Switch to Touch friendly when using a touchscreen."
@@ -104,17 +105,23 @@ export function renderAppearanceSection(container, { storage, storageKeys = {} }
 
   form.addEventListener("submit", async (event) => {
     event.preventDefault();
+    if (save.disabled) return;
     save.disabled = true;
-    const preferences = applyAppearance({
+    const preferences = {
       density: density.value,
       fontScale: fontScale.value,
       motion: motion.value
-    });
+    };
+    setStatus(statusNode, "Saving appearance settings...");
     try {
-      if (storage && key) {
-        await storage.set({ [key]: preferences });
+      if (!storage?.set || !key) {
+        throw new Error("Local settings storage is unavailable.");
       }
+      await storage.set({ [key]: preferences });
+      applyAppearance(preferences);
       setStatus(statusNode, "Appearance settings saved.", "success");
+    } catch (error) {
+      setStatus(statusNode, `Appearance settings could not be saved. Your previous appearance is unchanged. Try saving again. ${safeErrorMessage(error)}`, "error");
     } finally {
       save.disabled = false;
     }

--- a/browser-first/test/settings-appearance-save.test.mjs
+++ b/browser-first/test/settings-appearance-save.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { JSDOM } from "jsdom";
+import { renderAppearanceSection } from "../resonantos-side-panel-extension/src/lib/settings/appearance-section.js";
+
+const key = "appearance";
+const initial = { density: "comfortable", fontScale: "standard", motion: "full" };
+const changed = { density: "compact", fontScale: "large", motion: "reduced" };
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+async function setup(t, storage) {
+  const dom = new JSDOM("<main></main>");
+  globalThis.document = dom.window.document;
+  t.after(() => { dom.window.close(); delete globalThis.document; });
+  const root = document.querySelector("main");
+  renderAppearanceSection(root, { storage, storageKeys: { appearance: key } });
+  await tick();
+  const form = root.querySelector("form");
+  const save = form.querySelector("button");
+  const status = root.querySelector(".settings-status");
+  const choose = () => {
+    for (const [name, value] of Object.entries(changed)) form.elements[name].value = value;
+  };
+  const submit = () => form.dispatchEvent(new dom.window.Event("submit", { cancelable: true }));
+  return { root, form, save, status, choose, submit };
+}
+
+test("failed appearance save preserves applied preferences and allows retry with the same selection", async (t) => {
+  let fail = true;
+  let stored = { ...initial };
+  const storage = {
+    get: async () => ({ [key]: stored }),
+    set: async (values) => {
+      if (fail) throw new Error("storage unavailable");
+      stored = values[key];
+    }
+  };
+  const ui = await setup(t, storage);
+  ui.choose();
+  ui.submit();
+  await tick();
+  assert.deepEqual({ ...document.body.dataset }, initial);
+  assert.deepEqual(stored, initial);
+  assert.equal(ui.status.dataset.tone, "error");
+  assert.match(ui.status.textContent, /could not be saved/i);
+  assert.equal(ui.status.getAttribute("role"), "status");
+  assert.equal(ui.status.previousElementSibling, ui.save);
+  assert.equal(ui.save.disabled, false);
+  for (const [name, value] of Object.entries(changed)) assert.equal(ui.form.elements[name].value, value);
+  fail = false;
+  ui.submit();
+  await tick();
+  assert.deepEqual(stored, changed);
+  assert.deepEqual({ ...document.body.dataset }, changed);
+  assert.equal(ui.status.textContent, "Appearance settings saved.");
+  renderAppearanceSection(ui.root, { storage, storageKeys: { appearance: key } });
+  await tick();
+  for (const [name, value] of Object.entries(changed)) assert.equal(ui.root.querySelector(`[name="${name}"]`).value, value);
+});
+
+test("appearance changes apply only after persistence and duplicate pending submits do not write", async (t) => {
+  let finish;
+  let writes = 0;
+  const ui = await setup(t, {
+    get: async () => ({ [key]: initial }),
+    set: () => { writes += 1; return new Promise((resolve) => { finish = resolve; }); }
+  });
+  ui.choose();
+  ui.submit();
+  ui.submit();
+  assert.equal(writes, 1);
+  assert.deepEqual({ ...document.body.dataset }, initial);
+  assert.equal(ui.save.disabled, true);
+  assert.match(ui.status.textContent, /saving/i);
+  finish();
+  await tick();
+  assert.deepEqual({ ...document.body.dataset }, changed);
+  assert.equal(ui.save.disabled, false);
+});
+
+test("missing appearance storage cannot report a successful save", async (t) => {
+  const ui = await setup(t, undefined);
+  ui.choose();
+  ui.submit();
+  await tick();
+  assert.deepEqual({ ...document.body.dataset }, initial);
+  assert.equal(ui.status.dataset.tone, "error");
+  assert.doesNotMatch(ui.status.textContent, /settings saved\./);
+  assert.equal(ui.save.disabled, false);
+});


### PR DESCRIPTION
## Scope

When local storage rejects an Appearance save, the current UI applies the new preferences anyway and leaves the previous success message visible. This change waits for persistence before applying preferences, reports failures beside Save Appearance, and keeps the selected values available for retry. The status region is announced to assistive technology, and duplicate pending submissions cannot start another write.

Scope: one Settings renderer and its regression tests. Existing storage keys, preference values, host routes, and permission boundaries are preserved. Error details use the existing redaction helper.


Closes #356.
Project 2 release scope: pending maintainer triage.
Project 2 area: Settings proposed; canonical fields unverified.

## Modules And Ownership

- Affected modules: extension Settings renderer and regression tests.
- Ownership or boundary review: reviewed extension UI responsibility under MODULE-OWNERSHIP; no responsibility moves or host boundary changes.

## Safety And Privacy

- Safety/privacy impact: no new permissions, external actions, or private-data collection.
- Required human handoff or approval boundary: existing runtime boundaries preserved. Maintainers decide release scope and merge.
- Secret-handling impact: no credentials or generated configuration included.

## Validation

Base: `85957ae386d9e0c20813bc5e2c3ad4203c485f8a`. Clean installs and deterministic checks used the repository pin, Node.js 22.13.0.

| Command | Result |
| --- | --- |
| `npm ci`; `npm ci --prefix addons/resonant-browser-host` | Passed |
| `npm audit --audit-level=high`; browser-host equivalent with `--prefix addons/resonant-browser-host` | Both passed, zero vulnerabilities |
| `npm run verify:alpha` | Initial fail-fast run exited 1 at desktop tests; every skipped stage subsequently run unchanged and passed; failed stages passed serial rechecks |
| `npm test -- --run` | Latest complete run: 434/434 passed |
| `npm run test:browser-first` | Latest complete run: 1099/1099 passed |
| `node --test browser-first/test/settings-appearance-save.test.mjs` | 3/3 passed; earlier Node26 red-before proof retained |
| Engineer Runner verification | Complete staged two-file candidate verified, including focused tests, staged scope audit, and whitespace |
| `node scripts/security-pipeline/run-check.mjs --certify` | Passed all five checks |
| Pre-release and committed scope checks | Passed |

All 16 deterministic stages now have passing results on this exact candidate, across the initial run and serial rechecks. The local results above are distinct from the hosted result below.

Initial failures were timing-sensitive under heavy machine load. Appearance initially had 32 desktop failures and one memory-move assertion; Overview had three desktop failures. Fresh untouched dev passed the 74 tests in the affected desktop files and the memory-move test. Both full desktop suites and the affected extension suite then passed serially, without changes to code, assertions, time limits, or lockfiles. Initial receipts remain retained; this does not claim a root cause for every transient failure.

Live-browser proof: unchanged candidate loaded in isolated Chrome 152.0.7977.77 with the real authenticated bridge. Injected storage rejection preserved applied preferences and retry selection; restoring real storage enabled keyboard Save and reload persistence. Failure injection removed. Screenshots inspected locally; not attached. The observed states and reproduction are recorded here and in the linked issue. This browser proof used Node26; the deterministic checks above used Node22.

Hosted CI on this exact published head: [alpha-build passed](https://github.com/ResonantOS/2.0.0-alpha/actions/runs/34053582037), including the full Verify Alpha gate, extension packaging, and artifact scan. The security-observe check also passed. Earlier local failures remain recorded above.

## Documentation

Documentation impact: no installation, API, storage schema, or ownership changes. This corrects existing Settings behavior; regression tests and the issue describe the changed states. No runtime documentation changed.

## Checklist

- [x] The branch targets `dev` and does not include unrelated work.
- [ ] The linked issue and Project 2 fields reflect the intended release scope.
- [x] I reviewed module ownership and called out every cross-module boundary change.
- [x] I assessed security, privacy, secrets, and required human-only actions.
- [x] I added or updated tests for behavior changes.
- [x] I recorded every relevant command and its actual result above.
- [x] Redacted live-browser observations and reproduction steps are recorded above and in the linked issue (screenshots remain local).
- [x] I updated current documentation or explained why no documentation changed.
- [x] This pull request contains no credentials, tokens, private user data, browser profiles, or unredacted sensitive logs.
