### PR TITLE
refactor(bridge): route the runner's self-test invoker through the live evaluator (closes #415)

### DIFF
--- a/browser-first/host/bridge-self-test-invoker.mjs
+++ b/browser-first/host/bridge-self-test-invoker.mjs
@@ -1,0 +1,35 @@
+import {
+  bridgeCapabilityHeaderName,
+  bridgeTokenHeaderName,
+  evaluateBridgeRequestForSelfTest,
+} from "./bridge-server.mjs";
+
+export function createBridgeRouteSelfTestInvoker({
+  bridgeToken,
+  bridgeCapabilityTokens = {},
+  capabilityBootstrapToken,
+  routes = [],
+} = {}) {
+  return async function invokeBridgeRouteForSelfTest({
+    method = "POST",
+    routePath,
+    body = {},
+    capabilityToken = "",
+  } = {}) {
+    const headers = { [bridgeTokenHeaderName]: bridgeToken };
+    if (capabilityToken) {
+      headers[bridgeCapabilityHeaderName] = capabilityToken;
+    }
+
+    return evaluateBridgeRequestForSelfTest({
+      method,
+      url: routePath,
+      headers,
+      body,
+      bridgeToken,
+      bridgeCapabilityTokens,
+      capabilityBootstrapToken,
+      routes,
+    });
+  };
+}

--- a/browser-first/host/bridge-self-test-invoker.mjs
+++ b/browser-first/host/bridge-self-test-invoker.mjs
@@ -16,6 +16,9 @@ export function createBridgeRouteSelfTestInvoker({
     body = {},
     capabilityToken = "",
   } = {}) {
+    // Parity with the live HTTP path: the handler receives the REAL bridge and capability tokens in
+    // request.headers. Self-test handlers must never echo request.headers into payloads, logs, or audit
+    // entries (no current handler reads headers at all; keep it that way).
     const headers = { [bridgeTokenHeaderName]: bridgeToken };
     if (capabilityToken) {
       headers[bridgeCapabilityHeaderName] = capabilityToken;

--- a/browser-first/host/bridge-server.mjs
+++ b/browser-first/host/bridge-server.mjs
@@ -10,7 +10,7 @@ export const bridgeTokenHeaderName = "X-ResonantOS-Bridge-Token";
 const bridgeCapabilityHeader = "x-resonantos-bridge-capability-token";
 export const bridgeCapabilityHeaderName = "X-ResonantOS-Bridge-Capability-Token";
 const bridgeCapabilityBootstrapHeader = "x-resonantos-capability-bootstrap-token";
-export const bridgeCapabilityBootstrapHeaderName = "X-ResonantOS-Capability-Bootstrap-Token";
+const bridgeCapabilityBootstrapHeaderName = "X-ResonantOS-Capability-Bootstrap-Token";
 
 // ResonantOS bridge network configuration
 // (read by startBridgeServer / writeBridgeConfig)

--- a/browser-first/host/bridge-server.mjs
+++ b/browser-first/host/bridge-server.mjs
@@ -6,11 +6,11 @@ import net from "node:net";
 import path from "node:path";
 
 const bridgeTokenHeader = "x-resonantos-bridge-token";
-const bridgeTokenHeaderName = "X-ResonantOS-Bridge-Token";
+export const bridgeTokenHeaderName = "X-ResonantOS-Bridge-Token";
 const bridgeCapabilityHeader = "x-resonantos-bridge-capability-token";
-const bridgeCapabilityHeaderName = "X-ResonantOS-Bridge-Capability-Token";
+export const bridgeCapabilityHeaderName = "X-ResonantOS-Bridge-Capability-Token";
 const bridgeCapabilityBootstrapHeader = "x-resonantos-capability-bootstrap-token";
-const bridgeCapabilityBootstrapHeaderName = "X-ResonantOS-Capability-Bootstrap-Token";
+export const bridgeCapabilityBootstrapHeaderName = "X-ResonantOS-Capability-Bootstrap-Token";
 
 // ResonantOS bridge network configuration
 // (read by startBridgeServer / writeBridgeConfig)

--- a/browser-first/host/run-bridge-minimal.mjs
+++ b/browser-first/host/run-bridge-minimal.mjs
@@ -6,13 +6,13 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import {
-  constantTimeEqual,
   createBridgeToken,
   getBridgeHost,
   getBridgePublicUrl,
   startBridgeServerWithFallback,
   writeBridgeConfig,
 } from "./bridge-server.mjs";
+import { createBridgeRouteSelfTestInvoker } from "./bridge-self-test-invoker.mjs";
 import {
   countFiles,
   dashboardTarget,
@@ -392,21 +392,12 @@ const capabilityBootstrapToken = args.get("capability-bootstrap-token") ??
   createBridgeToken();
 const bridgeCapabilityTokens = buildBridgeCapabilityTokens({ args, mint: createBridgeToken });
 
-async function invokeBridgeRouteForSelfTest({ method = "POST", routePath, body = {}, capabilityToken = "" } = {}) {
-  const route = bridgeRoutes.find((entry) => entry.method === method && entry.path === routePath);
-  if (!route) {
-    return { status: 404, payload: { ok: false, error: "Unknown browser-first bridge route." } };
-  }
-  if (route.requiredCapability && !constantTimeEqual(capabilityToken, bridgeCapabilityTokens[route.requiredCapability])) {
-    return { status: 403, payload: { ok: false, error: `Bridge route requires ${route.requiredCapability} capability.` } };
-  }
-  try {
-    const result = await route.handler(body, { headers: {} });
-    return { status: 200, payload: { ok: true, ...result } };
-  } catch (error) {
-    return { status: 500, payload: { ok: false, error: error instanceof Error ? error.message : String(error) } };
-  }
-}
+const invokeBridgeRouteForSelfTest = createBridgeRouteSelfTestInvoker({
+  bridgeToken,
+  bridgeCapabilityTokens,
+  capabilityBootstrapToken,
+  routes: bridgeRoutes,
+});
 
 const selfTestHandled = await runBrowserFirstSelfTest({
   args,

--- a/browser-first/test/bridge-auth-inprocess-self-test.test.mjs
+++ b/browser-first/test/bridge-auth-inprocess-self-test.test.mjs
@@ -3,7 +3,58 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import test from "node:test";
 
+import { createBridgeRouteSelfTestInvoker } from "../host/bridge-self-test-invoker.mjs";
+
 const execFileAsync = promisify(execFile);
+
+test("minimal bridge self-test adapter enforces live default-deny and scoped capability checks", async () => {
+  const bridgeToken = "adapter-bridge-token";
+  const capabilityToken = "adapter-capability-token";
+  const bridgeCapabilityTokens = { "bridge-diagnostics-read": capabilityToken };
+  let observedHeaders = {};
+
+  const invokeBridgeRouteForSelfTest = createBridgeRouteSelfTestInvoker({
+    bridgeToken,
+    bridgeCapabilityTokens,
+    capabilityBootstrapToken: "adapter-bootstrap-token",
+    routes: [
+      {
+        method: "POST",
+        path: "/adapter-undeclared",
+        handler: async () => ({ unexpected: true }),
+      },
+      {
+        method: "POST",
+        path: "/adapter-declared",
+        requiredCapability: "bridge-diagnostics-read",
+        handler: async (payload, request) => {
+          observedHeaders = request.headers;
+          return { accepted: payload.accepted === true };
+        },
+      },
+    ],
+  });
+
+  const undeclared = await invokeBridgeRouteForSelfTest({
+    method: "POST",
+    routePath: "/adapter-undeclared",
+    body: { accepted: true },
+    capabilityToken,
+  });
+  assert.equal(undeclared.status, 403);
+  assert.equal(undeclared.payload.error, "Bridge route declares no capability; refused by default.");
+
+  const declared = await invokeBridgeRouteForSelfTest({
+    method: "POST",
+    routePath: "/adapter-declared",
+    body: { accepted: true },
+    capabilityToken,
+  });
+  assert.equal(declared.status, 200);
+  assert.equal(declared.payload.accepted, true);
+  assert.equal(observedHeaders["x-resonantos-bridge-token"], bridgeToken);
+  assert.equal(observedHeaders["x-resonantos-bridge-capability-token"], capabilityToken);
+});
 
 test("browser-first bridge auth passes in-process deterministic smoke test", async () => {
   const { stdout } = await execFileAsync(process.execPath, [


### PR DESCRIPTION
## Summary

Closes #415 (follow-up from the #373 review). The minimal runner's `invokeBridgeRouteForSelfTest` was a **second route evaluator** — its own route lookup and capability check, no default-deny — used by the browser-first self-test service at seven call sites. Two evaluators for one policy is a drift risk; #373's default-deny already applied to one and not the other.

It is now a thin adapter, `createBridgeRouteSelfTestInvoker` in `browser-first/host/bridge-self-test-invoker.mjs`: it builds a synthetic request carrying the bridge token and (when given) the capability token, and delegates to `evaluateBridgeRequestForSelfTest` with the runner's routes and tokens. The self-test path therefore enforces exactly what the live HTTP path enforces — 401 gate, 404, bootstrap 403, default-deny 403, capability 403 — with the same `{ status, payload }` shapes the call sites already read. The private predicate is gone; the header-name constants are exported for the adapter. No route, capability, or call site changed.

## Evidence

Head `53dcd1bb` (2 commits on `b9c02d92`), gates run outside the executor sandbox in a single invocation on the executor's commit `ee81b066`, then the focused suites + `tsc` re-run on the nit commit:

| Gate | Result |
|---|---|
| `npm run test:browser-first` | **1196 / 1196** (dev: 1195; +1 from this PR) |
| `vitest run` | 437 / 437 |
| `tsc --noEmit`, `test:security-pipeline` (46/46), `docs:check`, release-scope audit `--committed --strict` | clean |

Anti-false-green: mutation "adapter stops forwarding the capability token" → the new test goes **red** (declared route 403s under the live evaluator); restored byte-identical by `rig-mutate`. The reviewer independently confirmed the second failure mode — bypassing the evaluator makes the undeclared-route assertion fail.

Independent review: **DeepSeek V4 Pro (via `pi`) — CONFIRM**, no blocking or should-fix findings; it reproduced the focused suites (24/24) and the full browser-first suite (1196/1196, socket tests included), traced all seven self-test call sites for parity, and checked that no handler can see or echo the injected tokens. Two nits fixed in `53dcd1bb` (details in the PR comments).

## Process

Fleet executor (codex) from a maintainer spec with re-verified `file:line` facts (it also caught a stale fact in the spec: the header-name constants were not yet exported); maintainer read the full handback and committed it; independent correctness + security review by DeepSeek via `pi` (vendor ≠ author) — verdict in the PR comments.

Refs #373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
