### PR TITLE
security(bridge): every bridge route now requires a capability token (#346)

### DIFF
--- a/browser-first/host/addon-delegation-host-service.mjs
+++ b/browser-first/host/addon-delegation-host-service.mjs
@@ -8,15 +8,30 @@ export function createAddonDelegationHostService(handlers = {}) {
 
   return {
     addonDelegationRoutes: [
-      { method: "GET", path: "/addons/status", handler: required("executeAddonsStatus") },
-      { method: "GET", path: "/addons/execution-settings", handler: required("executeAddonExecutionSettingsGet") },
+      {
+        method: "GET",
+        path: "/addons/status",
+        requiredCapability: "addon-runtime-read",
+        handler: required("executeAddonsStatus"),
+      },
+      {
+        method: "GET",
+        path: "/addons/execution-settings",
+        requiredCapability: "addon-runtime-read",
+        handler: required("executeAddonExecutionSettingsGet"),
+      },
       {
         method: "POST",
         path: "/addons/execution-settings",
         requiredCapability: "addon-execution-settings-write",
         handler: required("executeAddonExecutionSettingsUpdate"),
       },
-      { method: "GET", path: "/opencode/status", handler: required("executeOpenCodeStatus") },
+      {
+        method: "GET",
+        path: "/opencode/status",
+        requiredCapability: "addon-runtime-read",
+        handler: required("executeOpenCodeStatus"),
+      },
       {
         method: "POST",
         path: "/hermes/dashboard/status",

--- a/browser-first/host/bridge-capability-tokens.mjs
+++ b/browser-first/host/bridge-capability-tokens.mjs
@@ -26,6 +26,7 @@ export const BRIDGE_CAPABILITY_TOKEN_SPECS = Object.freeze([
   { capability: "provider-diagnostics-read", arg: "provider-diagnostics-token", env: "RESONANTOS_BROWSER_FIRST_PROVIDER_DIAGNOSTICS_TOKEN" },
   { capability: "provider-model-invoke", arg: "provider-model-invoke-token", env: "RESONANTOS_BROWSER_FIRST_PROVIDER_MODEL_INVOKE_TOKEN" },
   { capability: "agent-control-plan", arg: "agent-control-plan-token", env: "RESONANTOS_BROWSER_FIRST_AGENT_CONTROL_PLAN_TOKEN" },
+  { capability: "memory-read", arg: "memory-read-token", env: "RESONANTOS_BROWSER_FIRST_MEMORY_READ_TOKEN" },
   { capability: "memory-settings-write", arg: "memory-settings-token", env: "RESONANTOS_BROWSER_FIRST_MEMORY_SETTINGS_TOKEN" },
   { capability: "memory-source-browse", arg: "memory-source-browse-token", env: "RESONANTOS_BROWSER_FIRST_MEMORY_SOURCE_BROWSE_TOKEN" },
   { capability: "memory-source-scan", arg: "memory-source-scan-token", env: "RESONANTOS_BROWSER_FIRST_MEMORY_SOURCE_SCAN_TOKEN" },
@@ -37,12 +38,14 @@ export const BRIDGE_CAPABILITY_TOKEN_SPECS = Object.freeze([
   { capability: "archive-read", arg: "archive-read-token", env: "RESONANTOS_BROWSER_FIRST_ARCHIVE_READ_TOKEN" },
   { capability: "archive-write", arg: "archive-write-token", env: "RESONANTOS_BROWSER_FIRST_ARCHIVE_WRITE_TOKEN" },
   { capability: "diagnostics-report-export", arg: "diagnostics-report-token", env: "RESONANTOS_BROWSER_FIRST_DIAGNOSTICS_REPORT_TOKEN" },
+  { capability: "bridge-diagnostics-read", arg: "bridge-diagnostics-read-token", env: "RESONANTOS_BROWSER_FIRST_BRIDGE_DIAGNOSTICS_READ_TOKEN" },
   { capability: "browser-download-action", arg: "browser-download-action-token", env: "RESONANTOS_BROWSER_FIRST_BROWSER_DOWNLOAD_ACTION_TOKEN" },
   { capability: "addon-execution-settings-write", arg: "addon-execution-settings-token", env: "RESONANTOS_BROWSER_FIRST_ADDON_EXECUTION_SETTINGS_TOKEN" },
   { capability: "addon-runtime-read", arg: "addon-runtime-read-token", env: "RESONANTOS_BROWSER_FIRST_ADDON_RUNTIME_READ_TOKEN" },
   { capability: "addon-runtime-control", arg: "addon-runtime-control-token", env: "RESONANTOS_BROWSER_FIRST_ADDON_RUNTIME_CONTROL_TOKEN" },
   { capability: "addon-record-read", arg: "addon-record-read-token", env: "RESONANTOS_BROWSER_FIRST_ADDON_RECORD_READ_TOKEN" },
   { capability: "addon-record-write", arg: "addon-record-write-token", env: "RESONANTOS_BROWSER_FIRST_ADDON_RECORD_WRITE_TOKEN" },
+  { capability: "extension-prefs-read", arg: "extension-prefs-read-token", env: "RESONANTOS_BROWSER_FIRST_EXTENSION_PREFS_READ_TOKEN" },
   { capability: "extension-prefs-write", arg: "extension-prefs-write-token", env: "RESONANTOS_BROWSER_FIRST_EXTENSION_PREFS_WRITE_TOKEN" },
 ]);
 

--- a/browser-first/host/browser-diagnostics-host-service.mjs
+++ b/browser-first/host/browser-diagnostics-host-service.mjs
@@ -80,10 +80,30 @@ export function createBrowserDiagnosticsHostService({
     ...service,
     executeSystemStatus,
     browserDiagnosticsRoutes: [
-      { method: "GET", path: "/status", handler: executeSystemStatus },
-      { method: "GET", path: "/workspace/inspect", handler: service.executeWorkspaceInspection },
-      { method: "GET", path: "/browser/downloads", handler: service.executeBrowserDownloads },
-      { method: "GET", path: "/browser/launch-diagnostics", handler: service.executeBrowserLaunchDiagnostics },
+      {
+        method: "GET",
+        path: "/status",
+        requiredCapability: "bridge-diagnostics-read",
+        handler: executeSystemStatus,
+      },
+      {
+        method: "GET",
+        path: "/workspace/inspect",
+        requiredCapability: "bridge-diagnostics-read",
+        handler: service.executeWorkspaceInspection,
+      },
+      {
+        method: "GET",
+        path: "/browser/downloads",
+        requiredCapability: "bridge-diagnostics-read",
+        handler: service.executeBrowserDownloads,
+      },
+      {
+        method: "GET",
+        path: "/browser/launch-diagnostics",
+        requiredCapability: "bridge-diagnostics-read",
+        handler: service.executeBrowserLaunchDiagnostics,
+      },
       {
         method: "POST",
         path: "/browser/downloads/action",

--- a/browser-first/host/browser-first-self-test-service.mjs
+++ b/browser-first/host/browser-first-self-test-service.mjs
@@ -210,7 +210,7 @@ export async function runBrowserFirstSelfTest(context) {
       bridgeCapabilityTokens,
       routes: bridgeRoutes,
     });
-    const authorized = await evaluateBridgeRequestForSelfTest({
+    const bridgeTokenOnly = await evaluateBridgeRequestForSelfTest({
       method: "GET",
       url: "/status",
       headers: { "X-ResonantOS-Bridge-Token": bridgeToken },
@@ -218,8 +218,20 @@ export async function runBrowserFirstSelfTest(context) {
       bridgeCapabilityTokens,
       routes: bridgeRoutes,
     });
+    const authorized = await evaluateBridgeRequestForSelfTest({
+      method: "GET",
+      url: "/status",
+      headers: {
+        "X-ResonantOS-Bridge-Token": bridgeToken,
+        "X-ResonantOS-Bridge-Capability-Token": bridgeCapabilityTokens["bridge-diagnostics-read"],
+      },
+      bridgeToken,
+      bridgeCapabilityTokens,
+      routes: bridgeRoutes,
+    });
     const ok = unauthorized.status === 401 &&
       wrongToken.status === 401 &&
+      bridgeTokenOnly.status === 403 &&
       authorized.status === 200 &&
       authorized.payload.ok === true;
     console.log(JSON.stringify({
@@ -228,6 +240,7 @@ export async function runBrowserFirstSelfTest(context) {
       route: "/status",
       unauthorizedStatus: unauthorized.status,
       wrongTokenStatus: wrongToken.status,
+      bridgeTokenOnlyStatus: bridgeTokenOnly.status,
       authorizedStatus: authorized.status,
     }, null, 2));
     process.exit(ok ? 0 : 1);
@@ -1350,13 +1363,16 @@ export async function runBrowserFirstSelfTest(context) {
       });
       const actualPort = bridgeServerPort(server, Number(args.get("bridge-port") ?? 0));
       const request = async (route, { method = "GET", body, capabilityToken } = {}) => {
+        const effectiveCapabilityToken = method === "GET"
+          ? capabilityTokenForRoute(route, method, capabilityToken)
+          : capabilityTokenForRoute(route, method, capabilityToken ?? "");
         const response = await fetch(`http://127.0.0.1:${actualPort}${route}`, {
           method,
           headers: {
             "Content-Type": "application/json",
             "Origin": resonantExtensionOrigin,
             "X-ResonantOS-Bridge-Token": bridgeToken,
-            ...(capabilityToken ? { "X-ResonantOS-Bridge-Capability-Token": capabilityToken } : {}),
+            ...(effectiveCapabilityToken ? { "X-ResonantOS-Bridge-Capability-Token": effectiveCapabilityToken } : {}),
           },
           ...(body ? { body: JSON.stringify(body) } : {}),
         });
@@ -1460,8 +1476,15 @@ export async function runBrowserFirstSelfTest(context) {
       await chmod(fakeOpenCode, 0o755).catch(() => undefined);
       process.env.HERMES_COMMAND = fakeHermes;
       process.env.OPENCODE_COMMAND = fakeOpenCode;
-      const request = (routePath, { method = "GET", body = {}, capabilityToken = "" } = {}) =>
-        invokeBridgeRouteForSelfTest({ method, routePath, body, capabilityToken });
+      const request = (routePath, { method = "GET", body = {}, capabilityToken } = {}) =>
+        invokeBridgeRouteForSelfTest({
+          method,
+          routePath,
+          body,
+          capabilityToken: method === "GET"
+            ? capabilityTokenForRoute(routePath, method, capabilityToken)
+            : capabilityTokenForRoute(routePath, method, capabilityToken ?? ""),
+        });
       const initial = await request("/addons/execution-settings");
       const denied = await request("/addons/execution-settings", {
         method: "POST",

--- a/browser-first/host/extension-prefs-host-service.mjs
+++ b/browser-first/host/extension-prefs-host-service.mjs
@@ -11,8 +11,8 @@
 // is debounced/coalesced via an in-memory pending-write flag. Multiple rapid
 // updates from the same client collapse into a single disk write.
 //
-// Reads do not require a capability token. Writes are capability-gated because
-// they persist host-side user preferences from the extension.
+// Reads and writes are capability-gated because extension preferences live in
+// host-side user state outside the browser profile.
 
 import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
@@ -159,7 +159,12 @@ export function createExtensionPrefsHostService({ userRoot } = {}) {
     executeWriteExtensionPrefs,
     flushPendingWrites,
     extensionPrefsRoutes: [
-      { method: "GET", path: "/settings/extension-prefs", handler: executeReadExtensionPrefs },
+      {
+        method: "GET",
+        path: "/settings/extension-prefs",
+        requiredCapability: "extension-prefs-read",
+        handler: executeReadExtensionPrefs,
+      },
       {
         method: "POST",
         path: "/settings/extension-prefs",

--- a/browser-first/host/memory-host-service.mjs
+++ b/browser-first/host/memory-host-service.mjs
@@ -8,8 +8,18 @@ export function createMemoryHostService(handlers = {}) {
 
   return {
     memoryBridgeRoutes: [
-      { method: "GET", path: "/memory/status", handler: required("executeMemoryStatus") },
-      { method: "GET", path: "/memory/settings", handler: required("executeMemorySettings") },
+      {
+        method: "GET",
+        path: "/memory/status",
+        requiredCapability: "memory-read",
+        handler: required("executeMemoryStatus"),
+      },
+      {
+        method: "GET",
+        path: "/memory/settings",
+        requiredCapability: "memory-read",
+        handler: required("executeMemorySettings"),
+      },
       {
         method: "POST",
         path: "/memory/settings",
@@ -82,7 +92,12 @@ export function createMemoryHostService(handlers = {}) {
         requiredCapability: "archive-read",
         handler: required("executeMemorySearch"),
       },
-      { method: "GET", path: "/memory/wiki/health", handler: required("executeMemoryWikiHealth") },
+      {
+        method: "GET",
+        path: "/memory/wiki/health",
+        requiredCapability: "memory-read",
+        handler: required("executeMemoryWikiHealth"),
+      },
       {
         method: "POST",
         path: "/memory/wiki/page/read",

--- a/browser-first/host/provider-host-service.mjs
+++ b/browser-first/host/provider-host-service.mjs
@@ -41,7 +41,12 @@ export function createProviderHostService({ redactDiagnosticText, extractJsonObj
   return {
     ...service,
     providerBridgeRoutes: [
-      { method: "GET", path: "/providers/status", handler: service.executeProviderStatus },
+      {
+        method: "GET",
+        path: "/providers/status",
+        requiredCapability: "provider-diagnostics-read",
+        handler: service.executeProviderStatus,
+      },
       {
         method: "POST",
         path: "/providers/health",

--- a/browser-first/resonantos-side-panel-extension/src/lib/bridge-client.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/bridge-client.js
@@ -419,6 +419,15 @@ function buildLoopbackCandidates(config) {
   return out;
 }
 
+// True when a bridge answered 403 because the route is capability-scoped (the bridge token was
+// accepted; only the per-route capability token is missing). Distinct from the IP-allowlist 403 and
+// from 401 (bridge token rejected). Exported for the settings Bridge Target probe.
+export function isCapabilityScopedBridgeReply(status, body) {
+  return status === 403
+    && typeof body?.error === "string"
+    && /requires [a-z0-9-]+ capability/i.test(body.error);
+}
+
 export async function detectLoopbackBridge(config, { fetchImpl: fetchOverride } = {}) {
   if (!config) return config;
   const fetchFn = fetchOverride ?? (typeof fetch !== "undefined" ? fetch : null);
@@ -442,10 +451,16 @@ export async function detectLoopbackBridge(config, { fetchImpl: fetchOverride } 
         signal: ac.signal,
       });
       clearTimeout(timer);
-      if (!res.ok) continue;
       let body = null;
       try { body = await res.json(); } catch { continue; }
-      if (body?.ok === true && (body?.service === "resonantos-bridge" || body?.bridge)) {
+      // A 200 {ok:true} identifies the bridge. Since #346 every route, including /status, is
+      // capability-scoped, and this probe runs BEFORE capability bootstrap, so a 403 whose body
+      // names a required capability is ALSO proof of a ResonantOS bridge that accepted our bridge
+      // token (a wrong token is 401; a foreign server has no such error shape).
+      const identified = res.ok
+        ? body?.ok === true && (body?.service === "resonantos-bridge" || body?.bridge)
+        : isCapabilityScopedBridgeReply(res.status, body);
+      if (identified) {
         return {
           ...config,
           bridgeUrl: candidate,

--- a/browser-first/resonantos-side-panel-extension/src/lib/bridge-client.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/bridge-client.js
@@ -22,6 +22,11 @@ const GENERATED_CONFIG_PREFIX = "globalThis.__RESONANTOS_BRIDGE_CONFIG__ = Objec
 const GENERATED_CONFIG_SUFFIX = ");";
 const UNAUTHORIZED_BRIDGE_ERROR = "Unauthorized browser-first bridge request.";
 const BRIDGE_ROUTE_CAPABILITIES = Object.freeze({
+  "GET /status": "bridge-diagnostics-read",
+  "GET /workspace/inspect": "bridge-diagnostics-read",
+  "GET /browser/downloads": "bridge-diagnostics-read",
+  "GET /browser/launch-diagnostics": "bridge-diagnostics-read",
+  "GET /providers/status": "provider-diagnostics-read",
   "POST /providers/health": "provider-diagnostics-read",
   "POST /providers/connectivity-test": "provider-diagnostics-read",
   "GET /providers/diagnostics-history": "provider-diagnostics-read",
@@ -36,6 +41,8 @@ const BRIDGE_ROUTE_CAPABILITIES = Object.freeze({
   "POST /augmentor/control-plan": "agent-control-plan",
   "POST /augmentor/next-action": "agent-control-plan",
   "POST /web/news": "agent-control-plan",
+  "GET /memory/status": "memory-read",
+  "GET /memory/settings": "memory-read",
   "POST /memory/settings": "memory-settings-write",
   "POST /memory/source/browse": "memory-source-browse",
   "POST /memory/source/scan": "memory-source-scan",
@@ -48,6 +55,7 @@ const BRIDGE_ROUTE_CAPABILITIES = Object.freeze({
   "POST /memory/source/file-intake": "memory-source-file-intake",
   "POST /memory/source/sync": "memory-source-file-intake",
   "POST /memory/search": "archive-read",
+  "GET /memory/wiki/health": "memory-read",
   "POST /memory/wiki/page/read": "archive-read",
   "POST /memory/wiki/lint": "memory-source-review",
   "POST /memory/source/versions": "memory-source-review",
@@ -69,7 +77,10 @@ const BRIDGE_ROUTE_CAPABILITIES = Object.freeze({
   "POST /archive/review/promotions/restore": "archive-write",
   "POST /browser/downloads/action": "browser-download-action",
   "POST /diagnostics/report": "diagnostics-report-export",
+  "GET /addons/status": "addon-runtime-read",
+  "GET /addons/execution-settings": "addon-runtime-read",
   "POST /addons/execution-settings": "addon-execution-settings-write",
+  "GET /opencode/status": "addon-runtime-read",
   "POST /hermes/dashboard/status": "addon-runtime-read",
   "POST /hermes/dashboard/start": "addon-runtime-control",
   "POST /hermes/dashboard/stop": "addon-runtime-control",
@@ -103,6 +114,7 @@ const BRIDGE_ROUTE_CAPABILITIES = Object.freeze({
   "POST /addons/delegate": "addon-record-write",
   "POST /addons/delegate/list": "addon-record-read",
   "POST /goals": "addon-record-write",
+  "GET /settings/extension-prefs": "extension-prefs-read",
   "POST /settings/extension-prefs": "extension-prefs-write",
 });
 export const RUNTIME_CAPABILITY_ALLOWLIST = Object.freeze([...new Set(Object.values(BRIDGE_ROUTE_CAPABILITIES))]);
@@ -277,9 +289,9 @@ export function createBridgeClient(config = globalThis.__RESONANTOS_BRIDGE_CONFI
       headers["X-ResonantOS-Bridge-Token"] = bridgeToken;
     }
     const capability = options.capability || capabilityForBridgeRoute(route, method);
-    const effectiveCapabilityTokens = { ..._capabilityTokens, ...bridgeCapabilityTokens };
-    if (capability && effectiveCapabilityTokens[capability]) {
-      headers["X-ResonantOS-Bridge-Capability-Token"] = effectiveCapabilityTokens[capability];
+    const capabilityToken = await capabilityTokenForRequest(capability, bridgeCapabilityTokens);
+    if (capabilityToken) {
+      headers["X-ResonantOS-Bridge-Capability-Token"] = capabilityToken;
     }
     let response;
     try {
@@ -319,9 +331,9 @@ export function createRawBridgeFetch(config = globalThis.__RESONANTOS_BRIDGE_CON
       headers["X-ResonantOS-Bridge-Token"] = bridgeToken;
     }
     const capability = options.capability || capabilityForBridgeRoute(path, method);
-    const effectiveCapabilityTokens = { ..._capabilityTokens, ...bridgeCapabilityTokens };
-    if (capability && effectiveCapabilityTokens[capability]) {
-      headers["X-ResonantOS-Bridge-Capability-Token"] = effectiveCapabilityTokens[capability];
+    const capabilityToken = await capabilityTokenForRequest(capability, bridgeCapabilityTokens);
+    if (capabilityToken) {
+      headers["X-ResonantOS-Bridge-Capability-Token"] = capabilityToken;
     }
     try {
       return await fetchImpl(`${bridgeUrl}${path}`, {
@@ -456,6 +468,24 @@ export async function detectLoopbackBridge(config, { fetchImpl: fetchOverride } 
 // into the build. The runtime-fetched tokens are an additional layer for
 // tokens that should NOT appear in the generated config file.
 const _capabilityTokens = {};
+let _capabilityTokensInFlight = null;
+
+async function capabilityTokenForRequest(capability, configCapabilityTokens = {}) {
+  if (!capability) return "";
+  let effectiveCapabilityTokens = { ..._capabilityTokens, ...configCapabilityTokens };
+  if (!effectiveCapabilityTokens[capability] && _capabilityTokensInFlight) {
+    await _capabilityTokensInFlight.catch(() => undefined);
+    effectiveCapabilityTokens = { ..._capabilityTokens, ...configCapabilityTokens };
+  }
+  return effectiveCapabilityTokens[capability] ?? "";
+}
+
+export function __resetCapabilityTokensForTests() {
+  for (const capability of Object.keys(_capabilityTokens)) {
+    delete _capabilityTokens[capability];
+  }
+  _capabilityTokensInFlight = null;
+}
 
 /**
  * Fetches capability tokens from the bridge server's authenticated endpoint
@@ -474,7 +504,7 @@ export async function initCapabilityTokens(config) {
   const capabilityBootstrapToken = cfg.capabilityBootstrapToken ?? "";
   const fetchImpl = cfg.fetchImpl ?? fetch;
   if (!bridgeToken || !capabilityBootstrapToken) return;
-  try {
+  const tokenBootstrap = (async () => {
     const response = await fetchImpl(`${bridgeUrl}/api/capability-tokens`, {
       method: "POST",
       headers: {
@@ -490,9 +520,17 @@ export async function initCapabilityTokens(config) {
         Object.assign(_capabilityTokens, payload.capabilityTokens);
       }
     }
-  } catch {
+  })().catch(() => {
     // Bridge may not be reachable yet (e.g. host not started). Capability
     // requests will fall back to config-supplied tokens until the bridge
     // is up.
+  });
+  _capabilityTokensInFlight = tokenBootstrap;
+  try {
+    await tokenBootstrap;
+  } finally {
+    if (_capabilityTokensInFlight === tokenBootstrap) {
+      _capabilityTokensInFlight = null;
+    }
   }
 }

--- a/browser-first/resonantos-side-panel-extension/src/lib/settings/bridge-target-section.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/settings/bridge-target-section.js
@@ -15,7 +15,7 @@
 
 import { bridgeAuthMessage } from "../runtime-error-messages.js";
 import { metricCard, noteCard, safeErrorMessage, setStatus, settingsHeader } from "./settings-common.js";
-import { BRIDGE_STORAGE_OVERRIDE_KEY, detectLoopbackBridge, resolveBridgeConfig } from "../bridge-client.js";
+import { BRIDGE_STORAGE_OVERRIDE_KEY, detectLoopbackBridge, isCapabilityScopedBridgeReply, resolveBridgeConfig } from "../bridge-client.js";
 
 const STATUS_KEYS = [BRIDGE_STORAGE_OVERRIDE_KEY];
 
@@ -70,7 +70,14 @@ async function probeBridge(url, token) {
   } catch {
     body = {};
   }
-  return { ok: response.ok && body?.ok === true, status: response.status, body };
+  return {
+    ok: response.ok && body?.ok === true,
+    status: response.status,
+    body,
+    // Since #346 /status is capability-scoped: a 403 naming a capability means the bridge accepted
+    // the bridge token (the panel attaches the capability token automatically after bootstrap).
+    capabilityScoped: isCapabilityScopedBridgeReply(response.status, body),
+  };
 }
 
 function buildField({ id, label, value, type = "text", placeholder = "", monospace = true, textarea = false, autocomplete = "off" }) {
@@ -390,6 +397,11 @@ export function renderBridgeTargetSection(container, { bridgeRequest, onBridgeCo
         healthCardEl.querySelector("p").textContent = "unauthorized - token mismatch";
         healthCardEl.dataset.tone = "error";
         setStatus(statusNode, `Bridge ${url} replied 401. ${bridgeAuthMessage()}`, "error");
+      } else if (result.status === 403 && result.capabilityScoped) {
+        healthCardEl.querySelector("strong").textContent = "Reachable";
+        healthCardEl.querySelector("p").textContent = "token accepted · /status is capability-scoped";
+        healthCardEl.dataset.tone = "success";
+        setStatus(statusNode, `Bridge ${url} accepted the bridge token. /status requires a capability token, which the panel attaches automatically after bootstrap.`, "success");
       } else if (result.status === 403) {
         healthCardEl.querySelector("strong").textContent = "403";
         healthCardEl.querySelector("p").textContent = "forbidden — IP not allowlisted";

--- a/browser-first/test/bridge-auth-inprocess-self-test.test.mjs
+++ b/browser-first/test/bridge-auth-inprocess-self-test.test.mjs
@@ -21,5 +21,6 @@ test("browser-first bridge auth passes in-process deterministic smoke test", asy
   assert.equal(result.route, "/status");
   assert.equal(result.unauthorizedStatus, 401);
   assert.equal(result.wrongTokenStatus, 401);
+  assert.equal(result.bridgeTokenOnlyStatus, 403);
   assert.equal(result.authorizedStatus, 200);
 });

--- a/browser-first/test/bridge-client-loopback.test.mjs
+++ b/browser-first/test/bridge-client-loopback.test.mjs
@@ -25,3 +25,60 @@ test("detectLoopbackBridge probes generated fallback loopback port before defaul
   assert.equal(result.source, "loopback:generated");
   assert.deepEqual(calls, ["http://127.0.0.1:48773/status"]);
 });
+
+test("detectLoopbackBridge accepts a capability-scoped 403 from /status as an authenticated bridge (#346)", async () => {
+  const calls = [];
+  const fetchImpl = async (url) => {
+    calls.push(url);
+    if (url === "http://127.0.0.1:48773/status") {
+      return new Response(JSON.stringify({ ok: false, error: "Bridge route requires bridge-diagnostics-read capability." }), {
+        headers: { "Content-Type": "application/json" },
+        status: 403,
+      });
+    }
+    throw new Error(`unexpected probe ${url}`);
+  };
+
+  const result = await detectLoopbackBridge(
+    { bridgeToken: "token", bridgeUrl: "http://127.0.0.1:48773", source: "generated" },
+    { fetchImpl },
+  );
+
+  assert.equal(result.bridgeUrl, "http://127.0.0.1:48773");
+  assert.equal(result.source, "loopback:generated");
+  assert.deepEqual(calls, ["http://127.0.0.1:48773/status"]);
+});
+
+test("detectLoopbackBridge still skips 401 (bridge token rejected) and IP-allowlist 403 candidates", async () => {
+  const calls = [];
+  const fetchImpl = async (url) => {
+    calls.push(url);
+    if (url === "http://127.0.0.1:48773/status") {
+      return new Response(JSON.stringify({ ok: false, error: "Unauthorized browser-first bridge request." }), { status: 401 });
+    }
+    if (url === "http://localhost:47773/status") {
+      return new Response(JSON.stringify({ ok: false, error: "Forbidden: client IP is not allowlisted." }), { status: 403 });
+    }
+    if (url === "http://bridge.lan:47773/status") {
+      return new Response(JSON.stringify({ ok: true, service: "resonantos-bridge" }), { status: 200 });
+    }
+    return new Response("", { status: 404 });
+  };
+
+  const result = await detectLoopbackBridge(
+    { bridgeToken: "token", bridgeUrl: "http://bridge.lan:47773", source: "generated" },
+    { fetchImpl },
+  );
+
+  assert.equal(result.bridgeUrl, "http://bridge.lan:47773", "falls through to the configured origin");
+  assert.ok(calls.at(-1) === "http://bridge.lan:47773/status");
+});
+
+test("isCapabilityScopedBridgeReply recognizes only the capability-scoped 403 shape", async () => {
+  const { isCapabilityScopedBridgeReply } = await import("../resonantos-side-panel-extension/src/lib/bridge-client.js");
+  assert.equal(isCapabilityScopedBridgeReply(403, { ok: false, error: "Bridge route requires memory-read capability." }), true);
+  assert.equal(isCapabilityScopedBridgeReply(403, { ok: false, error: "Forbidden: client IP is not allowlisted." }), false);
+  assert.equal(isCapabilityScopedBridgeReply(401, { ok: false, error: "Bridge route requires memory-read capability." }), false);
+  assert.equal(isCapabilityScopedBridgeReply(200, { ok: true }), false);
+  assert.equal(isCapabilityScopedBridgeReply(403, null), false);
+});

--- a/browser-first/test/bridge-get-routes-require-capability.test.mjs
+++ b/browser-first/test/bridge-get-routes-require-capability.test.mjs
@@ -1,0 +1,214 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { createAddonDelegationHostService } from "../host/addon-delegation-host-service.mjs";
+import { createBrowserDiagnosticsHostService } from "../host/browser-diagnostics-host-service.mjs";
+import { createExtensionPrefsHostService } from "../host/extension-prefs-host-service.mjs";
+import { createMemoryHostService } from "../host/memory-host-service.mjs";
+import { createProviderHostService } from "../host/provider-host-service.mjs";
+import { bridgeServerPort, evaluateBridgeRequestForSelfTest, startBridgeServer } from "../host/bridge-server.mjs";
+
+const bridgeToken = "bridge-token";
+const bridgeDiagnosticsReadToken = "bridge-diagnostics-read-token";
+const addonRuntimeReadToken = "addon-runtime-read-token";
+const providerDiagnosticsReadToken = "provider-diagnostics-read-token";
+const memoryReadToken = "memory-read-token";
+const extensionPrefsReadToken = "extension-prefs-read-token";
+
+const protectedGetRoutes = [
+  { route: "/status", capability: "bridge-diagnostics-read", correctToken: bridgeDiagnosticsReadToken, wrongToken: addonRuntimeReadToken },
+  { route: "/workspace/inspect", capability: "bridge-diagnostics-read", correctToken: bridgeDiagnosticsReadToken, wrongToken: addonRuntimeReadToken },
+  { route: "/browser/downloads", capability: "bridge-diagnostics-read", correctToken: bridgeDiagnosticsReadToken, wrongToken: addonRuntimeReadToken },
+  { route: "/browser/launch-diagnostics", capability: "bridge-diagnostics-read", correctToken: bridgeDiagnosticsReadToken, wrongToken: addonRuntimeReadToken },
+  { route: "/addons/status", capability: "addon-runtime-read", correctToken: addonRuntimeReadToken, wrongToken: bridgeDiagnosticsReadToken },
+  { route: "/addons/execution-settings", capability: "addon-runtime-read", correctToken: addonRuntimeReadToken, wrongToken: bridgeDiagnosticsReadToken },
+  { route: "/opencode/status", capability: "addon-runtime-read", correctToken: addonRuntimeReadToken, wrongToken: bridgeDiagnosticsReadToken },
+  { route: "/providers/status", capability: "provider-diagnostics-read", correctToken: providerDiagnosticsReadToken, wrongToken: bridgeDiagnosticsReadToken },
+  { route: "/memory/status", capability: "memory-read", correctToken: memoryReadToken, wrongToken: bridgeDiagnosticsReadToken },
+  { route: "/memory/settings", capability: "memory-read", correctToken: memoryReadToken, wrongToken: bridgeDiagnosticsReadToken },
+  { route: "/memory/wiki/health", capability: "memory-read", correctToken: memoryReadToken, wrongToken: bridgeDiagnosticsReadToken },
+  { route: "/settings/extension-prefs", capability: "extension-prefs-read", correctToken: extensionPrefsReadToken, wrongToken: bridgeDiagnosticsReadToken },
+];
+
+const memoryHandlerNames = [
+  "executeMemoryStatus",
+  "executeMemorySettings",
+  "executeMemorySettingsSave",
+  "executeMemorySourceBrowse",
+  "executeMemorySourceScan",
+  "executeMemorySourceAction",
+  "executeMemorySourceMovePreflight",
+  "executeMemorySourceMoveExecute",
+  "executeMemorySourceMoveRollback",
+  "executeMemorySourceReview",
+  "executeMemorySourceIntake",
+  "executeMemorySourceFileIntake",
+  "executeMemorySourceSync",
+  "executeMemorySearch",
+  "executeMemoryWikiHealth",
+  "executeMemoryWikiPageRead",
+  "executeMemoryWikiLint",
+  "executeMemorySourceVersions",
+  "executeMemorySourceVersionsRepair",
+  "executeMemorySourceDiff",
+  "executeArchiveIntake",
+  "executeArchiveIntakeList",
+  "executeArchiveIntakeRead",
+  "executeArchiveReviewRequest",
+  "executeArchiveReviewList",
+  "executeArchiveReviewTransition",
+  "executeArchiveReviewDraft",
+  "executeArchiveReviewArtifactRead",
+  "executeArchiveReviewArtifactVerify",
+  "executeArchiveVerificationRead",
+  "executeArchiveReviewArtifactRevise",
+  "executeArchiveReviewArtifactPromote",
+  "executeArchivePromotionList",
+  "executeArchivePromotionRestore",
+];
+
+function stubHandlers(names) {
+  return Object.fromEntries(names.map((name) => [name, async () => ({ name })]));
+}
+
+function createRoutes(root) {
+  const provider = createProviderHostService({
+    redactDiagnosticText: String,
+    extractJsonObject: JSON.parse,
+  });
+  const diagnostics = createBrowserDiagnosticsHostService({
+    repoRoot: root,
+    resonantExtension: path.join(root, "extension"),
+    userRoot: () => path.join(root, "user"),
+    browserFirstRoot: () => path.join(root, "BrowserFirst"),
+    memoryRoot: () => path.join(root, "Memory"),
+    profileDir: path.join(root, "profile"),
+    readProviderSecrets: async () => ({}),
+    executeProviderStatus: async () => ({ providers: [] }),
+    executeAddonsStatus: async () => ({ addons: [] }),
+    executeMemoryStatus: async () => ({}),
+    countFiles: async () => 0,
+    redactPathForDiagnostics: (value) => String(value ?? ""),
+    redactDiagnosticText: (value) => String(value ?? ""),
+  });
+  const memory = createMemoryHostService(stubHandlers(memoryHandlerNames));
+  const addon = createAddonDelegationHostService({
+    executeAddonsStatus: async () => ({ addons: [] }),
+    executeAddonExecutionSettingsGet: async () => ({
+      settings: {
+        hermes: { localCliExecution: false },
+        opencode: { localCliExecution: false },
+      },
+    }),
+    executeAddonExecutionSettingsUpdate: async () => ({ status: "updated" }),
+    executeOpenCodeStatus: async () => ({ mode: "stub", executionEnabled: false }),
+    executeHermesDashboardStatus: async () => ({}),
+    executeHermesDashboardStart: async () => ({}),
+    executeHermesDashboardStop: async () => ({}),
+    executeHermesStatus: async () => ({}),
+    executeHermesDelegationStart: async () => ({}),
+    executeHermesDelegationStatus: async () => ({}),
+    executeHermesDelegationArtifact: async () => ({}),
+    executeHermesDelegationCancel: async () => ({}),
+    executeOpenCodeDelegationStart: async () => ({}),
+    executeOpenCodeDelegationStatus: async () => ({}),
+    executeOpenCodeDelegationArtifact: async () => ({}),
+    executeOpenCodeDelegationCancel: async () => ({}),
+    executeOpenCodeWebUrl: async () => ({}),
+    executeAddonDraftRecord: async () => ({}),
+    executeAddonDraftList: async () => ({}),
+    executeAddonDraftRead: async () => ({}),
+    executeAddonDraftTransition: async () => ({}),
+    executeAddonDraftProviderHandoff: async () => ({}),
+    executeDelegationRecord: async () => ({}),
+    executeDelegationList: async () => ({}),
+    executeGoalRecord: async () => ({}),
+  });
+  const prefs = createExtensionPrefsHostService({ userRoot: () => root });
+  return [
+    ...diagnostics.browserDiagnosticsRoutes,
+    ...provider.providerBridgeRoutes,
+    ...memory.memoryBridgeRoutes,
+    ...addon.addonDelegationRoutes,
+    ...prefs.extensionPrefsRoutes,
+  ];
+}
+
+test("twelve bridge GET routes require route-scoped capability tokens", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "resonantos-bridge-get-routes-"));
+  const routes = createRoutes(root);
+  const bridgeCapabilityTokens = {
+    "bridge-diagnostics-read": bridgeDiagnosticsReadToken,
+    "addon-runtime-read": addonRuntimeReadToken,
+    "provider-diagnostics-read": providerDiagnosticsReadToken,
+    "memory-read": memoryReadToken,
+    "extension-prefs-read": extensionPrefsReadToken,
+  };
+  let server;
+  let bridgeUrl = "";
+  try {
+    try {
+      server = await startBridgeServer({
+        port: 0,
+        bridgeToken,
+        bridgeCapabilityTokens,
+        extensionOrigin: "chrome-extension://test",
+        routes,
+      });
+    } catch (error) {
+      if (error?.code === "EPERM" && error?.address === "127.0.0.1") {
+        server = null;
+      } else {
+        throw error;
+      }
+    }
+    bridgeUrl = server ? `http://127.0.0.1:${bridgeServerPort(server)}` : "";
+
+    const requestRoute = async (route, headers = {}) => {
+      if (server) {
+        const response = await fetch(`${bridgeUrl}${route}`, { headers });
+        return {
+          status: response.status,
+          payload: await response.json().catch(() => ({})),
+        };
+      }
+      return evaluateBridgeRequestForSelfTest({
+        method: "GET",
+        url: route,
+        headers,
+        bridgeToken,
+        bridgeCapabilityTokens,
+        routes,
+      });
+    };
+
+    for (const { route, capability, correctToken, wrongToken } of protectedGetRoutes) {
+      const noBridgeToken = await requestRoute(route);
+      assert.equal(noBridgeToken.status, 401, `${route} without bridge token`);
+
+      const bridgeTokenOnly = await requestRoute(route, { "X-ResonantOS-Bridge-Token": bridgeToken });
+      assert.equal(bridgeTokenOnly.status, 403, `${route} without ${capability}`);
+      assert.match(bridgeTokenOnly.payload.error ?? "", new RegExp(`requires ${capability} capability`));
+
+      const authorized = await requestRoute(route, {
+        "X-ResonantOS-Bridge-Token": bridgeToken,
+        "X-ResonantOS-Bridge-Capability-Token": correctToken,
+      });
+      assert.equal(authorized.status, 200, `${route} with ${capability}`);
+
+      const wrongCapability = await requestRoute(route, {
+        "X-ResonantOS-Bridge-Token": bridgeToken,
+        "X-ResonantOS-Bridge-Capability-Token": wrongToken,
+      });
+      assert.equal(wrongCapability.status, 403, `${route} with wrong capability`);
+    }
+  } finally {
+    if (server) {
+      await new Promise((resolve) => server.close(resolve));
+    }
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/browser-first/test/bridge-route-capability-audit.test.mjs
+++ b/browser-first/test/bridge-route-capability-audit.test.mjs
@@ -142,17 +142,21 @@ async function withBridgeRoutes(callback) {
       redactPathForDiagnostics: (value) => String(value ?? ""),
       redactDiagnosticText: (value) => String(value ?? ""),
     });
-    const routes = [
-      ...diagnostics.browserDiagnosticsRoutes,
-      ...provider.providerBridgeRoutes,
-      ...agent.agentControlRoutes,
-      ...memory.memoryBridgeRoutes,
-      ...addon.addonDelegationRoutes,
-      ...opencodeSession.opencodeSessionRoutes,
-      ...prefs.extensionPrefsRoutes,
-    ];
+    // Keyed by the exact identifier run-bridge-minimal.mjs spreads into `bridgeRoutes`, so the
+    // composition guard below can prove each composed array is actually CONSTRUCTED here — not
+    // merely named in a list.
+    const routeArrays = {
+      browserDiagnosticsRoutes: diagnostics.browserDiagnosticsRoutes,
+      providerBridgeRoutes: provider.providerBridgeRoutes,
+      agentControlRoutes: agent.agentControlRoutes,
+      memoryBridgeRoutes: memory.memoryBridgeRoutes,
+      addonDelegationRoutes: addon.addonDelegationRoutes,
+      opencodeSessionRoutes: opencodeSession.opencodeSessionRoutes,
+      extensionPrefsRoutes: prefs.extensionPrefsRoutes,
+    };
+    const routes = Object.values(routeArrays).flat();
 
-    await callback(routes);
+    await callback(routes, routeArrays);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -210,19 +214,14 @@ test("audit covers every route array composed by run-bridge-minimal", async () =
   );
   const bridgeRoutesInitializer = /const\s+bridgeRoutes\s*=\s*\[([\s\S]*?)\];/.exec(source)?.[1] ?? "";
   const composedRouteArrays = [...bridgeRoutesInitializer.matchAll(/\.\.\.(\w+)/g)].map((match) => match[1]);
-  const auditedRouteArrays = [
-    "browserDiagnosticsRoutes",
-    "providerBridgeRoutes",
-    "agentControlRoutes",
-    "memoryBridgeRoutes",
-    "addonDelegationRoutes",
-    "opencodeSessionRoutes",
-    "extensionPrefsRoutes",
-  ];
+  assert.ok(composedRouteArrays.length >= 7, "expected run-bridge-minimal to compose at least seven route arrays");
 
-  assert.deepEqual(
-    composedRouteArrays.filter((name) => !auditedRouteArrays.includes(name)),
-    [],
-    "run-bridge-minimal composes route arrays that bridge-route-capability-audit does not construct",
-  );
+  await withBridgeRoutes(async (_routes, routeArrays) => {
+    for (const name of composedRouteArrays) {
+      assert.ok(
+        Array.isArray(routeArrays[name]) && routeArrays[name].length > 0,
+        `${name} is composed by run-bridge-minimal but this audit does not construct it (add the service to withBridgeRoutes)`,
+      );
+    }
+  });
 });

--- a/browser-first/test/bridge-route-capability-audit.test.mjs
+++ b/browser-first/test/bridge-route-capability-audit.test.mjs
@@ -1,13 +1,16 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
 import { createAddonDelegationHostService } from "../host/addon-delegation-host-service.mjs";
 import { createAgentControlHostService } from "../host/agent-control-host-service.mjs";
+import { BRIDGE_CAPABILITIES } from "../host/bridge-capability-tokens.mjs";
+import { createBrowserDiagnosticsHostService } from "../host/browser-diagnostics-host-service.mjs";
 import { createExtensionPrefsHostService } from "../host/extension-prefs-host-service.mjs";
 import { createMemoryHostService } from "../host/memory-host-service.mjs";
+import { createOpencodeSessionHostService } from "../host/opencode-session-host-service.mjs";
 import { createProviderHostService } from "../host/provider-host-service.mjs";
 import { capabilityForBridgeRoute } from "../resonantos-side-panel-extension/src/lib/bridge-client.js";
 
@@ -76,11 +79,29 @@ const addonHandlers = [
   "executeGoalRecord",
 ];
 
+const opencodeSessionHandlers = [
+  "executeOpenCodeSessionStart",
+  "executeOpenCodeSessionPrompt",
+  "executeOpenCodeSessionPermission",
+  "executeOpenCodeSessionStop",
+  "executeOpenCodeSessionsList",
+  "executeOpenCodeSessionMessages",
+  "executeOpenCodeSessionAbort",
+  "executeOpenCodeSessionDiff",
+  "executeOpenCodeSessionRename",
+  "executeOpenCodeSessionDelete",
+  "executeOpenCodeSessionArchive",
+  "executeOpenCodeAgentsList",
+];
+
 function handlers(names) {
   return Object.fromEntries(names.map((name) => [name, async () => ({ name })]));
 }
 
-test("extension bridge client capability map matches gated host routes", async () => {
+// Every entry must be ["METHOD /path", "written rationale"].
+const UNGATED_ROUTE_ALLOWLIST = new Map([]);
+
+async function withBridgeRoutes(callback) {
   const root = await mkdtemp(path.join(os.tmpdir(), "resonantos-route-capability-audit-"));
   try {
     const provider = createProviderHostService({
@@ -104,23 +125,104 @@ test("extension bridge client capability map matches gated host routes", async (
     });
     const memory = createMemoryHostService(handlers(memoryHandlers));
     const addon = createAddonDelegationHostService(handlers(addonHandlers));
+    const opencodeSession = createOpencodeSessionHostService(handlers(opencodeSessionHandlers));
     const prefs = createExtensionPrefsHostService({ userRoot: () => root });
+    const diagnostics = createBrowserDiagnosticsHostService({
+      repoRoot: root,
+      resonantExtension: path.join(root, "extension"),
+      userRoot: () => path.join(root, "user"),
+      browserFirstRoot: () => path.join(root, "BrowserFirst"),
+      memoryRoot: () => path.join(root, "Memory"),
+      profileDir: path.join(root, "profile"),
+      readProviderSecrets: async () => ({}),
+      executeProviderStatus: async () => ({ providers: [] }),
+      executeAddonsStatus: async () => ({ addons: [] }),
+      executeMemoryStatus: async () => ({}),
+      countFiles: async () => 0,
+      redactPathForDiagnostics: (value) => String(value ?? ""),
+      redactDiagnosticText: (value) => String(value ?? ""),
+    });
     const routes = [
+      ...diagnostics.browserDiagnosticsRoutes,
       ...provider.providerBridgeRoutes,
       ...agent.agentControlRoutes,
       ...memory.memoryBridgeRoutes,
       ...addon.addonDelegationRoutes,
+      ...opencodeSession.opencodeSessionRoutes,
       ...prefs.extensionPrefsRoutes,
     ];
 
+    await callback(routes);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+function bridgeRouteKey(route) {
+  return `${route.method} ${route.path}`;
+}
+
+test("extension bridge client capability map matches gated host routes", async () => {
+  await withBridgeRoutes(async (routes) => {
     for (const route of routes.filter((entry) => entry.requiredCapability)) {
       assert.equal(
         capabilityForBridgeRoute(route.path, route.method),
         route.requiredCapability,
-        `${route.method} ${route.path}`,
+        bridgeRouteKey(route),
       );
     }
-  } finally {
-    await rm(root, { recursive: true, force: true });
-  }
+  });
+});
+
+test("every bridge route declares a capability or is allowlisted with a rationale", async () => {
+  await withBridgeRoutes(async (routes) => {
+    const routeKeys = new Set(routes.map(bridgeRouteKey));
+    for (const route of routes) {
+      const key = bridgeRouteKey(route);
+      assert.ok(
+        route.requiredCapability || UNGATED_ROUTE_ALLOWLIST.has(key),
+        `${key} must declare requiredCapability or be allowlisted with a rationale`,
+      );
+    }
+    for (const [key, rationale] of UNGATED_ROUTE_ALLOWLIST) {
+      assert.ok(routeKeys.has(key), `${key} is allowlisted but no route exists`);
+      assert.equal(typeof rationale, "string", `${key} allowlist rationale must be a string`);
+      assert.ok(rationale.trim(), `${key} allowlist rationale must not be empty`);
+    }
+  });
+});
+
+test("every route capability exists in the launcher catalog", async () => {
+  await withBridgeRoutes(async (routes) => {
+    for (const route of routes.filter((entry) => entry.requiredCapability)) {
+      assert.ok(
+        BRIDGE_CAPABILITIES.includes(route.requiredCapability),
+        `${bridgeRouteKey(route)} requires unknown capability ${route.requiredCapability}`,
+      );
+    }
+  });
+});
+
+test("audit covers every route array composed by run-bridge-minimal", async () => {
+  const source = await readFile(
+    new URL("../host/run-bridge-minimal.mjs", import.meta.url),
+    "utf8",
+  );
+  const bridgeRoutesInitializer = /const\s+bridgeRoutes\s*=\s*\[([\s\S]*?)\];/.exec(source)?.[1] ?? "";
+  const composedRouteArrays = [...bridgeRoutesInitializer.matchAll(/\.\.\.(\w+)/g)].map((match) => match[1]);
+  const auditedRouteArrays = [
+    "browserDiagnosticsRoutes",
+    "providerBridgeRoutes",
+    "agentControlRoutes",
+    "memoryBridgeRoutes",
+    "addonDelegationRoutes",
+    "opencodeSessionRoutes",
+    "extensionPrefsRoutes",
+  ];
+
+  assert.deepEqual(
+    composedRouteArrays.filter((name) => !auditedRouteArrays.includes(name)),
+    [],
+    "run-bridge-minimal composes route arrays that bridge-route-capability-audit does not construct",
+  );
 });

--- a/browser-first/test/bridge-server.test.mjs
+++ b/browser-first/test/bridge-server.test.mjs
@@ -164,6 +164,93 @@ test("bridge client sends scoped capability headers without localhost binding", 
   assert.equal(saved.saved, true);
 });
 
+test("bridge client waits for pending capability bootstrap before scoped GET", async () => {
+  const bridgeClientModule = await import("../resonantos-side-panel-extension/src/lib/bridge-client.js");
+  assert.equal(typeof bridgeClientModule.__resetCapabilityTokensForTests, "function");
+  bridgeClientModule.__resetCapabilityTokensForTests();
+
+  const bridgeToken = "runtime-general-test-token";
+  const capabilityBootstrapToken = "runtime-bootstrap-test-token";
+  const capabilityToken = "runtime-bridge-diagnostics-read-token";
+  let resolveBootstrapFetch;
+  const bootstrapFetchStarted = new Promise((resolve) => {
+    resolveBootstrapFetch = resolve;
+  });
+  let statusHeaders = null;
+
+  const fetchImpl = async (url, options = {}) => {
+    const pathname = new URL(url).pathname;
+    if (pathname === "/api/capability-tokens") {
+      return await new Promise((resolve) => {
+        bootstrapFetchStarted.then(() => resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            ok: true,
+            capabilityTokens: { "bridge-diagnostics-read": capabilityToken },
+          }),
+        }));
+      });
+    }
+    statusHeaders = options.headers ?? {};
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, service: "resonantos-bridge" }),
+    };
+  };
+
+  const bootstrap = initCapabilityTokens({
+    bridgeUrl: "http://127.0.0.1:47773",
+    bridgeToken,
+    capabilityBootstrapToken,
+    fetchImpl,
+  });
+  const client = createBridgeClient({
+    bridgeUrl: "http://127.0.0.1:47773",
+    bridgeToken,
+    bridgeCapabilityTokens: {},
+    fetchImpl,
+  });
+
+  const request = client("/status", { method: "GET" });
+  resolveBootstrapFetch();
+  await Promise.all([bootstrap, request]);
+
+  assert.equal(
+    statusHeaders?.["X-ResonantOS-Bridge-Capability-Token"],
+    capabilityToken,
+  );
+});
+
+test("bridge client does not wait when no capability bootstrap is in flight", async () => {
+  const bridgeClientModule = await import("../resonantos-side-panel-extension/src/lib/bridge-client.js");
+  assert.equal(typeof bridgeClientModule.__resetCapabilityTokensForTests, "function");
+  bridgeClientModule.__resetCapabilityTokensForTests();
+
+  let requestCount = 0;
+  let statusHeaders = null;
+  const client = createBridgeClient({
+    bridgeUrl: "http://127.0.0.1:47773",
+    bridgeToken: "general-test-token",
+    bridgeCapabilityTokens: {},
+    fetchImpl: async (_url, options = {}) => {
+      requestCount += 1;
+      statusHeaders = options.headers ?? {};
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true, service: "resonantos-bridge" }),
+      };
+    },
+  });
+
+  await client("/status", { method: "GET" });
+
+  assert.equal(requestCount, 1);
+  assert.equal(statusHeaders?.["X-ResonantOS-Bridge-Capability-Token"], undefined);
+});
+
 test("bridge client reports unreachable bridge fetches with settings guidance", async () => {
   const client = createBridgeClient({
     bridgeUrl: "http://127.0.0.1:47773",

--- a/browser-first/test/extension-prefs-host-service.test.mjs
+++ b/browser-first/test/extension-prefs-host-service.test.mjs
@@ -6,7 +6,7 @@ import test from "node:test";
 
 import { createExtensionPrefsHostService } from "../host/extension-prefs-host-service.mjs";
 
-test("extension prefs write route is capability gated", async () => {
+test("extension prefs routes are capability gated", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "resonantos-extension-prefs-"));
   try {
     const { extensionPrefsRoutes, flushPendingWrites } = createExtensionPrefsHostService({
@@ -16,7 +16,7 @@ test("extension prefs write route is capability gated", async () => {
 
     assert.equal(typeof routes.get("GET /settings/extension-prefs")?.handler, "function");
     assert.equal(typeof routes.get("POST /settings/extension-prefs")?.handler, "function");
-    assert.equal(routes.get("GET /settings/extension-prefs")?.requiredCapability, undefined);
+    assert.equal(routes.get("GET /settings/extension-prefs")?.requiredCapability, "extension-prefs-read");
     assert.equal(routes.get("POST /settings/extension-prefs")?.requiredCapability, "extension-prefs-write");
 
     await flushPendingWrites();

--- a/docs/browser-first-bridge-setup-runbook.md
+++ b/docs/browser-first-bridge-setup-runbook.md
@@ -70,6 +70,10 @@ The extension requests a fixed set of capabilities (`RUNTIME_CAPABILITY_ALLOWLIS
 derived from `BRIDGE_ROUTE_CAPABILITIES` in the extension's `bridge-client.js`).
 The bridge launcher must mint a token for each, or bootstrap 500s. Both are now
 derived from a single canonical source, `browser-first/host/bridge-capability-tokens.mjs`.
+Every bridge route now requires a per-route capability token in addition to the
+bridge token, and `bridge-route-capability-audit` fails when a route is ungated.
+Read-only bridge status, memory, and extension preference routes are protected
+by `bridge-diagnostics-read`, `memory-read`, and `extension-prefs-read`.
 
 ```bash
 # CI-equivalent drift check — must pass before any deploy:


### PR DESCRIPTION
## Summary

Closes #346. `isAuthorizedCapabilityRequest` returned `true` for any route without a `requiredCapability`, and **twelve** production GET routes relied on that — reachable with the bridge token alone (the issue counted eight; the executor found five more while building the gate). `/workspace/inspect` and `/browser/downloads` disclose local paths and state.

- **Every composed route now declares a capability.** Three read-only capabilities join the launcher catalog: `bridge-diagnostics-read` (`/status`, `/workspace/inspect`, `/browser/downloads`, `/browser/launch-diagnostics`), `memory-read` (`/memory/status`, `/memory/settings`, `/memory/wiki/health`) and `extension-prefs-read` (`/settings/extension-prefs`). `/addons/status`, `/addons/execution-settings`, `/opencode/status` use the existing `addon-runtime-read`; `/providers/status` uses the existing `provider-diagnostics-read`.
- **Extension:** the route→capability map gains the twelve GET entries, so the side panel bootstraps the new capabilities and attaches them automatically (every panel caller already goes through the bridge client). The client now **awaits an in-flight capability bootstrap** before sending a capability-scoped request — before this change an early GET succeeded on the bridge token alone; without the wait it would have raced the token fetch and 403'd on first paint.
- **The audit is now a real gate:** `bridge-route-capability-audit` fails if any route lacks a capability and is not in the (empty) allowlist with a written rationale; it constructs all seven route arrays the bridge composes, and a **composition guard** parses `run-bridge-minimal.mjs` and fails unless every array it spreads is actually constructed by the audit (adding an eighth service without auditing it fails CI).
- **Server-level proof** against a real bridge for all twelve routes: 401 without the bridge token, 403 with it alone (naming the capability), 403 with the wrong capability, success with the right one.
- **In-process auth self-test** now proves the bridge-token-only 403 path and the with-capability 200.

## Deployment (order matters)

1. Restart the bridge (it mints the new tokens). 2. Reload the extension (it requests them). Either alone leaves the panel's status views at 403 until the other happens — the runtime reviewer confirmed this by tracing the bootstrap.

## Evidence

- Full `test:browser-first` **1102 / 1102** (baseline 1096); focused suites 24 / 24; `test:security-pipeline` green; `docs:check` clean.
- Deterministic gate **14 / 14**: twelve map entries, three capabilities minted, empty allowlist, OpenCode-session routes audited, no single-line ungated route declarations left in any `*-host-service.mjs`, in-process self-test 403/200.
- Anti-false-green (rig-mutate, restored byte-identical): ungating `/status` → red; removing a map entry → red; making the server's capability check always pass → red; dropping a route array from the audit → red; removing the client's bootstrap wait → red; ungating `/settings/extension-prefs` → red; removing `memory-read` from the catalog → red; dropping a constructed route array from the audit's construction map → red; making the loopback probe reject the capability-scoped 403 → red. One further mutation (weakening the self-test's `ok` conjunct) stayed green because the wrapper test asserts the 403 status directly — redundant belt-and-braces, not a vacuous test.
- Process: Resonant-Rig standard+ tier — fleet executor (Codex) in two rounds from written specs; adjudicator review between rounds rejected an "out of scope" allowlist for the five extra routes, found the audit's OpenCode-session blind spot and the bootstrap race; two independent cross-vendor reviews: **security lens (Grok 4.6): CONFIRM** — one should-fix accepted (composition guard now proves construction, not a name list), two nits deferred to #373 (default-deny for routes without `requiredCapability`; constant-time compare in the self-test helper), two rejected with reasons in the ledger (length short-circuit in `constantTimeEqual`; 403 naming the capability is the existing contract); **runtime lens (DeepSeek v4-pro, with execution): **ISSUE, resolved** — it executed three in-process self-tests, the full suite and a runtime probe of the extension allowlist, then found what static review missed: the loopback detector (`detectLoopbackBridge`, runs before capability bootstrap) and the settings Bridge Target probe both raw-fetched `/status` with the bridge token only and would have read the new 403 as "no bridge here". Both fixed in the second commit (a capability-scoped 403 now counts as an authenticated bridge; 401 and IP-allowlist 403 still reject; helper tested). Its third finding, the React web-mode shell sending no capability tokens, is deferred with evidence to #374: `src/` is outside the alpha runtime boundary and that shell was already 403 on `/augmentor/chat`. Its nit (every 403 labelled IP-allowlist) is fixed**.

## Residual

- `isAuthorizedCapabilityRequest` still defaults to allow for a route with no `requiredCapability`; no composed route relies on that now and the audit fails if one appears, but default-deny is the root-cause backstop → #373.

Refs #339, #373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
