### PR TITLE
test(live): live SDK coverage lane; fix bridge shutdown record clearing; isolate lane runs (#350)

### DIFF
--- a/.github/workflows/agent-control-live.yml
+++ b/.github/workflows/agent-control-live.yml
@@ -33,6 +33,11 @@ on:
       - "browser-first/test/agent-control-live.mjs"
       - "browser-first/test/agent-control-live-report.mjs"
       - "browser-first/test/agent-control-live-report.test.mjs"
+      - "browser-first/test/live-harness.mjs"
+      - "browser-first/test/live-harness.test.mjs"
+      - "browser-first/test/live-sdk-lane.mjs"
+      - "browser-first/test/live-sdk-lane.test.mjs"
+      - "browser-first/host/opencode-version.json"
       - ".github/workflows/agent-control-live.yml"
       - "package.json"
       - "package-lock.json"
@@ -91,4 +96,69 @@ jobs:
 
       - name: Reject uncertified run
         if: always() && steps.certification.outcome != 'success'
+        run: exit 1
+
+  live-sdk:
+    name: Live SDK certification
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install stable Chrome
+        id: chrome
+        uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd
+        with:
+          chrome-version: stable
+          install-dependencies: true
+
+      - name: Install pinned OpenCode
+        # Into $HOME/.local so the binary lands in a root the bridge's pinned-roots discovery trusts
+        # (~/.local/bin + its lib/node_modules sibling). A toolcache install would be invisible to the
+        # bridge and the OpenCode scenarios would be excluded instead of proven.
+        run: npm install -g --prefix "$HOME/.local" opencode-ai@$(node -p "require('./browser-first/host/opencode-version.json').pinned")
+
+      - name: Run live SDK fault self-tests
+        id: live-sdk-self-tests
+        # The lane's --expect-fail self-tests need Chrome and the pinned binary; both exist only in this job.
+        # Stable Chrome comes from setup-chrome (no Playwright Chromium on the runner), so pass its path here too.
+        # continue-on-error so the certification run still executes and uploads evidence; the reject step fails the job.
+        continue-on-error: true
+        env:
+          CI: "true"
+          RESONANTOS_LIVE_CHROME_PATH: ${{ steps.chrome.outputs.chrome-path }}
+        run: OPENCODE_COMMAND="$HOME/.local/bin/opencode" xvfb-run -a node --test browser-first/test/live-sdk-lane.test.mjs
+
+      - name: Run live SDK certification
+        id: live-sdk-certification
+        continue-on-error: true
+        env:
+          CI: "true"
+          RESONANTOS_LIVE_CHROME_PATH: ${{ steps.chrome.outputs.chrome-path }}
+          RESONANTOS_LIVE_ARTIFACT_DIR: ${{ runner.temp }}/live-sdk/${{ github.run_id }}-${{ github.run_attempt }}
+        # OPENCODE_COMMAND is set in the shell: the Actions `env` context has no runner HOME, so `${{ env.HOME }}` is empty.
+        run: OPENCODE_COMMAND="$HOME/.local/bin/opencode" xvfb-run -a npm run test:browser-first:live-sdk
+
+      - name: Upload live SDK evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: live-sdk-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/live-sdk/${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Reject uncertified live SDK run
+        if: always() && (steps.live-sdk-certification.outcome != 'success' || steps.live-sdk-self-tests.outcome != 'success')
         run: exit 1

--- a/browser-first/host/opencode-client.mjs
+++ b/browser-first/host/opencode-client.mjs
@@ -19,6 +19,7 @@ const PROMPT_FALLBACK_TIMEOUT_MS = 600_000;
 const BRIDGE_REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 const inflight = new Map();
 const children = new Set();
+const writtenPidRecordDirectories = new Map();
 let hooksInstalled = false;
 let stalePidCleanupDone = false;
 let stalePidSkipWrite = false;
@@ -113,6 +114,7 @@ export async function opencodeServerEnforcesAuth({ fetchImpl, baseUrl, timeoutMs
 export function resetOpencodeServerSingletonForTests() {
   inflight.clear();
   children.clear();
+  writtenPidRecordDirectories.clear();
   hooksInstalled = false;
   stalePidCleanupDone = false;
   stalePidSkipWrite = false;
@@ -312,6 +314,7 @@ async function startOpencodeServer({
       installShutdownHooks(processImpl);
       if (!skipWrite) {
         await pidRecord.write(directory, { owner: processImpl.pid, pid: child.pid, port: announcedPort, startedAt: Date.now() });
+        trackWrittenPidRecord(pidRecord, directory);
       }
       return { key, baseUrl, spawned: true, process: child, directory, auth: { username, password, header } };
     }
@@ -359,9 +362,26 @@ async function cleanupStalePidOnce(pidRecord, directory, processImpl) {
       stalePidSkipWrite = true;
     } else if (pidRecord.isAlive(stale.pid) && /\bopencode(?:\.exe|\.cmd)?\s+serve\b/i.test(pidRecord.commandOf(stale.pid))) {
       pidRecord.kill(stale.pid);
+    } else if (!pidRecord.isAlive(stale.pid)) {
+      try { pidRecord.clear(directory); } catch { /* noop */ }
     }
   }
   return stalePidSkipWrite;
+}
+
+function trackWrittenPidRecord(pidRecord, directory) {
+  const directories = writtenPidRecordDirectories.get(pidRecord) ?? new Set();
+  directories.add(directory);
+  writtenPidRecordDirectories.set(pidRecord, directories);
+}
+
+function clearWrittenPidRecords() {
+  for (const [pidRecord, directories] of writtenPidRecordDirectories.entries()) {
+    for (const directory of directories) {
+      try { pidRecord.clear(directory); } catch { /* noop */ }
+    }
+  }
+  writtenPidRecordDirectories.clear();
 }
 
 function installShutdownHooks(processImpl) {
@@ -371,6 +391,7 @@ function installShutdownHooks(processImpl) {
     for (const child of children) {
       try { child?.kill?.(); } catch { /* noop */ }
     }
+    clearWrittenPidRecords();
   };
   processImpl.once?.("exit", killAll);
   for (const sig of ["SIGINT", "SIGTERM"]) {

--- a/browser-first/host/opencode-version.json
+++ b/browser-first/host/opencode-version.json
@@ -1,0 +1,4 @@
+{
+  "pinned": "1.18.4",
+  "install": "npm install -g opencode-ai@1.18.4"
+}

--- a/browser-first/host/run-bridge-minimal.mjs
+++ b/browser-first/host/run-bridge-minimal.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
-import { existsSync, realpathSync } from "node:fs";
+import { existsSync, realpathSync, statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
@@ -56,11 +56,31 @@ import {
 } from "./memory-source-history.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..", "..");
-const resonantExtension = path.join(repoRoot, "browser-first", "resonantos-side-panel-extension");
+const defaultResonantExtension = path.join(repoRoot, "browser-first", "resonantos-side-panel-extension");
+const resonantExtension = resolveResonantExtensionRoot();
 const defaultBridgePort = 47773;
 const resonantExtensionId = "cdpdmmalhmokbfcfgogoepnjplaakgnl";
 const resonantExtensionOrigin = `chrome-extension://${resonantExtensionId}`;
 const args = parseArgs(process.argv.slice(2));
+
+function resolveResonantExtensionRoot() {
+  const configured = String(process.env.RESONANTOS_EXTENSION_ROOT ?? "").trim();
+  if (!configured) return defaultResonantExtension;
+  if (!path.isAbsolute(configured)) {
+    console.error(`RESONANTOS_EXTENSION_ROOT must be an absolute path: ${configured}`);
+    process.exit(1);
+  }
+  try {
+    const resolved = realpathSync.native(configured);
+    if (!statSync(resolved).isDirectory()) {
+      throw new Error("not a directory");
+    }
+    return resolved;
+  } catch {
+    console.error(`RESONANTOS_EXTENSION_ROOT must point to an existing directory: ${configured}`);
+    process.exit(1);
+  }
+}
 
 function userRoot() {
   return path.resolve(process.env.RESONANTOS_BROWSER_FIRST_USER_ROOT || path.join(os.homedir(), "ResonantOS_User"));
@@ -443,8 +463,9 @@ console.log(JSON.stringify({
   recovered: bridgeInfo.recovered,
   bridgeUrl: bridgePublicUrl,
   bridgeConfigPath,
+  extensionRoot: resonantExtension,
 }, null, 2));
-console.log("Load browser-first/resonantos-side-panel-extension in Chrome as an unpacked extension.");
+console.log(`Load ${resonantExtension} in Chrome as an unpacked extension.`);
 
 const shutdown = async () => {
   await flushPendingExtensionPrefs().catch(() => undefined);

--- a/browser-first/test/agent-control-live-report.mjs
+++ b/browser-first/test/agent-control-live-report.mjs
@@ -44,6 +44,7 @@ export function decidePublicSubmitScenario({ mode = "auto", humanHandoff }) {
 
 export function createLiveCertificationReport({
   artifactDir,
+  certification = "resonantos-agent-control-live",
   profile,
   roots = [],
   runId = "local",
@@ -86,7 +87,7 @@ export function createLiveCertificationReport({
     );
     const payload = {
       schemaVersion: 1,
-      certification: "resonantos-agent-control-live",
+      certification,
       status,
       profile,
       run: { id: String(runId), attempt: String(runAttempt) },
@@ -101,12 +102,16 @@ export function createLiveCertificationReport({
     };
     const jsonPath = path.join(artifactDir, "scenario-matrix.json");
     const markdownPath = path.join(artifactDir, "scenario-matrix.md");
-    const markdownRows = scenarios.map((scenario) => {
+    const sortedScenarios = [...scenarios].sort((left, right) => {
+      const rank = { excluded: 0, failed: 1, gated: 2, passed: 3 };
+      return (rank[left.status] ?? 9) - (rank[right.status] ?? 9);
+    });
+    const markdownRows = sortedScenarios.map((scenario) => {
       const detail = scenario.detail.replaceAll("|", "\\|").replaceAll("\n", " ");
       return `| ${scenario.id} | ${scenario.status} | ${detail} |`;
     });
     const markdown = [
-      "# ResonantOS Agent Control Live Certification",
+      `# ${certificationTitle(certification)}`,
       "",
       `- Status: ${status}`,
       `- Profile: ${profile}`,
@@ -139,4 +144,13 @@ export function createLiveCertificationReport({
     scenarios,
     write,
   };
+}
+
+function certificationTitle(certification) {
+  const words = String(certification ?? "")
+    .replace(/^resonantos-/, "ResonantOS ")
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((word) => word === "SDK" ? word : word.charAt(0).toUpperCase() + word.slice(1));
+  return `${words.join(" ")} Certification`;
 }

--- a/browser-first/test/agent-control-live-report.test.mjs
+++ b/browser-first/test/agent-control-live-report.test.mjs
@@ -83,6 +83,27 @@ test("certification report emits a scenario matrix without absolute artifact pat
   }
 });
 
+test("certification report accepts a lane-specific certification name", async () => {
+  const artifactDir = await mkdtemp(path.join(os.tmpdir(), "resonantos-live-report-name-test-"));
+  try {
+    const report = createLiveCertificationReport({
+      artifactDir,
+      certification: "resonantos-live-sdk",
+      profile: "ci",
+      runId: "sdk",
+      runAttempt: "1",
+    });
+    report.record("bridge-start", "passed", "capabilities bootstrapped");
+    const output = await report.write({ status: "passed" });
+    const payload = JSON.parse(await readFile(output.jsonPath, "utf8"));
+    const markdown = await readFile(output.markdownPath, "utf8");
+    assert.equal(payload.certification, "resonantos-live-sdk");
+    assert.match(markdown, /ResonantOS Live Sdk Certification/);
+  } finally {
+    await rm(artifactDir, { recursive: true, force: true });
+  }
+});
+
 test("forced Chrome unavailability cannot certify a CI run and still emits evidence", async () => {
   const artifactDir = await mkdtemp(path.join(os.tmpdir(), "resonantos-live-unavailable-test-"));
   try {

--- a/browser-first/test/agent-control-live-workflow-paths.test.mjs
+++ b/browser-first/test/agent-control-live-workflow-paths.test.mjs
@@ -9,6 +9,11 @@ const WORKFLOW = new URL("../../.github/workflows/agent-control-live.yml", impor
 
 const REQUIRED_PATH_GLOBS = [
   "browser-first/host/**",
+  "browser-first/host/opencode-version.json",
+  "browser-first/test/live-harness.mjs",
+  "browser-first/test/live-harness.test.mjs",
+  "browser-first/test/live-sdk-lane.mjs",
+  "browser-first/test/live-sdk-lane.test.mjs",
   "browser-first/resonantos-side-panel-extension/src/**",
   "browser-first/resonantos-side-panel-extension/manifest.json",
   ".github/workflows/agent-control-live.yml",
@@ -25,4 +30,50 @@ test("live certification workflow triggers on bridge host and extension source c
   for (const glob of REQUIRED_PATH_GLOBS) {
     assert.ok(paths.includes(glob), `pull_request.paths must include ${glob}`);
   }
+});
+
+test("live SDK workflow job installs pinned OpenCode and uploads evidence (#350)", async () => {
+  const workflow = parse(await readFile(WORKFLOW, "utf8"));
+  const job = workflow.jobs?.["live-sdk"];
+  assert.ok(job, "workflow must include a live-sdk job");
+
+  const install = job.steps.find((step) => /Install pinned OpenCode/i.test(step.name ?? ""));
+  assert.ok(install, "live-sdk job must install the pinned OpenCode version");
+  assert.match(
+    install.run,
+    /npm install -g --prefix "\$HOME\/\.local" opencode-ai@\$\(node -p "require\('\.\/browser-first\/host\/opencode-version\.json'\)\.pinned"\)/,
+    "the pinned install must target $HOME/.local so the bridge's pinned-roots discovery can see the binary",
+  );
+  assert.equal(job.needs, undefined, "live-sdk must not depend on the agent-control job (independent evidence)");
+  assert.equal(job["timeout-minutes"], 15);
+  const selfTests = job.steps.find((step) => /Run live SDK fault self-tests/i.test(step.name ?? ""));
+  assert.ok(selfTests, "live-sdk job must run the lane's fault self-tests where Chrome and the pinned binary exist");
+  assert.match(selfTests.run, /^OPENCODE_COMMAND="\$HOME\/\.local\/bin\/opencode" xvfb-run -a node --test browser-first\/test\/live-sdk-lane\.test\.mjs$/, "self-tests launch Chrome (headless:false) and need the virtual display too");
+  assert.equal(selfTests.env?.CI, "true", "self-tests must run in CI mode");
+  assert.equal(selfTests.id, "live-sdk-self-tests");
+  assert.equal(selfTests["continue-on-error"], true, "a self-test failure must not skip the certification run and its evidence upload");
+  assert.ok(selfTests.env?.RESONANTOS_LIVE_CHROME_PATH, "self-tests need the setup-chrome path (no Playwright Chromium on the runner)");
+  const certificationStep = job.steps.find((step) => step.id === "live-sdk-certification");
+  assert.equal(certificationStep.env.OPENCODE_COMMAND, undefined, "OPENCODE_COMMAND must not be set via the Actions env context (no runner HOME there)");
+  assert.match(certificationStep.run, /^OPENCODE_COMMAND="\$HOME\/\.local\/bin\/opencode" xvfb-run -a npm run test:browser-first:live-sdk$/,
+  );
+
+  const runStep = job.steps.find((step) => step.id === "live-sdk-certification");
+  assert.ok(runStep, "live-sdk job must have a certification run step");
+  assert.equal(runStep["continue-on-error"], true);
+  assert.match(runStep.run, /xvfb-run -a npm run test:browser-first:live-sdk/);
+  assert.equal(runStep.env.CI, "true");
+  assert.ok(runStep.env.RESONANTOS_LIVE_CHROME_PATH);
+  assert.ok(runStep.env.RESONANTOS_LIVE_ARTIFACT_DIR);
+
+  const upload = job.steps.find((step) => /upload-artifact/.test(step.uses ?? "") && /live-sdk/.test(step.with?.name ?? ""));
+  assert.ok(upload, "live-sdk job must upload live SDK evidence");
+  assert.equal(upload.if, "always()");
+  assert.match(upload.with.name, /live-sdk-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/);
+  assert.equal(upload.with["retention-days"], 14);
+
+  const reject = job.steps.find((step) => step.name === "Reject uncertified live SDK run");
+  assert.match(reject.if, /steps\.live-sdk-self-tests\.outcome != 'success'/, "the reject step must also fail the job on a self-test failure");
+  assert.ok(reject, "live-sdk job must reject uncertified runs");
+  assert.match(reject.if, /steps\.live-sdk-certification\.outcome != 'success'/);
 });

--- a/browser-first/test/agent-control-live.mjs
+++ b/browser-first/test/agent-control-live.mjs
@@ -11,6 +11,7 @@ import {
   decidePublicSubmitScenario,
   decideUnavailableCertification,
 } from "./agent-control-live-report.mjs";
+import { freeLoopbackPort as sharedFreeLoopbackPort } from "./live-harness.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..", "..");
 const resonantExtensionId = "cdpdmmalhmokbfcfgogoepnjplaakgnl";
@@ -45,37 +46,25 @@ if (process.env.RESONANTOS_LIVE_FORCE_UNAVAILABLE === "1") {
 }
 
 async function freeLoopbackPort() {
-  const server = http.createServer();
-  await new Promise((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  }).catch((error) => {
+  try {
+    return await sharedFreeLoopbackPort();
+  } catch (error) {
     if (error?.code === "EPERM" || error?.code === "EACCES") {
-      return decideUnavailableCertification({
+      const unavailable = decideUnavailableCertification({
         ci: isCi,
         reason: "Localhost bind is denied in this environment.",
       });
+      certificationReport.record(
+        "environment-loopback",
+        isCi ? "failed" : "excluded",
+        unavailable.reason,
+      );
+      await certificationReport.write({ status: unavailable.status });
+      console.error(`agent-control-live ${unavailable.status}: ${unavailable.reason}`);
+      process.exit(unavailable.exitCode);
     }
     throw error;
-  });
-  if (!server.listening) {
-    const unavailable = decideUnavailableCertification({
-      ci: isCi,
-      reason: "Localhost bind is denied in this environment.",
-    });
-    certificationReport.record(
-      "environment-loopback",
-      isCi ? "failed" : "excluded",
-      unavailable.reason,
-    );
-    await certificationReport.write({ status: unavailable.status });
-    console.error(`agent-control-live ${unavailable.status}: ${unavailable.reason}`);
-    process.exit(unavailable.exitCode);
   }
-  const address = server.address();
-  const port = typeof address === "object" && address ? address.port : 0;
-  await new Promise((resolve) => server.close(resolve));
-  return port;
 }
 
 const fixturePort = await freeLoopbackPort();

--- a/browser-first/test/live-harness.mjs
+++ b/browser-first/test/live-harness.mjs
@@ -1,0 +1,452 @@
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { cp, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { deflateSync } from "node:zlib";
+import { chromium } from "playwright";
+
+export const resonantExtensionId = "cdpdmmalhmokbfcfgogoepnjplaakgnl";
+
+export async function freeLoopbackPort() {
+  const server = http.createServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  await new Promise((resolve) => server.close(resolve));
+  if (!Number.isInteger(port) || port < 1024) {
+    throw new Error("Could not allocate an ephemeral loopback port.");
+  }
+  return port;
+}
+
+export async function stageExtensionCopy(repoRoot) {
+  const source = path.join(repoRoot, "browser-first", "resonantos-side-panel-extension");
+  const root = await mkdtemp(path.join(os.tmpdir(), "resonantos-extension-stage-"));
+  const extensionRoot = path.join(root, "resonantos-side-panel-extension");
+  await cp(source, extensionRoot, {
+    recursive: true,
+    filter: (sourcePath) => {
+      const relative = path.relative(source, sourcePath);
+      if (!relative) return true;
+      if (relative === "node_modules" || relative.startsWith(`node_modules${path.sep}`)) return false;
+      return relative !== path.join("src", "bridge-config.generated.js");
+    },
+  });
+  return {
+    root,
+    extensionRoot,
+    cleanup: () => rm(root, { recursive: true, force: true }),
+  };
+}
+
+export class CdpClient {
+  constructor(url, { timeoutMs = 10_000 } = {}) {
+    this.url = url;
+    this.timeoutMs = timeoutMs;
+    this.nextId = 1;
+    this.pending = new Map();
+    this.listeners = new Map();
+  }
+
+  async connect() {
+    this.ws = new WebSocket(this.url);
+    this.ws.addEventListener("message", (event) => {
+      const message = JSON.parse(event.data);
+      if (message.id && this.pending.has(message.id)) {
+        const { resolve, reject } = this.pending.get(message.id);
+        this.pending.delete(message.id);
+        if (message.error) reject(new Error(message.error.message));
+        else resolve(message.result);
+        return;
+      }
+      if (message.method && this.listeners.has(message.method)) {
+        for (const listener of this.listeners.get(message.method)) {
+          listener(message.params ?? {});
+        }
+      }
+    });
+    await new Promise((resolve, reject) => {
+      this.ws.addEventListener("open", resolve, { once: true });
+      this.ws.addEventListener("error", reject, { once: true });
+    });
+  }
+
+  send(method, params = {}) {
+    const id = this.nextId++;
+    this.ws.send(JSON.stringify({ id, method, params }));
+    let timeoutId = null;
+    const response = new Promise((resolve, reject) => this.pending.set(id, {
+      resolve: (value) => {
+        clearTimeout(timeoutId);
+        resolve(value);
+      },
+      reject: (error) => {
+        clearTimeout(timeoutId);
+        reject(error);
+      },
+    }));
+    const timeout = new Promise((_, reject) => {
+      timeoutId = setTimeout(() => {
+        this.pending.delete(id);
+        const expression = typeof params.expression === "string"
+          ? ` expression=${JSON.stringify(params.expression.slice(0, 220))}`
+          : "";
+        reject(new Error(`CDP ${method} timed out after ${this.timeoutMs}ms.${expression}`));
+      }, this.timeoutMs);
+    });
+    return Promise.race([response, timeout]);
+  }
+
+  close() {
+    this.ws?.close();
+  }
+
+  on(method, listener) {
+    const listeners = this.listeners.get(method) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(method, listeners);
+    return () => listeners.delete(listener);
+  }
+}
+
+export async function evaluate(client, expression) {
+  const result = await client.send("Runtime.evaluate", { expression, awaitPromise: true, returnByValue: true });
+  if (result.exceptionDetails) {
+    throw new Error(
+      result.exceptionDetails.exception?.description
+        ?? result.exceptionDetails.text
+        ?? "CDP evaluation failed.",
+    );
+  }
+  return result;
+}
+
+export async function launchExtensionContext({
+  repoRoot,
+  debugPort,
+  profile = path.join(os.tmpdir(), `resonantos-live-profile-${Date.now()}`),
+  executablePath = process.env.RESONANTOS_LIVE_CHROME_PATH,
+  extensionPath = path.join(repoRoot, "browser-first", "resonantos-side-panel-extension"),
+} = {}) {
+  const launchOptions = {
+    headless: false,
+    args: [
+      `--disable-extensions-except=${extensionPath}`,
+      `--load-extension=${extensionPath}`,
+      `--remote-debugging-port=${debugPort}`,
+      "--no-first-run",
+      "--no-default-browser-check",
+    ],
+  };
+  if (executablePath) {
+    launchOptions.executablePath = executablePath;
+  }
+  const browserContext = await chromium.launchPersistentContext(profile, launchOptions);
+  return { browserContext, extensionPath, profile };
+}
+
+export function createLivePanelHarness({
+  debugPort,
+  extensionId = resonantExtensionId,
+  cdpTimeoutMs = 10_000,
+} = {}) {
+  const sidePanelPageUrl = `chrome-extension://${extensionId}/src/side-panel.html`;
+
+  async function browserTargets() {
+    return fetch(`http://127.0.0.1:${debugPort}/json`).then((response) => response.json());
+  }
+
+  async function waitForDebugPort(getHostLogs = () => "") {
+    for (let index = 0; index < 60; index += 1) {
+      try {
+        return await fetch(`http://127.0.0.1:${debugPort}/json/version`).then((response) => response.json());
+      } catch {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+    }
+    throw new Error(`Browser debug port ${debugPort} did not become available. Host logs:\n${getHostLogs()}`);
+  }
+
+  async function waitForSidePanelReady(panel, label, timeoutMs = 8000) {
+    let lastError = null;
+    let consecutiveErrors = 0;
+    let blankPolls = 0;
+    const deadline = Date.now() + timeoutMs;
+    for (let index = 0; index < 80; index += 1) {
+      try {
+        const state = (await evaluate(panel, `(() => {
+          const errorPage = location.href.startsWith("chrome-error://");
+          return {
+            ready: Boolean(window.__resonantosSidePanelReady && document.querySelector("#command-input")),
+            errorPage,
+            errorText: errorPage ? (document.body?.innerText?.slice(0, 160) ?? "") : null,
+            readyState: document.readyState,
+            hasInput: Boolean(document.querySelector("#command-input")),
+            marker: window.__resonantosSidePanelReady ?? null,
+            scripts: [...document.scripts].map((script) => script.src)
+          };
+        })()`)).result.value;
+        if (state.ready) return { ready: true };
+        if (state.errorPage) return { ready: false, errorPage: true, text: state.errorText ?? "" };
+        consecutiveErrors = 0;
+        if (state.readyState === "complete" && !state.hasInput) {
+          blankPolls += 1;
+          if (blankPolls >= 12) {
+            return { ready: false, reason: "complete page never bound the composer", ...state };
+          }
+        } else {
+          blankPolls = 0;
+        }
+        if (Date.now() >= deadline) {
+          return { ready: false, reason: `readiness window of ${timeoutMs}ms elapsed`, ...state };
+        }
+      } catch (error) {
+        lastError = error;
+        consecutiveErrors += 1;
+        if (consecutiveErrors >= 2) break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+    const state = (await evaluate(panel, `(() => ({
+      errorPage: location.href.startsWith("chrome-error://"),
+      readyState: document.readyState,
+      hasInput: Boolean(document.querySelector("#command-input")),
+      marker: window.__resonantosSidePanelReady ?? null,
+      error: window.__resonantosSidePanelReadyError || null,
+      scripts: [...document.scripts].map((script) => script.src)
+    }))()`).catch(() => ({ error: lastError instanceof Error ? lastError.message : String(lastError) }))).result?.value ?? {};
+    throw new Error(`${label} did not finish binding listeners: ${JSON.stringify(state)}`);
+  }
+
+  async function connectToReadyPanelTarget() {
+    const rejectedTargets = new Set();
+    for (let index = 0; index < 80; index += 1) {
+      const targets = await browserTargets().catch(() => []);
+      const candidates = targets.filter(
+        (target) => target.url === sidePanelPageUrl && target.webSocketDebuggerUrl && !rejectedTargets.has(target.id),
+      );
+      for (const candidate of candidates) {
+        const probe = new CdpClient(candidate.webSocketDebuggerUrl, { timeoutMs: cdpTimeoutMs });
+        try {
+          await probe.connect();
+          await probe.send("Runtime.enable");
+          await probe.send("Page.enable");
+          const ready = await waitForSidePanelReady(probe, "side panel readiness", 5000);
+          if (ready.ready) return probe;
+          probe.close();
+        } catch {
+          probe.close();
+        }
+        rejectedTargets.add(candidate.id);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+    return null;
+  }
+
+  async function openExtensionPanel() {
+    let lastError = null;
+    let created = null;
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      created = await fetch(
+        `http://127.0.0.1:${debugPort}/json/new?${encodeURIComponent(sidePanelPageUrl)}`,
+        { method: "PUT" },
+      ).then((response) => response.json());
+      const panel = await connectToReadyPanelTarget();
+      if (panel) return panel;
+      lastError = new Error("no side-panel target bound the composer within the discovery window");
+      await fetch(`http://127.0.0.1:${debugPort}/json/close/${created?.id}`, { method: "PUT" }).catch(() => undefined);
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+    }
+    throw new Error(`Could not open the ResonantOS side panel after 3 attempts.\n${String(lastError)}`);
+  }
+
+  async function waitForBrowserTarget(predicate, label) {
+    for (let index = 0; index < 80; index += 1) {
+      const targets = await browserTargets();
+      const target = targets.find(predicate);
+      if (target?.webSocketDebuggerUrl) return target;
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+    const targets = await browserTargets().catch(() => []);
+    throw new Error(`${label} did not appear in CDP targets.\nTargets:\n${JSON.stringify(targets, null, 2)}`);
+  }
+
+  async function waitForPanelText(panel, pattern, label) {
+    let lastError = null;
+    let consecutiveErrors = 0;
+    for (let index = 0; index < 100; index += 1) {
+      try {
+        const text = (await evaluate(panel, "document.body.innerText")).result.value;
+        if (pattern.test(text)) return text;
+        consecutiveErrors = 0;
+      } catch (error) {
+        lastError = error;
+        consecutiveErrors += 1;
+        if (consecutiveErrors >= 2) break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+    const text = await evaluate(panel, "document.body.innerText")
+      .then((result) => result.result.value)
+      .catch(() => `<panel text unavailable: ${lastError instanceof Error ? lastError.message : String(lastError)}>`);
+    throw new Error(`${label} did not appear. Panel text:\n${text}`);
+  }
+
+  return {
+    browserTargets,
+    openExtensionPanel,
+    sidePanelPageUrl,
+    waitForBrowserTarget,
+    waitForDebugPort,
+    waitForPanelText,
+    waitForSidePanelReady,
+  };
+}
+
+export async function captureScreenshotArtifact(client, filePath) {
+  const captureVisibleViewport = async () => {
+    await client.send("Page.bringToFront").catch(() => undefined);
+    await client.send("Runtime.evaluate", {
+      expression: "new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))",
+      awaitPromise: true,
+      returnByValue: true,
+    }).catch(() => undefined);
+    const metrics = await client.send("Page.getLayoutMetrics").catch(() => ({}));
+    const viewport = metrics.cssLayoutViewport ?? metrics.layoutViewport ?? {};
+    const width = Math.max(320, Math.min(1600, Math.floor(viewport.clientWidth ?? 1280)));
+    const height = Math.max(240, Math.min(1200, Math.floor(viewport.clientHeight ?? 900)));
+    return client.send("Page.captureScreenshot", {
+      captureBeyondViewport: false,
+      format: "png",
+      fromSurface: true,
+      clip: {
+        x: Math.max(0, Math.floor(viewport.pageX ?? 0)),
+        y: Math.max(0, Math.floor(viewport.pageY ?? 0)),
+        width,
+        height,
+        scale: 1,
+      },
+    });
+  };
+
+  try {
+    let shot = null;
+    let lastError = null;
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      try {
+        shot = await captureVisibleViewport();
+        break;
+      } catch (error) {
+        lastError = error;
+        await client.send("Page.stopLoading").catch(() => undefined);
+        await new Promise((resolve) => setTimeout(resolve, 350));
+      }
+    }
+    if (!shot?.data) {
+      throw lastError ?? new Error("CDP Page.captureScreenshot did not return image data.");
+    }
+    await writeFile(filePath, Buffer.from(shot.data, "base64"));
+    return { ok: true, path: filePath };
+  } catch (error) {
+    const snapshot = await client.send("Runtime.evaluate", {
+      expression: "document.body.innerText",
+      returnByValue: true,
+    }).catch((fallbackError) => ({
+      result: {
+        value: `Screenshot failed: ${error instanceof Error ? error.message : String(error)}\nText snapshot failed: ${fallbackError instanceof Error ? fallbackError.message : String(fallbackError)}`,
+      },
+    }));
+    await writeTextPreviewPng(filePath, String(snapshot?.result?.value ?? ""));
+    return {
+      ok: true,
+      path: filePath,
+      fallback: "node-rendered-text-png",
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function crc32(buffer) {
+  let crc = 0xffffffff;
+  for (const byte of buffer) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function pngChunk(type, data = Buffer.alloc(0)) {
+  const name = Buffer.from(type);
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(data.length, 0);
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(Buffer.concat([name, data])), 0);
+  return Buffer.concat([length, name, data, crc]);
+}
+
+function textHash(text) {
+  let hash = 2166136261;
+  for (const char of text) {
+    hash ^= char.charCodeAt(0);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+async function writeTextPreviewPng(filePath, text) {
+  const width = 1280;
+  const height = 900;
+  const hash = textHash(text);
+  const rows = [];
+  for (let y = 0; y < height; y += 1) {
+    const row = Buffer.alloc(1 + width * 4);
+    row[0] = 0;
+    for (let x = 0; x < width; x += 1) {
+      const i = 1 + x * 4;
+      const wave = Math.sin((x + y + (hash % 360)) / 55);
+      const grid = (x % 32 === 0 || y % 32 === 0) ? 30 : 0;
+      row[i] = 190 - grid;
+      row[i + 1] = Math.max(120, 245 - grid);
+      row[i + 2] = Math.max(130, 218 + Math.round(wave * 22) - grid);
+      row[i + 3] = 255;
+    }
+    rows.push(row);
+  }
+  const lines = text.split(/\n+/).map((line) => line.trim()).filter(Boolean).slice(0, 8);
+  lines.forEach((line, lineIndex) => {
+    const y = 70 + lineIndex * 46;
+    const blocks = Math.min(44, Math.max(8, Math.ceil(line.length / 3)));
+    for (let block = 0; block < blocks; block += 1) {
+      const x = 70 + block * 24;
+      for (let dy = 0; dy < 22; dy += 1) {
+        const row = rows[y + dy];
+        if (!row) continue;
+        for (let dx = 0; dx < 16; dx += 1) {
+          const i = 1 + (x + dx) * 4;
+          row[i] = 16;
+          row[i + 1] = 36;
+          row[i + 2] = 30;
+          row[i + 3] = 255;
+        }
+      }
+    }
+  });
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = 8;
+  ihdr[9] = 6;
+  const png = Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    pngChunk("IHDR", ihdr),
+    pngChunk("IDAT", deflateSync(Buffer.concat(rows))),
+    pngChunk("IEND"),
+  ]);
+  await writeFile(filePath, png);
+}

--- a/browser-first/test/live-harness.test.mjs
+++ b/browser-first/test/live-harness.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { stageExtensionCopy } from "./live-harness.mjs";
+
+test("stageExtensionCopy creates an isolated extension tree without generated config or node_modules", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "resonantos-live-harness-repo-"));
+  try {
+    const extensionRoot = path.join(repoRoot, "browser-first", "resonantos-side-panel-extension");
+    await mkdir(path.join(extensionRoot, "src"), { recursive: true });
+    await mkdir(path.join(extensionRoot, "node_modules", "ignored"), { recursive: true });
+    await writeFile(path.join(extensionRoot, "manifest.json"), JSON.stringify({ manifest_version: 3 }));
+    await writeFile(path.join(extensionRoot, "src", "side-panel.js"), "export {};\n");
+    await writeFile(path.join(extensionRoot, "src", "bridge-config.generated.js"), "secret config\n");
+    await writeFile(path.join(extensionRoot, "node_modules", "ignored", "package.json"), "{}\n");
+
+    const staged = await stageExtensionCopy(repoRoot);
+    try {
+      assert.notEqual(staged.extensionRoot, extensionRoot);
+      assert.equal(existsSync(path.join(staged.extensionRoot, "manifest.json")), true);
+      assert.equal(await readFile(path.join(staged.extensionRoot, "src", "side-panel.js"), "utf8"), "export {};\n");
+      assert.equal(existsSync(path.join(staged.extensionRoot, "src", "bridge-config.generated.js")), false);
+      assert.equal(existsSync(path.join(staged.extensionRoot, "node_modules")), false);
+    } finally {
+      await staged.cleanup();
+      assert.equal(existsSync(staged.root), false);
+    }
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});

--- a/browser-first/test/live-sdk-lane.mjs
+++ b/browser-first/test/live-sdk-lane.mjs
@@ -1,0 +1,736 @@
+#!/usr/bin/env node
+
+import { spawn, execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  createLiveCertificationReport,
+  sanitizeEvidenceText,
+} from "./agent-control-live-report.mjs";
+import {
+  CdpClient,
+  captureScreenshotArtifact,
+  createLivePanelHarness,
+  evaluate,
+  freeLoopbackPort,
+  launchExtensionContext,
+  stageExtensionCopy,
+} from "./live-harness.mjs";
+import {
+  capabilityForBridgeRoute,
+  RUNTIME_CAPABILITY_ALLOWLIST,
+} from "../resonantos-side-panel-extension/src/lib/bridge-client.js";
+import { opencodeInstallHint, opencodeRuntimeDiagnostics } from "../host/opencode-runtime.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+const checkoutBridgeConfigPath = path.join(
+  repoRoot,
+  "browser-first",
+  "resonantos-side-panel-extension",
+  "src",
+  "bridge-config.generated.js",
+);
+const artifactDir = path.resolve(
+  process.env.RESONANTOS_LIVE_ARTIFACT_DIR
+    ?? path.join(os.tmpdir(), "resonantos-live-sdk", new Date().toISOString().replace(/[:.]/g, "-")),
+);
+const isCi = /^(?:1|true)$/i.test(process.env.CI ?? "");
+const mode = isCi && !process.env.RESONANTOS_LIVE_SDK_MODEL ? "ci" : "local";
+const fault = String(process.env.RESONANTOS_LIVE_SDK_FAULT ?? "").trim();
+const expectFail = parseArgValue("--expect-fail");
+const childWaitBoundMs = 60_000;
+
+let userRoot = "";
+let bridgePort = 0;
+let debugPort = 0;
+let bridge = null;
+let bridgeLogs = "";
+let bridgeExitLine = "";
+let browserContext = null;
+let chromeProfile = "";
+let stagedExtension = null;
+let activeBridgeConfigPath = checkoutBridgeConfigPath;
+let checkoutConfigBefore = null;
+let opencodePid = 0;
+let cleanupStarted = false;
+
+const report = createLiveCertificationReport({
+  artifactDir,
+  certification: "resonantos-live-sdk",
+  profile: mode,
+  roots: [repoRoot, os.homedir()],
+  runId: process.env.GITHUB_RUN_ID ?? "local",
+  runAttempt: process.env.GITHUB_RUN_ATTEMPT ?? "1",
+});
+
+const ctx = {
+  artifactDir,
+  bridgeUrl: "",
+  config: null,
+  capabilityTokens: {},
+  mode,
+  userRoot: "",
+};
+
+class ScenarioExcluded extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "ScenarioExcluded";
+  }
+}
+
+function excluded(message) {
+  throw new ScenarioExcluded(message);
+}
+
+const scenarios = [
+  { id: "bridge-start", fatal: true, run: startBridgeScenario },
+  { id: "opencode-credential-server", run: opencodeCredentialServerScenario },
+  { id: "execution-settings-gate", run: executionSettingsGateScenario },
+  { id: "opencode-cli-delegation", run: opencodeCliDelegationScenario },
+  { id: "opencode-version-pin", run: opencodeVersionPinScenario },
+  { id: "public-manifests-validate", run: publicManifestsValidateScenario },
+  { id: "extension-status-cards", run: extensionStatusCardsScenario },
+  { id: "teardown", run: teardownScenario },
+  { id: "checkout-config-untouched", run: checkoutConfigUntouchedScenario },
+];
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.once(signal, () => {
+    void cleanup().finally(() => process.exit(signal === "SIGINT" ? 130 : 143));
+  });
+}
+
+let failed = false;
+let terminalError = null;
+try {
+  await mkdir(artifactDir, { recursive: true });
+  for (const scenario of scenarios) {
+    const status = await runScenario(scenario);
+    if (status === "failed") failed = true;
+    if (expectFail === scenario.id && status === "passed") break;
+    if (status === "failed" && scenario.fatal) break;
+  }
+} catch (error) {
+  failed = true;
+  terminalError = error;
+} finally {
+  await report.write({
+    status: failed ? "failed" : "passed",
+    error: terminalError,
+    metadata: {
+      mode,
+      commit: process.env.GITHUB_SHA ?? "local",
+      fault,
+      expectFail,
+    },
+  });
+  await cleanup();
+}
+
+if (failed) process.exit(1);
+
+async function runScenario(scenario) {
+  try {
+    const detail = await scenario.run({ ctx, report });
+    if (expectFail === scenario.id) {
+      report.record(scenario.id, "failed", `Expected failure did not occur: ${detail ?? "scenario passed"}`);
+      return "failed";
+    }
+    report.record(scenario.id, "passed", detail ?? "passed");
+    return "passed";
+  } catch (error) {
+    if (error instanceof ScenarioExcluded) {
+      if (expectFail === scenario.id) {
+        report.record(scenario.id, "failed", `Expected failure was excluded instead: ${error.message}`);
+        return "failed";
+      }
+      report.record(scenario.id, "excluded", error.message);
+      return "excluded";
+    }
+    const detail = error instanceof Error ? error.message : String(error);
+    if (expectFail === scenario.id) {
+      report.record(scenario.id, "passed", `Expected failure observed: ${detail}`);
+      return "passed";
+    }
+    report.record(scenario.id, "failed", detail);
+    return "failed";
+  }
+}
+
+function parseArgValue(name) {
+  const exact = process.argv.find((arg) => arg.startsWith(`${name}=`));
+  return exact ? exact.slice(name.length + 1) : "";
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function withTimeout(promise, timeoutMs, label) {
+  let timer = null;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function waitForChildExit(child, timeoutMs, label) {
+  if (!child || child.exitCode !== null) return true;
+  return withTimeout(new Promise((resolve) => child.once("exit", resolve)), timeoutMs, label);
+}
+
+async function execFileBound(command, args, options = {}) {
+  return withTimeout(new Promise((resolve) => {
+    execFile(command, args, options, (error, stdout, stderr) => {
+      resolve({ error, stdout: String(stdout ?? ""), stderr: String(stderr ?? "") });
+    });
+  }), childWaitBoundMs, `${path.basename(command)} ${args.join(" ")}`);
+}
+
+async function startBridgeScenario() {
+  checkoutConfigBefore = await fileFingerprint(checkoutBridgeConfigPath);
+  userRoot = await mkdtemp(path.join(os.tmpdir(), "resonantos-live-sdk-user-"));
+  ctx.userRoot = userRoot;
+  stagedExtension = await stageExtensionCopy(repoRoot);
+  if (fault === "extension-status-cards") {
+    // Real fault injection: strip the panel's capability mapping for GET /providers/status in the STAGED copy
+    // only (never the checkout). The Settings Overview itself always requests /providers/status, so the fault is
+    // deterministic on that target on every runner: the request goes out without a capability token and the
+    // bridge answers a genuine 403 that only the "no 403 outside the loopback probe" assertion can catch
+    // (the required-200 list is /status alone, so this fault does not trip it and the 403 guard is proven on its own).
+    const stagedClient = path.join(stagedExtension.extensionRoot, "src", "lib", "bridge-client.js");
+    const source = await readFile(stagedClient, "utf8");
+    const needle = '  "GET /providers/status": "provider-diagnostics-read",\n';
+    if (!source.includes(needle)) throw new Error("fault injection anchor missing in staged bridge-client.js");
+    await writeFile(stagedClient, source.replace(needle, ""));
+  }
+  activeBridgeConfigPath = path.join(stagedExtension.extensionRoot, "src", "bridge-config.generated.js");
+  try {
+    bridgePort = await freeLoopbackPort();
+    debugPort = await freeLoopbackPort();
+  } catch (error) {
+    // No sandbox shortcut: a lane that cannot bind loopback has proven nothing and must fail here (fatal).
+    throw error;
+  }
+  const bridgeEnv = {
+    ...process.env,
+    RESONANTOS_BROWSER_FIRST_USER_ROOT: userRoot,
+    RESONANTOS_BROWSER_FIRST_BRIDGE_PORT: String(bridgePort),
+    RESONANTOS_EXTENSION_ROOT: stagedExtension.extensionRoot,
+    ...(mode === "ci" && !process.env.OPENAI_API_KEY ? { OPENAI_API_KEY: "live-sdk-placeholder-key" } : {}),
+    ...(fault === "opencode-credential-server" ? { RESONANTOS_OPENCODE_PORT: "4231" } : {}),
+  };
+  bridge = spawn(process.execPath, [
+    "browser-first/host/run-bridge-minimal.mjs",
+    `--bridge-port=${bridgePort}`,
+  ], {
+    cwd: repoRoot,
+    env: bridgeEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  bridge.stdout.on("data", (chunk) => {
+    bridgeLogs += sanitizeEvidenceText(chunk, { roots: [repoRoot, userRoot] });
+  });
+  bridge.stderr.on("data", (chunk) => {
+    bridgeLogs += sanitizeEvidenceText(chunk, { roots: [repoRoot, userRoot] });
+  });
+  bridge.once("exit", (code, signal) => {
+    bridgeExitLine = `bridge exited code=${code ?? "null"} signal=${signal ?? "null"}`;
+    bridgeLogs += `\n${bridgeExitLine}\n`;
+  });
+
+  ctx.config = await waitForGeneratedConfig(bridgePort);
+  ctx.bridgeUrl = ctx.config.bridgeUrl;
+  const requestedCapabilities = RUNTIME_CAPABILITY_ALLOWLIST.filter(
+    () => true,
+  );
+  const response = await fetch(`${ctx.bridgeUrl}/api/capability-tokens`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-ResonantOS-Bridge-Token": ctx.config.bridgeToken,
+      "X-ResonantOS-Capability-Bootstrap-Token": ctx.config.capabilityBootstrapToken,
+    },
+    body: JSON.stringify({ capabilities: requestedCapabilities }),
+  });
+  const payload = await response.json().catch(() => ({}));
+  assert(response.status === 200 && payload.ok, `capability bootstrap failed with HTTP ${response.status}: ${payload.error ?? "unknown error"}`);
+  for (const capability of requestedCapabilities) {
+    assert(payload.capabilityTokens?.[capability], `capability bootstrap did not return token for ${capability}`);
+  }
+  ctx.capabilityTokens = payload.capabilityTokens;
+  return `Bridge started on ephemeral port ${new URL(ctx.bridgeUrl).port}; ${requestedCapabilities.length} capability tokens bootstrapped from staged extension root.`;
+}
+
+async function waitForGeneratedConfig(expectedPort) {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    const parsed = await readGeneratedConfig().catch(() => null);
+    if (parsed?.bridgeUrl) {
+      const url = new URL(parsed.bridgeUrl);
+      if (Number(url.port) === expectedPort && parsed.bridgeToken && parsed.capabilityBootstrapToken) {
+        return parsed;
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`Generated bridge config for port ${expectedPort} did not appear. ${bridgeLogTail()}`);
+}
+
+async function readGeneratedConfig() {
+  const source = await readFile(activeBridgeConfigPath, "utf8");
+  const match = source.trim().match(/^globalThis\.__RESONANTOS_BRIDGE_CONFIG__ = Object\.freeze\(([\s\S]+)\);$/);
+  if (!match) return null;
+  return JSON.parse(match[1]);
+}
+
+async function fileFingerprint(filePath) {
+  try {
+    const [metadata, content] = await Promise.all([stat(filePath), readFile(filePath)]);
+    return {
+      exists: true,
+      mtimeMs: metadata.mtimeMs,
+      hash: createHash("sha256").update(content).digest("hex"),
+    };
+  } catch {
+    return { exists: false, mtimeMs: null, hash: null };
+  }
+}
+
+function bridgeLogTail() {
+  return sanitizeEvidenceText(bridgeLogs.split("\n").slice(-20).join("\n"), { roots: [repoRoot, userRoot] });
+}
+
+async function bridgeJson(route, { method = "GET", body, capability } = {}) {
+  const requiredCapability = capability ?? capabilityForBridgeRoute(route, method);
+  const headers = {
+    "X-ResonantOS-Bridge-Token": ctx.config.bridgeToken,
+  };
+  if (body !== undefined) headers["Content-Type"] = "application/json";
+  const capabilityToken = ctx.capabilityTokens[requiredCapability];
+  if (capabilityToken) {
+    headers["X-ResonantOS-Bridge-Capability-Token"] = capabilityToken;
+  }
+  const response = await fetch(`${ctx.bridgeUrl}${route}`, {
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await response.text().catch(() => "");
+  let payload = {};
+  try { payload = text ? JSON.parse(text) : {}; } catch { payload = { raw: text }; }
+  return { status: response.status, ok: response.ok && payload.ok !== false, payload };
+}
+
+function currentOpenCodeRuntime() {
+  return opencodeRuntimeDiagnostics({ env: process.env });
+}
+
+async function opencodeCredentialServerScenario() {
+  const runtime = currentOpenCodeRuntime();
+  if (!runtime.command) {
+    // Locally a missing binary is a documented exclusion; in CI the runner installs the pinned binary into an
+    // allowlisted root, so absence means the install or the pinned-roots discovery is broken → FAIL, never exclude.
+    if (mode === "ci") throw new Error(`OpenCode binary unavailable in CI mode (install/pinned-roots regression). ${opencodeInstallHint()}`);
+    excluded(`OpenCode binary unavailable. ${opencodeInstallHint()}`);
+  }
+  const started = await bridgeJson("/opencode/session/start", { method: "POST" });
+  assert(started.status === 200 && started.payload.sessionId, `session start failed: HTTP ${started.status} ${started.payload.error ?? ""}`);
+  assert(started.payload.eventAuthorization, "session start did not return eventAuthorization");
+  const baseUrl = new URL(started.payload.baseUrl);
+  const port = Number(baseUrl.port);
+  assert(port >= 1024 && port !== 4096 && port !== 4231, `OpenCode server port ${port} is not an allowed ephemeral port.`);
+
+  for (const route of ["/doc", "/session", "/event"]) {
+    const unauth = await fetch(`${baseUrl.origin}${route}`).catch((error) => ({ status: 0, error }));
+    assert(unauth.status === 401, `${route} without credential returned ${unauth.status}, expected 401`);
+  }
+  const doc = await fetch(`${baseUrl.origin}/doc`, { headers: { Authorization: started.payload.eventAuthorization } });
+  assert(doc.status === 200, `/doc with credential returned ${doc.status}`);
+  const eventController = new AbortController();
+  const event = await fetch(`${baseUrl.origin}/event`, {
+    headers: { Authorization: started.payload.eventAuthorization },
+    signal: eventController.signal,
+  });
+  assert(event.status === 200, `/event with credential returned ${event.status}`);
+  eventController.abort();
+
+  const record = JSON.parse(await readFile(path.join(userRoot, "BrowserFirst", "opencode-server.json"), "utf8"));
+  opencodePid = Number(record.pid ?? 0);
+  assert(record.port === port, `PID record port ${record.port} did not match ${port}`);
+  assert(pidAlive(opencodePid), `OpenCode PID ${opencodePid} is not live`);
+  return `OpenCode session ${started.payload.sessionId} served on port ${port} with credential enforcement.`;
+}
+
+async function executionSettingsGateScenario() {
+  const runtime = currentOpenCodeRuntime();
+  const initial = await bridgeJson("/addons/execution-settings", { method: "GET" });
+  assert(initial.status === 200, `execution settings GET failed: HTTP ${initial.status}`);
+  assert(initial.payload.settings?.opencode?.localCliExecution === false, "OpenCode localCliExecution must default to false.");
+
+  if (!runtime.command) {
+    if (mode === "ci") throw new Error(`OpenCode binary unavailable in CI mode (install/pinned-roots regression). ${opencodeInstallHint()}`);
+    excluded(`OpenCode binary unavailable; disabled execution gate cannot reach the runtime branch. ${opencodeInstallHint()}`);
+  }
+
+  const created = await createOpenCodeDelegation("Live SDK disabled execution gate.");
+  const denied = await bridgeJson("/opencode/delegation/start", {
+    method: "POST",
+    body: { path: created.payload.path, model: process.env.RESONANTOS_LIVE_SDK_MODEL },
+  });
+  assert(denied.status === 200, `disabled delegation start returned HTTP ${denied.status}: ${denied.payload.error ?? ""}`);
+  assert(denied.payload.status === "blocked", `disabled delegation did not return blocked status: ${JSON.stringify(denied.payload)}`);
+  assert(
+    /execution (?:requires explicit enablement|is disabled)/i.test(denied.payload.blockedReason ?? ""),
+    `disabled delegation error shape did not cite blockedReason: ${JSON.stringify(denied.payload)}`,
+  );
+  if (fault !== "execution-settings-gate") {
+    const enabled = await bridgeJson("/addons/execution-settings", {
+      method: "POST",
+      body: { addon: "opencode", localCliExecution: true },
+    });
+    assert(enabled.status === 200 && enabled.payload.settings?.opencode?.localCliExecution === true, "OpenCode execution enable POST did not persist.");
+  }
+  const reflected = await bridgeJson("/addons/execution-settings", { method: "GET" });
+  assert(reflected.payload.settings?.opencode?.localCliExecution === true, "OpenCode execution setting did not reflect enabled state.");
+  return "OpenCode execution is disabled by default, blocks execution, and reflects explicit enablement.";
+}
+
+async function createOpenCodeDelegation(mission) {
+  const created = await bridgeJson("/addons/delegate", {
+    method: "POST",
+    body: {
+      target: "opencode",
+      mission,
+      contextMarkdown: "Live SDK lane bounded OpenCode delegation packet.",
+      source: "live-sdk-lane",
+    },
+  });
+  assert(created.status === 200 && created.payload.path, `delegation packet creation failed: HTTP ${created.status} ${created.payload.error ?? ""}`);
+  return created;
+}
+
+async function opencodeCliDelegationScenario() {
+  const runtime = currentOpenCodeRuntime();
+  if (!runtime.command) {
+    if (mode === "ci") throw new Error(`OpenCode binary unavailable in CI mode (install/pinned-roots regression). ${opencodeInstallHint()}`);
+    excluded(`OpenCode binary unavailable. ${opencodeInstallHint()}`);
+  }
+  const settings = await bridgeJson("/addons/execution-settings", {
+    method: "POST",
+    body: { addon: "opencode", localCliExecution: true },
+  });
+  assert(settings.status === 200, `execution enable failed: HTTP ${settings.status}`);
+  const created = await createOpenCodeDelegation("Live SDK OpenCode CLI delegation smoke test.");
+  const started = await bridgeJson("/opencode/delegation/start", {
+    method: "POST",
+    body: {
+      path: created.payload.path,
+      model: process.env.RESONANTOS_LIVE_SDK_MODEL,
+      timeoutMs: 90_000,
+    },
+  });
+  assert(started.status === 200, `OpenCode CLI delegation start failed HTTP ${started.status}: ${started.payload.error ?? ""}`);
+  const terminal = await pollDelegation(created.payload.path, 90_000);
+  if (mode === "local") {
+    assert(terminal.status === "completed", `local mode requires completed OpenCode delegation: ${JSON.stringify(terminal)}`);
+    const artifact = await bridgeJson("/opencode/delegation/artifact", { method: "POST", body: { path: created.payload.path } });
+    assert(artifact.status === 200 && String(artifact.payload.content ?? "").trim(), "OpenCode delegation artifact was empty.");
+    return "OpenCode CLI delegation completed and returned a non-empty artifact.";
+  }
+  assert(["completed", "failed"].includes(terminal.status), `CI mode terminal state must be completed or failed after binary execution: ${JSON.stringify(terminal)}`);
+  if (terminal.status === "failed") {
+    const detail = sanitizedDelegationError(terminal);
+    assert(!/command not found|spawn\s+ENOENT|\bENOENT\b|not found/i.test(detail), `OpenCode failed before reaching the binary: ${detail}`);
+    return `OpenCode binary reached and returned failed terminal state: ${detail}`;
+  }
+  return "OpenCode binary reached and completed in CI mode.";
+}
+
+function sanitizedDelegationError(terminal) {
+  const raw = [
+    terminal.failureReason,
+    terminal.resultExcerpt,
+    terminal.error,
+    terminal.stderr,
+    terminal.summary,
+  ].filter(Boolean).join(" ");
+  const normalized = raw.replace(/\s+/g, " ").trim() || JSON.stringify(terminal);
+  return sanitizeEvidenceText(normalized, { roots: [repoRoot, userRoot] }).slice(0, 160);
+}
+
+async function pollDelegation(relativePath, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  const terminalStatuses = new Set(["completed", "failed", "blocked", "cancelled"]);
+  let last = null;
+  while (Date.now() < deadline) {
+    const status = await bridgeJson("/opencode/delegation/status", { method: "POST", body: { path: relativePath } });
+    assert(status.status === 200, `delegation status failed: HTTP ${status.status}`);
+    last = status.payload;
+    if (terminalStatuses.has(last.status)) return last;
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+  throw new Error(`OpenCode delegation did not reach terminal state in ${timeoutMs}ms: ${JSON.stringify(last)}`);
+}
+
+async function opencodeVersionPinScenario() {
+  const runtime = currentOpenCodeRuntime();
+  const pinPath = path.join(repoRoot, "browser-first", "host", "opencode-version.json");
+  const pin = JSON.parse(await readFile(pinPath, "utf8"));
+  const expected = fault === "opencode-version-pin" ? "0.0.0" : String(pin.pinned ?? "").trim();
+  assert(expected, "opencode-version.json must declare pinned.");
+  if (!runtime.command) {
+    if (mode === "ci") throw new Error(`OpenCode binary unavailable in CI mode (install/pinned-roots regression). ${pin.install ?? opencodeInstallHint()}`);
+    excluded(`OpenCode binary unavailable. ${pin.install ?? opencodeInstallHint()}`);
+  }
+  const version = await execFileBound(runtime.command, ["--version"], { cwd: repoRoot, encoding: "utf8" });
+  assert(!version.error, `OpenCode --version failed: ${version.error?.message ?? version.stderr}`);
+  const actual = version.stdout.trim() || version.stderr.trim();
+  assert(actual === expected, `OpenCode version mismatch: expected ${expected}, actual ${actual}`);
+  return `OpenCode version ${actual} matches pin.`;
+}
+
+async function publicManifestsValidateScenario() {
+  const publicAddons = path.join(repoRoot, "public", "addons");
+  const indexNames = ["index.json", "dev-index.json"];
+  const names = new Set();
+  for (const indexName of indexNames) {
+    const entries = JSON.parse(await readFile(path.join(publicAddons, indexName), "utf8"));
+    assert(Array.isArray(entries), `${indexName} must be an array.`);
+    for (const entry of entries) names.add(entry);
+  }
+  const requiredFields = ["id", "name", "version", "runtimeType"];
+  const validated = [];
+  for (const filename of [...names].sort()) {
+    const manifest = JSON.parse(await readFile(path.join(publicAddons, filename), "utf8"));
+    for (const field of requiredFields) {
+      assert(typeof manifest[field] === "string" && manifest[field].trim(), `${filename} missing required string ${field}`);
+    }
+    assert(Array.isArray(manifest.requestedCapabilities), `${filename} requestedCapabilities must be an array.`);
+    if (manifest.systemSlots !== undefined) {
+      assert(Array.isArray(manifest.systemSlots), `${filename} systemSlots must be an array when present.`);
+    }
+    validated.push(filename);
+  }
+  return `Structurally validated ${validated.length} public add-on manifest(s).`;
+}
+
+async function extensionStatusCardsScenario() {
+  const profile = await mkdtemp(path.join(os.tmpdir(), "resonantos-live-sdk-chrome-"));
+  chromeProfile = profile;
+  let panel = null;
+  let settings = null;
+  const responses = [];
+  try {
+    const launched = await launchExtensionContext({
+      repoRoot,
+      debugPort,
+      profile,
+      executablePath: process.env.RESONANTOS_LIVE_CHROME_PATH,
+      extensionPath: stagedExtension.extensionRoot,
+    });
+    browserContext = launched.browserContext;
+    const first = browserContext.pages()[0] ?? await browserContext.newPage();
+    await first.goto("about:blank").catch(() => undefined);
+    const harness = createLivePanelHarness({ debugPort });
+    await harness.waitForDebugPort(() => bridgeLogTail());
+    panel = await harness.openExtensionPanel();
+    const settingsUrl = `chrome-extension://cdpdmmalhmokbfcfgogoepnjplaakgnl/src/main-workspace.html#settings/overview`;
+    const created = await fetch(`http://127.0.0.1:${debugPort}/json/new?${encodeURIComponent(settingsUrl)}`, { method: "PUT" })
+      .then((response) => response.json());
+    settings = new CdpClient(created.webSocketDebuggerUrl);
+    await settings.connect();
+    await settings.send("Runtime.enable");
+    await settings.send("Page.enable");
+    await settings.send("Network.enable");
+    // Classify by the REQUEST, not by time: the panel's loopback detector raw-fetches GET /status without a
+    // capability header (and does so again on every rebind, e.g. after a reload), so a time window around
+    // capability bootstrap can never be reliable. A /status request WITHOUT the capability header is the
+    // probe by definition and is recorded separately; every other bridge response is judged.
+    const requestMeta = new Map();
+    const judged = [];
+    const probes = [];
+    let bootstrapObserved = false;
+    settings.on("Network.requestWillBeSent", (event) => {
+      const url = event.request?.url ?? "";
+      if (url.startsWith(ctx.bridgeUrl)) {
+        const headers = Object.fromEntries(Object.entries(event.request?.headers ?? {}).map(([k, v]) => [k.toLowerCase(), v]));
+        requestMeta.set(event.requestId, {
+          method: event.request?.method ?? "",
+          hasCapabilityHeader: Boolean(headers["x-resonantos-bridge-capability-token"]),
+        });
+      }
+    });
+    settings.on("Network.responseReceived", (event) => {
+      const url = event.response?.url ?? "";
+      if (!url.startsWith(ctx.bridgeUrl)) return;
+      const meta = requestMeta.get(event.requestId) ?? { method: "", hasCapabilityHeader: false };
+      const pathname = new URL(url).pathname;
+      const entry = { method: meta.method, url, status: event.response.status, capabilityHeader: meta.hasCapabilityHeader };
+      responses.push(entry);
+      if (meta.method === "POST" && pathname === "/api/capability-tokens" && event.response.status === 200) {
+        bootstrapObserved = true;
+        return;
+      }
+      if (meta.method === "GET" && pathname === "/status" && !meta.hasCapabilityHeader) {
+        probes.push(entry);
+        return;
+      }
+      judged.push(entry);
+    });
+    await settings.send("Page.reload", { ignoreCache: true });
+    await waitForOverviewCards(settings);
+    assert(bootstrapObserved, `Settings Overview did not observe capability bootstrap: ${JSON.stringify(responses)}`);
+    assert(!judged.some((response) => response.status === 403), `Settings Overview collected a 403 bridge response outside the loopback probe: ${JSON.stringify({ probes, judged })}`);
+    // /status carries the aggregated provider/add-on/memory state the cards render from; it must be answered
+    // 200 to a capability-authorized request. Any other route that 403s is caught by the assertion above.
+    const required = ["GET /status"];
+    for (const key of required) {
+      const [, route] = key.split(" ");
+      assert(
+        judged.some((response) => new URL(response.url).pathname === route && response.status === 200 && response.capabilityHeader),
+        `Settings Overview did not collect a capability-authorized HTTP 200 for ${key}: ${JSON.stringify({ probes, judged })}`,
+      );
+    }
+    await mkdir(artifactDir, { recursive: true });
+    await captureScreenshotArtifact(settings, path.join(artifactDir, "extension-status-cards.png"));
+    return `Settings Overview status cards loaded; no 403 outside the loopback probe. ${JSON.stringify({ probes: probes.length, judged: judged.length, statuses: judged.map((r) => `${r.method} ${new URL(r.url).pathname} ${r.status}`) })}`;
+  } catch (error) {
+    // Only a genuinely missing/uninstallable browser is an exclusion. Any other launch failure (no display,
+    // sandbox, crash) is a real failure and must surface with its message — on CI it once hid a missing xvfb.
+    if (/executable doesn't exist|Executable doesn't exist|Host system is missing dependencies/i.test(error?.message ?? "")) {
+      excluded("Chrome is unavailable. Set RESONANTOS_LIVE_CHROME_PATH or install Playwright Chromium.");
+    }
+    throw error;
+  } finally {
+    settings?.close();
+    panel?.close();
+    await browserContext?.close().catch(() => undefined);
+    browserContext = null;
+  }
+}
+
+async function waitForOverviewCards(settings) {
+  let lastError = null;
+  for (let index = 0; index < 120; index += 1) {
+    let state = null;
+    try {
+      // Right after Page.reload the document (or its body) can be absent for a moment on a slow runner; every
+      // access below is null-safe and an evaluation exception means "not ready yet", never "failed".
+      state = (await evaluate(settings, `(() => {
+        const cards = [...(document.querySelectorAll?.(".settings-health-grid article") ?? [])].map((card) => ({
+          label: card.querySelector("span")?.textContent?.trim() ?? "",
+          value: card.querySelector("strong")?.textContent?.trim() ?? "",
+          text: card.innerText ?? ""
+        }));
+        const wanted = ["Providers", "Add-ons", "Memory"];
+        return {
+          cards,
+          ready: wanted.every((label) => {
+            const card = cards.find((entry) => entry.label === label);
+            return card && card.value && !/^Checking$/i.test(card.value);
+          }),
+          body: document.body?.innerText ?? ""
+        };
+      })()`)).result.value;
+    } catch (error) {
+      lastError = error;
+    }
+    if (state?.ready) return state;
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  const text = await evaluate(settings, "document.body?.innerText ?? ''").then((result) => result.result.value).catch(() => `<unavailable: ${lastError?.message ?? "no page text"}>`);
+  throw new Error(`Settings Overview cards did not load non-placeholder values. ${text.slice(0, 1000)}`);
+}
+
+async function teardownScenario() {
+  const teardown = await cleanupBridgeProcess();
+  if (opencodePid) {
+    await waitForPidToDie(opencodePid, 5000, 100);
+    assert(!pidAlive(opencodePid), `OpenCode child PID ${opencodePid} remained live after bridge teardown.`);
+  }
+  const record = await readOpencodePidRecord();
+  assert(!record || !record.pid || !pidAlive(Number(record.pid)), `OpenCode PID record still names a live process: ${JSON.stringify(record)}`);
+  return `Bridge exited on SIGTERM and OpenCode child/record were cleared or dead. ${JSON.stringify({ bridgeExit: teardown.exitLine, elapsedMs: teardown.elapsedMs, pidRecord: record })}`;
+}
+
+async function checkoutConfigUntouchedScenario() {
+  const after = await fileFingerprint(checkoutBridgeConfigPath);
+  assert(checkoutConfigBefore, "checkout bridge config fingerprint was not captured before lane start.");
+  assert(after.exists === checkoutConfigBefore.exists, `checkout bridge config existence changed: before=${checkoutConfigBefore.exists} after=${after.exists}`);
+  assert(after.hash === checkoutConfigBefore.hash, "checkout bridge config hash changed during isolated live SDK lane run.");
+  assert(after.mtimeMs === checkoutConfigBefore.mtimeMs, "checkout bridge config mtime changed during isolated live SDK lane run.");
+  return "Checkout bridge-config.generated.js mtime and hash were unchanged by the isolated live SDK lane.";
+}
+
+async function readOpencodePidRecord() {
+  try {
+    return JSON.parse(await readFile(path.join(userRoot, "BrowserFirst", "opencode-server.json"), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function pidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function cleanupBridgeProcess() {
+  if (!bridge) return { elapsedMs: 0, exitLine: bridgeExitLine || "bridge was not started" };
+  const startedAt = Date.now();
+  if (bridge.exitCode !== null) {
+    return { elapsedMs: 0, exitLine: bridgeExitLine || `bridge exited code=${bridge.exitCode ?? "null"} signal=${bridge.signalCode ?? "null"}` };
+  }
+  bridge.kill("SIGTERM");
+  const exited = await Promise.race([
+    waitForChildExit(bridge, 5000, "bridge SIGTERM wait").then(() => true),
+    new Promise((resolve) => setTimeout(() => resolve(false), 5000)),
+  ]);
+  if (!exited && bridge.exitCode === null) {
+    bridge.kill("SIGKILL");
+    await waitForChildExit(bridge, childWaitBoundMs, "bridge SIGKILL wait").catch(() => undefined);
+  }
+  return {
+    elapsedMs: Date.now() - startedAt,
+    exitLine: bridgeExitLine || `bridge exited code=${bridge.exitCode ?? "null"} signal=${bridge.signalCode ?? "null"}`,
+  };
+}
+
+async function waitForPidToDie(pid, timeoutMs, pollMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!pidAlive(pid)) return true;
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+  return !pidAlive(pid);
+}
+
+async function cleanup() {
+  if (cleanupStarted) return;
+  cleanupStarted = true;
+  await browserContext?.close().catch(() => undefined);
+  await cleanupBridgeProcess().catch(() => undefined);
+  if (userRoot) {
+    const record = await readOpencodePidRecord();
+    if (record?.pid && pidAlive(Number(record.pid)) && Number(record.owner) === bridge?.pid) {
+      try { process.kill(Number(record.pid), "SIGTERM"); } catch {}
+    }
+  }
+  if (chromeProfile) await rm(chromeProfile, { recursive: true, force: true }).catch(() => undefined);
+  if (stagedExtension) await stagedExtension.cleanup().catch(() => undefined);
+  if (userRoot) await rm(userRoot, { recursive: true, force: true }).catch(() => undefined);
+}

--- a/browser-first/test/live-sdk-lane.test.mjs
+++ b/browser-first/test/live-sdk-lane.test.mjs
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { existsSync, realpathSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { chromium } from "playwright";
+
+import { opencodeRuntimeDiagnostics } from "../host/opencode-runtime.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+const lanePath = path.join(repoRoot, "browser-first", "test", "live-sdk-lane.mjs");
+const bridgePath = path.join(repoRoot, "browser-first", "host", "run-bridge-minimal.mjs");
+const checkoutConfigPath = path.join(repoRoot, "browser-first", "resonantos-side-panel-extension", "src", "bridge-config.generated.js");
+
+// Prerequisites per fault: the three OpenCode faults need the pinned binary in a trusted root; the status-card fault
+// needs a Chrome the harness can launch. Where a prerequisite is missing the self-test SKIPS with the reason (the
+// live-sdk CI job runs these with both present); it never reports a pass it did not earn.
+function chromeAvailable() {
+  const override = process.env.RESONANTOS_LIVE_CHROME_PATH;
+  if (override) return existsSync(override);
+  try { return existsSync(chromium.executablePath()); } catch { return false; }
+}
+function opencodeAvailable() {
+  try { return Boolean(opencodeRuntimeDiagnostics({ env: process.env }).command); } catch { return false; }
+}
+const faultPrerequisites = {
+  "opencode-credential-server": () => (opencodeAvailable() ? null : "pinned opencode binary not found in a trusted root"),
+  "execution-settings-gate": () => (opencodeAvailable() ? null : "pinned opencode binary not found in a trusted root"),
+  "opencode-version-pin": () => (opencodeAvailable() ? null : "pinned opencode binary not found in a trusted root"),
+  "extension-status-cards": () => (chromeAvailable() ? null : "no launchable Chrome (set RESONANTOS_LIVE_CHROME_PATH or install Playwright Chromium)"),
+};
+
+const faultScenarios = [
+  "opencode-credential-server",
+  "execution-settings-gate",
+  "opencode-version-pin",
+  "extension-status-cards",
+];
+
+function runLaneFault(scenarioId, artifactDir) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      [lanePath, `--expect-fail=${scenarioId}`],
+      {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          CI: "1",
+          RESONANTOS_LIVE_ARTIFACT_DIR: artifactDir,
+          RESONANTOS_LIVE_SDK_FAULT: scenarioId,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      reject(new Error(`${scenarioId} fault run timed out.\n${stdout}\n${stderr}`));
+    }, 120_000);
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+async function fileFingerprint(filePath) {
+  try {
+    const [metadata, content] = await Promise.all([stat(filePath), readFile(filePath)]);
+    return {
+      exists: true,
+      mtimeMs: metadata.mtimeMs,
+      hash: createHash("sha256").update(content).digest("hex"),
+      content,
+    };
+  } catch {
+    return { exists: false, mtimeMs: null, hash: null, content: null };
+  }
+}
+
+async function restoreFile(filePath, fingerprint) {
+  if (fingerprint.exists) {
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, fingerprint.content);
+  } else {
+    await rm(filePath, { force: true });
+  }
+}
+
+function waitForBridgeStarted(child, { timeoutMs = 30_000 } = {}) {
+  return new Promise((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      reject(new Error(`bridge_started did not appear within ${timeoutMs}ms.\n${stdout}\n${stderr}`));
+    }, timeoutMs);
+    const finish = (value) => {
+      clearTimeout(timer);
+      resolve(value);
+    };
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+      if (/"browser\.first\.bridge_started"/.test(stdout)) finish({ stdout, stderr });
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.on("exit", (code, signal) => {
+      if (/"browser\.first\.bridge_started"/.test(stdout)) return;
+      clearTimeout(timer);
+      reject(new Error(`bridge exited before bridge_started code=${code ?? "null"} signal=${signal ?? "null"}.\n${stdout}\n${stderr}`));
+    });
+  });
+}
+
+for (const scenarioId of faultScenarios) {
+  test(`live SDK lane detects injected ${scenarioId} fault`, { concurrency: false }, async (t) => {
+    const missing = faultPrerequisites[scenarioId]?.();
+    if (missing) {
+      t.skip(`prerequisite missing on this runner: ${missing}`);
+      return;
+    }
+    const artifactDir = await mkdtemp(path.join(os.tmpdir(), `resonantos-live-sdk-${scenarioId}-`));
+    try {
+      const result = await runLaneFault(scenarioId, artifactDir);
+      const payload = JSON.parse(await readFile(path.join(artifactDir, "scenario-matrix.json"), "utf8"));
+      assert.equal(result.code, 0, `${result.stdout}\n${result.stderr}\n${JSON.stringify(payload, null, 2)}`);
+      const scenario = payload.scenarios.find((entry) => entry.id === scenarioId);
+      assert.equal(payload.certification, "resonantos-live-sdk");
+      assert.equal(scenario?.status, "passed", JSON.stringify(payload.scenarios, null, 2));
+      assert.match(scenario.detail, /Expected failure observed/i);
+    } finally {
+      await rm(artifactDir, { recursive: true, force: true });
+    }
+  });
+}
+
+test("run-bridge-minimal honors RESONANTOS_EXTENSION_ROOT without writing checkout bridge config", { concurrency: false }, async (t) => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "resonantos-extension-root-test-"));
+  const tempExtension = path.join(tempRoot, "extension");
+  const tempUserRoot = path.join(tempRoot, "user");
+  const before = await fileFingerprint(checkoutConfigPath);
+  let child = null;
+  try {
+    await mkdir(path.join(tempExtension, "src"), { recursive: true });
+    await writeFile(path.join(tempExtension, "manifest.json"), JSON.stringify({ manifest_version: 3, name: "Temp ResonantOS", version: "0.0.0" }));
+    child = spawn(process.execPath, [bridgePath, "--bridge-port=0"], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        RESONANTOS_BROWSER_FIRST_USER_ROOT: tempUserRoot,
+        RESONANTOS_EXTENSION_ROOT: tempExtension,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const started = await waitForBridgeStarted(child).catch((error) => {
+      if (/EPERM|EACCES|operation not permitted/i.test(error.message)) {
+        t.skip(`loopback listen is denied by this sandbox: ${error.message.split("\n")[0]}`);
+        return null;
+      }
+      throw error;
+    });
+    if (!started) return;
+    const tempConfigPath = path.join(tempExtension, "src", "bridge-config.generated.js");
+    assert.equal(existsSync(tempConfigPath), true, "bridge config must be written under RESONANTOS_EXTENSION_ROOT");
+    const after = await fileFingerprint(checkoutConfigPath);
+    assert.equal(after.exists, before.exists, "checkout bridge config existence changed");
+    assert.equal(after.hash, before.hash, "checkout bridge config content changed");
+    assert.equal(after.mtimeMs, before.mtimeMs, "checkout bridge config mtime changed");
+    // The bridge logs the realpath-resolved root (macOS: /var/folders → /private/var/folders).
+    const loggedRoot = realpathSync.native(tempExtension);
+    assert.match(started.stdout, new RegExp(JSON.stringify(loggedRoot).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  } finally {
+    if (child && child.exitCode === null) {
+      child.kill("SIGTERM");
+      await new Promise((resolve) => {
+        const timer = setTimeout(() => {
+          child.kill("SIGKILL");
+          resolve();
+        }, 5000);
+        child.once("exit", () => {
+          clearTimeout(timer);
+          resolve();
+        });
+      });
+    }
+    await restoreFile(checkoutConfigPath, before);
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/browser-first/test/opencode-client.test.mjs
+++ b/browser-first/test/opencode-client.test.mjs
@@ -717,6 +717,70 @@ test("shutdown hooks kill children and install only once", async () => {
   assert.equal(child.killed, true);
 });
 
+test("SIGTERM shutdown kills children and synchronously clears pid records this process wrote", async () => {
+  resetOpencodeServerSingletonForTests();
+  const processImpl = fakeProcess();
+  processImpl.pid = 777;
+  const child = fakeChild();
+  const clears = [];
+  const writes = [];
+  const env = { OPENCODE_SERVER_PASSWORD: "signal-clear-secret" };
+  await ensureTestOpencodeServer({
+    fetchImpl: authedFetch(basicAuthHeader("opencode", env.OPENCODE_SERVER_PASSWORD), []),
+    spawnImpl: () => child,
+    command: "/bin/opencode",
+    cwd: "/repo/root",
+    env,
+    pidRecord: {
+      read: async () => null,
+      write: async (directory, rec) => { writes.push({ directory, rec }); },
+      clear: (directory) => { clears.push(directory); },
+      isAlive: () => false,
+      commandOf: () => "",
+      kill: () => {}
+    },
+    processImpl,
+    sleep: immediateSleep,
+    pollMs: 1,
+    maxWaitMs: 100
+  });
+  assert.equal(writes.length, 1);
+  processImpl.emit("SIGTERM");
+  assert.equal(child.killed, true);
+  assert.deepEqual(clears, ["/repo/root"]);
+  assert.equal(processImpl.exitCode, 143);
+});
+
+test("SIGTERM shutdown does not clear pid records written by another owner", async () => {
+  resetOpencodeServerSingletonForTests();
+  const processImpl = fakeProcess();
+  processImpl.pid = 777;
+  const child = fakeChild();
+  const clears = [];
+  const env = { OPENCODE_SERVER_PASSWORD: "foreign-signal-secret" };
+  await ensureTestOpencodeServer({
+    fetchImpl: authedFetch(basicAuthHeader("opencode", env.OPENCODE_SERVER_PASSWORD), []),
+    spawnImpl: () => child,
+    command: "/bin/opencode",
+    env,
+    pidRecord: {
+      read: async () => ({ owner: 888, pid: 999, port: 45123, startedAt: 0 }),
+      write: async () => {},
+      clear: (directory) => { clears.push(directory); },
+      isAlive: (pid) => pid === 888,
+      commandOf: () => "/x/opencode-ai/bin/opencode serve --port 45123",
+      kill: () => {}
+    },
+    processImpl,
+    sleep: immediateSleep,
+    pollMs: 1,
+    maxWaitMs: 100
+  });
+  processImpl.emit("SIGTERM");
+  assert.equal(child.killed, true);
+  assert.deepEqual(clears, []);
+});
+
 test("pidRecord cleans stale opencode serve processes and records the new child", async () => {
   const writes = [];
   const killed = [];
@@ -754,6 +818,37 @@ test("pidRecord cleans stale opencode serve processes and records the new child"
   assert.equal(writes[0].port, 45123);
   assert.equal(writes[1].pid, 4242);
   assert.equal(writes[1].port, 45123);
+});
+
+test("startup clears a stale pid record whose child pid is already dead", async () => {
+  resetOpencodeServerSingletonForTests();
+  const clears = [];
+  const writes = [];
+  const env = { OPENCODE_SERVER_PASSWORD: "dead-record-secret" };
+  const processImpl = fakeProcess();
+  processImpl.pid = 777;
+  await ensureTestOpencodeServer({
+    fetchImpl: authedFetch(basicAuthHeader("opencode", env.OPENCODE_SERVER_PASSWORD), []),
+    spawnImpl: () => fakeChild(),
+    command: "/bin/opencode",
+    cwd: "/repo/root",
+    env,
+    pidRecord: {
+      read: async () => ({ owner: 888, pid: 999, port: 45123, startedAt: 0 }),
+      write: async (_directory, rec) => { writes.push(rec); },
+      clear: (directory) => { clears.push(directory); },
+      isAlive: () => false,
+      commandOf: () => "",
+      kill: () => {}
+    },
+    processImpl,
+    sleep: immediateSleep,
+    pollMs: 1,
+    maxWaitMs: 100
+  });
+  assert.deepEqual(clears, ["/repo/root"]);
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0].owner, 777);
 });
 
 test("base URL helpers strip auth and require explicit positive ports", () => {
@@ -1144,6 +1239,7 @@ test("child exit clears the pid record only when this process owns it", async ()
   // owner matches this process -> cleared
   resetOpencodeServerSingletonForTests();
   let clears = 0;
+  let ownerReads = 0;
   const child = fakeChild();
   await ensureTestOpencodeServer({
     fetchImpl: authedFetch(expectedHeader, []),
@@ -1151,7 +1247,10 @@ test("child exit clears the pid record only when this process owns it", async ()
     command: "/bin/opencode",
     env,
     pidRecord: {
-      read: async () => ({ owner: 777, pid: child.pid }),
+      read: async () => {
+        ownerReads += 1;
+        return ownerReads === 1 ? null : { owner: 777, pid: child.pid };
+      },
       write: async () => {},
       clear: () => { clears += 1; },
       isAlive: () => false,
@@ -1170,6 +1269,7 @@ test("child exit clears the pid record only when this process owns it", async ()
   // owner differs -> left alone
   resetOpencodeServerSingletonForTests();
   clears = 0;
+  let foreignReads = 0;
   const otherChild = fakeChild();
   await ensureTestOpencodeServer({
     fetchImpl: authedFetch(expectedHeader, []),
@@ -1177,7 +1277,10 @@ test("child exit clears the pid record only when this process owns it", async ()
     command: "/bin/opencode",
     env,
     pidRecord: {
-      read: async () => ({ owner: 888, pid: otherChild.pid }),
+      read: async () => {
+        foreignReads += 1;
+        return foreignReads === 1 ? null : { owner: 888, pid: otherChild.pid };
+      },
       write: async () => {},
       clear: () => { clears += 1; },
       isAlive: () => false,

--- a/docs/browser-first-bridge-setup-runbook.md
+++ b/docs/browser-first-bridge-setup-runbook.md
@@ -107,7 +107,31 @@ The iframe is broken. Work top-down:
 - **Residual exposure (documented, not fixed here):** the password is present in the `opencode serve` child environment (readable by other processes of the same user, and inherited by any subprocess OpenCode itself spawns) — env is the only secret channel the binary supports. A bridge killed with `SIGKILL` can leave an authenticated orphan on a random port until the next bridge start reaps it via the PID record. The extension's `/event` fetch relies on MV3 `host_permissions` to send the header cross-origin. These are tracked under #326 and #321.
 - **Recovery:** if the bridge reports "did not announce a listening port", check the opencode binary version (`opencode --version`, expected ≥ 1.18) and confirm `opencode serve --hostname 127.0.0.1 --port <any free port>` prints the listening line.
 
+## Live SDK lane
+
+`npm run test:browser-first:live-sdk` proves the browser-first bridge and SDK-facing add-on routes work together in an isolated live run: capability bootstrap covers the extension allowlist, OpenCode serve uses a credentialed ephemeral loopback port, execution settings gate local CLI execution, public add-on manifests remain structurally valid, and the Settings Overview cards call capability-mapped bridge routes without 403s.
+
+The lane stages a temporary copy of the extension and passes it to both the bridge (`RESONANTOS_EXTENSION_ROOT`) and Chrome, so it is safe to run from the same checkout that serves a deployed bridge; the checkout's `src/bridge-config.generated.js` mtime and hash are checked for drift.
+
+Run the local provider-backed lane with:
+
+```bash
+RESONANTOS_LIVE_SDK_MODEL=<provider/model> npm run test:browser-first:live-sdk
+```
+
+Without `RESONANTOS_LIVE_SDK_MODEL`, CI mode records terminal OpenCode CLI evidence without requiring a real provider credential. With `RESONANTOS_LIVE_SDK_MODEL`, local mode expects the real OpenCode delegation to complete and return a non-empty artifact. Evidence lands in `RESONANTOS_LIVE_ARTIFACT_DIR` when set, otherwise under the system temp directory at `resonantos-live-sdk/<timestamp>`. The OpenCode drift detector reads the pinned version from [`../browser-first/host/opencode-version.json`](../browser-first/host/opencode-version.json).
+
+If an older lane rewrote the deployed checkout config, restart the launchd-managed bridge to regenerate it:
+
+```bash
+launchctl kickstart -k gui/$(id -u)/resonantos.browser-first.bridge
+```
+
+During shutdown, the bridge now clears OpenCode PID records written by the current bridge process before exiting and the live lane waits for the child process to die before evaluating teardown evidence.
+
 ## See also
 
 - `browser-first/test/bridge-first-run-smoke.test.mjs` — CI smoke test for the in-repo bug classes (1 and 4).
 - Issues #199–#204 — the original diagnoses.
+
+Deep manifest validation (the SDK's `validateAddOnManifest`) is not part of the lane yet: the validator is TypeScript and the Node lane has no loader. The lane validates every public manifest structurally; deep validation stays a follow-up.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:browser-host": "node --test addons/resonant-browser-host/test/*.test.mjs",
     "test:browser-first": "node scripts/run-browser-first-extension-tests.mjs",
     "test:browser-first:live": "node browser-first/test/agent-control-live.mjs",
+    "test:browser-first:live-sdk": "node browser-first/test/live-sdk-lane.mjs",
     "browser-first:dev": "node run-bridge-minimal.mjs",
     "browser-first:bridge": "node run-bridge-minimal.mjs",
     "health": "node scripts/health-check.mjs",


### PR DESCRIPTION
## Summary

Refs #350 (items 1, 3, 4; item 2 landed in #376). Adds `npm run test:browser-first:live-sdk`, a live lane that proves the browser-first bridge and its SDK-facing routes work together **against real processes**, and fixes two real defects the lane found on its first runs.

**What the lane proves** (each a scenario with pass/fail evidence in `scenario-matrix.json/.md`, screenshots included):
1. `bridge-start` — bridge started from the checkout on an ephemeral port with an isolated user root; every capability in the extension allowlist bootstrapped in one request (launcher catalog == extension allowlist, at runtime).
2. `opencode-credential-server` — the #320 seam: bridge-picked port (never 4096/4231), `/doc` `/session` `/event` 401 without the credential, 200 with it, `/event` opens, PID record matches.
3. `execution-settings-gate` — OpenCode execution off by default, delegation refused with the structured error, enable via the write capability, GET reflects it.
4. `opencode-cli-delegation` — a real delegation through the bridge to the **real, pinned `opencode` binary**. CI mode (no provider keys) proves discovery, spawn and a structured terminal state and fails on spawn/ENOENT/not-found; `RESONANTOS_LIVE_SDK_MODEL=<provider/model>` proves completion locally.
5. `opencode-version-pin` — `browser-first/host/opencode-version.json` (1.18.4) vs `opencode --version`: the drift detector that would have caught the `opencode.exe` wrapper case (#343).
6. `public-manifests-validate` — all 16 public manifests load and validate structurally (deep TypeScript validation needs a TS loader in the Node lane; recorded as a follow-up in the runbook, not as a permanently excluded row).
7. `extension-status-cards` — the side panel loaded in real Chrome over CDP; its Settings Overview bootstraps capabilities and its status cards render from capability-authorized 200s with **no 403 outside the loopback probe**. Responses are classified by the request itself (a `/status` request without the capability header is the loopback detector's probe by definition; anything else that 403s fails), not by a timing window — the first version used a window and flaked when the panel re-probed after a reload. This is the #346 deployment story, proven end to end.
8. `teardown` — bridge exits on SIGTERM, the OpenCode child dies, the PID record is cleared.
9. `checkout-config-untouched` — the checkout's `bridge-config.generated.js` is byte-identical after the run.

**Two defects fixed** (both found by running the lane for real):
- **Bridge shutdown left a stale OpenCode PID record and a slow-dying child.** `installShutdownHooks` in `opencode-client.mjs` signalled the child and then exited; the record was cleared only by the child's exit handler inside the bridge, which cannot run after the bridge exits. The seam now tracks the records this process wrote, clears them synchronously in the exit/SIGTERM hooks, and reaps a stale record whose pid is already dead at start. Verified live: bridge exit 143 in 3 ms, child dead, record cleared. Unit tests cover own-record clear, foreign-record preservation, dead-pid reap.
- **A lane run from a checkout that also serves a deployed bridge overwrote that bridge's generated config** (`run-bridge-minimal.mjs` hardcoded the extension root; this happened on the maintainer machine on 2026-09-06 and broke the panel until a restart). The bridge now honors `RESONANTOS_EXTENSION_ROOT`; the lane stages a copy of the extension (excluding the generated config) and points both the bridge and Chrome at it; scenario 9 asserts the checkout config is untouched.

**Structure:** shared live helpers move to `browser-first/test/live-harness.mjs` (the agent-control lane keeps identical behavior; its report writer is parameterized by certification name). `--expect-fail=<scenario>` fault injection with subprocess self-tests proves each scenario can go red. New CI job `live-sdk` mirrors the agent-control job (same pinned actions, stable Chrome, evidence upload, reject-uncertified), installs the pinned `opencode-ai`, 12-minute ceiling; the guard test asserts all of it.

## Evidence

- Real isolated runs on the maintainer machine (opencode 1.18.4, Chrome): **all nine scenarios passed, twice in a row** on the final head; the sibling agent-control lane run from the same worktree: **58 / 58**; no credential-looking material in output or evidence; no `opencode serve` left running; deployed bridge and its config untouched.
- `test:browser-first` **1117 / 1117**; lane + seam + harness + workflow tests green (including the four `--expect-fail` fault self-tests, each driven by a real fault, and the `RESONANTOS_EXTENSION_ROOT` spawn test).
- Anti-false-green (rig-mutate, restored byte-identical): **9 / 9** guard mutations went red — removing the synchronous PID-record clear from the shutdown hooks; removing the start-time dead-record reap; making the bridge ignore `RESONANTOS_EXTENSION_ROOT`; letting the staged copy include the generated config; un-pinning the CI install step; and removing each of the four fault-targeted assertions (403-outside-probe, ephemeral-port, version-pin, enable-reflected). Two of the fault self-tests originally passed via canned throws and were caught as vacuous by this check; every fault is now a real one..
- Process: Resonant-Rig standard tier — design approved by the maintainer (two-mode lane, real binary in CI, status-card scenario in the existing harness); fleet executor (Codex) in two rounds from written specs; adjudicator ran the lane for real between rounds, found the two defects above and two expectation errors (the Overview requests only `/status` and `/providers/status`; the spawn test must compare the realpath-resolved root), and fixed them; independent reviews: **CI/workflow lens (Grok 4.6): ISSUE → resolved** — its blocking finding was real and important: `npm install -g` on the runner lands in the setup-node toolcache, which the bridge's pinned-roots discovery rejects, so the OpenCode scenarios would have been `excluded` and the CI job green while proving nothing; the job now installs into `$HOME/.local` (a trusted root), sets `OPENCODE_COMMAND`, runs independently of the agent-control job, has a 15-minute ceiling, and CI mode **fails** on a missing binary; the guard test locks all of it. **Runtime lens (DeepSeek v4-pro, with execution): ISSUE → resolved** — it ran the lane, all four fault self-tests, the isolation and hygiene probes (clean), and found that the shared-harness refactor had dropped `import http` from the agent-control lane, killing it with a ReferenceError that `node --check` and 1117 green unit tests could not see; the import is restored, the gate now executes the sibling lane for real, and its two nits (permanently-excluded row; `CI=0` truthiness) are fixed. A delta re-review of the CI fixes (Grok) returned ISSUE once more on a mistake in the fix itself — `${{ env.HOME }}` is not a valid Actions expression — so `OPENCODE_COMMAND` is now set in the shell line and the guard test forbids the env-context form.

## Deployment

No bridge restart is required for the lane itself. The seam fix ships in `opencode-client.mjs`, so the next bridge restart picks it up (and clears the stale record currently on the maintainer machine).

## Not in scope / follow-ups

Hermes in CI (needs a Python agent and a model); deep manifest validation from the Node lane (needs a TS loader); making the lane a required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
