### PR TITLE
extension: preserve routing drafts when another strategy saves

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/lib/settings/routing-section.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/settings/routing-section.js
@@ -41,6 +41,7 @@ function routingCard({ strategy, models, bridgeRequest, getBridgeRequest, status
   const bridge = () => (typeof getBridgeRequest === "function" ? getBridgeRequest() : bridgeRequest);
   const card = document.createElement("article");
   card.className = "settings-routing-card";
+  card.dataset.strategyId = strategy.id;
   card.dataset.state = strategy.routeState;
 
   const heading = document.createElement("div");
@@ -98,6 +99,7 @@ function routingCard({ strategy, models, bridgeRequest, getBridgeRequest, status
   form.append(primary, fallback, cost, hardStop, save);
   form.addEventListener("submit", async (event) => {
     event.preventDefault();
+    if (save.disabled) return;
     save.disabled = true;
     setStatus(statusNode, `Saving ${strategy.label} routing strategy...`);
     try {
@@ -147,18 +149,27 @@ export function renderRoutingSection(container, { bridgeRequest, getBridgeReques
     })
   );
 
-  const load = async () => {
+  const load = async (savedStrategyId = null) => {
     const result = await bridge()("/providers/routing-strategies", { method: "GET" });
     const models = Array.isArray(result.models) ? result.models : [];
     const strategies = Array.isArray(result.strategies) ? result.strategies : [];
-    grid.replaceChildren(...strategies.map((strategy) => routingCard({
+    const renderCard = (strategy) => routingCard({
       strategy,
       models,
       bridgeRequest,
       getBridgeRequest,
       statusNode,
-      reload: load
-    })));
+      reload: () => load(strategy.id)
+    });
+    if (savedStrategyId === null) {
+      grid.replaceChildren(...strategies.map(renderCard));
+    } else {
+      // Refresh only the saved strategy; other cards may contain unsaved user edits.
+      const saved = strategies.find((strategy) => strategy.id === savedStrategyId);
+      if (!saved) throw new Error("Saved strategy is missing from the refreshed routing response.");
+      const card = [...grid.children].find((node) => node.dataset.strategyId === savedStrategyId);
+      card?.replaceWith(renderCard(saved));
+    }
     const routable = strategies.filter((strategy) => strategy.routeState === "routable").length;
     setStatus(statusNode, strategies.length
       ? `${routable}/${strategies.length} routing strategies currently have at least one available route.`

--- a/browser-first/test/settings-routing-drafts.test.mjs
+++ b/browser-first/test/settings-routing-drafts.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { JSDOM } from "jsdom";
+import { renderRoutingSection } from "../resonantos-side-panel-extension/src/lib/settings/routing-section.js";
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+async function setup(t, { failWrite = false, holdWrite = false } = {}) {
+  const dom = new JSDOM("<main></main>");
+  globalThis.document = dom.window.document;
+  t.after(() => { dom.window.close(); delete globalThis.document; });
+  const strategies = ["a", "b"].map((id) => ({ id, label: id, primaryModel: "fixture-model", fallbackModels: [], costPosture: "subscription-first", hardStop: false }));
+  const writes = [];
+  let finish;
+  const root = document.querySelector("main");
+  renderRoutingSection(root, { bridgeRequest: async (_route, options) => {
+    if (options.method === "POST") {
+      writes.push(options.body);
+      if (failWrite) throw Error("fixture write failed");
+      if (holdWrite) await new Promise((resolve) => { finish = resolve; });
+      Object.assign(strategies.find((strategy) => strategy.id === options.body.strategyId), options.body);
+      return { ok: true };
+    }
+    return { models: [{ model: "fixture-model", label: "Fixture", providerLabel: "Fixture" }], strategies };
+  } });
+  await tick();
+  return { root, writes, finish: () => finish(), forms: () => root.querySelectorAll("form"),
+    submit: (index) => root.querySelectorAll("form")[index].dispatchEvent(new dom.window.Event("submit", { cancelable: true })) };
+}
+
+test("saving one routing strategy preserves another strategy's unsaved fallback and hard-stop edits", async (t) => {
+  const ui = await setup(t);
+  const draft = ui.forms()[1];
+  draft.elements.fallbackModels.value = "fixture-fallback";
+  draft.elements.hardStop.checked = true;
+  ui.forms()[0].elements.costPosture.value = "quality-first";
+  ui.submit(0); await tick();
+  assert.equal(ui.forms()[1], draft);
+  assert.equal(draft.elements.fallbackModels.value, "fixture-fallback");
+  assert.equal(draft.elements.hardStop.checked, true);
+  assert.equal(ui.forms()[0].elements.costPosture.value, "quality-first");
+  ui.submit(1); await tick();
+  assert.equal(ui.writes.length, 2);
+  assert.deepEqual(ui.writes[1].fallbackModels, ["fixture-fallback"]);
+  assert.equal(ui.writes[1].hardStop, true);
+});
+
+test("failed routing save preserves both forms and exposes the error", async (t) => {
+  const ui = await setup(t, { failWrite: true });
+  ui.forms()[0].elements.fallbackModels.value = "first-draft";
+  ui.forms()[1].elements.fallbackModels.value = "second-draft";
+  ui.submit(0); await tick();
+  assert.equal(ui.forms()[0].elements.fallbackModels.value, "first-draft");
+  assert.equal(ui.forms()[1].elements.fallbackModels.value, "second-draft");
+  assert.match(ui.root.querySelector(".settings-status").textContent, /Save failed/);
+});
+
+test("edits made while a different strategy is saving survive its refresh", async (t) => {
+  const ui = await setup(t, { holdWrite: true });
+  ui.submit(0); ui.submit(0);
+  assert.equal(ui.writes.length, 1);
+  ui.forms()[1].elements.costPosture.value = "low-cost-first";
+  ui.finish(); await tick();
+  assert.equal(ui.forms()[1].elements.costPosture.value, "low-cost-first");
+});


### PR DESCRIPTION
## Scope

Saving one routing strategy previously replaced every form and silently discarded other drafts. Refresh only the saved strategy so other forms retain unsaved model, fallback, cost, and hard-stop choices. Guard duplicate submissions while a save is pending.

Closes #361.

Project 2 release scope: pending maintainer triage.
Project 2 area: proposed Settings; not assigned by this contribution.

## Modules And Ownership

- Affected modules: workspace presentation, `browser-first/resonantos-side-panel-extension/src/lib/settings/routing-section.js`; regression tests, `browser-first/test/settings-routing-drafts.test.mjs`.
- Ownership or boundary review: one renderer and one test file. Host routing policy, storage format, capabilities, and ownership boundaries are unchanged.

## Safety And Privacy

- Safety/privacy impact: retain unsaved cost and hard-stop choices without implicitly saving other strategies.
- Required human handoff or approval boundary: each strategy still requires its own explicit Save. Maintainers decide release scope and merge.
- Secret-handling impact: no credentials or personal configuration in the patch. Browser proof used disposable routing settings and made no provider call.

## Validation

Validated on Node.js 22.13.0 against `85957ae386d9e0c20813bc5e2c3ad4203c485f8a`.

- `node --test browser-first/test/settings-routing-drafts.test.mjs`: 3 passed.
- Staged Engineer Runner verification and `git diff --cached --check`: passed for the complete two-file patch.
- `npm run verify:alpha`: hygiene, docs checks, 229 documentation tests, and build passed; initial desktop run timed out in `auto-launches OpenCode when workspace access is already configured` (433/434 passed).
- `npm test -- --run --maxWorkers=1 --no-file-parallelism`: full desktop recheck passed 434/434.
- `npm run test:browser-first`: 1099/1099 passed.
- All remaining commands passed: `npm run test:browser-host`, `npm run test:living-archive-mcp`, `npm run test:living-archive-memory-service`, `npm run test:health`, `npm run test:engineer-runner`, `npm run test:security-pipeline`, `npm run test:module-ownership`, `node scripts/security-pipeline/run-check.mjs --certify`, `npm run pre-release:scan`, `node scripts/browser-first-release-scope-audit.mjs --committed --strict`.
- `npm audit --audit-level=high` and `npm audit --prefix addons/resonant-browser-host --audit-level=high`: zero vulnerabilities.

All 16 validation stages have passing results across the initial run and rechecks. The initial aggregate was not green. No assertions, timeouts, desktop code, or test configuration changed.

Live-browser proof: the real bridge returned POST200 for strategy A; the candidate preserved strategy B's fallback and hard-stop draft, while unchanged dev discarded it. Before/after screenshots were inspected locally and are not attached; the observed behavior is recorded here and in the linked issue.

Hosted CI on this exact published head: [alpha-build passed](https://github.com/ResonantOS/2.0.0-alpha/actions/runs/34053649102), including the full Verify Alpha gate, extension packaging, and artifact scan. The security-observe check also passed. Earlier local failures remain recorded above.

## Documentation

Documentation impact: fixes draft loss in the existing per-strategy Save workflow. Installation, routing policy, and contributor guidance are unchanged; regression tests describe draft preservation.

## Checklist

- [x] The branch targets `dev` and does not include unrelated work.
- [ ] The linked issue and Project 2 fields reflect the intended release scope.
- [x] I reviewed module ownership and called out every cross-module boundary change.
- [x] I assessed security, privacy, secrets, and required human-only actions.
- [x] I added or updated tests for behavior changes.
- [x] I recorded every relevant command and its actual result above.
- [x] Redacted live-browser observations and reproduction steps are recorded above and in the linked issue (screenshots remain local).
- [x] I updated current documentation or explained why no documentation changed.
- [x] This pull request contains no credentials, tokens, private user data, browser profiles, or unredacted sensitive logs.
