### PR TITLE
feat(addons): `uninstalled` installation state — tombstone rebase, fresh-grant snapshot and reinstall (#180 task 1)

### DIFF
--- a/docs/architecture/ADR-006-addon-runtime-sdk.md
+++ b/docs/architecture/ADR-006-addon-runtime-sdk.md
@@ -106,6 +106,7 @@ Add-ons must have explicit lifecycle states:
 - `degraded`
 - `update-available`
 - `incompatible`
+- `uninstalled`
 
 ## Interfaces Constrained By This ADR
 

--- a/src/core/contracts.ts
+++ b/src/core/contracts.ts
@@ -76,7 +76,15 @@ export type WorkloadClass =
   | "archive-ingest"
   | "recovery"
   | "background";
-export type InstallationStatus = "available" | "installed" | "enabled" | "disabled" | "degraded" | "update-available" | "incompatible";
+export type InstallationStatus =
+  | "available"
+  | "installed"
+  | "enabled"
+  | "disabled"
+  | "degraded"
+  | "update-available"
+  | "incompatible"
+  | "uninstalled";
 export type CoreServiceStatus = "ready" | "attention" | "planned";
 export type ArchiveActorType = "core-agent" | "addon" | "service";
 export type ArchiveAction = "archive-read" | "archive-intake-write" | "archive-knowledge-write" | "archive-ingest-request";

--- a/src/core/policies.test.ts
+++ b/src/core/policies.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest";
-import type { AddOnManifest } from "./contracts";
+import type { AddOnInstallation, AddOnManifest, InstallationStatus } from "./contracts";
 import { buildDefaultState } from "./defaults";
-import { applyProviderDiagnostics, canPerformArchiveAction, resolveProviderPath, resolveProviderRoute, strategistDisplayName } from "./policies";
+import {
+  applyProviderDiagnostics,
+  canPerformArchiveAction,
+  createInstallationSnapshot,
+  resolveProviderPath,
+  resolveProviderRoute,
+  strategistDisplayName,
+} from "./policies";
 import { rebaseStateOnManifests } from "./runtime";
 
 const testManifest = (id: string): AddOnManifest => ({
@@ -169,6 +176,34 @@ describe("manifest rebase", () => {
         installation.grantedCapabilities.filter((grant) => grant.granted),
       ),
     ).toEqual([]);
+  });
+
+  it("createInstallationSnapshot rebuilds fresh grants after reinstall", () => {
+    const manifest = {
+      ...testManifest("addon.obsidian"),
+      requestedCapabilities: [{ capability: "filesystem", granted: false, scope: "shared", revocationBehavior: "hard-stop" }],
+    } satisfies AddOnManifest;
+    const base = buildDefaultState([manifest]);
+    const staleUninstalled = {
+      ...base.installations["addon.obsidian"],
+      status: "uninstalled" as InstallationStatus,
+      installed: false,
+      enabled: false,
+      grantedCapabilities: [{ capability: "filesystem", granted: true, scope: "shared", revocationBehavior: "hard-stop" }],
+      privateProviderProfileIds: ["profile-stale"],
+      config: { vaultPath: "/tmp/stale-vault" },
+    } satisfies AddOnInstallation;
+
+    const snapshot = createInstallationSnapshot(manifest, staleUninstalled, "bundled");
+
+    expect(snapshot.status).toBe("uninstalled");
+    expect(snapshot.installed).toBe(false);
+    expect(snapshot.enabled).toBe(false);
+    expect(snapshot.grantedCapabilities).toEqual([
+      { capability: "filesystem", granted: false, scope: "shared", revocationBehavior: "hard-stop" },
+    ]);
+    expect(snapshot.privateProviderProfileIds).toEqual([]);
+    expect("config" in snapshot).toBe(false);
   });
 });
 

--- a/src/core/policies.ts
+++ b/src/core/policies.ts
@@ -319,21 +319,30 @@ export const createInstallationSnapshot = (
   source: AddOnInstallation["source"],
 ): AddOnInstallation => {
   if (current) {
+    const isUninstalled = current.status === "uninstalled";
+    const currentSnapshot = { ...current };
+    if (isUninstalled) {
+      delete currentSnapshot.config;
+    }
     const existingGrants = new Map(current.grantedCapabilities.map((grant) => [grant.capability, grant]));
     const grantedCapabilities = manifest.requestedCapabilities.map((grant) => ({
       ...grant,
-      granted: existingGrants.get(grant.capability)?.granted ?? false,
+      granted: isUninstalled ? false : (existingGrants.get(grant.capability)?.granted ?? false),
     }));
     return {
-      ...current,
+      ...currentSnapshot,
       source,
       provenanceTier: source === "sideload" ? "sideloaded-unverified" : (manifest.provenance?.tier ?? current.provenanceTier),
       verificationState: source === "sideload" ? "unverified" : (manifest.provenance?.verificationState ?? current.verificationState),
       grantedCapabilities,
       recommendedGrantPresetIds: (manifest.grantPresets ?? []).map((preset) => preset.id),
-      grantRecommendationSource: manifest.grantPresets?.length ? "preset-bundle" : current.grantRecommendationSource,
-      privateProviderProfileIds: current.privateProviderProfileIds ?? [],
-      config: current.config ?? {},
+      grantRecommendationSource: manifest.grantPresets?.length
+        ? "preset-bundle"
+        : isUninstalled
+          ? "manifest-request"
+          : current.grantRecommendationSource,
+      privateProviderProfileIds: isUninstalled ? [] : (current.privateProviderProfileIds ?? []),
+      ...(isUninstalled ? {} : { config: current.config ?? {} }),
       notes: current.notes ?? [],
     };
   }

--- a/src/core/runtime.test.ts
+++ b/src/core/runtime.test.ts
@@ -1,10 +1,27 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { AddOnManifest, ResonantShellState } from "./contracts";
+import type { AddOnManifest, InstallationStatus, ResonantShellState } from "./contracts";
 import { buildDefaultState } from "./defaults";
 import { applyProviderCredentialStatuses, normalizeState, rebaseStateOnManifests, requestProviderSmokeTest } from "./runtime";
 
 afterEach(() => {
   vi.unstubAllGlobals();
+});
+
+const testManifest = (id: string): AddOnManifest => ({
+  id,
+  name: id,
+  version: "0.1.0",
+  author: "test",
+  category: "integration",
+  description: "test",
+  runtimeType: "local-service",
+  surfaces: [],
+  requestedCapabilities: [],
+  providerRequirements: { sharedProfiles: [], supportsPrivateCredentials: false },
+  archiveIntegration: { readScopes: [], intakeWriteScopes: [], canRequestIngest: false, canWriteKnowledgePages: false },
+  health: { strategy: "none" },
+  installHooks: {},
+  compatibility: { shellVersion: "^0.1.0", platforms: ["macOS"] },
 });
 
 describe("runtime state migration", () => {
@@ -417,5 +434,38 @@ describe("runtime state migration", () => {
       "ui-embedding",
     ]);
     expect(rebased.installations["addon.browser"].recommendedGrantPresetIds).toContain("browser-visible-session");
+  });
+
+  it("rebaseStateOnManifests preserves uninstalled state without restoring grants", () => {
+    const manifest = {
+      ...testManifest("addon.obsidian"),
+      requestedCapabilities: [{ capability: "filesystem", granted: false, scope: "shared", revocationBehavior: "hard-stop" }],
+    } satisfies AddOnManifest;
+    const base = buildDefaultState([manifest]);
+    const stale = {
+      ...base,
+      installations: {
+        ...base.installations,
+        "addon.obsidian": {
+          ...base.installations["addon.obsidian"],
+          installed: false,
+          enabled: false,
+          status: "uninstalled" as InstallationStatus,
+          grantedCapabilities: [{ capability: "filesystem", granted: true, scope: "shared", revocationBehavior: "hard-stop" }],
+          privateProviderProfileIds: ["profile-stale"],
+          config: { vaultPath: "/tmp/stale-vault" },
+        },
+      },
+    } satisfies ResonantShellState;
+
+    const rebased = rebaseStateOnManifests(stale, [manifest], []);
+    const installation = rebased.installations["addon.obsidian"];
+
+    expect(installation.status).toBe("uninstalled");
+    expect(installation.installed).toBe(false);
+    expect(installation.enabled).toBe(false);
+    expect(installation.grantedCapabilities).toEqual([]);
+    expect(installation.privateProviderProfileIds).toEqual([]);
+    expect("config" in installation).toBe(false);
   });
 });

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -1519,11 +1519,24 @@ export const rebaseStateOnManifests = (
 ): ResonantShellState => {
   const installations = { ...state.installations };
   for (const manifest of manifests) {
-    installations[manifest.id] = createInstallationSnapshot(
+    const snapshot = createInstallationSnapshot(
       manifest,
       installations[manifest.id],
       sideloadedIds.includes(manifest.id) ? "sideload" : "bundled",
     );
+    if (snapshot.status === "uninstalled") {
+      const uninstalledSnapshot = {
+        ...snapshot,
+        installed: false,
+        enabled: false,
+        grantedCapabilities: [],
+        privateProviderProfileIds: [],
+      };
+      delete uninstalledSnapshot.config;
+      installations[manifest.id] = uninstalledSnapshot;
+      continue;
+    }
+    installations[manifest.id] = snapshot;
   }
 
   for (const installation of Object.values(installations)) {

--- a/src/modules/addons/AddOnsWorkspace.tsx
+++ b/src/modules/addons/AddOnsWorkspace.tsx
@@ -9,6 +9,7 @@ import type {
   AddOnScriptDefinition,
   BrowserEngineStatus,
   CapabilityGrant,
+  InstallationStatus,
   LogicianExecutionArtifact,
   VerifyAgentReport,
   ShellSectionId,
@@ -90,6 +91,20 @@ const hasScaffoldContract = (manifest: AddOnManifest): boolean =>
 const shellNavigationSectionFor = (manifest: AddOnManifest): ShellSectionId | null =>
   manifest.surfaces.find((surface) => surface.shellNavigation)?.shellNavigation?.sectionId ?? null;
 
+const installationStatusLabel = (status: InstallationStatus): string => {
+  const labels: Record<InstallationStatus, string> = {
+    available: "Available",
+    installed: "Installed",
+    enabled: "Enabled",
+    disabled: "Disabled",
+    degraded: "Degraded",
+    "update-available": "Update available",
+    incompatible: "Incompatible",
+    uninstalled: "Uninstalled",
+  };
+  return labels[status];
+};
+
 const addonPrimaryActionLabel = (manifest: AddOnManifest, installation: AddOnInstallation | null): string => {
   if (manifest.id === "addon.browser" && !isBrowserVisibleReady(installation)) {
     return "Install and grant browser access";
@@ -153,7 +168,7 @@ export function AddOnsWorkspace(props: AddOnsWorkspaceProps) {
                     </p>
                   </div>
                   <span className={`tone tone-${effectiveInstallation?.enabled ? "active" : "neutral"}`}>
-                    {registryEntry.installState}
+                    {installationStatusLabel(registryEntry.installState)}
                   </span>
                 </div>
                 <p>{manifest.description}</p>
@@ -289,7 +304,7 @@ function AddOnDetailPanel(props: AddOnDetailPanelProps) {
           </p>
         </div>
         <div className="addon-registry-strip">
-          <span>{props.registryEntry.installState}</span>
+          <span>{installationStatusLabel(props.registryEntry.installState)}</span>
           <span>{props.registryEntry.verificationState}</span>
           <span>{props.registryEntry.manifestRef.label}</span>
         </div>

--- a/src/modules/addons/controller.test.ts
+++ b/src/modules/addons/controller.test.ts
@@ -130,6 +130,34 @@ describe("toggleAddonInstallation", () => {
     expect(state.installations["addon.test"].status).toBe("enabled");
   });
 
+  it("reinstalling an uninstalled addon rebuilds fresh grants from the manifest", () => {
+    const manifest = {
+      ...createMinimalManifest("addon.test", "Test Addon"),
+      requestedCapabilities: [capability("network"), capability("archive-read")],
+    };
+    let state = buildDefaultState([manifest]);
+    state.installations["addon.test"] = {
+      ...createMinimalInstallation("addon.test", false, false, "uninstalled"),
+      grantedCapabilities: [{ ...capability("network"), granted: true }],
+      privateProviderProfileIds: ["profile-stale"],
+      config: { vaultPath: "/tmp/stale-vault" },
+    };
+
+    toggleAddonInstallation(manifest, (updater) => {
+      state = updater(state);
+    });
+
+    const installation = state.installations["addon.test"];
+    expect(installation.installed).toBe(true);
+    expect(installation.status).toBe("enabled");
+    expect(installation.grantedCapabilities).toEqual([
+      { ...capability("network"), granted: false },
+      { ...capability("archive-read"), granted: false },
+    ]);
+    expect(installation.privateProviderProfileIds).toEqual([]);
+    expect("config" in installation).toBe(false);
+  });
+
   it("disables an enabled addon", () => {
     const manifest = createMinimalManifest("addon.test", "Test Addon");
     let state = buildDefaultState([manifest]);

--- a/src/modules/addons/controller.ts
+++ b/src/modules/addons/controller.ts
@@ -65,6 +65,12 @@ export const toggleAddonInstallation = (
       return draft;
     }
     if (!installation.installed) {
+      if (installation.status === "uninstalled") {
+        // Reinstall after uninstall is a fresh grant flow: nothing from the removed installation carries over.
+        installation.grantedCapabilities = manifest.requestedCapabilities.map((grant) => ({ ...grant, granted: false }));
+        installation.privateProviderProfileIds = [];
+        delete installation.config;
+      }
       installation.installed = true;
       installation.enabled = true;
       installation.status = "enabled";

--- a/src/modules/overview/OverviewWorkspace.tsx
+++ b/src/modules/overview/OverviewWorkspace.tsx
@@ -96,7 +96,7 @@ export function OverviewWorkspace({
                   <small>{runtimeLabel(app.runtimeSurface)}</small>
                   <span>{app.description}</span>
                 </span>
-                <span className={`app-status app-status-${statusTone(app.status)}`}>{app.status}</span>
+                <span className={`app-status app-status-${statusTone(app.status)}`}>{statusLabel(app.status)}</span>
               </button>
             ))}
           </div>
@@ -182,7 +182,7 @@ function ActiveAppSurface({
           <h3>{app.name}</h3>
           <p>{app.description}</p>
         </div>
-        <span className={`app-status app-status-${statusTone(app.status)}`}>{app.status}</span>
+        <span className={`app-status app-status-${statusTone(app.status)}`}>{statusLabel(app.status)}</span>
       </div>
 
       <div className={`workspace-preview ${isTerminal ? "terminal" : isEmbedded ? "embedded" : "system"}`}>
@@ -272,7 +272,7 @@ function buildLauncherApps(state: ResonantShellState, manifests: AddOnManifest[]
     const installation = state.installations[manifest.id];
     const installedStatus = installation?.enabled
       ? "enabled"
-      : installation?.installed
+      : installation
         ? installation.status
         : "available";
 
@@ -401,6 +401,22 @@ function statusTone(status: LauncherApp["status"]) {
     return "warning";
   }
   return "idle";
+}
+
+function statusLabel(status: LauncherApp["status"]) {
+  const labels: Record<LauncherApp["status"], string> = {
+    available: "Available",
+    installed: "Installed",
+    enabled: "Enabled",
+    disabled: "Disabled",
+    degraded: "Degraded",
+    "update-available": "Update available",
+    incompatible: "Incompatible",
+    uninstalled: "Uninstalled",
+    core: "Core",
+    planned: "Planned",
+  };
+  return labels[status];
 }
 
 function appIcon(app: LauncherApp) {


### PR DESCRIPTION
## Summary

Build-plan **task 1** of the merged design note (`docs/addons/addon-lifecycle-uninstall-design.md`, #414) for #180: the `uninstalled` installation state and its core semantics. Contracts and core only — the `uninstallAddon` mutation, the UI action, and the host audit route are tasks 2–4 and wait on the release owner's answers to the note's open questions.

- **Contract:** `InstallationStatus` gains `"uninstalled"`; the ADR-006 lifecycle list is updated.
- **Rebase (catalog load):** `rebaseStateOnManifests` keeps a catalog-present uninstalled record as a clean tombstone — `installed: false`, `enabled: false`, `grantedCapabilities: []`, `privateProviderProfileIds: []`, no `config`. It is never reset to `available` and never regains grants from the manifest's requested capabilities.
- **Snapshot (re-install source):** `createInstallationSnapshot` treats an uninstalled current record as fresh — grants rebuilt from the current manifest with `granted: false`, private provider ids cleared, config omitted, recommendation source from the manifest.
- **Display:** exhaustive `Record<InstallationStatus, string>` label maps in the Add-ons workspace and the Overview launcher, so TypeScript forces every future status through them. Two visible side effects, disclosed: status chips now render capitalized labels ("Enabled" not "enabled") for every status, and the launcher shows a non-installed record's own status instead of forcing "available".

No behaviour change for any record that is not `uninstalled` other than the label casing.

## Evidence

Head `743a99a2` (2 commits on `b9c02d92`), gates run outside the executor sandbox:

| Gate | Result |
|---|---|
| `vitest run` (full) | **440 / 440** (dev: 437; +3 tests from this PR) |
| `npm run test:browser-first` | 1195 / 1195 |
| `tsc --noEmit`, `test:security-pipeline` (46/46), `docs:check`, release-scope audit `--committed --strict` | clean |

Anti-false-green — three mutations via `rig-mutate`, each restored byte-identical:

| Mutation | Result |
|---|---|
| m1: rebase stops clearing grants on the tombstone | `runtime.test.ts` → **red** |
| m2: snapshot keeps a stale `granted: true` for an uninstalled record | `policies.test.ts` → **red** |
| m3: reinstall stops rebuilding grants from the manifest | `controller.test.ts` → **red** |

All three new tests were observed red before their implementation (executor's red run for the first two used `vitest --configLoader runner` because its sandbox could not write `.vite-temp`; the maintainer's red run for the third is in the session log).

Independent review: **DeepSeek V4 Pro (via `pi`) — CONFIRM**; one should-fix (the reinstall gap, fixed in `743a99a2`) and two nits adjudicated in the PR comments.

## Process

Fleet executor (codex) from a maintainer spec derived from the design note's task 1; maintainer read the full handback and committed it; independent correctness review by DeepSeek via `pi` (vendor ≠ author) — verdict in the PR comments.

Refs #180 (stays open for tasks 2–6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
