### PR TITLE
extension: stack Bridge Target fields at narrow widths

### DIFF
--- a/browser-first/resonantos-side-panel-extension/src/lib/settings/bridge-target-section.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/settings/bridge-target-section.js
@@ -233,7 +233,7 @@ export function renderBridgeTargetSection(container, { bridgeRequest, onBridgeCo
   formHint.textContent =
     "Set a different bridge URL, bridge token, and capability-bootstrap token to point this browser at a different host. Leave token fields blank only when the generated config still targets that bridge.";
   const form = document.createElement("form");
-  form.className = "settings-provider-form";
+  form.className = "settings-provider-form settings-bridge-target-form";
   form.addEventListener("submit", (event) => event.preventDefault());
   const urlField = buildField({
     id: "bridge-url",

--- a/browser-first/resonantos-side-panel-extension/src/styles/main-workspace/responsive.css
+++ b/browser-first/resonantos-side-panel-extension/src/styles/main-workspace/responsive.css
@@ -36,6 +36,10 @@
 }
 
 @media (max-width: 640px) {
+  .settings-bridge-target-form {
+    flex-direction: column;
+  }
+
   .settings-subnav {
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
At narrow widths, Bridge Target squeezes its URL and two token fields into one row. At320px with large text, the URL input is only60px wide. A scoped form class now stacks these fields at the existing640px breakpoint, giving that input the full290px available width.

Closes #421.

Only the Bridge Target form's class list and one narrow CSS rule change. Provider credential forms keep their existing class/layout. Wide geometry, palette, radii, labels, field types, values, tab order, handlers and credential boundaries are preserved. This is independent of #420 and the previous Settings shape/sizing/dialog contributions; combined renderer proof also passes.

Validation on Node22.13.0:

- `npm run test:browser-first`:1192 passed,0 failed,4 existing runtime skips.
- Staged Engineer Runner: extension scope audit and whitespace checks passed.
- Chrome152:18 cases covering1280/768/641/640/390/320px, all three densities with large text. Narrow fields occupy full form width and stack without overlap. URL → token → bootstrap keyboard order and synthetic input values persist.
- Before/after computed colors/radii and all field geometry above640px are identical.

Browser evidence renders actual extension modules and the complete CSS cascade with synthetic network-isolated data. It is presentation proof, separate from extension/bridge certification. No real credentials were used.
