### PR TITLE
extension: retain active authentication when testing the same bridge

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/lib/settings/bridge-target-section.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/settings/bridge-target-section.js
@@ -276,7 +276,10 @@ export function renderBridgeTargetSection(container, { bridgeRequest, onBridgeCo
             setStatus(statusNode, parsed.error, "error");
             return;
           }
-          await runProbe(parsed.override.bridgeUrl, parsed.override.bridgeToken);
+          const { bridgeUrl, bridgeToken } = parsed.override;
+          // Reuse the active credential only for that exact target, never a newly entered one.
+          const sameTarget = activeConfig && bridgeUrl.replace(/\/$/, "") === activeConfig.bridgeUrl.replace(/\/$/, "");
+          await runProbe(bridgeUrl, bridgeToken || (sameTarget ? activeConfig.bridgeToken : ""));
         },
       },
       {

--- a/browser-first/test/settings-bridge-test-auth.test.mjs
+++ b/browser-first/test/settings-bridge-test-auth.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { JSDOM } from "jsdom";
+import { renderBridgeTargetSection } from "../resonantos-side-panel-extension/src/lib/settings/bridge-target-section.js";
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+const url = "http://127.0.0.1:47773";
+const token = "fixture-generated-token";
+
+async function setup(t) {
+  const dom = new JSDOM("<main></main>");
+  const keys = ["document", "chrome", "fetch", "__RESONANTOS_BRIDGE_CONFIG__"];
+  const previous = keys.map((key) => Object.getOwnPropertyDescriptor(globalThis, key));
+  t.after(() => {
+    dom.window.close();
+    keys.forEach((key, index) => {
+      if (previous[index]) Object.defineProperty(globalThis, key, previous[index]);
+      else delete globalThis[key];
+    });
+  });
+  globalThis.document = dom.window.document;
+  let writes = 0;
+  globalThis.chrome = { storage: { local: { get: async () => ({}), set: async () => { writes++; } } } };
+  globalThis.__RESONANTOS_BRIDGE_CONFIG__ = { bridgeUrl: url, bridgeToken: token };
+  const calls = [];
+  globalThis.fetch = async (target, options = {}) => {
+    calls.push({ target, headers: options.headers });
+    const ok = options.headers?.["X-ResonantOS-Bridge-Token"] === token;
+    return { ok, status: ok ? 200 : 401, json: async () => ({ ok, service: "resonantos-bridge" }) };
+  };
+  const root = document.querySelector("main");
+  renderBridgeTargetSection(root);
+  await tick();
+  return { root, calls, writes: () => writes, probe: async () => {
+    [...root.querySelectorAll("button")].find((button) => button.textContent === "Test connection").click();
+    await tick();
+    return calls.at(-1);
+  } };
+}
+
+test("Test connection uses the effective token for the unchanged target without saving or filling it", async (t) => {
+  const ui = await setup(t);
+  assert.equal(ui.root.querySelector('[name="bridge-token"]').value, "");
+  const call = await ui.probe();
+  assert.equal(call.headers["X-ResonantOS-Bridge-Token"], token);
+  assert.equal(ui.root.querySelector(".settings-health-grid").children[2].querySelector("strong").textContent, "Online");
+  assert.equal(ui.root.querySelector('[name="bridge-token"]').value, "");
+  assert.equal(ui.writes(), 0);
+});
+
+test("explicit test token wins over the effective token", async (t) => {
+  const ui = await setup(t);
+  ui.root.querySelector('[name="bridge-token"]').value = "explicit-fixture-token";
+  assert.equal((await ui.probe()).headers["X-ResonantOS-Bridge-Token"], "explicit-fixture-token");
+});
+
+test("blank token does not reuse credentials for a changed origin or path", async (t) => {
+  const ui = await setup(t);
+  for (const target of ["http://example.test:47773", "http://127.0.0.1:47774", `${url}/other`]) {
+    ui.root.querySelector('[name="bridge-url"]').value = target;
+    assert.equal((await ui.probe()).headers["X-ResonantOS-Bridge-Token"], undefined);
+  }
+});
+
+test("a trailing slash on the same target retains authentication", async (t) => {
+  const ui = await setup(t);
+  ui.root.querySelector('[name="bridge-url"]').value = `${url}/`;
+  assert.equal((await ui.probe()).headers["X-ResonantOS-Bridge-Token"], token);
+});


### PR DESCRIPTION
## Scope

Bridge Target's Test connection sends no token when the default token field is blank, turning a healthy bridge into a false 401. Reuse the active credential for the same target, preserve explicit test credentials, and withhold inherited credentials when the target changes. Testing remains read-only.

Closes #358.

Project 2 release scope: pending maintainer triage.
Project 2 area: Settings proposed; not independently verified in Project 2.

## Modules And Ownership

- Affected modules: extension Settings `bridge-target-section.js` and `settings-bridge-test-auth.test.mjs`.
- Ownership or boundary review: workspace presentation remains in the extension. No host, transport resolver, storage schema, or module ownership changes.

## Safety And Privacy

- Safety/privacy impact: fallback authentication is restricted to the exact active target, allowing a trailing slash only. Tests cover changed host, port, and path.
- Required human handoff or approval boundary: user still chooses the target and invokes Test connection; maintainers accept scope and review the linked PR.
- Secret-handling impact: no credential persistence, token-field population, logging, or generated configuration in the patch.

## Validation

| Command | Result |
| --- | --- |
| `node --test browser-first/test/settings-bridge-test-auth.test.mjs` | 4 passed; the two fallback cases fail on unchanged dev |
| `npm run verify:alpha` | All 16 stages passed in one run, Node 22.13.0; browser-first 1100/1100, desktop 434/434 |
| `npm audit --audit-level=high` | Zero vulnerabilities |
| `npm audit --prefix addons/resonant-browser-host --audit-level=high` | Zero vulnerabilities |
| `node scripts/engineer-runner.mjs verify <task-contract.json>` | Complete staged two-file patch verified; focused tests, staged scope audit, and diff check passed |
| `git diff --cached --check` | Passed before commit |

The first full run used a temporary home directory and hit the existing macOS Library protection assertion. Unchanged dev reproduced that failure; its 27-test suite passed with the normal home directory. The complete passing run used the normal home directory in an otherwise sanitized environment. No tests or timeouts were weakened.

Live-browser proof: real unpacked Chrome extension and authenticated Node bridge; unchanged blank-token test returned 200, and a changed target received no inherited token. The loaded source was verified after reinstalling the extension. Before/after screenshots were inspected locally and are not attached; the observed behavior is recorded here and in the linked issue.

Hosted CI on this exact published head: [alpha-build passed](https://github.com/ResonantOS/2.0.0-alpha/actions/runs/34053605912), including the full Verify Alpha gate, extension packaging, and artifact scan. The security-observe check also passed. Earlier local failures remain recorded above.

## Documentation

Documentation impact: no documentation change. The patch restores the token field's existing documented behavior within the active target boundary.

## Checklist

- [x] The PR targets `dev`; the branch contains only this two-file change.
- [ ] The linked issue and Project 2 fields reflect accepted release scope.
- [x] Module ownership and boundaries reviewed.
- [x] Safety, privacy, secrets, and human actions assessed.
- [x] Regression tests added and exact validation recorded.
- [x] Redacted live-browser observations and reproduction steps are recorded above and in the linked issue (screenshots remain local).
- [x] Documentation impact explained.
- [x] Patch excludes credentials, private data, browser state, and local evidence.
