### PR TITLE
extension: separate and wrap Bridge Target action buttons

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/styles/main-workspace/settings.css
+++ b/browser-first/resonantos-side-panel-extension/src/styles/main-workspace/settings.css
@@ -705,7 +705,8 @@
   accent-color: var(--accent);
 }
 
-.settings-provider-actions {
+.settings-provider-actions,
+.settings-provider-account-actions {
   display: flex;
   flex-wrap: wrap;
   align-items: center;


### PR DESCRIPTION
Bridge Target's override and preference-sync buttons touch because their action-row class has no layout rule. Reuse the existing provider-action flex layout so both groups have an 8px gap and wrap with the same vertical spacing.

Closes #419.

This adds one selector in extension Settings CSS. No action handlers, labels, credential handling, palette, radii or density rules change. The patch is independent of #404, #411 and #412; combined browser proof also passes.

Validation on Node 22.13.0:

- `npm run test:browser-first`: 1192 passed, 0 failed, 4 existing runtime skips.
- Staged Engineer Runner: extension scope audit and whitespace check passed.
- Chrome 152 with actual extension modules and complete CSS: both action groups checked at 1280/768/390/320px, in comfortable/compact/touch density with large text. All 12 cases pass, including wrapped rows with an 8px vertical gap.
- Computed button dimensions, labels, colors and radii match before/after; combined approved shape/sizing changes retain 12px action corners.

Browser evidence uses synthetic, network-isolated data and is presentation proof, separate from extension/bridge certification. Existing narrow Bridge Target field compression is outside this action-row fix.
