### PR TITLE
extension: preserve Saved Work search focus and drafts

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/lib/settings/work-section.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/settings/work-section.js
@@ -341,6 +341,40 @@ export function renderWorkSection(container, { bridgeRequest, getBridgeRequest, 
   const status = document.createElement("p");
   status.className = "settings-status";
 
+  const tools = document.createElement("form");
+  tools.className = "settings-work-tools";
+  const search = document.createElement("input");
+  search.type = "search";
+  search.placeholder = "Search chats and projects";
+  search.setAttribute("aria-label", "Search chats and projects");
+  search.addEventListener("input", () => {
+    query = search.value.trim();
+    renderBody();
+  });
+  const projectNameInput = document.createElement("input");
+  projectNameInput.name = "projectName";
+  projectNameInput.placeholder = "New project name";
+  projectNameInput.setAttribute("aria-label", "New project name");
+  const createProject = document.createElement("button");
+  createProject.type = "submit";
+  createProject.textContent = "Create project";
+  tools.append(search, projectNameInput, createProject);
+  tools.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const name = projectNameInput.value.trim();
+    if (name.length < 2) {
+      setStatus(status, "Project name needs at least 2 characters.", "warning");
+      return;
+    }
+    await chatSessionStore.createProject?.(name);
+    projectNameInput.value = "";
+    setStatus(status, `Created project: ${name}`, "success");
+    renderBody();
+  });
+  let renderedMetrics;
+  let renderedActiveList;
+  let renderedArchive;
+
   const renderBody = () => {
     const sessions = chatSessionStore.getSessions?.() ?? [];
     const projects = chatSessionStore.getProjects?.() ?? [];
@@ -356,38 +390,6 @@ export function renderWorkSection(container, { bridgeRequest, getBridgeRequest, 
       metricCard({ label: "Projects", value: String(activeProjects.length), detail: "active work containers" }),
       metricCard({ label: "Archived", value: String(archivedChats.length + archivedProjects.length), detail: "restorable work objects" })
     );
-
-    const tools = document.createElement("form");
-    tools.className = "settings-work-tools";
-    const search = document.createElement("input");
-    search.type = "search";
-    search.placeholder = "Search chats and projects";
-    search.value = query;
-    search.setAttribute("aria-label", "Search chats and projects");
-    search.addEventListener("input", () => {
-      query = search.value.trim();
-      renderBody();
-      search.focus();
-    });
-    const projectNameInput = document.createElement("input");
-    projectNameInput.name = "projectName";
-    projectNameInput.placeholder = "New project name";
-    projectNameInput.setAttribute("aria-label", "New project name");
-    const createProject = document.createElement("button");
-    createProject.type = "submit";
-    createProject.textContent = "Create project";
-    tools.append(search, projectNameInput, createProject);
-    tools.addEventListener("submit", async (event) => {
-      event.preventDefault();
-      const name = projectNameInput.value.trim();
-      if (name.length < 2) {
-        setStatus(status, "Project name needs at least 2 characters.", "warning");
-        return;
-      }
-      await chatSessionStore.createProject?.(name);
-      setStatus(status, `Created project: ${name}`, "success");
-      renderBody();
-    });
 
     const activeList = document.createElement("ol");
     activeList.className = "settings-work-list";
@@ -484,18 +486,28 @@ export function renderWorkSection(container, { bridgeRequest, getBridgeRequest, 
     }
     archive.append(archiveTitle, archiveBody, archiveList);
 
-    panel.replaceChildren(
-      metrics,
-      tools,
-      status,
-      noteCard({
-        title: "Active work",
-        body: "Move chats between projects, open active chats, archive completed work, or delete work after confirmation."
-      }),
-      activeList,
-      archive,
-      artifactManagementPanel({ bridgeRequest, getBridgeRequest })
-    );
+    if (renderedMetrics) {
+      // Keep the form and artifact state mounted while only work results change.
+      renderedMetrics.replaceWith(metrics);
+      renderedActiveList.replaceWith(activeList);
+      renderedArchive.replaceWith(archive);
+    } else {
+      panel.append(
+        metrics,
+        tools,
+        status,
+        noteCard({
+          title: "Active work",
+          body: "Move chats between projects, open active chats, archive completed work, or delete work after confirmation."
+        }),
+        activeList,
+        archive,
+        artifactManagementPanel({ bridgeRequest, getBridgeRequest })
+      );
+    }
+    renderedMetrics = metrics;
+    renderedActiveList = activeList;
+    renderedArchive = archive;
   };
 
   container.replaceChildren(

--- a/browser-first/test/settings-work-search.test.mjs
+++ b/browser-first/test/settings-work-search.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { JSDOM } from "jsdom";
+import { renderWorkSection } from "../resonantos-side-panel-extension/src/lib/settings/work-section.js";
+
+function setup(t) {
+  const dom = new JSDOM("<main></main>", { url: "https://example.test" });
+  const previous = globalThis.document;
+  globalThis.document = dom.window.document;
+  t.after(() => { globalThis.document = previous; dom.window.close(); });
+  const container = document.querySelector("main");
+  const projects = [];
+  const sessions = [{ id: "one", title: "Alpha work" }, { id: "two", title: "Other chat" }];
+  let loads = 0;
+  renderWorkSection(container, {
+    chatSessionStore: {
+      getSessions: () => sessions, getProjects: () => projects,
+      createProject: async (name) => { projects.push({ id: "new", name }); }
+    },
+    bridgeRequest: async () => { loads += 1; return { entries: [] }; }
+  });
+  return {
+    container, dom, projects, loads: () => loads,
+    search: () => container.querySelector('[aria-label="Search chats and projects"]'),
+    draft: () => container.querySelector('[name="projectName"]'),
+    input(node, value) {
+      node.value = value;
+      node.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+    }
+  };
+}
+
+test("search retains focus and raw whitespace throughout continuous typing", async (t) => {
+  const ui = setup(t);
+  await Promise.resolve();
+  ui.search().focus();
+  for (const value of ["A", "Al", "Alpha", "Alpha ", "Alpha w"]) {
+    ui.input(ui.search(), value);
+    assert.equal(document.activeElement, ui.search());
+    assert.equal(ui.search().value, value);
+  }
+  assert.match(ui.container.querySelector(".settings-work-list").textContent, /Alpha work/);
+  assert.doesNotMatch(ui.container.querySelector(".settings-work-list").textContent, /Other chat/);
+});
+
+test("selection edits keep the caret without replacing the input", async (t) => {
+  const ui = setup(t);
+  await Promise.resolve();
+  const search = ui.search();
+  search.focus();
+  search.value = "Alpha work";
+  search.setSelectionRange(2, 5, "backward");
+  search.dispatchEvent(new ui.dom.window.Event("input", { bubbles: true }));
+  assert.equal(ui.search(), search);
+  assert.equal(search.selectionStart, 2);
+  assert.equal(search.selectionEnd, 5);
+  assert.equal(search.selectionDirection, "backward");
+});
+
+test("filtering preserves project drafts and the independent artifact panel", async (t) => {
+  const ui = setup(t);
+  await Promise.resolve();
+  ui.draft().value = "Unsubmitted project";
+  const artifacts = ui.container.querySelector(".settings-work-artifacts");
+  const artifactSearch = artifacts.querySelector("input");
+  ui.input(artifactSearch, "existing filter");
+  ui.input(ui.search(), "Alpha");
+  assert.equal(ui.draft().value, "Unsubmitted project");
+  assert.equal(ui.container.querySelector(".settings-work-artifacts"), artifacts);
+  assert.equal(artifactSearch.value, "existing filter");
+  assert.equal(ui.loads(), 1);
+});
+
+test("creating a project clears only the submitted project draft", async (t) => {
+  const ui = setup(t);
+  await Promise.resolve();
+  ui.input(ui.search(), "Alpha");
+  ui.draft().value = "Alpha project";
+  ui.container.querySelector(".settings-work-tools").dispatchEvent(new ui.dom.window.Event("submit", { bubbles: true, cancelable: true }));
+  await Promise.resolve();
+  assert.deepEqual(ui.projects, [{ id: "new", name: "Alpha project" }]);
+  assert.equal(ui.draft().value, "");
+  assert.equal(ui.search().value, "Alpha");
+  assert.equal(ui.loads(), 1);
+});


### PR DESCRIPTION
## Scope

Saved Work keeps its search form and artifact panel mounted while replacing only work results. Continuous typing, selection edits and raw search whitespace are preserved, along with an unsubmitted project name and the independent artifact filter. Creating a project still clears the submitted name.

Closes #381.

Project 2 release scope: maintainer classification pending; no release promotion requested.
Project 2 area: Settings (proposed).

## Modules And Ownership

Only the extension Settings renderer `work-section.js` and its focused test file change. Existing stores and module ownership remain; no host route, persistence schema or archive-promotion change.

## Safety And Privacy

No credential handling, provider access or human-only policy changes. Tests use synthetic chats and projects. Search no longer discards independent drafts or restarts artifact requests.

## Validation

Node.js 22.13.0, macOS 26.6.2.

- `node --test browser-first/test/settings-work-search.test.mjs`: 4/4 pass; all four failed on unmodified code.
- `npm run test:browser-first`: 1110/1110 pass in a clean environment.
- `node scripts/engineer-runner.mjs verify <local-task-contract.json>`: scope, focused tests, staged release-scope audit and staged whitespace checks pass.

Prior results retained: initial inherited-environment run 1107/1110; Hermes/OpenCode CLI artifact smoke tests and the Memory move-preflight timing assertion failed. All three pass in a clean-environment targeted run on unchanged dev `5d12d3c`. The final clean full candidate run passes; the initial failures are not attributed to this Settings change.

Live-browser proof: Chrome 152.0.7977.77, actual unpacked extension and Settings renderer, disposable profile and injected synthetic stores. Typed `Alpha w` continuously: focus stayed in search, the project-name draft remained, the matching chat was shown, and the artifact list loaded once. Local screenshots were inspected; screenshots are not attached here. This is renderer interaction proof, not end-to-end persistence certification.

## Documentation

No interface, configuration or architectural contract changes. This repairs existing Settings behavior; acceptance and verification are recorded in the issue and PR.

## Checklist

- [x] Targets dev; one linked issue and two files.
- [x] Ownership, privacy, secrets and human-only boundaries reviewed.
- [x] Regression tests, exact results and browser observations recorded.
- [x] No generated credentials, profiles or private evidence committed.
- [ ] Maintainer Project 2 classification and review.

Hosted validation: [full Alpha build](https://github.com/ResonantOS/2.0.0-alpha/actions/runs/34065607487) and [live-browser certification](https://github.com/ResonantOS/2.0.0-alpha/actions/runs/34065607320) passed on this PR head. Both security checks and Project sync also passed. Maintainer review and merge remain pending.
