### PR TITLE
extension: preserve preferences when sync storage access fails

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/lib/prefs-sync.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/prefs-sync.js
@@ -55,33 +55,26 @@ function shouldTakeRemote(remote, local) {
 }
 
 async function readLocalValues(storage, keys) {
-  if (!storage?.get) return {};
-  try {
-    const result = await storage.get(keys);
-    // Normalize: chrome.storage.get returns `{}` for any keys that are
-    // absent. Collapse that to a real undefined for each key so callers
-    // can tell "not set locally" from "explicitly set to a value".
-    const out = {};
-    for (const key of keys) {
-      if (result && Object.prototype.hasOwnProperty.call(result, key)) {
-        out[key] = result[key];
-      } else {
-        out[key] = undefined;
-      }
+  if (typeof storage?.get !== "function") throw new Error("Local preference storage is unavailable.");
+  const result = await storage.get(keys);
+  if (!isPlainObject(result)) throw new Error("Local preferences could not be read safely.");
+  // Normalize: chrome.storage.get returns `{}` for any keys that are
+  // absent. Collapse that to a real undefined for each key so callers
+  // can tell "not set locally" from "explicitly set to a value".
+  const out = {};
+  for (const key of keys) {
+    if (result && Object.prototype.hasOwnProperty.call(result, key)) {
+      out[key] = result[key];
+    } else {
+      out[key] = undefined;
     }
-    return out;
-  } catch {
-    return {};
   }
+  return out;
 }
 
-async function writeLocalValue(storage, key, value) {
-  if (!storage?.set) return;
-  try {
-    await storage.set({ [key]: value });
-  } catch {
-    /* ignore — quota, locked storage, etc. */
-  }
+async function writeLocalValues(storage, values) {
+  if (typeof storage?.set !== "function") throw new Error("Local preference storage is unavailable.");
+  await storage.set(values);
 }
 
 async function fetchRemotePrefs(getBridge) {
@@ -147,15 +140,24 @@ export function createPrefsSync({ bridgeRequest, getBridgeRequest, storage, sync
   };
 
   let pushTimer = null;
-  let pushInflight = false;
-  let pushQueued = false;
+  let operations = Promise.resolve();
+  let pullRequired = false;
+  let disposed = false;
   let listener = null;
+
+  // Pulls and pushes must not publish each other's incomplete snapshots.
+  function enqueue(operation) {
+    const next = operations.then(operation);
+    operations = next.catch(() => undefined);
+    return next;
+  }
 
   function nowMs() {
     return Date.now();
   }
 
   function schedulePush() {
+    if (disposed) return;
     state.pending = true;
     if (pushTimer) return;
     pushTimer = setTimeout(() => {
@@ -164,14 +166,20 @@ export function createPrefsSync({ bridgeRequest, getBridgeRequest, storage, sync
     }, PUSH_DEBOUNCE_MS);
   }
 
-  async function flush() {
-    if (pushInflight) {
-      pushQueued = true;
-      return;
-    }
-    pushInflight = true;
+  function flush() {
+    if (pushTimer) clearTimeout(pushTimer);
+    pushTimer = null;
+    return enqueue(flushLocal);
+  }
+
+  async function flushLocal() {
+    if (disposed) return;
+    if (pushTimer) clearTimeout(pushTimer);
+    pushTimer = null;
+    state.pushing = true;
     state.pending = false;
     try {
+      if (pullRequired) throw new Error("Pull from bridge again before pushing preferences; the previous pull could not be applied safely.");
       const local = await readLocalValues(storage, syncedKeys);
       const prefs = { ...local, _meta: { pushedAt: nowMs(), version: 1 } };
       const result = await pushPrefs(resolveBridgeRequest, prefs);
@@ -181,41 +189,56 @@ export function createPrefsSync({ bridgeRequest, getBridgeRequest, storage, sync
       } else {
         state.lastError = result.error;
       }
+    } catch (error) {
+      state.lastError = error?.message ?? String(error);
     } finally {
-      pushInflight = false;
-      if (pushQueued) {
-        pushQueued = false;
-        void flush();
-      } else if (state.pending) {
-        schedulePush();
-      }
+      state.pushing = false;
     }
   }
 
-  async function hydrate() {
-    const remote = await fetchRemotePrefs(resolveBridgeRequest);
-    state.lastPullAt = nowMs();
-    if (!remote.ok) {
-      state.lastError = remote.error;
-      return { ok: false, reason: remote.error };
-    }
-    state.lastSource = remote.source;
-    const local = await readLocalValues(storage, syncedKeys);
-    let wroteAny = false;
-    for (const key of syncedKeys) {
-      const remoteValue = remote.prefs?.[key];
-      const localValue = local?.[key];
-      if (shouldTakeRemote(remoteValue, localValue)) {
-        await writeLocalValue(storage, key, remoteValue);
-        wroteAny = true;
+  function hydrate() {
+    return enqueue(hydrateLocal);
+  }
+
+  async function hydrateLocal() {
+    if (disposed) return { ok: false, reason: "sync-stopped" };
+    try {
+      const remote = await fetchRemotePrefs(resolveBridgeRequest);
+      if (!remote.ok) {
+        state.lastError = remote.error;
+        return { ok: false, reason: remote.error };
       }
+      const local = await readLocalValues(storage, syncedKeys);
+      const updates = {};
+      for (const key of syncedKeys) {
+        const remoteValue = remote.prefs?.[key];
+        const localValue = local?.[key];
+        if (shouldTakeRemote(remoteValue, localValue)) {
+          updates[key] = remoteValue;
+        }
+      }
+      const wroteAny = Object.keys(updates).length > 0;
+      if (wroteAny) {
+        // A rejected write may have partially applied. A new pull must reconcile
+        // local state before either a queued or manual push is allowed.
+        pullRequired = true;
+        await writeLocalValues(storage, updates);
+      }
+      pullRequired = false;
+      state.lastPullAt = nowMs();
+      state.lastSource = remote.source;
+      state.lastError = null;
+      if (wroteAny) {
+        schedulePush();
+      }
+      return { ok: true, source: remote.source, wroteAny };
+    } catch (error) {
+      state.lastError = `${error?.message ?? String(error)}${pullRequired ? " Pull from bridge again before pushing preferences." : ""}`;
+      if (pushTimer) clearTimeout(pushTimer);
+      pushTimer = null;
+      state.pending = false;
+      return { ok: false, reason: state.lastError };
     }
-    // If we have nothing locally yet, push the (empty) local doc up so the
-    // bridge learns about this machine's existence.
-    if (wroteAny || !local || Object.keys(local).length === 0) {
-      schedulePush();
-    }
-    return { ok: true, source: remote.source, wroteAny };
   }
 
   function install() {
@@ -239,6 +262,8 @@ export function createPrefsSync({ bridgeRequest, getBridgeRequest, storage, sync
   }
 
   function teardown() {
+    disposed = true;
+    state.pending = false;
     if (pushTimer) {
       clearTimeout(pushTimer);
       pushTimer = null;

--- a/browser-first/resonantos-side-panel-extension/src/lib/settings/bridge-target-section.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/settings/bridge-target-section.js
@@ -191,6 +191,10 @@ export function renderBridgeTargetSection(container, { bridgeRequest, onBridgeCo
             setStatus(syncStatus, "Pushing to bridge...", "");
             try {
               await prefsSync.flush();
+              const state = prefsSync.getState();
+              setStatus(syncStatus, state.lastError
+                ? `Push failed: ${safeErrorMessage(state.lastError)}`
+                : "Preferences pushed to bridge.", state.lastError ? "error" : "success");
               refreshSyncStatus();
             } catch (error) {
               setStatus(syncStatus, safeErrorMessage(error), "error");

--- a/browser-first/test/prefs-sync-storage.test.mjs
+++ b/browser-first/test/prefs-sync-storage.test.mjs
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { JSDOM } from "jsdom";
+import { createPrefsSync } from "../resonantos-side-panel-extension/src/lib/prefs-sync.js";
+import { renderBridgeTargetSection } from "../resonantos-side-panel-extension/src/lib/settings/bridge-target-section.js";
+
+function fixture(t, storage, remote = { augmentorModel: "remote-model" }) {
+  const posts = [];
+  const sync = createPrefsSync({ storage, bridgeRequest: async (_, options) => {
+    if (options.method === "POST") { posts.push(options.body.prefs); return { ok: true }; }
+    return { prefs: remote, source: "stored" };
+  } });
+  t.after(() => sync.teardown());
+  return { sync, posts };
+}
+
+test("failed local push read preserves remote preferences and explicit retry recovers", async (t) => {
+  let fail = true;
+  const { sync, posts } = fixture(t, { get: async () => {
+    if (fail) throw new Error("fixture read failure");
+    return { augmentorModel: "local-model" };
+  } });
+  await sync.flush();
+  assert.equal(posts.length, 0);
+  assert.match(sync.getState().lastError, /fixture read failure/);
+  assert.equal(sync.getState().lastPushAt, 0);
+  fail = false;
+  await sync.flush();
+  assert.equal(posts.length, 1);
+  assert.equal(posts[0].augmentorModel, "local-model");
+  assert.equal(sync.getState().lastError, null);
+});
+
+test("failed local pull read performs no writes or push", async (t) => {
+  let writes = 0;
+  const { sync, posts } = fixture(t, { get: async () => { throw new Error("read unavailable"); }, set: async () => { writes++; } });
+  const result = await sync.hydrate();
+  assert.equal(result.ok, false);
+  assert.equal(writes, 0);
+  assert.equal(posts.length, 0);
+  assert.equal(sync.getState().pending, false);
+});
+
+test("failed pull write cannot claim application and blocks pushes until a successful pull", async (t) => {
+  let fail = true;
+  const local = {};
+  const { sync, posts } = fixture(t, { get: async () => ({ ...local }), set: async (values) => {
+    if (fail) throw new Error("fixture write failure");
+    Object.assign(local, values);
+  } });
+  const result = await sync.hydrate();
+  assert.equal(result.ok, false);
+  assert.notEqual(result.wroteAny, true);
+  assert.equal(sync.getState().lastPullAt, 0);
+  await sync.flush();
+  assert.equal(posts.length, 0);
+  assert.match(sync.getState().lastError, /Pull from bridge again/);
+  fail = false;
+  assert.equal((await sync.hydrate()).ok, true);
+  await sync.flush();
+  assert.equal(posts[0].augmentorModel, "remote-model");
+  assert.equal(sync.getState().lastError, null);
+});
+
+test("queued push cannot publish a partially applied failed pull", async (t) => {
+  let release;
+  const gate = new Promise((resolve) => { release = resolve; });
+  let entered;
+  const started = new Promise((resolve) => { entered = resolve; });
+  const local = {};
+  const { sync, posts } = fixture(t, { get: async () => ({ ...local }), set: async (values) => {
+    local.augmentorModel = values.augmentorModel;
+    entered();
+    await gate;
+    throw new Error("partial write failure");
+  } }, { augmentorModel: "remote-model", augmentorThinkingDepth: "deep" });
+  const pull = sync.hydrate();
+  await started;
+  const push = sync.flush();
+  release();
+  assert.equal((await pull).ok, false);
+  await push;
+  assert.equal(posts.length, 0);
+});
+
+test("missing or malformed storage is not treated as an empty snapshot", async (t) => {
+  for (const storage of [{}, { get: async () => null }, { get: async () => [] }]) {
+    const { sync, posts } = fixture(t, storage);
+    await sync.flush();
+    assert.equal(posts.length, 0);
+    assert.ok(sync.getState().lastError);
+  }
+});
+
+test("new profile pull applies remote values and an empty remote does not auto-push", async (t) => {
+  const local = {};
+  const { sync } = fixture(t, { get: async () => ({ ...local }), set: async (values) => Object.assign(local, values) });
+  assert.equal((await sync.hydrate()).wroteAny, true);
+  assert.equal(local.augmentorModel, "remote-model");
+  const empty = fixture(t, { get: async () => ({}) }, {});
+  assert.deepEqual(await empty.sync.hydrate(), { ok: true, source: "stored", wroteAny: false });
+  assert.equal(empty.sync.getState().pending, false);
+});
+
+test("push waits for a successful pull to finish applying all values", async (t) => {
+  const local = {};
+  let release;
+  const gate = new Promise((resolve) => { release = resolve; });
+  const { sync, posts } = fixture(t, { get: async () => ({ ...local }), set: async (values) => {
+    await gate;
+    Object.assign(local, values);
+  } });
+  const pull = sync.hydrate();
+  const push = sync.flush();
+  release();
+  await Promise.all([pull, push]);
+  assert.equal(posts.length, 1);
+  assert.equal(posts[0].augmentorModel, "remote-model");
+});
+
+test("Settings Push leaves the pending message for failure and successful recovery", async (t) => {
+  const dom = new JSDOM("<main></main>");
+  const previousDocument = globalThis.document;
+  const previousFetch = globalThis.fetch;
+  globalThis.document = dom.window.document;
+  globalThis.fetch = async () => new Response(JSON.stringify({ ok: true, bridge: true }), { status: 200 });
+  t.after(() => { globalThis.document = previousDocument; globalThis.fetch = previousFetch; dom.window.close(); });
+  const state = { lastError: null, lastPushAt: 0 };
+  let fail = true;
+  renderBridgeTargetSection(document.querySelector("main"), { prefsSync: {
+    getState: () => ({ ...state }),
+    flush: async () => { state.lastError = fail ? "Local preference storage is unavailable." : null; state.lastPushAt = fail ? 0 : Date.now(); },
+  } });
+  const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+  await tick();
+  const card = document.querySelector(".settings-provider-card");
+  const push = [...card.querySelectorAll("button")].find((button) => button.textContent === "Push to bridge now");
+  push.click();
+  await tick();
+  assert.match(card.querySelector(".settings-status").textContent, /Push failed: Local preference storage/);
+  fail = false;
+  push.click();
+  await tick();
+  assert.equal(card.querySelector(".settings-status").textContent, "Preferences pushed to bridge.");
+});


### PR DESCRIPTION
## Scope

A failed preference read now stops the push instead of replacing the bridge document with an empty snapshot. Pulls and pushes are serialized; rejected local application reports failure and requires a successful pull before publishing. Settings Push now finishes with a clear success or failure message.

Closes #395.

Project2 area: Settings (proposed). Release classification and review remain with maintainers.

## Modules And Ownership

Existing extension Settings/preferences code and focused regression tests. No host route, persistence schema, capability boundary, provider credential handling or human-only action changes. No new module ownership.

## Validation

Node22.13.0 on macOS26.6.2, fresh npm ci, clean environment.

- `node --test browser-first/test/prefs-sync-storage.test.mjs`: 8/8 pass.
- `npm run test:browser-first`: 1164 pass, 0 failures, 4 prerequisite skips.
- Staged Engineer Runner: allowed-file scope, focused tests, strict release-scope audit and whitespace checks pass.

The four skips are existing live SDK fault cases: three require a pinned trusted-root OpenCode binary; one requires the live lane Chrome configuration. They are not counted as passes. Hosted checks run the applicable live lanes.

Chrome152.0.7977.77 proof: Unpacked Chrome with real disposable local storage and injected failures: failed read and failed write produced zero captured POSTs; explicit pull recovery followed by push sent the complete fixture values once. Settings failure and recovery messages were inspected. The actual extension modules and a disposable profile were used; bridge calls were injected and captured. This is renderer/storage proof, not real-provider or host-filesystem certification. Screenshots were inspected locally and are not attached.

## Safety And Documentation

Synthetic fixtures only. No credentials, real user profile, generated configuration or private evidence committed. The issue and PR describe the bounded behavior correction; public interfaces and architecture are unchanged.

## Checklist

- [x] Linked issue, dev target and bounded scope.
- [x] Deterministic checks and Chrome proof with evidence limits.
- [x] Ownership, privacy and authority boundaries reviewed.
- [ ] Maintainer classification, review and merge.

## Hosted validation

All reported checks passed on this submitted head (2026-09-07):

- [Agent Control live-browser certification](https://github.com/ResonantOS/2.0.0-alpha/actions/runs/34079861981/job/101612974456): SUCCESS.
- [Build Chrome extension alpha](https://github.com/ResonantOS/2.0.0-alpha/actions/runs/34079862010/job/101612974468): SUCCESS.
- [Sync Project 2 release fields and issue labels](https://github.com/ResonantOS/2.0.0-alpha/actions/runs/34079861989/job/101612974476): SUCCESS.
- [security pipeline (observe)](https://github.com/ResonantOS/2.0.0-alpha/actions/runs/34079861983/job/101612974382): SUCCESS.
- [Live SDK certification](https://github.com/ResonantOS/2.0.0-alpha/actions/runs/34079861981/job/101612974635): SUCCESS.
- [committed private key material (gating)](https://github.com/ResonantOS/2.0.0-alpha/actions/runs/34079861983/job/101612974179): SUCCESS.

Maintainer classification, review and merge remain separate.

