### PR TITLE
ci(live): run the live-browser certification on bridge host and extension source changes (#350)

### DIFF
--- a/.github/workflows/agent-control-live.yml
+++ b/.github/workflows/agent-control-live.yml
@@ -18,6 +18,11 @@ on:
     branches:
       - dev
     paths:
+      # Any bridge host or extension source change can break the live panel (#350): the #320
+      # mitigation (#339) changed both and never triggered this lane, while a lockfile-only PR did.
+      - "browser-first/host/**"
+      - "browser-first/resonantos-side-panel-extension/src/**"
+      - "browser-first/resonantos-side-panel-extension/manifest.json"
       - "browser-first/resonantos-side-panel-extension/src/lib/agent-control*"
       - "browser-first/resonantos-side-panel-extension/src/lib/control-*"
       - "browser-first/resonantos-side-panel-extension/src/lib/browser-page-actions.js"

--- a/browser-first/test/agent-control-live-workflow-paths.test.mjs
+++ b/browser-first/test/agent-control-live-workflow-paths.test.mjs
@@ -1,0 +1,28 @@
+// #350: the live-browser certification must run for any change that can break the live panel.
+// Guards the pull_request path filter of .github/workflows/agent-control-live.yml.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { parse } from "yaml";
+
+const WORKFLOW = new URL("../../.github/workflows/agent-control-live.yml", import.meta.url);
+
+const REQUIRED_PATH_GLOBS = [
+  "browser-first/host/**",
+  "browser-first/resonantos-side-panel-extension/src/**",
+  "browser-first/resonantos-side-panel-extension/manifest.json",
+  ".github/workflows/agent-control-live.yml",
+  "package.json",
+  "package-lock.json",
+];
+
+test("live certification workflow triggers on bridge host and extension source changes (#350)", async () => {
+  const workflow = parse(await readFile(WORKFLOW, "utf8"));
+  const pullRequest = workflow.on?.pull_request ?? workflow.true?.pull_request;
+  assert.ok(pullRequest, "workflow must declare a pull_request trigger");
+  assert.deepEqual(pullRequest.branches, ["dev"]);
+  const paths = pullRequest.paths ?? [];
+  for (const glob of REQUIRED_PATH_GLOBS) {
+    assert.ok(paths.includes(glob), `pull_request.paths must include ${glob}`);
+  }
+});


### PR DESCRIPTION
## Summary

Refs #350 (sub-item 2). The live-browser certification workflow's `pull_request` path filter listed a handful of agent-control files plus the lockfile, so the #320 mitigation (#339, which changed `browser-first/host/**` and the extension's OpenCode surface) never triggered it, while the lockfile-only #340 did. The filter now includes `browser-first/host/**`, the extension source tree, and its manifest.

Facts behind the decision (maintainer-approved 2026-09-06):
- The lane completes in **1–2 minutes** in practice; 20 minutes is the job's timeout ceiling.
- `dev` has no branch protection, so the lane is a non-blocking signal.
- 20 of the 33 PRs merged in the last 30 days touched host or extension source, so the lane will now run on roughly two thirds of PRs.
- Its two recent PR failures (Sep 4) were real detections on community feature branches, not flakes; nightly runs are green.

## Evidence

- New `browser-first/test/agent-control-live-workflow-paths.test.mjs` parses the workflow and asserts the filter covers the host tree, the extension source tree, the manifest, the workflow itself and the lockfiles; full `test:browser-first` green with it included.
- Anti-false-green: removing the host glob turns the test red (rig-mutate, restored byte-identical).
- Process: Resonant-Rig micro tier (one workflow line-set + its test).

Sequencing: merge this before #346's next push so #346 gets the live lane. The full `live-sdk` lane (sub-items 1, 3, 4 of #350) follows as a separate, spec-first run after #346 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)