### PR TITLE
docs(release): declare the beta.2 exit criteria and gate (#402)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -30,6 +30,19 @@ state, milestone, and project fields decide scheduling.
 
 ## Beta.2
 
+Exit criteria are tracked in
+[#402: beta.2 exit criteria](https://github.com/ResonantOS/2.0.0-alpha/issues/402).
+Gating: the committed feature track and the security line below; every other
+beta.2 item stays deferred with a recorded disposition.
+
+- [#402: beta.2 exit criteria](https://github.com/ResonantOS/2.0.0-alpha/issues/402)
+- [#227: Research trail save and archive review handoff](https://github.com/ResonantOS/2.0.0-alpha/issues/227)
+- [#232: Spreadsheet and document artifact contract](https://github.com/ResonantOS/2.0.0-alpha/issues/232)
+- [#252: Explicit `@tab` referencing](https://github.com/ResonantOS/2.0.0-alpha/issues/252)
+- [#321: Governed OpenCode boundary (bridge-authenticated proxy)](https://github.com/ResonantOS/2.0.0-alpha/issues/321)
+- [#326: Add-on delegation OS-level isolation](https://github.com/ResonantOS/2.0.0-alpha/issues/326)
+- [#373: Default-deny routes without a required capability](https://github.com/ResonantOS/2.0.0-alpha/issues/373)
+- [#180: Add-on uninstall and capability cleanup](https://github.com/ResonantOS/2.0.0-alpha/issues/180)
 - [#216: Personal connectors, voice, and delegated automation](https://github.com/ResonantOS/2.0.0-alpha/issues/216)
 - [#234: Draft-only Gmail and Calendar handoff audit UX](https://github.com/ResonantOS/2.0.0-alpha/issues/234)
 - [#235: Permission-light transcript-to-composer voice flow](https://github.com/ResonantOS/2.0.0-alpha/issues/235)

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -112,6 +112,18 @@ An open issue is not proof that every deterministic check currently fails. It
 is unresolved release evidence until the issue is closed or explicitly
 dispositioned in Project 2.
 
+The **beta.2** gate is **open**. Its exit criteria — the committed feature track
+([#227](https://github.com/ResonantOS/2.0.0-alpha/issues/227),
+[#232](https://github.com/ResonantOS/2.0.0-alpha/issues/232),
+[#252](https://github.com/ResonantOS/2.0.0-alpha/issues/252)), the security line
+([#321](https://github.com/ResonantOS/2.0.0-alpha/issues/321),
+[#326](https://github.com/ResonantOS/2.0.0-alpha/issues/326),
+[#373](https://github.com/ResonantOS/2.0.0-alpha/issues/373),
+[#180](https://github.com/ResonantOS/2.0.0-alpha/issues/180)), the
+[#216](https://github.com/ResonantOS/2.0.0-alpha/issues/216) acceptance
+criteria, and the release evidence — are tracked in
+[#402](https://github.com/ResonantOS/2.0.0-alpha/issues/402).
+
 ## Out of Scope
 
 - Tauri and Electron shells are historical or future work, not Alpha runtime.


### PR DESCRIPTION
Applies the release owner's 2026-09-06 decisions on the beta.2 exit criteria: #321 and #326 gate, #180 joins the milestone, none of the deferred expansion items are promoted. Adds the gating issues to ROADMAP.md's Beta.2 section and a beta.2 gate paragraph to STATUS.md's Release Gate, both pointing at the tracking epic #402. Docs-only; `docs:check` and `test:docs` green locally. Milestone assignments and issue labels were applied directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)