### PR TITLE
extension: align Settings component shapes with documented roles

### DIFF
--- a/.github/workflows/agent-control-live.yml
+++ b/.github/workflows/agent-control-live.yml
@@ -76,6 +76,11 @@ jobs:
           install-dependencies: true
 
       - name: Check rendered Settings component shapes
+        id: settings-shapes
+        # A shapes failure must not skip the certification run and its
+        # evidence upload (the live-sdk self-test convention): fail soft
+        # here, surface both outcomes in the reject step below.
+        continue-on-error: true
         env:
           CI: "true"
           RESONANTOS_LIVE_CHROME_PATH: ${{ steps.chrome.outputs.chrome-path }}
@@ -103,7 +108,7 @@ jobs:
           retention-days: 14
 
       - name: Reject uncertified run
-        if: always() && steps.certification.outcome != 'success'
+        if: always() && (steps.certification.outcome != 'success' || steps.settings-shapes.outcome != 'success')
         run: exit 1
 
   live-sdk:

--- a/.github/workflows/agent-control-live.yml
+++ b/.github/workflows/agent-control-live.yml
@@ -35,6 +35,7 @@ on:
       - "browser-first/test/agent-control-live-report.test.mjs"
       - "browser-first/test/live-harness.mjs"
       - "browser-first/test/live-harness.test.mjs"
+      - "browser-first/test/settings-shapes-live.mjs"
       - "browser-first/test/live-sdk-lane.mjs"
       - "browser-first/test/live-sdk-lane.test.mjs"
       - "browser-first/host/opencode-version.json"
@@ -73,6 +74,12 @@ jobs:
         with:
           chrome-version: stable
           install-dependencies: true
+
+      - name: Check rendered Settings component shapes
+        env:
+          RESONANTOS_LIVE_CHROME_PATH: ${{ steps.chrome.outputs.chrome-path }}
+          RESONANTOS_SETTINGS_ARTIFACT_DIR: ${{ runner.temp }}/agent-control-live/${{ github.run_id }}-${{ github.run_attempt }}/settings-shapes
+        run: xvfb-run -a npm run test:browser-first:settings-shapes
 
       - name: Run live Agent Control certification
         id: certification

--- a/.github/workflows/agent-control-live.yml
+++ b/.github/workflows/agent-control-live.yml
@@ -77,9 +77,10 @@ jobs:
 
       - name: Check rendered Settings component shapes
         env:
+          CI: "true"
           RESONANTOS_LIVE_CHROME_PATH: ${{ steps.chrome.outputs.chrome-path }}
           RESONANTOS_SETTINGS_ARTIFACT_DIR: ${{ runner.temp }}/agent-control-live/${{ github.run_id }}-${{ github.run_attempt }}/settings-shapes
-        run: xvfb-run -a npm run test:browser-first:settings-shapes
+        run: npm run test:browser-first:settings-shapes
 
       - name: Run live Agent Control certification
         id: certification

--- a/browser-first/resonantos-side-panel-extension/src/styles/main-workspace/responsive.css
+++ b/browser-first/resonantos-side-panel-extension/src/styles/main-workspace/responsive.css
@@ -81,29 +81,7 @@
   .memory-review-draft,
   .memory-review-preview,
   .memory-source-candidate,
-  .opencode-card,
-  .settings-workspace,
-  .settings-subnav,
-  .settings-provider-card,
-  .settings-addon-card,
-  .settings-routing-card,
-  .settings-note,
-  .settings-health-card,
-  .settings-provider-panel,
-  .settings-provider-modal-panel,
-  .settings-provider-field input,
-  .settings-provider-field select,
-  .settings-provider-field textarea,
-  .settings-route-badge,
-  .settings-provider-summary span,
-  .settings-provider-model-options label,
-  .settings-provider-recovery-row,
-  .settings-provider-history-row,
-  .settings-diagnostics-row,
-  .settings-control-row,
-  .settings-work-row,
-  .settings-archive-row,
-  .settings-work-empty
+  .opencode-card
 ) {
   border-radius: 3px !important;
 }
@@ -133,9 +111,24 @@ button:not(.icon-button):not(.send-button):not(.rail-icon-button),
   .opencode-card button
 ) {
   border: 0 !important;
-  border-radius: 3px !important;
   box-shadow: none !important;
   padding: 5px 8px;
+}
+
+/* Settings owns its component shapes; keep the compact skin elsewhere. */
+button:not(.icon-button):not(.send-button):not(.rail-icon-button):not(.settings-workspace *):not(.settings-provider-modal *),
+:where(
+  .module-form button,
+  .module-action-row button,
+  .addon-card-actions button,
+  .artifacts-hero button,
+  .memory-card button,
+  .memory-review-actions button,
+  .memory-source-candidates button,
+  .artifact-actions button,
+  .opencode-card button
+) {
+  border-radius: 3px !important;
 }
 
 :where(

--- a/browser-first/resonantos-side-panel-extension/src/styles/main-workspace/settings.css
+++ b/browser-first/resonantos-side-panel-extension/src/styles/main-workspace/settings.css
@@ -1,3 +1,17 @@
+/* Settings shape contract: docs/design/SETTINGS-COMPONENT-SHAPES.md. */
+:root {
+  --settings-radius-input: 12px;
+  --settings-radius-compact: 16px;
+  --settings-radius-card: 20px;
+  --settings-radius-panel: 22px;
+  --settings-radius-subnav: 24px;
+  --settings-radius-pill: 999px;
+}
+
+:where(.settings-workspace, .settings-provider-modal) button {
+  border-radius: var(--settings-radius-pill);
+}
+
 .settings-workspace {
   display: grid;
   grid-template-columns: minmax(180px, 220px) minmax(0, 1fr);
@@ -15,7 +29,7 @@
   gap: 8px;
   min-width: 0;
   border: 1px solid rgba(36, 209, 143, 0.12);
-  border-radius: 24px;
+  border-radius: var(--settings-radius-subnav);
   background: rgba(10, 15, 12, 0.72);
   padding: 10px;
 }
@@ -38,7 +52,7 @@
   gap: 3px;
   width: 100%;
   border: 1px solid transparent;
-  border-radius: 16px;
+  border-radius: var(--settings-radius-compact);
   background: transparent;
   color: rgba(214, 229, 219, 0.76);
   cursor: pointer;
@@ -124,7 +138,7 @@
   gap: 9px;
   min-width: 0;
   border: 1px solid rgba(36, 209, 143, 0.16);
-  border-radius: 22px;
+  border-radius: var(--settings-radius-panel);
   background:
     radial-gradient(circle at 10% 0%, rgba(36, 209, 143, 0.1), transparent 38%),
     rgba(17, 22, 19, 0.68);
@@ -137,7 +151,7 @@
   width: 26px;
   height: 26px;
   border: 1px solid rgba(36, 209, 143, 0.24);
-  border-radius: 999px;
+  border-radius: var(--settings-radius-pill);
   color: var(--accent);
   font-size: 0.72rem;
   font-weight: 950;
@@ -158,7 +172,7 @@
 .settings-setup-card button {
   justify-self: start;
   border: 1px solid rgba(36, 209, 143, 0.22);
-  border-radius: 999px;
+  border-radius: var(--settings-radius-pill);
   background: rgba(36, 209, 143, 0.1);
   color: rgba(247, 255, 249, 0.92);
   font-size: 0.75rem;
@@ -222,7 +236,7 @@
   grid-template-columns: minmax(110px, 0.7fr) minmax(76px, auto) minmax(0, 1.4fr);
   align-items: center;
   gap: 10px;
-  border-radius: 16px;
+  border-radius: var(--settings-radius-compact);
   padding: 12px 14px;
 }
 
@@ -243,14 +257,14 @@
   gap: 12px;
   min-width: 0;
   border: 1px solid rgba(36, 209, 143, 0.15);
-  border-radius: 20px;
+  border-radius: var(--settings-radius-card);
   background: rgba(17, 22, 19, 0.72);
   padding: 18px;
 }
 
 .settings-provider-card {
   gap: 8px;
-  border-radius: 16px;
+  border-radius: var(--settings-radius-card);
   padding: 12px 14px;
 }
 
@@ -279,7 +293,7 @@
   gap: 14px;
   min-width: 0;
   border: 1px solid rgba(36, 209, 143, 0.12);
-  border-radius: 24px;
+  border-radius: var(--settings-radius-panel);
   background:
     radial-gradient(circle at 10% 0%, rgba(36, 209, 143, 0.08), transparent 34%),
     rgba(11, 15, 13, 0.52);
@@ -298,7 +312,7 @@
 
 .settings-status-pill {
   border: 1px solid rgba(36, 209, 143, 0.22);
-  border-radius: 999px;
+  border-radius: var(--settings-radius-pill);
   color: rgba(36, 209, 143, 0.9);
   flex: 0 0 auto;
   font-size: 0.62rem;
@@ -421,7 +435,7 @@
 
 .settings-route-badge {
   border: 1px solid rgba(36, 209, 143, 0.17);
-  border-radius: 999px;
+  border-radius: var(--settings-radius-pill);
   background: rgba(36, 209, 143, 0.07);
   color: rgba(214, 229, 219, 0.82);
   font-size: 0.72rem;
@@ -448,7 +462,7 @@
 .settings-routing-form select {
   min-width: 0;
   border: 1px solid rgba(36, 209, 143, 0.13);
-  border-radius: 14px;
+  border-radius: var(--settings-radius-input);
   background: rgba(0, 0, 0, 0.2);
   color: var(--text);
   outline: none;
@@ -468,7 +482,7 @@
 
 .settings-path-picker button {
   border: 1px solid rgba(36, 209, 143, 0.2);
-  border-radius: 999px;
+  border-radius: var(--settings-radius-pill);
   background: rgba(36, 209, 143, 0.08);
   color: rgba(247, 255, 249, 0.9);
   font-weight: 950;
@@ -486,7 +500,7 @@
 
 .settings-routing-form button {
   border: 0;
-  border-radius: 999px;
+  border-radius: var(--settings-radius-pill);
   background: var(--accent);
   color: #06110d;
   font-weight: 950;
@@ -518,7 +532,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
   gap: 5px;
   min-width: 0;
   border: 1px solid rgba(36, 209, 143, 0.12);
-  border-radius: 16px;
+  border-radius: var(--settings-radius-compact);
   background: rgba(0, 0, 0, 0.14);
   padding: 12px;
 }
@@ -538,7 +552,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 .settings-appearance-control select {
   min-width: 0;
   border: 1px solid rgba(36, 209, 143, 0.13);
-  border-radius: 14px;
+  border-radius: var(--settings-radius-input);
   background: rgba(0, 0, 0, 0.2);
   color: var(--text);
   outline: none;
@@ -548,7 +562,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 .settings-appearance-form button {
   justify-self: start;
   border: 0;
-  border-radius: 999px;
+  border-radius: var(--settings-radius-pill);
   background: var(--accent);
   color: #06110d;
   font-weight: 950;
@@ -574,7 +588,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 .settings-addon-disclosure {
   min-width: 0;
   border: 1px solid rgba(36, 209, 143, 0.12);
-  border-radius: 16px;
+  border-radius: var(--settings-radius-compact);
   background: rgba(11, 16, 13, 0.42);
   padding: 10px 12px;
 }
@@ -629,7 +643,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 
 .settings-addon-capability-group span {
   border: 1px solid rgba(36, 209, 143, 0.18);
-  border-radius: 999px;
+  border-radius: var(--settings-radius-pill);
   background: rgba(36, 209, 143, 0.07);
   color: rgba(214, 229, 219, 0.82);
   font-size: 0.7rem;
@@ -702,7 +716,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
   align-items: center;
   gap: 6px;
   border: 1px solid rgba(36, 209, 143, 0.16);
-  border-radius: 999px;
+  border-radius: var(--settings-radius-pill);
   background: rgba(36, 209, 143, 0.06);
   color: rgba(214, 229, 219, 0.82);
   font-size: 0.72rem;
@@ -730,7 +744,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 .settings-provider-model-policy button,
 .settings-provider-more summary {
   border: 1px solid rgba(36, 209, 143, 0.24);
-  border-radius: 999px;
+  border-radius: var(--settings-radius-pill);
   background: rgba(36, 209, 143, 0.1);
   color: rgba(247, 255, 249, 0.9);
   font-size: 0.72rem;
@@ -761,7 +775,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
   gap: 6px;
   min-width: 260px;
   border: 1px solid rgba(36, 209, 143, 0.18);
-  border-radius: 18px;
+  border-radius: var(--settings-radius-card);
   background: rgba(11, 17, 13, 0.98);
   box-shadow: 0 18px 50px rgba(0, 0, 0, 0.34);
   padding: 8px;
@@ -788,7 +802,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 
 .settings-provider-summary span {
   border: 1px solid rgba(36, 209, 143, 0.16);
-  border-radius: 999px;
+  border-radius: var(--settings-radius-pill);
   background: rgba(36, 209, 143, 0.06);
   color: rgba(214, 229, 219, 0.82);
   font-size: 0.68rem;
@@ -824,7 +838,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
   display: grid;
   gap: 12px;
   border: 1px solid rgba(36, 209, 143, 0.12);
-  border-radius: 20px;
+  border-radius: var(--settings-radius-card);
   background: rgba(17, 22, 19, 0.46);
   padding: 12px;
 }
@@ -877,7 +891,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
   gap: 10px;
   min-width: 0;
   border: 1px solid rgba(36, 209, 143, 0.12);
-  border-radius: 18px;
+  border-radius: var(--settings-radius-card);
   background: rgba(17, 22, 19, 0.42);
   padding: 11px;
 }
@@ -907,7 +921,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 .settings-control-advanced {
   min-width: 0;
   border: 1px solid rgba(36, 209, 143, 0.13);
-  border-radius: 18px;
+  border-radius: var(--settings-radius-card);
   background: rgba(11, 16, 13, 0.46);
   padding: 13px 15px;
 }
@@ -988,7 +1002,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 .settings-provider-field textarea {
   min-width: 0;
   border: 1px solid rgba(36, 209, 143, 0.13);
-  border-radius: 14px;
+  border-radius: var(--settings-radius-input);
   background: rgba(0, 0, 0, 0.22);
   color: var(--text);
   font: inherit;
@@ -1035,7 +1049,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
   max-height: min(760px, 92vh);
   overflow: auto;
   border: 1px solid rgba(36, 209, 143, 0.24);
-  border-radius: 24px;
+  border-radius: var(--settings-radius-panel);
   background:
     radial-gradient(circle at 0 0, rgba(36, 209, 143, 0.16), transparent 32%),
     rgba(8, 13, 10, 0.98);
@@ -1066,7 +1080,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 .settings-provider-modal-heading button,
 .settings-provider-modal-actions button {
   border: 1px solid rgba(36, 209, 143, 0.22);
-  border-radius: 999px;
+  border-radius: var(--settings-radius-pill);
   background: rgba(36, 209, 143, 0.08);
   color: rgba(247, 255, 249, 0.9);
   font-size: 0.74rem;
@@ -1129,7 +1143,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
   gap: 4px;
   list-style: none;
   border: 1px solid rgba(36, 209, 143, 0.16);
-  border-radius: 14px;
+  border-radius: var(--settings-radius-compact);
   background: rgba(36, 209, 143, 0.08);
   padding: 10px 11px;
 }
@@ -1164,7 +1178,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
   gap: 4px;
   list-style: none;
   border: 1px solid rgba(36, 209, 143, 0.12);
-  border-radius: 14px;
+  border-radius: var(--settings-radius-compact);
   background: rgba(0, 0, 0, 0.15);
   padding: 10px 11px;
 }
@@ -1199,7 +1213,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 .settings-diagnostics-advanced {
   min-width: 0;
   border: 1px solid rgba(36, 209, 143, 0.13);
-  border-radius: 18px;
+  border-radius: var(--settings-radius-card);
   background: rgba(11, 16, 13, 0.46);
   padding: 13px 15px;
 }
@@ -1240,7 +1254,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
   min-width: 0;
   list-style: none;
   border: 1px solid rgba(36, 209, 143, 0.12);
-  border-radius: 14px;
+  border-radius: var(--settings-radius-compact);
   background: rgba(0, 0, 0, 0.14);
   padding: 11px 12px;
 }
@@ -1304,7 +1318,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 
 .settings-control-row button {
   border: 1px solid rgba(36, 209, 143, 0.2);
-  border-radius: 999px;
+  border-radius: var(--settings-radius-pill);
   background: rgba(36, 209, 143, 0.08);
   color: rgba(247, 255, 249, 0.9);
   font-size: 0.72rem;
@@ -1330,7 +1344,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 
 .settings-overview-action-buttons button {
   border: 1px solid rgba(36, 209, 143, 0.22);
-  border-radius: 999px;
+  border-radius: var(--settings-radius-pill);
   background: rgba(36, 209, 143, 0.08);
   color: rgba(247, 255, 249, 0.9);
   font-size: 0.74rem;
@@ -1340,7 +1354,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 
 .settings-inline-actions button {
   border: 0;
-  border-radius: 3px;
+  border-radius: var(--settings-radius-pill);
   background: rgba(36, 209, 143, 0.1);
   color: rgba(223, 237, 228, 0.88);
   font-size: 0.72rem;
@@ -1356,7 +1370,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 .settings-primary-action {
   justify-self: start;
   border: 0;
-  border-radius: 999px;
+  border-radius: var(--settings-radius-pill);
   background: var(--accent);
   color: #06110d;
   font-weight: 950;
@@ -1380,7 +1394,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 
 .settings-provider-heading > span {
   border: 1px solid rgba(36, 209, 143, 0.18);
-  border-radius: 999px;
+  border-radius: var(--settings-radius-pill);
   color: rgba(247, 255, 249, 0.9);
   font-size: 0.7rem;
   font-weight: 950;
@@ -1397,7 +1411,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
   min-width: 0;
   flex: 1;
   border: 1px solid rgba(36, 209, 143, 0.13);
-  border-radius: 15px;
+  border-radius: var(--settings-radius-input);
   background: rgba(0, 0, 0, 0.2);
   color: var(--text);
   outline: none;
@@ -1406,7 +1420,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 
 .settings-provider-form button {
   border: 0;
-  border-radius: 999px;
+  border-radius: var(--settings-radius-pill);
   background: var(--accent);
   color: #06110d;
   font-weight: 950;
@@ -1442,7 +1456,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 .settings-work-project-select {
   min-width: 0;
   border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 14px;
+  border-radius: var(--settings-radius-input);
   background: rgba(0, 0, 0, 0.18);
   color: rgba(247, 255, 249, 0.92);
   font: inherit;
@@ -1452,7 +1466,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 
 .settings-work-tools button {
   border: 1px solid rgba(36, 209, 143, 0.24);
-  border-radius: 999px;
+  border-radius: var(--settings-radius-pill);
   background: rgba(36, 209, 143, 0.12);
   color: rgba(247, 255, 249, 0.94);
   font-size: 0.72rem;
@@ -1470,7 +1484,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
   min-width: min(260px, 100%);
   flex: 1;
   border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 999px;
+  border-radius: var(--settings-radius-input);
   background: rgba(0, 0, 0, 0.18);
   color: rgba(247, 255, 249, 0.92);
   font: inherit;
@@ -1480,7 +1494,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 
 .settings-work-artifact-actions button {
   border: 1px solid rgba(36, 209, 143, 0.24);
-  border-radius: 999px;
+  border-radius: var(--settings-radius-pill);
   background: rgba(36, 209, 143, 0.1);
   color: rgba(247, 255, 249, 0.9);
   font-size: 0.72rem;
@@ -1494,7 +1508,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
   max-height: 280px;
   overflow: auto;
   border: 1px solid rgba(36, 209, 143, 0.14);
-  border-radius: 16px;
+  border-radius: var(--settings-radius-compact);
   background: rgba(0, 0, 0, 0.22);
   padding: 12px;
 }
@@ -1549,7 +1563,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
   min-width: 0;
   list-style: none;
   border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 14px;
+  border-radius: var(--settings-radius-compact);
   background: rgba(0, 0, 0, 0.16);
   padding: 10px;
 }
@@ -1582,7 +1596,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
   min-width: 0;
   flex: 1;
   border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 999px;
+  border-radius: var(--settings-radius-input);
   background: rgba(0, 0, 0, 0.18);
   color: rgba(247, 255, 249, 0.92);
   font: inherit;
@@ -1598,7 +1612,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 .settings-work-row button,
 .settings-archive-row button {
   border: 1px solid rgba(36, 209, 143, 0.2);
-  border-radius: 999px;
+  border-radius: var(--settings-radius-pill);
   background: rgba(36, 209, 143, 0.08);
   color: rgba(247, 255, 249, 0.9);
   font-size: 0.72rem;
@@ -1614,9 +1628,21 @@ body:not([data-density="compact"]):not([data-density="touch"])
 .settings-work-empty {
   list-style: none;
   border: 1px dashed rgba(255, 255, 255, 0.1);
-  border-radius: 14px;
+  border-radius: var(--settings-radius-compact);
   color: rgba(143, 159, 149, 0.8);
   font-size: 0.78rem;
   font-weight: 800;
   padding: 12px;
+}
+
+/* Multiline fields use the larger input shape from ROSI A03. */
+.settings-provider-field textarea {
+  border-radius: var(--settings-radius-compact);
+}
+
+/* Keep keyboard focus distinct from component hover styles. */
+.settings-workspace :is(button, input, select, textarea):focus-visible,
+.settings-provider-modal :is(button, input, select, textarea):focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 2px;
 }

--- a/browser-first/resonantos-side-panel-extension/src/styles/main-workspace/settings.css
+++ b/browser-first/resonantos-side-panel-extension/src/styles/main-workspace/settings.css
@@ -1,6 +1,7 @@
 /* Settings shape contract: docs/design/SETTINGS-COMPONENT-SHAPES.md. */
 :root {
   --settings-radius-input: 12px;
+  --settings-radius-action: var(--settings-radius-input);
   --settings-radius-compact: 16px;
   --settings-radius-card: 20px;
   --settings-radius-panel: 22px;
@@ -9,7 +10,7 @@
 }
 
 :where(.settings-workspace, .settings-provider-modal) button {
-  border-radius: var(--settings-radius-pill);
+  border-radius: var(--settings-radius-action);
 }
 
 .settings-workspace {
@@ -172,7 +173,7 @@
 .settings-setup-card button {
   justify-self: start;
   border: 1px solid rgba(36, 209, 143, 0.22);
-  border-radius: var(--settings-radius-pill);
+  border-radius: var(--settings-radius-action);
   background: rgba(36, 209, 143, 0.1);
   color: rgba(247, 255, 249, 0.92);
   font-size: 0.75rem;
@@ -482,7 +483,7 @@
 
 .settings-path-picker button {
   border: 1px solid rgba(36, 209, 143, 0.2);
-  border-radius: var(--settings-radius-pill);
+  border-radius: var(--settings-radius-action);
   background: rgba(36, 209, 143, 0.08);
   color: rgba(247, 255, 249, 0.9);
   font-weight: 950;
@@ -500,7 +501,7 @@
 
 .settings-routing-form button {
   border: 0;
-  border-radius: var(--settings-radius-pill);
+  border-radius: var(--settings-radius-action);
   background: var(--accent);
   color: #06110d;
   font-weight: 950;
@@ -562,7 +563,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 .settings-appearance-form button {
   justify-self: start;
   border: 0;
-  border-radius: var(--settings-radius-pill);
+  border-radius: var(--settings-radius-action);
   background: var(--accent);
   color: #06110d;
   font-weight: 950;
@@ -716,7 +717,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
   align-items: center;
   gap: 6px;
   border: 1px solid rgba(36, 209, 143, 0.16);
-  border-radius: var(--settings-radius-pill);
+  border-radius: var(--settings-radius-action);
   background: rgba(36, 209, 143, 0.06);
   color: rgba(214, 229, 219, 0.82);
   font-size: 0.72rem;
@@ -744,7 +745,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 .settings-provider-model-policy button,
 .settings-provider-more summary {
   border: 1px solid rgba(36, 209, 143, 0.24);
-  border-radius: var(--settings-radius-pill);
+  border-radius: var(--settings-radius-action);
   background: rgba(36, 209, 143, 0.1);
   color: rgba(247, 255, 249, 0.9);
   font-size: 0.72rem;
@@ -1080,7 +1081,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 .settings-provider-modal-heading button,
 .settings-provider-modal-actions button {
   border: 1px solid rgba(36, 209, 143, 0.22);
-  border-radius: var(--settings-radius-pill);
+  border-radius: var(--settings-radius-action);
   background: rgba(36, 209, 143, 0.08);
   color: rgba(247, 255, 249, 0.9);
   font-size: 0.74rem;
@@ -1318,7 +1319,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 
 .settings-control-row button {
   border: 1px solid rgba(36, 209, 143, 0.2);
-  border-radius: var(--settings-radius-pill);
+  border-radius: var(--settings-radius-action);
   background: rgba(36, 209, 143, 0.08);
   color: rgba(247, 255, 249, 0.9);
   font-size: 0.72rem;
@@ -1344,7 +1345,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 
 .settings-overview-action-buttons button {
   border: 1px solid rgba(36, 209, 143, 0.22);
-  border-radius: var(--settings-radius-pill);
+  border-radius: var(--settings-radius-action);
   background: rgba(36, 209, 143, 0.08);
   color: rgba(247, 255, 249, 0.9);
   font-size: 0.74rem;
@@ -1354,7 +1355,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 
 .settings-inline-actions button {
   border: 0;
-  border-radius: var(--settings-radius-pill);
+  border-radius: var(--settings-radius-action);
   background: rgba(36, 209, 143, 0.1);
   color: rgba(223, 237, 228, 0.88);
   font-size: 0.72rem;
@@ -1370,7 +1371,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 .settings-primary-action {
   justify-self: start;
   border: 0;
-  border-radius: var(--settings-radius-pill);
+  border-radius: var(--settings-radius-action);
   background: var(--accent);
   color: #06110d;
   font-weight: 950;
@@ -1420,7 +1421,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 
 .settings-provider-form button {
   border: 0;
-  border-radius: var(--settings-radius-pill);
+  border-radius: var(--settings-radius-action);
   background: var(--accent);
   color: #06110d;
   font-weight: 950;
@@ -1466,7 +1467,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 
 .settings-work-tools button {
   border: 1px solid rgba(36, 209, 143, 0.24);
-  border-radius: var(--settings-radius-pill);
+  border-radius: var(--settings-radius-action);
   background: rgba(36, 209, 143, 0.12);
   color: rgba(247, 255, 249, 0.94);
   font-size: 0.72rem;
@@ -1494,7 +1495,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 
 .settings-work-artifact-actions button {
   border: 1px solid rgba(36, 209, 143, 0.24);
-  border-radius: var(--settings-radius-pill);
+  border-radius: var(--settings-radius-action);
   background: rgba(36, 209, 143, 0.1);
   color: rgba(247, 255, 249, 0.9);
   font-size: 0.72rem;
@@ -1612,7 +1613,7 @@ body:not([data-density="compact"]):not([data-density="touch"])
 .settings-work-row button,
 .settings-archive-row button {
   border: 1px solid rgba(36, 209, 143, 0.2);
-  border-radius: var(--settings-radius-pill);
+  border-radius: var(--settings-radius-action);
   background: rgba(36, 209, 143, 0.08);
   color: rgba(247, 255, 249, 0.9);
   font-size: 0.72rem;

--- a/browser-first/test/agent-control-live-workflow-paths.test.mjs
+++ b/browser-first/test/agent-control-live-workflow-paths.test.mjs
@@ -14,6 +14,7 @@ const REQUIRED_PATH_GLOBS = [
   "browser-first/test/live-harness.test.mjs",
   "browser-first/test/live-sdk-lane.mjs",
   "browser-first/test/live-sdk-lane.test.mjs",
+  "browser-first/test/settings-shapes-live.mjs",
   "browser-first/resonantos-side-panel-extension/src/**",
   "browser-first/resonantos-side-panel-extension/manifest.json",
   ".github/workflows/agent-control-live.yml",
@@ -76,4 +77,40 @@ test("live SDK workflow job installs pinned OpenCode and uploads evidence (#350)
   assert.match(reject.if, /steps\.live-sdk-self-tests\.outcome != 'success'/, "the reject step must also fail the job on a self-test failure");
   assert.ok(reject, "live-sdk job must reject uncertified runs");
   assert.match(reject.if, /steps\.live-sdk-certification\.outcome != 'success'/);
+});
+
+// #404 review: the settings-shapes check must never be able to skip the
+// certification run and its evidence upload — mirror of the live-sdk
+// self-test convention, plus path-filter and step pinning.
+test("agent-control job pins the settings-shapes check without skipping certification (#404)", async () => {
+  const workflow = parse(await readFile(WORKFLOW, "utf8"));
+  const job = workflow.jobs?.["agent-control-live"];
+  assert.ok(job, "workflow must include an agent-control-live job");
+
+  const shapes = job.steps.find((step) => /Check rendered Settings component shapes/i.test(step.name ?? ""));
+  assert.ok(shapes, "agent-control job must run the rendered settings-shapes check");
+  assert.equal(shapes.id, "settings-shapes");
+  assert.equal(
+    shapes["continue-on-error"],
+    true,
+    "a shapes failure must not skip the certification run and its evidence upload",
+  );
+  assert.equal(shapes.env?.CI, "true");
+  assert.ok(shapes.env?.RESONANTOS_LIVE_CHROME_PATH, "shapes check needs the setup-chrome path");
+  assert.ok(shapes.env?.RESONANTOS_SETTINGS_ARTIFACT_DIR, "shapes check must declare its artifact dir");
+  assert.match(shapes.run, /test:browser-first:settings-shapes/);
+
+  const certification = job.steps.find((step) => step.name === "Run live Agent Control certification");
+  assert.ok(certification, "agent-control job must keep its certification run");
+  assert.equal(certification["continue-on-error"], true, "certification outcome must be surfaced, not skipped");
+  assert.equal(certification.if, undefined, "certification must not be conditioned on the shapes outcome");
+
+  const reject = job.steps.find((step) => step.name === "Reject uncertified run");
+  assert.ok(reject, "agent-control job must reject uncertified runs");
+  assert.match(reject.if, /steps\.certification\.outcome != 'success'/);
+  assert.match(
+    reject.if,
+    /steps\.settings-shapes\.outcome != 'success'/,
+    "the reject step must also fail the job on a shapes failure",
+  );
 });

--- a/browser-first/test/settings-shapes-live.mjs
+++ b/browser-first/test/settings-shapes-live.mjs
@@ -70,12 +70,13 @@ try {
     await radius(".settings-nav-item", 16);
     await radius(".settings-setup-card", 22);
     await radius(".settings-health-card", 20);
-    await radius(".settings-setup-card button", 999);
+    await radius(".settings-setup-card button", 12);
+    await radius(".settings-setup-card span", 999);
     await radius("#outside", 3);
     await page.screenshot({ path: path.join(artifacts, `overview-${width}.png`), fullPage: true });
     await render("appearance");
     await radius(".settings-appearance-control select", 12);
-    await radius(".settings-panel button", 999);
+    await radius(".settings-panel button", 12);
     await page.getByRole("combobox").first().focus();
     await page.keyboard.press("Tab");
     assert.equal(await page.evaluate(() => getComputedStyle(document.activeElement).outlineStyle), "solid");
@@ -86,7 +87,7 @@ try {
     await radius(".settings-provider-modal-panel", 22);
     await radius(".settings-provider-field input", 12);
     await radius(".settings-provider-field textarea", 16);
-    await radius(".settings-provider-modal-actions button", 999);
+    await radius(".settings-provider-modal-actions button", 12);
     await page.screenshot({ path: path.join(artifacts, `provider-modal-${width}.png`), fullPage: true });
     await page.locator(".settings-provider-modal").getByRole("button", { name: "Close", exact: true }).click();
     await page.locator(".settings-provider-modal").waitFor({ state: "detached" });
@@ -97,7 +98,11 @@ try {
   await assert.rejects(() => radius(".settings-health-card", 20), { name: "AssertionError" });
   await override.evaluate(node => node.remove());
   await radius(".settings-health-card", 20);
-  console.log(JSON.stringify({ passed: true, chrome: browser.version(), viewports: [1280, 768, 390], injectedOverrideDetected: true }));
+  const pillOverride = await page.addStyleTag({ content: ".settings-setup-card button { border-radius: 999px !important; }" });
+  await assert.rejects(() => radius(".settings-setup-card button", 12), { name: "AssertionError" });
+  await pillOverride.evaluate(node => node.remove());
+  await radius(".settings-setup-card button", 12);
+  console.log(JSON.stringify({ passed: true, chrome: browser.version(), viewports: [1280, 768, 390], injectedOverrideDetected: true, injectedPillDetected: true }));
 } finally {
   await browser?.close();
   await new Promise(resolve => server.close(resolve));

--- a/browser-first/test/settings-shapes-live.mjs
+++ b/browser-first/test/settings-shapes-live.mjs
@@ -36,7 +36,8 @@ let browser;
 try {
   await mkdir(artifacts, { recursive: true });
   browser = await chromium.launch({
-    headless: false,
+    // CI has no interactive desktop; use Chrome's native headless compositor.
+    headless: /^(?:1|true)$/i.test(process.env.CI ?? ""),
     ...(process.env.RESONANTOS_LIVE_CHROME_PATH
       ? { executablePath: process.env.RESONANTOS_LIVE_CHROME_PATH }
       : { channel: "chrome" }),

--- a/browser-first/test/settings-shapes-live.mjs
+++ b/browser-first/test/settings-shapes-live.mjs
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { mkdir, readFile } from "node:fs/promises";
+import { chromium } from "playwright";
+
+// Render the actual extension modules and complete CSS cascade with fixture data.
+// This is a presentation regression check, not bridge/extension certification.
+const extensionRoot = path.resolve(import.meta.dirname, "../resonantos-side-panel-extension");
+const artifacts = process.env.RESONANTOS_SETTINGS_ARTIFACT_DIR
+  ?? path.join(os.tmpdir(), `resonantos-settings-shapes-${process.pid}`);
+const html = '<!doctype html><html lang="en"><meta charset="utf-8"><title>Settings shape fixtures</title><link rel="stylesheet" href="/src/main-workspace.css"><body><main id="root"></main><button id="outside">Outside Settings</button></body></html>';
+const server = http.createServer(async (request, response) => {
+  try {
+    const pathname = decodeURIComponent(new URL(request.url, "http://localhost").pathname);
+    if (pathname === "/") {
+      response.writeHead(200, { "Content-Type": "text/html" });
+      response.end(html);
+      return;
+    }
+    const file = path.resolve(extensionRoot, `.${pathname}`);
+    if (!file.startsWith(`${extensionRoot}${path.sep}`)
+      || !/\.(?:css|js)$/.test(file) || file.endsWith("bridge-config.generated.js")) {
+      response.writeHead(404).end();
+      return;
+    }
+    response.writeHead(200, { "Content-Type": file.endsWith(".css") ? "text/css" : "text/javascript" });
+    response.end(await readFile(file));
+  } catch {
+    response.end();
+  }
+});
+await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+let browser;
+try {
+  await mkdir(artifacts, { recursive: true });
+  browser = await chromium.launch({
+    headless: false,
+    ...(process.env.RESONANTOS_LIVE_CHROME_PATH
+      ? { executablePath: process.env.RESONANTOS_LIVE_CHROME_PATH }
+      : { channel: "chrome" }),
+  });
+  const page = await browser.newPage();
+  // No provider, bridge or public-network access is needed for these fixtures.
+  const origin = `http://127.0.0.1:${server.address().port}`;
+  await page.route("**/*", route => route.request().url().startsWith(`${origin}/`)
+    ? route.continue() : route.abort());
+  await page.goto(origin);
+  async function render(section) {
+    await page.evaluate(async initialSection => {
+      const { renderSettingsWorkspace } = await import("/src/lib/main-workspace-settings.js");
+      renderSettingsWorkspace({
+        container: document.querySelector("#root"), initialSection,
+        bridgeRequest: async () => ({ providers: [], addons: [], memory: {} }),
+        chromeApi: { storage: { local: { get: async () => ({}), set: async () => {} } } },
+      });
+    }, section);
+    await page.locator(".settings-panel").waitFor();
+  }
+  async function radius(selector, expected) {
+    const actual = await page.locator(selector).first().evaluate(node => getComputedStyle(node).borderRadius);
+    assert.equal(actual, `${expected}px`, selector);
+  }
+  for (const width of [1280, 768, 390]) {
+    await page.setViewportSize({ width, height: 1000 });
+    await render("overview");
+    await radius(".settings-subnav", 24);
+    await radius(".settings-nav-item", 16);
+    await radius(".settings-setup-card", 22);
+    await radius(".settings-health-card", 20);
+    await radius(".settings-setup-card button", 999);
+    await radius("#outside", 3);
+    await page.screenshot({ path: path.join(artifacts, `overview-${width}.png`), fullPage: true });
+    await render("appearance");
+    await radius(".settings-appearance-control select", 12);
+    await radius(".settings-panel button", 999);
+    await page.getByRole("combobox").first().focus();
+    await page.keyboard.press("Tab");
+    assert.equal(await page.evaluate(() => getComputedStyle(document.activeElement).outlineStyle), "solid");
+    await page.evaluate(async () => {
+      const { openProviderAccountModal } = await import("/src/lib/settings/providers-section.js");
+      openProviderAccountModal({ bridgeRequest: async () => ({}), statusNode: document.createElement("p"), reload: async () => {} });
+    });
+    await radius(".settings-provider-modal-panel", 22);
+    await radius(".settings-provider-field input", 12);
+    await radius(".settings-provider-field textarea", 16);
+    await radius(".settings-provider-modal-actions button", 999);
+    await page.screenshot({ path: path.join(artifacts, `provider-modal-${width}.png`), fullPage: true });
+    await page.locator(".settings-provider-modal").getByRole("button", { name: "Close", exact: true }).click();
+    await page.locator(".settings-provider-modal").waitFor({ state: "detached" });
+  }
+  // Prove the check catches the original regression: a later important override.
+  await render("overview");
+  const override = await page.addStyleTag({ content: ".settings-health-card { border-radius: 3px !important; }" });
+  await assert.rejects(() => radius(".settings-health-card", 20), { name: "AssertionError" });
+  await override.evaluate(node => node.remove());
+  await radius(".settings-health-card", 20);
+  console.log(JSON.stringify({ passed: true, chrome: browser.version(), viewports: [1280, 768, 390], injectedOverrideDetected: true }));
+} finally {
+  await browser?.close();
+  await new Promise(resolve => server.close(resolve));
+}

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -4,6 +4,10 @@ Community-contributed design reference for ResonantOS. Nothing here is
 imported by the runtime; these are the visual contracts and source material
 for anyone building panels, add-ons, or app-shell UI.
 
+- [Browser-first Settings component shapes](SETTINGS-COMPONENT-SHAPES.md) —
+  scoped runtime radius contract; preserves the existing palette and explains
+  which ROSI generation informs Settings components.
+
 ## ROSI — Resonant OS Interface design system
 
 For implemented Settings density behavior, see

--- a/docs/design/SETTINGS-COMPONENT-SHAPES.md
+++ b/docs/design/SETTINGS-COMPONENT-SHAPES.md
@@ -29,6 +29,13 @@ The later `responsive.css` compact-skin rules must not override these Settings
 shapes. Existing color, border and density rules remain in effect. Keep visible
 keyboard focus distinct from hover using the existing accent token.
 
+Run `npm run test:browser-first:settings-shapes` with stable Chrome installed
+(or set `RESONANTOS_LIVE_CHROME_PATH`). The live-browser CI lane runs this check
+and retains screenshots with its evidence. It renders actual extension modules
+and styles with synthetic, network-isolated data at 390/768/1280px; it does not
+replace extension/bridge certification. It also injects the old important
+override to verify that the regression detector rejects it.
+
 When changing these rules, check actual computed styles in Chrome: Start Here,
 Profile, Providers (including its modal), Routing, Appearance and Bridge Target.
 Compare the same viewport and state before and after; inspect textareas, nested

--- a/docs/design/SETTINGS-COMPONENT-SHAPES.md
+++ b/docs/design/SETTINGS-COMPONENT-SHAPES.md
@@ -31,7 +31,8 @@ keyboard focus distinct from hover using the existing accent token.
 
 Run `npm run test:browser-first:settings-shapes` with stable Chrome installed
 (or set `RESONANTOS_LIVE_CHROME_PATH`). The live-browser CI lane runs this check
-and retains screenshots with its evidence. It renders actual extension modules
+and retains screenshots with its evidence. CI uses headless Chrome; local runs
+use a visible window unless `CI=true` is set. It renders actual extension modules
 and styles with synthetic, network-isolated data at 390/768/1280px; it does not
 replace extension/bridge certification. It also injects the old important
 override to verify that the regression detector rejects it.

--- a/docs/design/SETTINGS-COMPONENT-SHAPES.md
+++ b/docs/design/SETTINGS-COMPONENT-SHAPES.md
@@ -5,23 +5,24 @@ normalizes component shapes without changing the runtime palette, typography,
 control density, or the compact skin in other workspaces.
 
 The [ROSI v3 extraction](rosi-design-system/reference/ui-extraction-browser-v3.md)
-provides the Button, Card, and Input shape guidance. The ROSI README describes
+provides historical Button, Card, and Input shape guidance. The ROSI README describes
 v0.2; it is historical context, not a command to replace the runtime palette.
 This scoped contract does not resolve the extraction's outstanding brand signoff.
 
 | Role | CSS token | Radius |
 | --- | --- | --- |
 | Text, search and select fields | `--settings-radius-input` | 12px |
+| Action buttons and model-option controls | `--settings-radius-action` | 12px (shares the input radius) |
 | Textareas, nested rows, compact cards and nav items | `--settings-radius-compact` | 16px |
 | Standard cards and disclosure containers | `--settings-radius-card` | 20px |
 | Setup, personalization and modal panels | `--settings-radius-panel` | 22px |
 | Subnav container | `--settings-radius-subnav` | 24px |
-| Action buttons, badges and circular markers | `--settings-radius-pill` | 999px |
+| Badges and circular markers | `--settings-radius-pill` | 999px |
 
-The v3 component-specific pill button rule takes precedence over its generic
-radius table's reference to 16px buttons. Navigation items remain nested 16px
-containers, rather than action pills. Compact rows use the 16px scale step;
-they do not introduce additional 14px, 15px or 18px values.
+The extraction contains conflicting button guidance. This Settings contract
+uses 12px rounded rectangles for actions, matching adjacent fields. Its historical
+pill-button rule does not apply to Settings actions. Navigation items and compact
+rows use the 16px scale step; they do not introduce additional 14px, 15px or 18px values.
 
 Implementation lives in
 `browser-first/resonantos-side-panel-extension/src/styles/main-workspace/settings.css`.
@@ -35,7 +36,7 @@ and retains screenshots with its evidence. CI uses headless Chrome; local runs
 use a visible window unless `CI=true` is set. It renders actual extension modules
 and styles with synthetic, network-isolated data at 390/768/1280px; it does not
 replace extension/bridge certification. It also injects the old important
-override to verify that the regression detector rejects it.
+override and a pill-button override to verify that the regression detector rejects both.
 
 When changing these rules, check actual computed styles in Chrome: Start Here,
 Profile, Providers (including its modal), Routing, Appearance and Bridge Target.

--- a/docs/design/SETTINGS-COMPONENT-SHAPES.md
+++ b/docs/design/SETTINGS-COMPONENT-SHAPES.md
@@ -1,0 +1,35 @@
+# Browser-first Settings component shapes
+
+This contract covers the extension Settings workspace and provider modal. It
+normalizes component shapes without changing the runtime palette, typography,
+control density, or the compact skin in other workspaces.
+
+The [ROSI v3 extraction](rosi-design-system/reference/ui-extraction-browser-v3.md)
+provides the Button, Card, and Input shape guidance. The ROSI README describes
+v0.2; it is historical context, not a command to replace the runtime palette.
+This scoped contract does not resolve the extraction's outstanding brand signoff.
+
+| Role | CSS token | Radius |
+| --- | --- | --- |
+| Text, search and select fields | `--settings-radius-input` | 12px |
+| Textareas, nested rows, compact cards and nav items | `--settings-radius-compact` | 16px |
+| Standard cards and disclosure containers | `--settings-radius-card` | 20px |
+| Setup, personalization and modal panels | `--settings-radius-panel` | 22px |
+| Subnav container | `--settings-radius-subnav` | 24px |
+| Action buttons, badges and circular markers | `--settings-radius-pill` | 999px |
+
+The v3 component-specific pill button rule takes precedence over its generic
+radius table's reference to 16px buttons. Navigation items remain nested 16px
+containers, rather than action pills. Compact rows use the 16px scale step;
+they do not introduce additional 14px, 15px or 18px values.
+
+Implementation lives in
+`browser-first/resonantos-side-panel-extension/src/styles/main-workspace/settings.css`.
+The later `responsive.css` compact-skin rules must not override these Settings
+shapes. Existing color, border and density rules remain in effect. Keep visible
+keyboard focus distinct from hover using the existing accent token.
+
+When changing these rules, check actual computed styles in Chrome: Start Here,
+Profile, Providers (including its modal), Routing, Appearance and Bridge Target.
+Compare the same viewport and state before and after; inspect textareas, nested
+rows, badges, enabled/disabled actions, keyboard focus and narrow layouts.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:browser-host": "node --test addons/resonant-browser-host/test/*.test.mjs",
     "test:browser-first": "node scripts/run-browser-first-extension-tests.mjs",
     "test:browser-first:live": "node browser-first/test/agent-control-live.mjs",
+    "test:browser-first:settings-shapes": "node browser-first/test/settings-shapes-live.mjs",
     "test:browser-first:live-sdk": "node browser-first/test/live-sdk-lane.mjs",
     "browser-first:dev": "node run-bridge-minimal.mjs",
     "browser-first:bridge": "node run-bridge-minimal.mjs",


### PR DESCRIPTION
Settings mixes square controls and health cards with rounded setup panels because the later compact skin overrides only part of the component CSS. This change gives Settings a documented shape scale and excludes it from that compact shape override. Action buttons use 12px rounded rectangles, matching fields; badges and circular markers retain their pill radius. Palette and density are preserved.

Closes #401.

The Settings contract resolves conflicting historical button guidance: actions use 12px, nested rows/nav/textareas 16px, cards 20px, panels 22px, and subnav 24px. A visible keyboard-focus outline uses the existing accent. Other workspaces retain their compact skin.

The rendered regression check loads actual extension modules and the full CSS cascade at 390/768/1280px. It verifies action/field/card shapes, round markers, keyboard focus, and the outside-Settings compact skin. Injected 3px card and 999px action overrides must both fail the detector. The existing live-browser CI lane runs it and retains Chrome screenshots.

Validation on Node 22.13.0:

- Browser-first suite: 1156 passed, 0 failed, 4 existing runtime skips.
- Documentation contract check passed; documentation tests: 231 passed.
- Chrome 152 renderer checks passed at all three viewport widths, including both injected regressions.
- Staged Engineer Runner: workflow tests, extension scope audit, and whitespace passed.
- Combined sizing/shape renderer checks passed in comfortable, compact and touch density.

Browser fixtures are network-isolated presentation evidence, separate from extension/bridge certification. This contribution changes presentation and documentation, with no provider authority or persistence changes. Control sizing and native provider-dialog keyboard behavior are separate contributions in #411 and #412.


## Validation

Rebased onto current `dev` (0f62904; also drops the Sept 4-8 attacker workflow file from this branch's ancestry) and re-ran locally at head `6f0ac0f`:

- `node --test browser-first/test/agent-control-live-workflow-paths.test.mjs` — pass (includes the new settings-shapes pin test)
- `npm run test:browser-first` — pass
- `npm run repo:hygiene`, `npm run docs:check`, `npm run test:security-pipeline` — pass
- `node scripts/browser-first-release-scope-audit.mjs --committed --strict` — pass

The rendered shapes check itself (`test:browser-first:settings-shapes`) and the live certification run need runner Chrome — left to CI on the clean runner.
