### PR TITLE
extension: show diagnostics independently and retry unavailable checks

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/lib/settings/diagnostics-section.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/settings/diagnostics-section.js
@@ -1,6 +1,9 @@
 import { metricCard, noteCard, safeErrorMessage, setStatus, settingsHeader } from "./settings-common.js";
 
+const DIAGNOSTICS_TIMEOUT_MS = 10_000;
+
 function serviceStatus(result) {
+  if (result.status === "pending") return { value: "Checking", detail: "waiting for status endpoint", tone: "" };
   if (result.status === "rejected") {
     return { value: "Error", detail: safeErrorMessage(result.reason), tone: "warning" };
   }
@@ -8,6 +11,7 @@ function serviceStatus(result) {
 }
 
 function browserLaunchStatus(result) {
+  if (result.status === "pending") return { value: "Checking", detail: "waiting for browser diagnostics", tone: "" };
   if (result.status === "rejected") {
     return { value: "Error", detail: safeErrorMessage(result.reason), tone: "warning" };
   }
@@ -53,6 +57,7 @@ export function renderDiagnosticsSection(container, { bridgeRequest, getBridgeRe
   const bridge = () => (typeof getBridgeRequest === "function" ? getBridgeRequest() : bridgeRequest);
   const statusNode = document.createElement("p");
   statusNode.className = "settings-status";
+  statusNode.setAttribute("role", "status");
   statusNode.textContent = "Checking diagnostics endpoints...";
   const grid = document.createElement("div");
   grid.className = "settings-health-grid settings-diagnostics-health";
@@ -60,8 +65,13 @@ export function renderDiagnosticsSection(container, { bridgeRequest, getBridgeRe
     metricCard({ label: "Bridge", value: "Checking", detail: "loading system status" }),
     metricCard({ label: "Providers", value: "Checking", detail: "loading provider status" }),
     metricCard({ label: "Add-ons", value: "Checking", detail: "loading add-on status" }),
-    metricCard({ label: "Memory", value: "Checking", detail: "loading memory status" })
+    metricCard({ label: "Memory", value: "Checking", detail: "loading memory status" }),
+    metricCard({ label: "Chromium", value: "Checking", detail: "loading browser diagnostics" })
   );
+  const retry = document.createElement("button");
+  retry.type = "button";
+  retry.textContent = "Retry unavailable checks";
+  retry.hidden = true;
 
   const details = document.createElement("ol");
   details.className = "settings-diagnostics-list";
@@ -96,6 +106,7 @@ export function renderDiagnosticsSection(container, { bridgeRequest, getBridgeRe
       body: "Check whether ResonantOS is healthy. Detailed endpoint data and redacted report export are available when needed."
     }),
     statusNode,
+    retry,
     grid,
     endpointDetails,
     exportDetails
@@ -118,16 +129,28 @@ export function renderDiagnosticsSection(container, { bridgeRequest, getBridgeRe
     }
   });
 
-  const load = async () => {
-    const [statusResult, providerResult, addonResult, memoryResult] = await Promise.allSettled([
-      bridge()("/status", { method: "GET" }),
-      bridge()("/providers/status", { method: "GET" }),
-      bridge()("/addons/status", { method: "GET" }),
-      bridge()("/memory/status", { method: "GET" })
-    ]);
-    const [browserLaunchResult] = await Promise.allSettled([
-      bridge()("/browser/launch-diagnostics", { method: "GET" })
-    ]);
+  const routes = ["/status", "/providers/status", "/addons/status", "/memory/status", "/browser/launch-diagnostics"];
+  const results = routes.map(() => ({ status: "pending" }));
+
+  async function probe(route) {
+    const controller = new AbortController();
+    let timer;
+    // Bound each endpoint separately, including transports that ignore AbortSignal.
+    const timeout = new Promise((_, reject) => {
+      timer = setTimeout(() => {
+        reject(new Error("Status request timed out after 10 seconds."));
+        controller.abort();
+      }, DIAGNOSTICS_TIMEOUT_MS);
+    });
+    try {
+      return await Promise.race([bridge()(route, { method: "GET", signal: controller.signal }), timeout]);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  function renderResults() {
+    const [statusResult, providerResult, addonResult, memoryResult, browserLaunchResult] = results;
     const statusValue = serviceStatus(statusResult);
     const providerValue = serviceStatus(providerResult);
     const addonValue = serviceStatus(addonResult);
@@ -149,28 +172,28 @@ export function renderDiagnosticsSection(container, { bridgeRequest, getBridgeRe
     details.replaceChildren(
       diagnosticsRow({
         label: "Bridge",
-        value: system?.bridge ?? "Unavailable",
-        detail: statusResult.status === "fulfilled" ? "Core bridge responded." : safeErrorMessage(statusResult.reason)
+        value: statusResult.status === "pending" ? "Checking" : system?.bridge ?? "Unavailable",
+        detail: statusResult.status === "pending" ? "Waiting for bridge status." : statusResult.status === "fulfilled" ? "Core bridge responded." : safeErrorMessage(statusResult.reason)
       }),
       diagnosticsRow({
         label: "Providers",
-        value: `${providers.filter((provider) => provider.configured).length}/${providers.length}`,
+        value: providerResult.status === "pending" ? "Checking" : `${providers.filter((provider) => provider.configured).length}/${providers.length}`,
         detail: "configured provider profiles"
       }),
       diagnosticsRow({
         label: "Add-ons",
-        value: `${addons.filter((addon) => addon.available || addon.enabled).length}/${addons.length}`,
+        value: addonResult.status === "pending" ? "Checking" : `${addons.filter((addon) => addon.available || addon.enabled).length}/${addons.length}`,
         detail: "available add-ons"
       }),
       diagnosticsRow({
         label: "Memory",
-        value: `${memory?.wiki?.pages ?? 0} pages`,
-        detail: `${memory?.intake?.artifacts ?? 0} intake artifacts`
+        value: memoryResult.status === "pending" ? "Checking" : `${memory?.wiki?.pages ?? 0} pages`,
+        detail: memoryResult.status === "pending" ? "Waiting for memory status." : `${memory?.intake?.artifacts ?? 0} intake artifacts`
       }),
       diagnosticsRow({
         label: "Chromium host",
-        value: browserLaunch?.status ?? "Unavailable",
-        detail: browserLaunchResult.status === "fulfilled"
+        value: browserLaunchResult.status === "pending" ? "Checking" : browserLaunch?.status ?? "Unavailable",
+        detail: browserLaunchResult.status === "pending" ? "Waiting for browser diagnostics." : browserLaunchResult.status === "fulfilled"
           ? [
               `launch=${browserLaunch.launchMode ?? "unknown"}`,
               `menu=${browserLaunch.appkitMenu ?? "unknown"}`,
@@ -181,16 +204,29 @@ export function renderDiagnosticsSection(container, { bridgeRequest, getBridgeRe
           : safeErrorMessage(browserLaunchResult.reason)
       })
     );
-    const failed = [statusResult, providerResult, addonResult, memoryResult, browserLaunchResult]
-      .filter((result) => result.status === "rejected").length;
-    setStatus(statusNode, failed
+    const failed = results.filter((result) => result.status === "rejected").length;
+    const pending = results.filter((result) => result.status === "pending").length;
+    retry.hidden = failed === 0;
+    setStatus(statusNode, pending
+      ? `Checking ${pending} diagnostics endpoint${pending === 1 ? "" : "s"}; ${failed} unavailable.`
+      : failed
       ? `Diagnostics loaded with ${failed} unavailable endpoint${failed === 1 ? "" : "s"}.`
       : "Diagnostics loaded from host-mediated status endpoints.",
-      failed ? "warning" : "success"
+      failed ? "warning" : pending ? "" : "success"
     );
-  };
+  }
 
-  void load().catch((error) => {
-    setStatus(statusNode, `Diagnostics unavailable: ${safeErrorMessage(error)}`, "error");
+  function startCheck(index) {
+    results[index] = { status: "pending" };
+    void probe(routes[index]).then(
+      (value) => { results[index] = { status: "fulfilled", value }; renderResults(); },
+      (reason) => { results[index] = { status: "rejected", reason }; renderResults(); }
+    );
+  }
+
+  retry.addEventListener("click", () => {
+    results.forEach((result, index) => { if (result.status === "rejected") startCheck(index); });
+    renderResults();
   });
+  routes.forEach((_, index) => startCheck(index));
 }

--- a/browser-first/test/main-workspace-settings.test.mjs
+++ b/browser-first/test/main-workspace-settings.test.mjs
@@ -2258,6 +2258,8 @@ test("settings workspace renders add-on status and capability boundaries", async
     container.querySelector('[data-section="diagnostics"]').click();
     assert.match(container.textContent, /Diagnostics/);
     assert.match(container.textContent, /Checking diagnostics endpoints/);
+    await waitForCondition(() => /Diagnostics loaded from host-mediated status endpoints/.test(container.textContent));
+    assert.match(container.textContent, /Diagnostics loaded from host-mediated status endpoints/);
   } finally {
     cleanup();
   }

--- a/browser-first/test/settings-diagnostics-recovery.test.mjs
+++ b/browser-first/test/settings-diagnostics-recovery.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { setImmediate } from "node:timers/promises";
+import { JSDOM } from "jsdom";
+import { renderDiagnosticsSection } from "../resonantos-side-panel-extension/src/lib/settings/diagnostics-section.js";
+
+async function setup(t, request) {
+  const dom = new JSDOM("<main></main>");
+  globalThis.document = dom.window.document;
+  t.after(() => { dom.window.close(); delete globalThis.document; });
+  const root = document.querySelector("main");
+  renderDiagnosticsSection(root, { bridgeRequest: request });
+  await setImmediate();
+  return { root, values: () => [...root.querySelectorAll(".settings-diagnostics-health strong")].map((node) => node.textContent),
+    retry: () => [...root.querySelectorAll("button")].find((node) => node.textContent === "Retry unavailable checks") };
+}
+const ready = { ok: true, status: "ready", providers: [], addons: [] };
+
+test("a pending endpoint does not block completed services or the browser diagnostic request", async (t) => {
+  let finish;
+  const calls = [];
+  const ui = await setup(t, async (route) => {
+    calls.push(route);
+    if (route === "/memory/status") return new Promise((resolve) => { finish = resolve; });
+    return ready;
+  });
+  try {
+    assert.equal(calls.length, 5);
+    assert.deepEqual(ui.values(), ["Ready", "Ready", "Ready", "Checking", "Ready"]);
+    assert.match(ui.root.querySelector(".settings-status").textContent, /1.*endpoint/);
+  } finally {
+    finish(ready);
+    await setImmediate();
+  }
+});
+
+test("a timed-out endpoint aborts, offers retry, and ignores its late completion", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  let finishOld;
+  let signal;
+  let memoryCalls = 0;
+  const calls = [];
+  const ui = await setup(t, async (route, options) => {
+    calls.push(route);
+    if (route === "/memory/status" && ++memoryCalls === 1) {
+      signal = options.signal;
+      return new Promise((resolve) => { finishOld = resolve; });
+    }
+    return ready;
+  });
+  t.mock.timers.tick(10_000);
+  await setImmediate();
+  assert.equal(signal.aborted, true);
+  assert.equal(ui.values()[3], "Error");
+  assert.match(ui.root.textContent, /timed out/i);
+  assert.equal(ui.retry().hidden, false);
+  ui.retry().click(); ui.retry().click();
+  await setImmediate();
+  assert.equal(calls.length, 6);
+  assert.equal(memoryCalls, 2);
+  assert.deepEqual(ui.values(), ["Ready", "Ready", "Ready", "Ready", "Ready"]);
+  assert.equal(ui.retry().hidden, true);
+  finishOld({ ok: true, wiki: { pages: 999 } });
+  await setImmediate();
+  assert.doesNotMatch(ui.root.textContent, /999 pages/);
+});
+
+test("retry checks only failed endpoints and keeps successful results visible", async (t) => {
+  let providerCalls = 0;
+  let otherCalls = 0;
+  const ui = await setup(t, async (route) => {
+    if (route === "/providers/status") {
+      if (++providerCalls === 1) throw Error("fixture provider unavailable");
+    } else otherCalls++;
+    return ready;
+  });
+  assert.deepEqual(ui.values(), ["Ready", "Error", "Ready", "Ready", "Ready"]);
+  ui.retry().click(); await setImmediate();
+  assert.equal(providerCalls, 2);
+  assert.equal(otherCalls, 4);
+  assert.equal(ui.retry().hidden, true);
+  assert.equal(ui.root.querySelector(".settings-status").getAttribute("role"), "status");
+});


### PR DESCRIPTION
## Scope

One stalled status request previously kept every Diagnostics card at Checking and prevented browser diagnostics from starting. Start all five checks together, render each result independently, bound requests at ten seconds, and retry unavailable checks only. Late results from timed-out attempts cannot overwrite a retry.

Closes #362.

Project 2 release scope: pending maintainer triage.
Project 2 area: proposed Settings; not assigned by this contribution.

## Modules And Ownership

- Affected modules: workspace presentation, `browser-first/resonantos-side-panel-extension/src/lib/settings/diagnostics-section.js`; focused regression tests, `browser-first/test/settings-diagnostics-recovery.test.mjs`; integration coverage, `browser-first/test/main-workspace-settings.test.mjs`.
- Ownership or boundary review: one renderer, one new test file, and a two-line integration-test wait/assertion before DOM cleanup. No host endpoints, capability rules, report-export behavior, or ownership boundaries change.

## Safety And Privacy

- Safety/privacy impact: retries perform status GETs only. They do not change settings, restart services, or repeat successful checks.
- Required human handoff or approval boundary: GET-only retry is user initiated. Project 2 triage, hosted CI, and maintainer review remain pending. The reproduced local baseline test failure remains documented below.
- Secret-handling impact: no generated credentials, private reports, browser profiles, or user configuration in the patch. Existing response-payload interpretation remains unchanged.

## Validation

Validated on Node.js 22.13.0 against `85957ae386d9e0c20813bc5e2c3ad4203c485f8a`.

- `node --test browser-first/test/settings-diagnostics-recovery.test.mjs`: 3 passed.
- `node --test browser-first/test/main-workspace-settings.test.mjs browser-first/test/settings-diagnostics-recovery.test.mjs`: 38 passed after correcting integration-test cleanup.
- Engineer Runner verified the original renderer/test patch and the integration-test follow-up. Staged scope and whitespace checks passed; committed scope and `git diff 85957ae HEAD --check` passed on the final three-file change.
- `npm run verify:alpha`: hygiene, docs checks, 229 documentation tests, and build passed; initial desktop run failed 8 App tests (426/434). Full names and failure details are recorded in [the governing issue](https://github.com/ResonantOS/2.0.0-alpha/issues/362).
- `npm test -- --run --maxWorkers=1 --no-file-parallelism`: full desktop recheck passed 434/434 with unchanged assertions and timeouts.
- Initial `npm run test:browser-first`: all 1099 subtests passed, but the Settings test file failed because a navigation test deleted the DOM before independent diagnostics completed. The test keeps its pending-state assertions and now waits for, and asserts, completion before cleanup.
- Browser rerun after that correction: 1097/1099; Hermes and OpenCode CLI artifact smoke tests failed. Clean-environment rerun: 1098/1099, both CLI tests passed; only `settings memory section completes real move-on-import and rollback against a temporary source` failed, with preflight still pending after its fixed 20 ms wait.
- `node --test --test-concurrency=1 --test-name-pattern='settings memory section completes real move-on-import|Hermes CLI execution bridge|OpenCode CLI execution bridge' browser-first/test/main-workspace-settings.test.mjs browser-first/test/addon-cli-execution-inprocess-self-test.test.mjs`: 2/3 on both final candidate and unchanged dev. Both CLI tests pass; the same Memory preflight assertion fails on both. That test and its implementation are unchanged.
- Other commands passed: `npm run test:browser-host`, `npm run test:living-archive-mcp`, `npm run test:living-archive-memory-service`, `npm run test:health`, `npm run test:engineer-runner`, `npm run test:security-pipeline`, `npm run test:module-ownership`, `node scripts/security-pipeline/run-check.mjs --certify`, `npm run pre-release:scan`, `node scripts/browser-first-release-scope-audit.mjs --committed --strict`.
- `npm audit --audit-level=high` and `npm audit --prefix addons/resonant-browser-host --audit-level=high`: zero vulnerabilities.

The local broad browser run remained non-green due to the reproduced baseline Memory test failure. No assertion or timeout was weakened to obtain a passing result.

Live-browser proof: actual unpacked Chrome and Node22 bridge show completed results while Memory stalls, a ten-second timeout, and recovery with one additional Memory GET and no repeated healthy checks. Screenshots were inspected locally and are not attached; the observed behavior is recorded here and in the linked issue.

Hosted CI on this exact published head: [alpha-build passed](https://github.com/ResonantOS/2.0.0-alpha/actions/runs/34053664716), including the full Verify Alpha gate, extension packaging, and artifact scan. The security-observe check also passed. Earlier local failures remain recorded above.

## Documentation

Documentation impact: recovery extends the existing Diagnostics view. Installation, endpoint contracts, and report-export guidance are unchanged. Regression tests document timeout and recovery behavior.

## Checklist

- [x] The branch targets `dev` and does not include unrelated work.
- [ ] The linked issue and Project 2 fields reflect the intended release scope.
- [x] I reviewed module ownership and called out every cross-module boundary change.
- [x] I assessed security, privacy, secrets, and required human-only actions.
- [x] I added or updated tests for behavior changes.
- [x] I recorded every relevant command and its actual result above.
- [x] Redacted live-browser observations and reproduction steps are recorded above and in the linked issue (screenshots remain local).
- [x] I updated current documentation or explained why no documentation changed.
- [x] This pull request contains no credentials, tokens, private user data, browser profiles, or unredacted sensitive logs.
