### PR TITLE
build(release-scope): recognize docs/addons/resonant-extension-framework/ as approved documentation

### DIFF
--- a/scripts/browser-first-release-scope-audit.mjs
+++ b/scripts/browser-first-release-scope-audit.mjs
@@ -260,6 +260,12 @@ export function classify(changedPath, state) {
       reason: "security-pipeline policy and check documentation",
     };
   }
+  if (changedPath.startsWith("docs/addons/resonant-extension-framework/")) {
+    return {
+      bucket: "include",
+      reason: "Resonant Extension Framework specification documentation",
+    };
+  }
   if (canonicalRootFiles.has(changedPath) || changedPath === "public/icons/README.md") {
     return {
       bucket: "include",

--- a/scripts/browser-first-release-scope-audit.test.mjs
+++ b/scripts/browser-first-release-scope-audit.test.mjs
@@ -374,3 +374,14 @@ test("security-pipeline documentation is approved release documentation", () => 
   });
   assert.equal(classify("docs/unlisted/notes.md", "added").bucket, "review");
 });
+
+test("Resonant Extension Framework specification docs are approved release documentation", () => {
+  const classify = requireExport("classify");
+
+  assert.deepEqual(classify("docs/addons/resonant-extension-framework/ADDON_PACKAGE_AND_MANIFEST_SPEC_V0.1.md", "added"), {
+    bucket: "include",
+    reason: "Resonant Extension Framework specification documentation",
+  });
+  assert.equal(classify("docs/addons/other-framework/notes.md", "added").bucket, "review");
+  assert.equal(classify("docs/REVIEW_PACKET_2026-08-25.md", "added").bucket, "review", "process artifacts at the docs root still need manual review");
+});


### PR DESCRIPTION
Unblocks #327's strict release-scope audit: the Resonant Extension Framework specification docs under `docs/addons/resonant-extension-framework/` become an approved documentation root (same pattern as `docs/design/` and `docs/security-pipeline/`, the latter added in #363). A `classify()` test locks it and confirms that process artifacts at the docs root (e.g. review packets) still need manual review. Mutation-checked (removing the rule turns the test red). Micro tier; audit tests green.

Refs #327.

🤖 Generated with [Claude Code](https://claude.com/claude-code)