### PR TITLE
extension: recover add-on execution settings after request failures

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/lib/settings/addons-section.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/settings/addons-section.js
@@ -109,9 +109,35 @@ export function renderAddonsSection(container, { bridgeRequest, getBridgeRequest
   const bridge = () => (typeof getBridgeRequest === "function" ? getBridgeRequest() : bridgeRequest);
   const statusNode = document.createElement("p");
   statusNode.className = "settings-status";
+  statusNode.setAttribute("role", "status");
   statusNode.textContent = "Loading add-on registry...";
   const grid = document.createElement("div");
   grid.className = "settings-addon-grid";
+  const refreshExecution = document.createElement("button");
+  refreshExecution.type = "button";
+  refreshExecution.textContent = "Refresh execution state";
+  refreshExecution.hidden = true;
+  let updatingExecution = false;
+
+  function lockExecutionControls(unknown = false) {
+    for (const panel of grid.querySelectorAll(".settings-addon-execution")) {
+      panel.querySelector("button").disabled = true;
+      if (unknown) panel.querySelector("small").textContent = "Current execution state could not be confirmed. Refresh before changing it.";
+    }
+  }
+
+  refreshExecution.addEventListener("click", async () => {
+    if (updatingExecution || refreshExecution.disabled) return;
+    refreshExecution.disabled = true;
+    try {
+      await load();
+      refreshExecution.hidden = true;
+    } catch (error) {
+      setStatus(statusNode, `Execution state could not be confirmed: ${safeErrorMessage(error)}. Try refreshing again.`, "error");
+    } finally {
+      refreshExecution.disabled = false;
+    }
+  });
 
   container.replaceChildren(
     settingsHeader({
@@ -120,6 +146,7 @@ export function renderAddonsSection(container, { bridgeRequest, getBridgeRequest
       body: "Enable replaceable capabilities without lock-in. Start by checking availability and trust posture; open details only when you need grants or runtime controls."
     }),
     statusNode,
+    refreshExecution,
     noteCard({
       title: "Permission rule",
       body: "Add-ons declare requirements. ResonantOS mediates provider, memory, browser, filesystem, and future wallet access through scoped capability grants."
@@ -132,14 +159,35 @@ export function renderAddonsSection(container, { bridgeRequest, getBridgeRequest
     const addons = Array.isArray(result.addons) ? result.addons : [];
     grid.replaceChildren(...addons.map((addon) => addonCard(addon, {
       onToggleExecution: async (selected, enabled) => {
+        if (updatingExecution || refreshExecution.disabled) return;
+        updatingExecution = true;
+        lockExecutionControls();
+        refreshExecution.hidden = true;
         const addon = selected.id === "addon.hermes" ? "hermes" : "opencode";
         setStatus(statusNode, `${enabled ? "Enabling" : "Disabling"} ${selected.name} local execution...`);
-        await bridge()("/addons/execution-settings", {
-          method: "POST",
-          capability: "addon-execution-settings-write",
-          body: { addon, localCliExecution: enabled }
-        });
-        await load();
+        let writeError = null;
+        try {
+          await bridge()("/addons/execution-settings", {
+            method: "POST",
+            capability: "addon-execution-settings-write",
+            body: { addon, localCliExecution: enabled }
+          });
+        } catch (error) {
+          writeError = error;
+        }
+        // A failed response can leave the write outcome uncertain. Read the host state before another change.
+        try {
+          await load();
+          if (writeError) setStatus(statusNode, `Execution change request failed: ${safeErrorMessage(writeError)}. Current state refreshed; review it before retrying.`, "error");
+        } catch (error) {
+          lockExecutionControls(true);
+          refreshExecution.hidden = false;
+          setStatus(statusNode, writeError
+            ? `Execution change request failed: ${safeErrorMessage(writeError)}. Current state could not be confirmed; refresh before retrying.`
+            : `Execution setting saved, but current state could not be confirmed: ${safeErrorMessage(error)}. Refresh to confirm it.`, "warning");
+        } finally {
+          updatingExecution = false;
+        }
       }
     })));
     setStatus(statusNode, addons.length

--- a/browser-first/test/settings-addon-execution-feedback.test.mjs
+++ b/browser-first/test/settings-addon-execution-feedback.test.mjs
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { JSDOM } from "jsdom";
+import { renderAddonsSection } from "../resonantos-side-panel-extension/src/lib/settings/addons-section.js";
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+async function setup(t, request) {
+  const dom = new JSDOM("<main></main>");
+  globalThis.document = dom.window.document;
+  t.after(() => { dom.window.close(); delete globalThis.document; });
+  const root = document.querySelector("main");
+  renderAddonsSection(root, { bridgeRequest: request });
+  await tick();
+  return { root, status: root.querySelector(".settings-status"),
+    toggle: () => root.querySelector(".settings-addon-execution button"),
+    retry: () => [...root.querySelectorAll("button")].find((button) => button.textContent === "Refresh execution state") };
+}
+const snapshot = (enabled) => ({ addons: [{ id: "addon.hermes", name: "Hermes", available: true, execution: { localCliExecution: enabled } }] });
+
+test("an uncertain write response shows the actual changed host state without repeating the write", async (t) => {
+  let enabled = true;
+  let writes = 0;
+  const ui = await setup(t, async (_route, options) => {
+    if (options.method === "POST") {
+      writes++;
+      enabled = false;
+      throw Error("response unavailable");
+    }
+    return snapshot(enabled);
+  });
+  ui.toggle().click(); await tick();
+  assert.equal(writes, 1);
+  assert.match(ui.status.textContent, /request failed/);
+  assert.equal(ui.toggle().textContent, "Enable local execution");
+});
+
+test("rejected execution change reports failure and refreshes the actual state for retry", async (t) => {
+  let enabled = true;
+  let writes = 0;
+  const ui = await setup(t, async (_route, options) => {
+    if (options.method === "POST") {
+      if (++writes === 1) throw Error("fixture write unavailable");
+      enabled = options.body.localCliExecution;
+    }
+    return snapshot(enabled);
+  });
+  ui.toggle().click(); await tick();
+  assert.match(ui.status.textContent, /failed.*fixture write unavailable/i);
+  assert.equal(ui.toggle().textContent, "Disable local execution");
+  assert.equal(ui.toggle().disabled, false);
+  ui.toggle().click(); await tick();
+  assert.equal(writes, 2);
+  assert.equal(enabled, false);
+  assert.equal(ui.toggle().textContent, "Enable local execution");
+});
+
+test("successful write followed by failed status refresh offers a read-only recovery", async (t) => {
+  let writes = 0;
+  let failRead = true;
+  const ui = await setup(t, async (_route, options) => {
+    if (options.method === "POST") { writes++; return { ok: true }; }
+    if (writes && failRead) throw Error("fixture refresh unavailable");
+    return snapshot(!writes);
+  });
+  ui.toggle().click(); await tick();
+  assert.equal(writes, 1);
+  assert.match(ui.status.textContent, /saved.*could not.*confirm/i);
+  assert.equal(ui.toggle().disabled, true);
+  assert.equal(ui.retry().hidden, false);
+  failRead = false;
+  ui.retry().click(); await tick();
+  assert.equal(writes, 1);
+  assert.equal(ui.retry().hidden, true);
+  assert.equal(ui.toggle().textContent, "Enable local execution");
+  assert.equal(ui.toggle().disabled, false);
+});
+
+test("pending execution write disables controls and prevents duplicate submission", async (t) => {
+  let writes = 0;
+  let finish;
+  const ui = await setup(t, async (_route, options) => {
+    if (options.method === "POST") { writes++; await new Promise((resolve) => { finish = resolve; }); }
+    return snapshot(!writes);
+  });
+  ui.toggle().click(); ui.toggle().click();
+  assert.equal(writes, 1);
+  assert.equal(ui.toggle().disabled, true);
+  finish(); await tick();
+  assert.equal(ui.toggle().disabled, false);
+  assert.equal(ui.status.getAttribute("role"), "status");
+});
+
+test("failed write and failed refresh leave execution state unconfirmed until a read succeeds", async (t) => {
+  let writes = 0;
+  let failRead = true;
+  const ui = await setup(t, async (_route, options) => {
+    if (options.method === "POST") { writes++; throw Error("write unavailable"); }
+    if (writes && failRead) throw Error("read unavailable");
+    return snapshot(true);
+  });
+  ui.toggle().click(); await tick();
+  assert.match(ui.status.textContent, /failed/i);
+  assert.equal(ui.toggle().disabled, true);
+  ui.retry().click(); await tick();
+  assert.equal(ui.retry().hidden, false);
+  assert.equal(writes, 1);
+  failRead = false;
+  ui.retry().click(); await tick();
+  assert.equal(ui.toggle().textContent, "Disable local execution");
+  assert.equal(ui.toggle().disabled, false);
+});


### PR DESCRIPTION
## Scope

An execution-setting request failure previously left Settings > Add-ons showing Enabling or Disabling with a stale control. The change reports failures, reconciles host state even after a failed POST response, and offers a GET-only recovery when current state cannot be confirmed. Pending or unconfirmed changes lock execution controls.

Closes #360.

Project 2 release scope: pending maintainer triage.
Project 2 area: proposed Settings; not assigned by this contribution.

## Modules And Ownership

- Affected modules: workspace presentation, `browser-first/resonantos-side-panel-extension/src/lib/settings/addons-section.js`; regression tests, `browser-first/test/settings-addon-execution-feedback.test.mjs`.
- Ownership or boundary review: one renderer and one test file. No module moves, host changes, execution-policy changes, or ownership-map changes.

## Safety And Privacy

- Safety/privacy impact: local execution requires the existing explicit setting and governed task path. Uncertain state blocks another change until refreshed; recovery never repeats a write.
- Required human handoff or approval boundary: existing execution-setting confirmation remains in place. Maintainers decide release scope and merge.
- Secret-handling impact: none; no generated credentials, browser profiles, logs, or local host settings in the patch.

## Validation

Validated on Node.js 22.13.0 against `85957ae386d9e0c20813bc5e2c3ad4203c485f8a`.

- `node --test browser-first/test/settings-addon-execution-feedback.test.mjs`:5 passed.
- Staged Engineer Runner verification and `git diff --cached --check`: passed for the exact two-file patch.
- `npm run verify:alpha`: hygiene, docs checks,229 documentation tests, and build passed; desktop433/434 with a 20-second Notes-save timeout.
- `npm test -- --run --maxWorkers=1 --no-file-parallelism`:433/434, with a different 5-second compact-memory test timeout. The Notes test passed.
- `npm test -- --run src/App.test.tsx --maxWorkers=1 --no-file-parallelism -t 'opens the Resonant Notes workspace and saves a note through the audited host command|carries compact memory into a branched chat before the next provider request'`:2 passed,69 intentionally skipped. This does not make either full desktop run green.
- `npm run test:browser-first`:1101/1101 passed.
- All remaining certification commands passed: `npm run test:browser-host`, `npm run test:living-archive-mcp`, `npm run test:living-archive-memory-service`, `npm run test:health`, `npm run test:engineer-runner`, `npm run test:security-pipeline`, `npm run test:module-ownership`, `node scripts/security-pipeline/run-check.mjs --certify`, `npm run pre-release:scan`, `node scripts/browser-first-release-scope-audit.mjs --committed --strict`.
- `npm audit --audit-level=high` and `npm audit --prefix addons/resonant-browser-host --audit-level=high`: zero vulnerabilities.

Final desktop recheck: `npm test -- --run --maxWorkers=1 --no-file-parallelism` passed all 434 tests after the other full suites and browser proof processes finished. All 16 stages now have passing results across runs; the earlier failures remain disclosed above.

Live-browser proof: actual unpacked Chrome and Node22 bridge verified rejected writes, applied writes with failed responses, saved writes with failed refreshes, and GET-only recovery. Before/after screenshots were inspected locally and are not attached; the observed behavior is recorded here and in the linked issue. Earlier desktop failures remain visible above. No assertions, timeouts, or configuration were weakened.

Hosted CI on this exact published head: [alpha-build passed](https://github.com/ResonantOS/2.0.0-alpha/actions/runs/34053635571), including the full Verify Alpha gate, extension packaging, and artifact scan. The security-observe check also passed. Earlier local failures remain recorded above.

## Documentation

Documentation impact: recovery behavior uses the existing Settings workflow; installation, routes, capabilities, and contributor guidance are unchanged. Regression tests describe the changed states.

## Checklist

- [x] The branch targets `dev` and does not include unrelated work.
- [ ] The linked issue and Project 2 fields reflect the intended release scope.
- [x] I reviewed module ownership and called out every cross-module boundary change.
- [x] I assessed security, privacy, secrets, and required human-only actions.
- [x] I added or updated tests for behavior changes.
- [x] I recorded every relevant command and its actual result above.
- [x] Redacted live-browser observations and reproduction steps are recorded above and in the linked issue (screenshots remain local).
- [x] I updated current documentation or explained why no documentation changed.
- [x] This pull request contains no credentials, tokens, private user data, browser profiles, or unredacted sensitive logs.
