### PR TITLE
security(bridge): refuse routes that declare no capability by default (closes #373)

### DIFF
--- a/browser-first/host/bridge-server.mjs
+++ b/browser-first/host/bridge-server.mjs
@@ -79,7 +79,8 @@ export function createBridgeToken() {
   return randomBytes(32).toString("base64url");
 }
 
-function constantTimeEqual(left, right) {
+export function constantTimeEqual(left, right) {
+  if (!left || !right) return false;
   const leftBuffer = Buffer.from(String(left ?? ""));
   const rightBuffer = Buffer.from(String(right ?? ""));
   return leftBuffer.length === rightBuffer.length && timingSafeEqual(leftBuffer, rightBuffer);
@@ -1003,7 +1004,7 @@ export async function writeBridgeConfig({
 
 function isAuthorizedCapabilityRequest(request, bridgeCapabilityTokens, requiredCapability) {
   if (!requiredCapability) {
-    return true;
+    return false;
   }
   const expectedToken = bridgeCapabilityTokens?.[requiredCapability];
   return Boolean(expectedToken) && constantTimeEqual(request.headers[bridgeCapabilityHeader], expectedToken);
@@ -1066,6 +1067,17 @@ export async function evaluateBridgeRequestForSelfTest({
     }
     if (route.requiredCapabilityBootstrap && !isAuthorizedCapabilityBootstrapRequest(request, capabilityBootstrapToken)) {
       return { status: 403, payload: { ok: false, error: "Bridge route requires capability bootstrap authorization." } };
+    }
+    if (!route.requiredCapability) {
+      if (route.requiredCapabilityBootstrap) {
+        const payload = method === "POST" ? body : {};
+        const result = await route.handler(payload, request);
+        return { status: 200, payload: { ok: true, ...result } };
+      }
+      return {
+        status: 403,
+        payload: { ok: false, error: "Bridge route declares no capability; refused by default." },
+      };
     }
     if (!isAuthorizedCapabilityRequest(request, bridgeCapabilityTokens, route.requiredCapability)) {
       return { status: 403, payload: { ok: false, error: `Bridge route requires ${route.requiredCapability} capability.` } };
@@ -1407,25 +1419,41 @@ export async function startBridgeServerWithFallback({
 }
 
 export async function runBridgeAuthSelfTest({ port, bridgeToken, extensionOrigin }) {
+  const selfTestCapability = "bridge-self-test";
+  const selfTestCapabilityToken = createBridgeToken();
   const server = await startBridgeServer({
     port,
     bridgeToken,
+    bridgeCapabilityTokens: { [selfTestCapability]: selfTestCapabilityToken },
     extensionOrigin,
-    routes: [{ method: "GET", path: "/status", handler: async () => ({ bridge: "self-test" }) }],
+    routes: [{
+      method: "GET",
+      path: "/status",
+      requiredCapability: selfTestCapability,
+      handler: async () => ({ bridge: "self-test" }),
+    }],
   });
   const actualPort = bridgeServerPort(server, port);
   const unauthorized = await fetch(`http://127.0.0.1:${actualPort}/status`);
   const wrongToken = await fetch(`http://127.0.0.1:${actualPort}/status`, {
     headers: { [bridgeTokenHeaderName]: "wrong-token" },
   });
-  const authorized = await fetch(`http://127.0.0.1:${actualPort}/status`, {
+  const missingCapability = await fetch(`http://127.0.0.1:${actualPort}/status`, {
     headers: { [bridgeTokenHeaderName]: bridgeToken },
+  });
+  const authorized = await fetch(`http://127.0.0.1:${actualPort}/status`, {
+    headers: {
+      [bridgeTokenHeaderName]: bridgeToken,
+      [bridgeCapabilityHeaderName]: selfTestCapabilityToken,
+    },
   });
   server.close();
   return {
-    ok: unauthorized.status === 401 && wrongToken.status === 401 && authorized.ok,
+    ok: unauthorized.status === 401 && wrongToken.status === 401 && missingCapability.status === 403 && authorized.ok,
     unauthorizedStatus: unauthorized.status,
     wrongTokenStatus: wrongToken.status,
+    missingCapabilityStatus: missingCapability.status,
+    bridgeTokenOnlyStatus: missingCapability.status,
     authorizedStatus: authorized.status,
   };
 }

--- a/browser-first/host/bridge-server.mjs
+++ b/browser-first/host/bridge-server.mjs
@@ -1443,12 +1443,25 @@ export async function runBridgeAuthSelfTest({ port, bridgeToken, extensionOrigin
     },
   });
   server.close();
-  return {
-    ok: unauthorized.status === 401 && wrongToken.status === 401 && missingCapability.status === 403 && authorized.ok,
+  return summarizeBridgeAuthSelfTest({
     unauthorizedStatus: unauthorized.status,
     wrongTokenStatus: wrongToken.status,
     missingCapabilityStatus: missingCapability.status,
-    bridgeTokenOnlyStatus: missingCapability.status,
     authorizedStatus: authorized.status,
+  });
+}
+
+// Pure so the pass/fail rule is unit-testable without a socket: the self-test is only ok when
+// token auth held (401/401), default-deny held (bridge token alone -> 403), and the fully
+// authorized probe succeeded. bridgeTokenOnlyStatus mirrors the in-process self-test's field name.
+export function summarizeBridgeAuthSelfTest({ unauthorizedStatus, wrongTokenStatus, missingCapabilityStatus, authorizedStatus }) {
+  const authorizedOk = authorizedStatus >= 200 && authorizedStatus < 300;
+  return {
+    ok: unauthorizedStatus === 401 && wrongTokenStatus === 401 && missingCapabilityStatus === 403 && authorizedOk,
+    unauthorizedStatus,
+    wrongTokenStatus,
+    missingCapabilityStatus,
+    bridgeTokenOnlyStatus: missingCapabilityStatus,
+    authorizedStatus,
   };
 }

--- a/browser-first/host/bridge-server.mjs
+++ b/browser-first/host/bridge-server.mjs
@@ -1068,18 +1068,13 @@ export async function evaluateBridgeRequestForSelfTest({
     if (route.requiredCapabilityBootstrap && !isAuthorizedCapabilityBootstrapRequest(request, capabilityBootstrapToken)) {
       return { status: 403, payload: { ok: false, error: "Bridge route requires capability bootstrap authorization." } };
     }
-    if (!route.requiredCapability) {
-      if (route.requiredCapabilityBootstrap) {
-        const payload = method === "POST" ? body : {};
-        const result = await route.handler(payload, request);
-        return { status: 200, payload: { ok: true, ...result } };
-      }
+    if (!route.requiredCapability && !route.requiredCapabilityBootstrap) {
       return {
         status: 403,
         payload: { ok: false, error: "Bridge route declares no capability; refused by default." },
       };
     }
-    if (!isAuthorizedCapabilityRequest(request, bridgeCapabilityTokens, route.requiredCapability)) {
+    if (route.requiredCapability && !isAuthorizedCapabilityRequest(request, bridgeCapabilityTokens, route.requiredCapability)) {
       return { status: 403, payload: { ok: false, error: `Bridge route requires ${route.requiredCapability} capability.` } };
     }
     const payload = method === "POST" ? body : {};

--- a/browser-first/host/run-bridge-minimal.mjs
+++ b/browser-first/host/run-bridge-minimal.mjs
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import {
+  constantTimeEqual,
   createBridgeToken,
   getBridgeHost,
   getBridgePublicUrl,
@@ -396,7 +397,7 @@ async function invokeBridgeRouteForSelfTest({ method = "POST", routePath, body =
   if (!route) {
     return { status: 404, payload: { ok: false, error: "Unknown browser-first bridge route." } };
   }
-  if (route.requiredCapability && capabilityToken !== bridgeCapabilityTokens[route.requiredCapability]) {
+  if (route.requiredCapability && !constantTimeEqual(capabilityToken, bridgeCapabilityTokens[route.requiredCapability])) {
     return { status: 403, payload: { ok: false, error: `Bridge route requires ${route.requiredCapability} capability.` } };
   }
   try {

--- a/browser-first/test/bridge-server.test.mjs
+++ b/browser-first/test/bridge-server.test.mjs
@@ -16,6 +16,7 @@ test("constant-time token comparison preserves exact-match and length checks", (
   assert.equal(constantTimeEqual("capability-token", "capability-tokfn"), false);
   assert.equal(constantTimeEqual("capability-token", "capability-token-extra"), false);
   assert.equal(constantTimeEqual("", undefined), false);
+  assert.equal(constantTimeEqual("", ""), false, "two empty tokens must never compare equal (fail closed)");
 });
 
 test("bridge capability behavior is deterministic without localhost binding", async () => {
@@ -702,4 +703,18 @@ test("bridge client uses runtime-scoped capability tokens after bootstrap", asyn
     body: { providerId: "shared-minimax", credential: "minimax-test-credential" },
   });
   assert.equal(saved.saved, true);
+});
+
+test("runBridgeAuthSelfTest proves token auth and default-deny on a real socket", async () => {
+  const { runBridgeAuthSelfTest } = await import("../host/bridge-server.mjs");
+  const result = await runBridgeAuthSelfTest({
+    port: 0,
+    bridgeToken: "self-test-bridge-token",
+    extensionOrigin: "chrome-extension://test",
+  });
+  assert.equal(result.unauthorizedStatus, 401);
+  assert.equal(result.wrongTokenStatus, 401);
+  assert.equal(result.missingCapabilityStatus, 403, "a valid bridge token without the capability header must be refused");
+  assert.equal(result.authorizedStatus, 200);
+  assert.equal(result.ok, true);
 });

--- a/browser-first/test/bridge-server.test.mjs
+++ b/browser-first/test/bridge-server.test.mjs
@@ -9,7 +9,7 @@ import {
   isUnauthorizedBridgeError,
   resolveBridgeConfig,
 } from "../resonantos-side-panel-extension/src/lib/bridge-client.js";
-import { constantTimeEqual, evaluateBridgeRequestForSelfTest, startBridgeServer } from "../host/bridge-server.mjs";
+import { constantTimeEqual, evaluateBridgeRequestForSelfTest, startBridgeServer, summarizeBridgeAuthSelfTest } from "../host/bridge-server.mjs";
 
 test("constant-time token comparison preserves exact-match and length checks", () => {
   assert.equal(constantTimeEqual("capability-token", "capability-token"), true);
@@ -717,4 +717,14 @@ test("runBridgeAuthSelfTest proves token auth and default-deny on a real socket"
   assert.equal(result.missingCapabilityStatus, 403, "a valid bridge token without the capability header must be refused");
   assert.equal(result.authorizedStatus, 200);
   assert.equal(result.ok, true);
+});
+
+test("bridge auth self-test summary only reports ok when default-deny held", () => {
+  const healthy = summarizeBridgeAuthSelfTest({ unauthorizedStatus: 401, wrongTokenStatus: 401, missingCapabilityStatus: 403, authorizedStatus: 200 });
+  assert.equal(healthy.ok, true);
+  assert.equal(healthy.bridgeTokenOnlyStatus, 403, "the in-process self-test's field name is mirrored for operators");
+  const denyRegressed = summarizeBridgeAuthSelfTest({ unauthorizedStatus: 401, wrongTokenStatus: 401, missingCapabilityStatus: 200, authorizedStatus: 200 });
+  assert.equal(denyRegressed.ok, false, "a bridge-token-only 200 means an undeclared or unguarded route was served; the self-test must fail");
+  const tokenRegressed = summarizeBridgeAuthSelfTest({ unauthorizedStatus: 200, wrongTokenStatus: 401, missingCapabilityStatus: 403, authorizedStatus: 200 });
+  assert.equal(tokenRegressed.ok, false);
 });

--- a/browser-first/test/bridge-server.test.mjs
+++ b/browser-first/test/bridge-server.test.mjs
@@ -9,13 +9,25 @@ import {
   isUnauthorizedBridgeError,
   resolveBridgeConfig,
 } from "../resonantos-side-panel-extension/src/lib/bridge-client.js";
-import { evaluateBridgeRequestForSelfTest, startBridgeServer } from "../host/bridge-server.mjs";
+import { constantTimeEqual, evaluateBridgeRequestForSelfTest, startBridgeServer } from "../host/bridge-server.mjs";
+
+test("constant-time token comparison preserves exact-match and length checks", () => {
+  assert.equal(constantTimeEqual("capability-token", "capability-token"), true);
+  assert.equal(constantTimeEqual("capability-token", "capability-tokfn"), false);
+  assert.equal(constantTimeEqual("capability-token", "capability-token-extra"), false);
+  assert.equal(constantTimeEqual("", undefined), false);
+});
 
 test("bridge capability behavior is deterministic without localhost binding", async () => {
   const bridgeToken = "general-test-token";
   const capabilityToken = "credential-write-test-token";
   const routes = [
-    { method: "GET", path: "/public", handler: async () => ({ public: true }) },
+    {
+      method: "GET",
+      path: "/public",
+      requiredCapability: "bridge-diagnostics-read",
+      handler: async () => ({ public: true }),
+    },
     {
       method: "POST",
       path: "/providers/credentials",
@@ -27,9 +39,15 @@ test("bridge capability behavior is deterministic without localhost binding", as
   const publicResult = await evaluateBridgeRequestForSelfTest({
     method: "GET",
     url: "/public",
-    headers: { "X-ResonantOS-Bridge-Token": bridgeToken },
+    headers: {
+      "X-ResonantOS-Bridge-Token": bridgeToken,
+      "X-ResonantOS-Bridge-Capability-Token": capabilityToken,
+    },
     bridgeToken,
-    bridgeCapabilityTokens: { "provider-credential-write": capabilityToken },
+    bridgeCapabilityTokens: {
+      "bridge-diagnostics-read": capabilityToken,
+      "provider-credential-write": capabilityToken,
+    },
     routes,
   });
   assert.equal(publicResult.status, 200);
@@ -84,6 +102,73 @@ test("bridge capability behavior is deterministic without localhost binding", as
   });
   assert.equal(saved.status, 200);
   assert.equal(saved.payload.saved, true);
+});
+
+test("bridge refuses undeclared routes by default while preserving declared capability and bootstrap routes", async () => {
+  const bridgeToken = "default-deny-test-token";
+  const capabilityBootstrapToken = "default-deny-bootstrap-token";
+  const capabilityToken = "default-deny-capability-token";
+
+  const undeclared = await evaluateBridgeRequestForSelfTest({
+    method: "GET",
+    url: "/default-deny",
+    headers: { "X-ResonantOS-Bridge-Token": bridgeToken },
+    bridgeToken,
+    bridgeCapabilityTokens: { "bridge-diagnostics-read": capabilityToken },
+    capabilityBootstrapToken,
+    routes: [
+      { method: "GET", path: "/default-deny", handler: async () => ({ reached: true }) },
+    ],
+  });
+  assert.equal(undeclared.status, 403);
+  assert.deepEqual(undeclared.payload, {
+    ok: false,
+    error: "Bridge route declares no capability; refused by default.",
+  });
+
+  const declared = await evaluateBridgeRequestForSelfTest({
+    method: "GET",
+    url: "/default-deny",
+    headers: {
+      "X-ResonantOS-Bridge-Token": bridgeToken,
+      "X-ResonantOS-Bridge-Capability-Token": capabilityToken,
+    },
+    bridgeToken,
+    bridgeCapabilityTokens: { "bridge-diagnostics-read": capabilityToken },
+    capabilityBootstrapToken,
+    routes: [
+      {
+        method: "GET",
+        path: "/default-deny",
+        requiredCapability: "bridge-diagnostics-read",
+        handler: async () => ({ reached: true }),
+      },
+    ],
+  });
+  assert.equal(declared.status, 200);
+  assert.equal(declared.payload.reached, true);
+
+  const bootstrapOnly = await evaluateBridgeRequestForSelfTest({
+    method: "POST",
+    url: "/bootstrap-only",
+    headers: {
+      "X-ResonantOS-Bridge-Token": bridgeToken,
+      "X-ResonantOS-Capability-Bootstrap-Token": capabilityBootstrapToken,
+    },
+    bridgeToken,
+    bridgeCapabilityTokens: { "bridge-diagnostics-read": capabilityToken },
+    capabilityBootstrapToken,
+    routes: [
+      {
+        method: "POST",
+        path: "/bootstrap-only",
+        requiredCapabilityBootstrap: true,
+        handler: async () => ({ bootstrapped: true }),
+      },
+    ],
+  });
+  assert.equal(bootstrapOnly.status, 200);
+  assert.equal(bootstrapOnly.payload.bootstrapped, true);
 });
 
 test("bridge client sends scoped capability headers without localhost binding", async () => {
@@ -475,17 +560,24 @@ test("bridge capability-token bootstrap is scoped and separate from the bridge t
 test("bridge privileged routes require a route-scoped capability token", async (t) => {
   const bridgeToken = "general-test-token";
   const capabilityToken = "credential-write-test-token";
+  const diagnosticsToken = "diagnostics-read-test-token";
   let server;
   try {
     server = await startBridgeServer({
       port: 0,
       bridgeToken,
       bridgeCapabilityTokens: {
+        "bridge-diagnostics-read": diagnosticsToken,
         "provider-credential-write": capabilityToken,
       },
       extensionOrigin: "chrome-extension://test",
       routes: [
-        { method: "GET", path: "/public", handler: async () => ({ public: true }) },
+        {
+          method: "GET",
+          path: "/status",
+          requiredCapability: "bridge-diagnostics-read",
+          handler: async () => ({ service: "resonantos-bridge" }),
+        },
         {
           method: "POST",
           path: "/providers/credentials",
@@ -507,6 +599,7 @@ test("bridge privileged routes require a route-scoped capability token", async (
     bridgeUrl,
     bridgeToken,
     bridgeCapabilityTokens: {
+      "bridge-diagnostics-read": diagnosticsToken,
       "provider-credential-write": capabilityToken,
     },
   });
@@ -517,7 +610,7 @@ test("bridge privileged routes require a route-scoped capability token", async (
   });
 
   try {
-    assert.equal((await client("/public", { method: "GET" })).public, true);
+    assert.equal((await client("/status", { method: "GET" })).service, "resonantos-bridge");
 
     await assert.rejects(
       () => clientWithoutCapability("/providers/credentials", {

--- a/browser-first/test/bridge-tls.test.mjs
+++ b/browser-first/test/bridge-tls.test.mjs
@@ -115,11 +115,20 @@ test("ensureBridgeTls: idempotent on second call (no regen)", async () => {
 test("startBridgeServersWithTls: HTTP and HTTPS serve the same routes", async () => {
   const tls = await ensureBridgeTls({ dir: tmp });
   const TOKEN = "tls-test-token-1";
-  const routes = [{ method: "GET", path: "/ping", handler: async () => ({ pong: true }) }];
+  const CAPABILITY_TOKEN = "tls-test-capability-token-1";
+  const routes = [{
+    method: "GET",
+    path: "/ping",
+    requiredCapability: "bridge-diagnostics-read",
+    handler: async () => ({ pong: true }),
+  }];
   const result = await startBridgeServersWithTls({
     httpPort: 0, httpsPort: 0,
     tls: { key: tls.key, cert: tls.cert },
-    bridgeToken: TOKEN, routes, host: "127.0.0.1",
+    bridgeToken: TOKEN,
+    bridgeCapabilityTokens: { "bridge-diagnostics-read": CAPABILITY_TOKEN },
+    routes,
+    host: "127.0.0.1",
   });
   try {
     assert.ok(result.httpServer);
@@ -127,13 +136,19 @@ test("startBridgeServersWithTls: HTTP and HTTPS serve the same routes", async ()
     assert.notEqual(result.httpPort, result.httpsPort);
     // HTTP
     const httpResp = await fetch(`http://127.0.0.1:${result.httpPort}/ping`, {
-      headers: { "X-ResonantOS-Bridge-Token": TOKEN },
+      headers: {
+        "X-ResonantOS-Bridge-Token": TOKEN,
+        "X-ResonantOS-Bridge-Capability-Token": CAPABILITY_TOKEN,
+      },
     });
     assert.equal(httpResp.status, 200);
     // HTTPS
     const httpsResp = await httpsGet(`https://127.0.0.1:${result.httpsPort}/ping`, {
       ca: tls.ca,
-      headers: { "X-ResonantOS-Bridge-Token": TOKEN },
+      headers: {
+        "X-ResonantOS-Bridge-Token": TOKEN,
+        "X-ResonantOS-Bridge-Capability-Token": CAPABILITY_TOKEN,
+      },
     });
     assert.equal(httpsResp.status, 200);
     const body = JSON.parse(httpsResp.body);
@@ -148,11 +163,18 @@ test("startBridgeServersWithTls: HTTP and HTTPS serve the same routes", async ()
 test("startBridgeServersWithTls: HTTPS enforces token auth (401 without header)", async () => {
   const tls = await ensureBridgeTls({ dir: tmp });
   const TOKEN = "tls-test-token-2";
+  const CAPABILITY_TOKEN = "tls-test-capability-token-2";
   const result = await startBridgeServersWithTls({
     httpPort: 0, httpsPort: 0,
     tls: { key: tls.key, cert: tls.cert },
     bridgeToken: TOKEN,
-    routes: [{ method: "GET", path: "/ping", handler: async () => ({ pong: true }) }],
+    bridgeCapabilityTokens: { "bridge-diagnostics-read": CAPABILITY_TOKEN },
+    routes: [{
+      method: "GET",
+      path: "/ping",
+      requiredCapability: "bridge-diagnostics-read",
+      handler: async () => ({ pong: true }),
+    }],
     host: "127.0.0.1",
   });
   try {

--- a/docs/browser-first-bridge-setup-runbook.md
+++ b/docs/browser-first-bridge-setup-runbook.md
@@ -72,6 +72,9 @@ The bridge launcher must mint a token for each, or bootstrap 500s. Both are now
 derived from a single canonical source, `browser-first/host/bridge-capability-tokens.mjs`.
 Every bridge route now requires a per-route capability token in addition to the
 bridge token, and `bridge-route-capability-audit` fails when a route is ungated.
+Routes that declare neither `requiredCapability` nor `requiredCapabilityBootstrap`
+are refused by default as defense in depth; the audit test remains the readable
+gate for route capability coverage.
 Read-only bridge status, memory, and extension preference routes are protected
 by `bridge-diagnostics-read`, `memory-read`, and `extension-prefs-read`.
 


### PR DESCRIPTION
## Summary

Closes #373. Defense in depth after #346: the bridge now **refuses any route that declares neither `requiredCapability` nor `requiredCapabilityBootstrap`** with `403 Bridge route declares no capability; refused by default.` — even with a valid bridge token. The capability audit test remains the readable gate; this is the backstop for any route table the audit does not construct (a second launcher, a fixture that escapes into production, a future service).

- `isAuthorizedCapabilityRequest` no longer treats a missing `requiredCapability` as authorized; the dispatch path checks the declaration once, before the capability check. Bootstrap-only routes (`POST /api/capability-tokens`) keep working after bootstrap authorization.
- `runBridgeAuthSelfTest` (the `--bridge-auth-self-test` mode) declares a `bridge-self-test` capability, mints a scoped token, sends it on the authorized probe, and adds a bridge-token-only probe that must be **403** (`missingCapabilityStatus`, folded into `ok`). It had no test at all; it now runs on a real socket in `bridge-server.test.mjs`.
- `constantTimeEqual` is exported and **fails closed on empty inputs** — before, an empty configured token compared equal to a missing header. The minimal runner's self-test helper uses it instead of `!==` (the issue's second item).
- Fixtures that relied on the open default (`bridge-server.test.mjs` `/public` and its socket fixture, `bridge-tls.test.mjs` `/ping`) now declare a capability and send its header so their 200 assertions stay meaningful. New test: undeclared → 403 with the exact error, declared → 200, bootstrap-only → 200.
- Runbook sentence documents the default-deny.

## Evidence

Head `af919cc9` (3 commits on `82d32427`), gates run outside the executor sandbox in a single invocation:

| Gate | Result |
|---|---|
| `npm run test:browser-first` | **1195 / 1195** (dev: 1191; +4 from this PR) |
| `vitest run` | 437 / 437 |
| `tsc --noEmit`, `test:security-pipeline` (46/46), `docs:check`, release-scope audit `--strict` | clean |
| `bridge-route-capability-audit` | pass (every composed route declares a capability) |

Anti-false-green — three mutations via `rig-mutate`, each restored byte-identical:

| Mutation | Result |
|---|---|
| m1: delete the default-deny block | `bridge-server.test.mjs` → **red** |
| m2: drop the fail-closed guard in `constantTimeEqual` | → **red** (`constantTimeEqual("", "")` would be `true`) |
| m3: drop the 403 requirement from the self-test's pass rule | → **red** — *after* a fix: the first form of this mutation was **vacuous** (in a healthy run the 403 still arrives, so `ok` stayed true either way). The pass rule was extracted into the pure `summarizeBridgeAuthSelfTest` with a unit test that feeds it a bridge-token-only 200; the mutation is now observable. Disclosed here because a vacuous mutation is exactly the signal this step exists to catch. |

Independent review: **DeepSeek V4 Pro (via `pi`) — CONFIRM**, 36/36 focused tests reproduced; four nits adjudicated in the PR comments (one becomes a follow-up issue).

## Process

Fleet executor (codex, from a maintainer spec with re-verified `file:line` facts); maintainer adjudication of the handback (dispatch collapsed to one predicate; the self-test alias kept for parity with the in-process mode; missing socket test added); independent security + correctness review by DeepSeek via `pi` (vendor ≠ author) — verdict and adjudication in the PR comments. Live proofs against the deployed bridge after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
