### PR TITLE
extension: use native provider dialog keyboard lifecycle

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/lib/settings/providers-section.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/settings/providers-section.js
@@ -111,8 +111,9 @@ function providerAccountForm(provider = {}) {
 
 export function openProviderAccountModal({ bridgeRequest, getBridgeRequest, statusNode, reload }) {
   const bridge = () => (typeof getBridgeRequest === "function" ? getBridgeRequest() : bridgeRequest);
-  const overlay = document.createElement("div");
+  const overlay = document.createElement("dialog");
   overlay.className = "settings-provider-modal";
+  overlay.setAttribute("aria-label", "Add provider account");
   const panel = document.createElement("section");
   panel.className = "settings-provider-modal-panel";
   const heading = document.createElement("div");
@@ -146,10 +147,16 @@ export function openProviderAccountModal({ bridgeRequest, getBridgeRequest, stat
   panel.append(heading, form, modalStatus);
   overlay.append(panel);
   document.body.append(overlay);
-  close.addEventListener("click", () => overlay.remove());
+  // Native modal lifecycle owns focus containment, Escape and invoker restoration.
+  overlay.addEventListener("close", () => overlay.remove(), { once: true });
+  const dismiss = () => {
+    if (overlay.open) overlay.close();
+  };
+  close.addEventListener("click", dismiss);
   overlay.addEventListener("click", (event) => {
-    if (event.target === overlay) overlay.remove();
+    if (event.target === overlay) dismiss();
   });
+  overlay.showModal();
   form.addEventListener("submit", async (event) => {
     event.preventDefault();
     save.disabled = true;
@@ -161,7 +168,7 @@ export function openProviderAccountModal({ bridgeRequest, getBridgeRequest, stat
         body: providerAccountPayload(form),
       });
       // Success: close the dialog, then surface confirmation on the settings page.
-      overlay.remove();
+      dismiss();
       setStatus(statusNode, "Provider account saved.", "success");
       await reload();
     } catch (error) {

--- a/browser-first/resonantos-side-panel-extension/src/styles/main-workspace/settings.css
+++ b/browser-first/resonantos-side-panel-extension/src/styles/main-workspace/settings.css
@@ -994,12 +994,28 @@
 .settings-provider-modal {
   position: fixed;
   inset: 0;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  max-height: none;
+  margin: 0;
+  border: 0;
+  color: inherit;
   z-index: 1000;
   display: grid;
   place-items: center;
   background: rgba(0, 0, 0, 0.56);
   backdrop-filter: blur(10px);
   padding: 18px;
+}
+
+.settings-provider-modal:not([open]) {
+  display: none;
+}
+
+/* The full-window dialog already owns the existing backdrop treatment. */
+.settings-provider-modal::backdrop {
+  background: transparent;
 }
 
 .settings-provider-modal-panel {

--- a/browser-first/test/dialog-dom-fixture.mjs
+++ b/browser-first/test/dialog-dom-fixture.mjs
@@ -1,0 +1,11 @@
+// JSDOM does not implement showModal/close. Simulate lifecycle events only;
+// real Chrome proof owns focus, inertness, Escape and invoker restoration.
+export function installDialogLifecycle(window) {
+  window.HTMLDialogElement.prototype.showModal = function () {
+    this.open = true;
+  };
+  window.HTMLDialogElement.prototype.close = function () {
+    this.open = false;
+    this.dispatchEvent(new window.Event("close"));
+  };
+}

--- a/browser-first/test/main-workspace-settings.test.mjs
+++ b/browser-first/test/main-workspace-settings.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { JSDOM } from "jsdom";
+import { installDialogLifecycle } from "./dialog-dom-fixture.mjs";
 import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
@@ -37,6 +38,7 @@ function setupDom() {
   const dom = new JSDOM("<!doctype html><main id=\"root\"></main>", { url: "https://resonantos.local/" });
   dom.window.confirm = () => true;
   dom.window.prompt = () => "";
+  installDialogLifecycle(dom.window);
   globalThis.window = dom.window;
   globalThis.document = dom.window.document;
   globalThis.HTMLElement = dom.window.HTMLElement;

--- a/browser-first/test/provider-dialog-lifecycle.test.mjs
+++ b/browser-first/test/provider-dialog-lifecycle.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { JSDOM } from "jsdom";
+import { installDialogLifecycle } from "./dialog-dom-fixture.mjs";
+import { openProviderAccountModal } from "../resonantos-side-panel-extension/src/lib/settings/providers-section.js";
+
+function setup(t, bridgeRequest) {
+  const dom = new JSDOM('<button id="invoker">Add provider account</button><p id="status"></p>');
+  const previous = globalThis.document;
+  globalThis.document = dom.window.document;
+  installDialogLifecycle(dom.window);
+  t.after(() => { globalThis.document = previous; dom.window.close(); });
+  const statusNode = document.querySelector('#status');
+  let reloads = 0;
+  const open = () => {
+    openProviderAccountModal({ bridgeRequest, statusNode, reload: async () => { reloads++; } });
+    return document.querySelector('dialog[open]');
+  };
+  const submit = (dialog) => dialog.querySelector('form').dispatchEvent(new dom.window.Event('submit', { bubbles: true, cancelable: true }));
+  return { open, submit, statusNode, reloads: () => reloads };
+}
+
+test('provider dialog exposes a name and removes itself after native close', (t) => {
+  const { open } = setup(t, async () => ({}));
+  const dialog = open();
+  assert.equal(dialog.getAttribute('aria-label'), 'Add provider account');
+  dialog.querySelector('button').click();
+  assert.equal(dialog.isConnected, false);
+});
+
+test('provider dialog backdrop dismisses but panel content does not', (t) => {
+  const { open } = setup(t, async () => ({}));
+  const dialog = open();
+  dialog.querySelector('section').click();
+  assert.equal(dialog.open, true);
+  dialog.click();
+  assert.equal(dialog.isConnected, false);
+});
+
+test('provider dialog preserves errors and retries through the original capability', async (t) => {
+  const requests = [];
+  const { open, submit, statusNode, reloads } = setup(t, async (path, options) => {
+    requests.push({ path, options });
+    if (requests.length === 1) throw new Error('Account unavailable');
+    return {};
+  });
+  const dialog = open();
+  const label = dialog.querySelector('input[name="label"]');
+  label.value = 'Fixture account';
+  submit(dialog);
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(dialog.open, true);
+  assert.match(dialog.querySelector('[role="status"]').textContent, /Account unavailable/);
+  assert.equal(label.value, 'Fixture account');
+  assert.equal(dialog.querySelector('[type="submit"]').disabled, false);
+  submit(dialog);
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(dialog.isConnected, false);
+  assert.equal(reloads(), 1);
+  assert.match(statusNode.textContent, /saved/);
+  assert.equal(requests.length, 2);
+  assert.equal(requests[1].path, '/providers/accounts');
+  assert.equal(requests[1].options.capability, 'provider-credential-write');
+  assert.equal(requests[1].options.body.label, 'Fixture account');
+});
+
+test('completion of a dismissed dialog does not close a newer dialog', async (t) => {
+  let resolveRequest;
+  const { open, submit, reloads } = setup(t, () => new Promise(resolve => { resolveRequest = resolve; }));
+  const first = open();
+  submit(first);
+  assert.equal(first.querySelector('[type="submit"]').disabled, true);
+  first.close();
+  const second = open();
+  resolveRequest({});
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(first.isConnected, false);
+  assert.equal(second.open, true);
+  assert.equal(second.isConnected, true);
+  assert.equal(reloads(), 1);
+});

--- a/browser-first/test/providers-section-modal.test.mjs
+++ b/browser-first/test/providers-section-modal.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { JSDOM } from "jsdom";
+import { installDialogLifecycle } from "./dialog-dom-fixture.mjs";
 
 import { openProviderAccountModal } from "../resonantos-side-panel-extension/src/lib/settings/providers-section.js";
 
@@ -12,6 +13,7 @@ import { openProviderAccountModal } from "../resonantos-side-panel-extension/src
 function setupDom() {
   const dom = new JSDOM("<!doctype html><main id=\"root\"></main>", { url: "https://resonantos.local/" });
   globalThis.window = dom.window;
+  installDialogLifecycle(dom.window);
   globalThis.document = dom.window.document;
   globalThis.Event = dom.window.Event;
   globalThis.FormData = dom.window.FormData;


### PR DESCRIPTION
The provider account overlay did not support Escape or contain keyboard focus. Use a labelled native modal dialog so Chrome owns focus entry, containment, Escape and return to the invoker. Close, backdrop dismissal and successful saves use the same close lifecycle; save failures retain the form and its local error message.

Closes #408.

Validation on Node 22.13.0:
- `npm run test:browser-first`: 1,160 passed, 0 failed, 4 existing live-runtime skips.
- Focused provider/workspace tests: 41 passed, including dismissal, error retention/retry, and completion after an older dialog was dismissed.
- Chrome 152: Tab stays within the modal; Escape, Close and backdrop dismissal restore invoker focus. Enter submits the form; a simulated failure preserves input and a successful retry closes it and restores focus.
- Staged Engineer Runner, scope audit and whitespace: passed.

The initial full run exposed two existing tests whose JSDOM setup lacked native dialog methods. A shared test-only lifecycle fixture fixes that environment gap without weakening assertions. Native focus and Escape are verified in Chrome, not simulated by that fixture.

No provider route, payload, capability, credential transport, palette or human-only boundary changes. The same-file provider work in #318 remains independent. This change is compatible with the Settings presentation work in #404; it does not require that PR to merge first.
