### PR TITLE
extension: derive Settings bridge status from host health

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/lib/settings/overview-section.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/settings/overview-section.js
@@ -55,6 +55,7 @@ export function renderOverviewSection(container, { bridgeRequest, getBridgeReque
   const bridge = () => (typeof getBridgeRequest === "function" ? getBridgeRequest() : bridgeRequest);
   const statusNode = document.createElement("p");
   statusNode.className = "settings-status";
+  statusNode.setAttribute("role", "status");
   statusNode.textContent = "Checking ResonantOS health...";
   const grid = document.createElement("div");
   grid.className = "settings-health-grid";
@@ -62,7 +63,7 @@ export function renderOverviewSection(container, { bridgeRequest, getBridgeReque
     metricCard({ label: "Providers", value: "Checking", detail: "loading provider profiles" }),
     metricCard({ label: "Add-ons", value: "Checking", detail: "loading add-on registry" }),
     metricCard({ label: "Memory", value: "Checking", detail: "loading memory-system state" }),
-    metricCard({ label: "Browser bridge", value: "Ready", detail: "extension workspace is active", tone: "success" })
+    metricCard({ label: "Browser bridge", value: "Checking", detail: "waiting for host health status" })
   );
 
   const setupGrid = document.createElement("div");
@@ -182,7 +183,14 @@ export function renderOverviewSection(container, { bridgeRequest, getBridgeReque
       metricCard({ label: "Providers", ...provider }),
       metricCard({ label: "Add-ons", ...addons }),
       metricCard({ label: "Memory", ...memory }),
-      metricCard({ label: "Browser bridge", value: "Ready", detail: "extension workspace is active", tone: "success" })
+      metricCard({
+        label: "Browser bridge",
+        value: statusResult.status === "fulfilled" ? "Connected" : "Unavailable",
+        detail: statusResult.status === "fulfilled"
+          ? "host health status received"
+          : "host health check failed; open Diagnostics for connection help",
+        tone: statusResult.status === "fulfilled" ? "success" : "warning"
+      })
     );
     const failed = [providerResult, statusResult].filter((result) => result.status === "rejected").length;
     setStatus(statusNode, failed

--- a/browser-first/test/settings-overview-health.test.mjs
+++ b/browser-first/test/settings-overview-health.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { JSDOM } from "jsdom";
+import { renderOverviewSection } from "../resonantos-side-panel-extension/src/lib/settings/overview-section.js";
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function setup(t, bridgeRequest) {
+  const dom = new JSDOM("<main></main>");
+  globalThis.document = dom.window.document;
+  t.after(() => { dom.window.close(); delete globalThis.document; });
+  const root = document.querySelector("main");
+  renderOverviewSection(root, { bridgeRequest });
+  return {
+    root,
+    status: root.querySelector(".settings-status"),
+    bridge: () => [...root.querySelectorAll(".settings-health-card")]
+      .find((card) => card.querySelector("span").textContent === "Browser bridge")
+  };
+}
+
+test("overview does not claim bridge connectivity before the health request completes", async (t) => {
+  let finish;
+  const status = new Promise((resolve) => { finish = resolve; });
+  const ui = setup(t, async (route) => route === "/status" ? status : { providers: [] });
+  assert.equal(ui.bridge().querySelector("strong").textContent, "Checking");
+  assert.notEqual(ui.bridge().dataset.tone, "success");
+  finish({ addons: [], memory: {} });
+  await tick();
+  assert.equal(ui.bridge().querySelector("strong").textContent, "Connected");
+  assert.equal(ui.bridge().dataset.tone, "success");
+  assert.equal(ui.status.getAttribute("role"), "status");
+});
+
+for (const failure of ["Failed to fetch", "Bridge authentication failed"]) {
+  test(`overview reports an unavailable bridge when health requests fail: ${failure}`, async (t) => {
+    const ui = setup(t, async () => { throw new Error(failure); });
+    await tick();
+    assert.equal(ui.bridge().querySelector("strong").textContent, "Unavailable");
+    assert.equal(ui.bridge().dataset.tone, "warning");
+    assert.match(ui.bridge().textContent, /Diagnostics/);
+    assert.equal(ui.status.dataset.tone, "warning");
+    assert.doesNotMatch(ui.bridge().textContent, /Ready|Connected/);
+  });
+}
+
+test("provider failure does not hide confirmed bridge connectivity", async (t) => {
+  const ui = setup(t, async (route) => {
+    if (route === "/providers/status") throw new Error("provider status unavailable");
+    return { addons: [], memory: {} };
+  });
+  await tick();
+  assert.equal(ui.bridge().querySelector("strong").textContent, "Connected");
+  assert.equal(ui.status.dataset.tone, "warning");
+});
+
+test("provider success cannot substitute for a failed host health check", async (t) => {
+  const ui = setup(t, async (route) => {
+    if (route === "/status") throw new Error("status unavailable");
+    return { providers: [{ configured: true }] };
+  });
+  await tick();
+  assert.equal(ui.bridge().querySelector("strong").textContent, "Unavailable");
+  assert.match(ui.root.textContent, /1\/1/);
+  assert.equal(ui.status.dataset.tone, "warning");
+});


### PR DESCRIPTION
## Scope

Start Here currently displays “Browser bridge: Ready” before health requests finish and continues to display it when they fail. The card now starts at Checking, reports Connected after a successful `/status` request, and reports Unavailable with a Diagnostics hint when that request fails. A provider-status failure remains a partial-health warning without erasing confirmed bridge connectivity.

Scope: one Settings renderer and its regression tests. The existing authenticated requests and security boundaries are unchanged. Connected describes a successful host health response; it does not claim provider or add-on readiness. The overall health message is announced to assistive technology.


Closes #357.
Project 2 release scope: pending maintainer triage.
Project 2 area: Settings proposed; canonical fields unverified.

## Modules And Ownership

- Affected modules: extension Settings renderer and regression tests.
- Ownership or boundary review: reviewed extension UI responsibility under MODULE-OWNERSHIP; no responsibility moves or host boundary changes.

## Safety And Privacy

- Safety/privacy impact: no new permissions, external actions, or private-data collection.
- Required human handoff or approval boundary: existing runtime boundaries preserved. Maintainers decide release scope and merge.
- Secret-handling impact: no credentials or generated configuration included.

## Validation

Base: `85957ae386d9e0c20813bc5e2c3ad4203c485f8a`. Clean installs and deterministic checks used the repository pin, Node.js 22.13.0.

| Command | Result |
| --- | --- |
| `npm ci`; `npm ci --prefix addons/resonant-browser-host` | Passed |
| `npm audit --audit-level=high`; browser-host equivalent with `--prefix addons/resonant-browser-host` | Both passed, zero vulnerabilities |
| `npm run verify:alpha` | Initial fail-fast run exited 1 at desktop tests; every skipped stage subsequently run unchanged and passed; failed stages passed serial rechecks |
| `npm test -- --run` | Latest complete run: 434/434 passed |
| `npm run test:browser-first` | Latest complete run: 1101/1101 passed |
| `node --test browser-first/test/settings-overview-health.test.mjs` | 5/5 passed; earlier Node26 red-before proof retained |
| Engineer Runner verification | Complete staged two-file candidate verified, including focused tests, staged scope audit, and whitespace |
| `node scripts/security-pipeline/run-check.mjs --certify` | Passed all five checks |
| Pre-release and committed scope checks | Passed |

All 16 deterministic stages now have passing results on this exact candidate, across the initial run and serial rechecks. The local results above are distinct from the hosted result below.

Initial failures were timing-sensitive under heavy machine load. Appearance initially had 32 desktop failures and one memory-move assertion; Overview had three desktop failures. Fresh untouched dev passed the 74 tests in the affected desktop files and the memory-move test. Both full desktop suites and the affected extension suite then passed serially, without changes to code, assertions, time limits, or lockfiles. Initial receipts remain retained; this does not claim a root cause for every transient failure.

Live-browser proof: unchanged candidate loaded in isolated Chrome 152.0.7977.77 with the real authenticated bridge. Connected with the bridge running, then Unavailable after stopping the bridge and reloading. Screenshots inspected locally; not attached. The observed states and reproduction are recorded here and in the linked issue. This browser proof used Node26; the deterministic checks above used Node22.

Hosted CI on this exact published head: [alpha-build passed](https://github.com/ResonantOS/2.0.0-alpha/actions/runs/34053595769), including the full Verify Alpha gate, extension packaging, and artifact scan. The security-observe check also passed. Earlier local failures remain recorded above.

## Documentation

Documentation impact: no installation, API, storage schema, or ownership changes. This corrects existing Settings behavior; regression tests and the issue describe the changed states. No runtime documentation changed.

## Checklist

- [x] The branch targets `dev` and does not include unrelated work.
- [ ] The linked issue and Project 2 fields reflect the intended release scope.
- [x] I reviewed module ownership and called out every cross-module boundary change.
- [x] I assessed security, privacy, secrets, and required human-only actions.
- [x] I added or updated tests for behavior changes.
- [x] I recorded every relevant command and its actual result above.
- [x] Redacted live-browser observations and reproduction steps are recorded above and in the linked issue (screenshots remain local).
- [x] I updated current documentation or explained why no documentation changed.
- [x] This pull request contains no credentials, tokens, private user data, browser profiles, or unredacted sensitive logs.
