### PR TITLE
extension: align Settings control heights with density rules

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/styles/main-workspace/settings.css
+++ b/browser-first/resonantos-side-panel-extension/src/styles/main-workspace/settings.css
@@ -504,6 +504,15 @@
   min-width: 0;
 }
 
+/* ROSI standard controls are 40px; compact and touch keep their own density. */
+body:not([data-density="compact"]):not([data-density="touch"])
+  :is(.settings-workspace, .settings-provider-modal)
+  :is(button:not(.settings-nav-item):not(.icon-button),
+      input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="hidden"]),
+      select) {
+  min-height: 40px;
+}
+
 .settings-appearance-control {
   display: grid;
   gap: 5px;

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -6,6 +6,9 @@ for anyone building panels, add-ons, or app-shell UI.
 
 ## ROSI — Resonant OS Interface design system
 
+For implemented Settings density behavior, see
+[Settings control sizing](SETTINGS-CONTROL-SIZING.md).
+
 Contributed by Michel Navarra (PR #208). Extracted from the live Browser
 extension UI into a token catalog.
 

--- a/docs/design/SETTINGS-CONTROL-SIZING.md
+++ b/docs/design/SETTINGS-CONTROL-SIZING.md
@@ -1,0 +1,17 @@
+# Settings control sizing
+
+The browser-first Settings workspace and provider modal follow the
+[ROSI v3 control-height guidance](rosi-design-system/reference/ui-extraction-browser-v3.md):
+standard text actions, single-line fields and selects have a 40px minimum height.
+The default density and explicit `comfortable` density use this rule.
+
+Compact density retains its existing compact padding. Touch density retains
+the existing global 42px minimum. These are minimums, not fixed heights: large
+text and wrapped labels may grow. Navigation rows, icon-only buttons, native
+checkboxes/radios, range controls and hidden inputs are excluded from the new
+standard-density rule. Textareas retain their multiline sizing.
+
+This contract changes height only. Palette, corner shapes, field behavior and
+preference persistence are separate concerns. Check Overview actions,
+Appearance selects and provider form fields at narrow/wide widths and all
+three densities before changing the rule.


### PR DESCRIPTION
Settings standard-density actions could render at about 27px high even though the ROSI v3 control guidance specifies 40px. Add a scoped minimum height for text actions, single-line fields and selects. Compact density keeps its existing sizing; touch retains its 42px minimum. Palette, corners, labels and persistence are unchanged.

Closes #407.

Validation on Node 22.13.0:
- `npm run test:browser-first`: 1,156 passed, 0 failed, 4 existing live-runtime skips.
- `npm run docs:check`: passed; `npm run test:docs`: 232 passed.
- Staged Engineer Runner:Settings tests, scope audit and whitespace passed.
- Chrome 152 actual-renderer proof at 390/768/1280, with large text and all three densities: standard actions increased to 40px; compact measurements stayed unchanged; touch remained at least 42px. Fields retain content-driven growth.

Ownership is limited to Settings CSS and its sizing reference. Navigation rows, icon-only controls, native checkboxes/radios, ranges, hidden inputs and textareas are excluded from the new rule. No routes, provider logic, permissions, credentials or human-only authority changes. Independent of the shape work in #404; browser fixture proof does not claim full accessibility or extension/bridge certification.

The initial hosted documentation check caught a missing index link after the new document became tracked. The design index now links the contract, and validation passes with the document tracked. The sizing implementation is unchanged.
