### PR TITLE
extension: recover failed Settings permission actions

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/lib/settings/browser-control-section.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/settings/browser-control-section.js
@@ -43,7 +43,7 @@ function row({ title, meta, actionLabel = "", onAction = null, actions = [] }) {
       const action = document.createElement("button");
       action.type = "button";
       action.textContent = itemAction.label;
-      action.addEventListener("click", () => void itemAction.onAction());
+      action.addEventListener("click", () => void itemAction.onAction(action));
       actionGroup.append(action);
     });
     item.append(actionGroup);
@@ -205,6 +205,32 @@ export function renderBrowserControlSection(container, { bridgeRequest, getBridg
     jobsDisclosure
   );
 
+  let grantPending = false;
+  const grantAction = (label, mutate) => {
+    let updated = false;
+    return async (button) => {
+      if (button.disabled || grantPending) return;
+      grantPending = true;
+      button.disabled = true;
+      setStatus(statusNode, updated ? "Refreshing permissions..." : `${label} in progress...`);
+      try {
+        if (!updated) {
+          await mutate();
+          updated = true;
+        }
+        await load();
+      } catch (error) {
+        setStatus(statusNode, updated
+          ? `Permission updated, but settings refresh failed: ${safeErrorMessage(error)}. Use Refresh to check current grants.`
+          : `${label} could not be confirmed: ${safeErrorMessage(error)}. Refresh Settings to check current grants before retrying.`, "error");
+      } finally {
+        grantPending = false;
+        button.textContent = updated ? "Refresh" : label;
+        button.disabled = false;
+      }
+    };
+  };
+
   const load = async () => {
     const tab = await activeTab(chromeApi);
     const siteKey = readableTab(tab) && sitePermissionStore
@@ -214,8 +240,8 @@ export function renderBrowserControlSection(container, { bridgeRequest, getBridg
       ? await sitePermissionStore.permissionForUrl(tab.url)
       : "unavailable";
     const [sitePermissions, taskConsents, jobs, activeJobId, downloads] = await Promise.all([
-      sitePermissionStore?.sitePermissions?.().catch(() => ({})) ?? {},
-      taskConsentStore?.taskConsents?.().catch(() => ({})) ?? {},
+      sitePermissionStore?.sitePermissions?.() ?? {},
+      taskConsentStore?.taskConsents?.() ?? {},
       readStored(storage, storageKeys.browserJobs, []),
       readStored(storage, storageKeys.activeBrowserJob, ""),
       bridgeRequest?.("/browser/downloads", { method: "GET" }).catch(() => ({ entries: [], total: 0, root: "" })) ?? { entries: [], total: 0, root: "" }
@@ -242,10 +268,12 @@ export function renderBrowserControlSection(container, { bridgeRequest, getBridg
         title: key,
         meta: `site permission · ${permissionLabel(value)}`,
         actionLabel: "Reset",
-        onAction: async () => {
-          await sitePermissionStore?.resetSitePermission?.(key, { reason: "Reset from Settings Browser Control", source: "settings" });
-          await load();
-        }
+        onAction: grantAction("Reset", async () => {
+          if (typeof sitePermissionStore?.resetSitePermission !== "function") {
+            throw new Error("Site permission reset is unavailable.");
+          }
+          await sitePermissionStore.resetSitePermission(key, { reason: "Reset from Settings Browser Control", source: "settings" });
+        })
       }));
     }
     for (const consent of consentEntries) {
@@ -253,15 +281,17 @@ export function renderBrowserControlSection(container, { bridgeRequest, getBridg
         title: `${consent.siteKey} · ${consent.taskClass}`,
         meta: `task consent · ${consent.mode} · expires ${new Date(consent.expiresAt).toLocaleDateString()}`,
         actionLabel: "Revoke",
-        onAction: async () => {
-          await taskConsentStore?.revokeTaskConsent?.({
+        onAction: grantAction("Revoke", async () => {
+          if (typeof taskConsentStore?.revokeTaskConsent !== "function") {
+            throw new Error("Task consent revocation is unavailable.");
+          }
+          await taskConsentStore.revokeTaskConsent({
             siteKey: consent.siteKey,
             taskClass: consent.taskClass,
             reason: "Revoked from Settings Browser Control",
             source: "settings"
           });
-          await load();
-        }
+        })
       }));
     }
     if (!permissionEntries.length && !consentEntries.length) {

--- a/browser-first/test/settings-grant-recovery.test.mjs
+++ b/browser-first/test/settings-grant-recovery.test.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { JSDOM } from "jsdom";
+import { renderBrowserControlSection } from "../resonantos-side-panel-extension/src/lib/settings/browser-control-section.js";
+
+async function until(predicate) {
+  for (let i = 0; i < 100; i += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  assert.fail("Settings did not settle");
+}
+
+function setup(t, options) {
+  const dom = new JSDOM("<main></main>", { url: "https://example.test" });
+  const previous = globalThis.document;
+  globalThis.document = dom.window.document;
+  t.after(() => { globalThis.document = previous; dom.window.close(); });
+  const container = document.querySelector("main");
+  renderBrowserControlSection(container, {
+    chromeApi: { tabs: { query: async () => [] } },
+    ...options
+  });
+  return {
+    container,
+    status: container.querySelector(".settings-status"),
+    button: (label) => [...container.querySelectorAll("button")].find((node) => node.textContent === label)
+  };
+}
+
+test("a concurrent history refresh cannot expose a second pending revocation", async (t) => {
+  let calls = 0;
+  let release;
+  let granted = true;
+  const ui = setup(t, {
+    storageKeys: { browserJobs: "jobs" },
+    storage: { get: async () => ({ jobs: [] }), set: async () => {} },
+    taskConsentStore: {
+      taskConsents: async () => granted ? { fixture: { siteKey: "example.test", taskClass: "read" } } : {},
+      revokeTaskConsent: async () => {
+        calls += 1;
+        await new Promise((resolve) => { release = resolve; });
+        granted = false;
+      }
+    }
+  });
+  await until(() => ui.status.dataset.tone === "success");
+  const original = ui.button("Revoke");
+  original.click();
+  ui.button("Clear Completed Browser Jobs").click();
+  await until(() => ui.button("Revoke") !== original);
+  ui.button("Revoke").click();
+  assert.equal(calls, 1);
+  release();
+  await until(() => !ui.button("Revoke"));
+});
+
+for (const label of ["Reset", "Revoke"]) {
+  function stores(action, reads = async () => ({})) {
+    let granted = true;
+    const consent = { siteKey: "example.test", taskClass: "read", mode: "allow-safe", expiresAt: 2000000000000 };
+    return {
+      options: {
+        sitePermissionStore: {
+          sitePermissions: async () => { await reads(); return label === "Reset" && granted ? { "example.test": "allow-safe" } : {}; },
+          resetSitePermission: label === "Reset" ? async () => { await action(); granted = false; } : undefined
+        },
+        taskConsentStore: {
+          taskConsents: async () => label === "Revoke" && granted ? { consent } : {},
+          revokeTaskConsent: label === "Revoke" ? async () => { await action(); granted = false; } : undefined
+        }
+      },
+      granted: () => granted
+    };
+  }
+
+  test(`${label} catches failure, blocks pending duplicates and supports retry`, async (t) => {
+    let reject;
+    let calls = 0;
+    let fail = true;
+    const store = stores(async () => {
+      calls += 1;
+      if (fail) await new Promise((resolve, rejectPromise) => { reject = rejectPromise; });
+    });
+    const ui = setup(t, store.options);
+    await until(() => ui.status.dataset.tone === "success");
+    const button = ui.button(label);
+    button.click();
+    button.dispatchEvent(new button.ownerDocument.defaultView.Event("click"));
+    assert.equal(calls, 1);
+    assert.equal(button.disabled, true);
+    reject(new Error("Permission write unavailable"));
+    await until(() => !button.disabled);
+    assert.equal(ui.status.dataset.tone, "error");
+    assert.match(ui.status.textContent, /could not be confirmed/i);
+    assert.equal(store.granted(), true);
+    fail = false;
+    button.click();
+    await until(() => !ui.button(label));
+    assert.equal(calls, 2);
+    assert.equal(store.granted(), false);
+    assert.match(ui.status.textContent, /0 stored grants/);
+  });
+
+  test(`${label} refresh failure retries reads without replaying the mutation`, async (t) => {
+    let calls = 0;
+    let failRead = false;
+    const store = stores(async () => { calls += 1; failRead = true; }, async () => {
+      if (failRead) throw new Error("Grant read unavailable");
+    });
+    const ui = setup(t, store.options);
+    await until(() => ui.status.dataset.tone === "success");
+    ui.button(label).click();
+    await until(() => ui.status.dataset.tone === "error");
+    assert.match(ui.status.textContent, /updated.*refresh failed/i);
+    assert.equal(store.granted(), false);
+    failRead = false;
+    ui.button("Refresh").click();
+    await until(() => ui.status.dataset.tone === "success");
+    assert.equal(calls, 1);
+    assert.match(ui.status.textContent, /0 stored grants/);
+  });
+
+  test(`${label} reports an unavailable mutation method`, async (t) => {
+    const store = stores(async () => {});
+    if (label === "Reset") delete store.options.sitePermissionStore.resetSitePermission;
+    else delete store.options.taskConsentStore.revokeTaskConsent;
+    const ui = setup(t, store.options);
+    await until(() => ui.status.dataset.tone === "success");
+    ui.button(label).click();
+    await until(() => !ui.button(label).disabled);
+    assert.equal(ui.status.dataset.tone, "error");
+    assert.equal(store.granted(), true);
+  });
+}


### PR DESCRIPTION
## Scope

Settings Reset/Revoke now catch errors, prevent overlapping permission mutations and report when the result cannot be confirmed. After a confirmed mutation, refresh failures offer a read-only Refresh action. Grant-read failures no longer appear as a successful empty grant list.

Closes #380.

Project 2 release scope: maintainer classification pending; no release promotion requested.
Project 2 area: Settings (proposed).

## Modules And Ownership

One extension Settings renderer and one focused test file. Existing extension presentation/persistence ownership remains; no host route, storage schema or scheduler change.

## Safety And Privacy

Existing permission stores, audits and human-only controls remain authoritative. An audit failure can follow a state write, so rejection is described as unconfirmed rather than unchanged. A refresh retry never repeats a confirmed mutation. No credential handling or private fixtures added.

## Validation

Node.js 22.13.0, macOS 26.6.2.

- `node --test browser-first/test/settings-grant-recovery.test.mjs`: 7/7 pass; relevant regressions failed on unmodified code.
- `npm run test:browser-first`: 1113/1113 pass in a clean environment.
- `node scripts/engineer-runner.mjs verify <local-task-contract.json>`: scope, focused tests, staged release-scope audit and staged whitespace checks pass.
- `node scripts/security-pipeline/run-check.mjs` and `node scripts/security-pipeline/run-check.mjs --certify`: pass.

Prior results retained: Initial inherited-environment run (before the additional concurrent-refresh regression): 1110/1112; Hermes and OpenCode CLI artifact smoke tests failed. Final clean-environment full run: 1113/1113. The three CLI/Memory tests pass in a clean-environment targeted run on unchanged dev `5d12d3c`; the initial failures are not attributed to these Settings changes.

Live-browser proof: Chrome 152.0.7977.77, disposable profile, actual unpacked extension and Settings renderer with injected in-memory dependencies for deterministic failures. Injected a consent-store rejection in the actual unpacked extension renderer: the error appeared, the fixture grant remained, and a successful retry removed it. Deterministic tests additionally cover Reset, missing methods, read-only refresh recovery and a concurrent history refresh exposing replacement controls. Local captures were inspected; screenshots are not attached here. These checks do not constitute an end-to-end scheduler or real permission-store certification.

## Documentation

No interface, configuration or architectural contract changes. This repairs existing Settings behavior; acceptance and verification are recorded in the issue and PR.

## Checklist

- [x] Targets dev; one linked issue and two files.
- [x] Ownership, privacy, secrets and human-only boundaries reviewed.
- [x] Regression tests, exact local results and browser observations recorded.
- [x] No generated credentials, profiles or private evidence committed.
- [ ] Maintainer Project 2 classification and review.

Hosted validation: [full Alpha build](https://github.com/ResonantOS/2.0.0-alpha/actions/runs/34065574359) and [live-browser certification](https://github.com/ResonantOS/2.0.0-alpha/actions/runs/34065574355) passed on this PR head. Both security checks and Project sync also passed. Maintainer review and merge remain pending.
