### PR TITLE
feat(addons): uninstallAddon mutation and typed system-slot selection of record (#180 task 2)

### DIFF
--- a/docs/addons/addon-lifecycle-uninstall-design.md
+++ b/docs/addons/addon-lifecycle-uninstall-design.md
@@ -212,6 +212,7 @@ while they are the active provider for a kernel-adjacent system slot; disable is
 still allowed. Sideloaded add-ons are always uninstallable. Once a replacement
 owns the affected slot, the bundled default can be uninstalled because ADR-026
 requires replaceability.
+The typed selection lives in `ResonantShellState.activeSystemSlotProviderIds`, `activeSystemSlotProvider` consults it first, and changing a selection is a later task.
 
 Build-testable predicate:
 
@@ -237,10 +238,10 @@ when the sideloaded add-on provides a system slot.
 2. Should uninstall stop or cancel currently running local add-on work first?
    Recommended default: yes, attempt a best-effort stop before the state
    mutation and block uninstall if the runtime cannot reach a safe stopped
-   state.
+   state. **Answered 2026-09-07 (release owner): yes — implemented in task 2.**
 3. Which surface owns active system-slot provider selection?
    Recommended default: add an explicit typed field under shared runtime state
-   before enforcing kernel-adjacent uninstall blocking.
+   before enforcing kernel-adjacent uninstall blocking. **Answered 2026-09-07 (release owner): yes — implemented in task 2.**
 4. Should "also delete user data" delete app-owned delegation and intake records
    together or as separate choices?
    Recommended default: separate choices, because Living Archive intake/review

--- a/src/core/contracts.ts
+++ b/src/core/contracts.ts
@@ -2866,6 +2866,7 @@ export interface ResonantShellState {
   goalWorkspaces: GoalWorkspace[];
   recoverySession: RecoverySession;
   installations: Record<string, AddOnInstallation>;
+  activeSystemSlotProviderIds: Partial<Record<SystemSlotId, string>>;
   uiPreferences: UiPreferences;
   distributionModel: "curated-plus-sideload";
 }

--- a/src/core/defaults.test.ts
+++ b/src/core/defaults.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import type { AddOnManifest, CapabilityGrant, SystemSlotId } from "./contracts";
+import { buildDefaultState } from "./defaults";
+
+const capability = (name: CapabilityGrant["capability"]): CapabilityGrant => ({
+  capability: name,
+  granted: false,
+  scope: "shared",
+  revocationBehavior: "hard-stop",
+});
+
+const manifestForSlot = (
+  id: string,
+  slotId: SystemSlotId,
+  role: NonNullable<AddOnManifest["systemSlots"]>[number]["role"],
+  recommended: boolean,
+): AddOnManifest => ({
+  id,
+  name: id,
+  version: "0.1.0",
+  author: "test",
+  category: "agent",
+  description: "test",
+  runtimeType: "ui-module",
+  surfaces: [],
+  requestedCapabilities: [capability("agent-delegation")],
+  providerRequirements: { sharedProfiles: [], supportsPrivateCredentials: false },
+  systemSlots: [{ id: slotId, role, replaceable: true, recommended }],
+  archiveIntegration: { readScopes: [], intakeWriteScopes: [], canRequestIngest: false, canWriteKnowledgePages: false },
+  health: { strategy: "none" },
+  installHooks: {},
+  compatibility: { shellVersion: "^0.1.0", platforms: ["macOS"] },
+});
+
+describe("buildDefaultState", () => {
+  it("selects recommended default providers for system slots", () => {
+    const first = manifestForSlot("addon.first", "primary-agent", "default-provider", true);
+    const second = manifestForSlot("addon.second", "primary-agent", "default-provider", true);
+    const notRecommended = manifestForSlot("addon.not-recommended", "chat-interface", "default-provider", false);
+    const alternative = manifestForSlot("addon.alternative", "memory-system", "alternative-provider", true);
+
+    const state = buildDefaultState([first, second, notRecommended, alternative]);
+
+    expect(state.activeSystemSlotProviderIds).toEqual({ "primary-agent": "addon.first" });
+  });
+});

--- a/src/core/defaults.ts
+++ b/src/core/defaults.ts
@@ -19,6 +19,7 @@ import type {
   ProviderRoutingState,
   ProviderRuntimeNode,
   ResonantShellState,
+  SystemSlotId,
   WorkspaceDefinition,
 } from "./contracts";
 
@@ -899,6 +900,21 @@ export const createDefaultInstallation = (manifest: AddOnManifest, source: AddOn
   notes: ["Not installed yet."],
 });
 
+export const selectRecommendedDefaultSystemSlotProviderIds = (
+  manifests: AddOnManifest[],
+  current: Partial<Record<SystemSlotId, string>> = {},
+): Partial<Record<SystemSlotId, string>> => {
+  const selected = { ...current };
+  for (const manifest of manifests) {
+    for (const slot of manifest.systemSlots ?? []) {
+      if (slot.role === "default-provider" && slot.recommended === true && !selected[slot.id]) {
+        selected[slot.id] = manifest.id;
+      }
+    }
+  }
+  return selected;
+};
+
 export const buildDefaultState = (manifests: AddOnManifest[]): ResonantShellState => {
   const installations = Object.fromEntries(
     manifests.map((manifest) => [manifest.id, createDefaultInstallation(manifest, "bundled")]),
@@ -928,6 +944,7 @@ export const buildDefaultState = (manifests: AddOnManifest[]): ResonantShellStat
     goalWorkspaces: [],
     recoverySession,
     installations,
+    activeSystemSlotProviderIds: selectRecommendedDefaultSystemSlotProviderIds(manifests),
     uiPreferences: {
       activeSection: "overview",
       activeChatThreadId: "thread-main-desktop",

--- a/src/core/runtime.test.ts
+++ b/src/core/runtime.test.ts
@@ -468,4 +468,65 @@ describe("runtime state migration", () => {
     expect(installation.privateProviderProfileIds).toEqual([]);
     expect("config" in installation).toBe(false);
   });
+
+  it("normalizeState keeps persisted slot selection and fills missing slots from defaults", () => {
+    const defaultMemoryProvider = {
+      ...testManifest("addon.default-memory"),
+      systemSlots: [
+        { id: "memory-system", role: "default-provider", replaceable: true, recommended: true },
+      ],
+    } satisfies AddOnManifest;
+    const persistedChatProvider = {
+      ...testManifest("addon.persisted-chat"),
+      systemSlots: [
+        { id: "chat-interface", role: "default-provider", replaceable: true, recommended: true },
+      ],
+    } satisfies AddOnManifest;
+    const base = buildDefaultState([defaultMemoryProvider, persistedChatProvider]);
+    const persisted = {
+      ...base,
+      activeSystemSlotProviderIds: { "chat-interface": "addon.custom-chat" },
+    } satisfies ResonantShellState;
+
+    const normalized = normalizeState(persisted, base);
+
+    expect(normalized.activeSystemSlotProviderIds).toEqual({
+      "memory-system": "addon.default-memory",
+      "chat-interface": "addon.custom-chat",
+    });
+  });
+
+  it("rebaseStateOnManifests preserves slot selection and tolerates a legacy object without the field", () => {
+    const defaultChatProvider = {
+      ...testManifest("addon.default-chat"),
+      systemSlots: [
+        { id: "chat-interface", role: "default-provider", replaceable: true, recommended: true },
+      ],
+    } satisfies AddOnManifest;
+    const persistedMemoryProvider = {
+      ...testManifest("addon.persisted-memory"),
+      systemSlots: [
+        { id: "memory-system", role: "default-provider", replaceable: true, recommended: true },
+      ],
+    } satisfies AddOnManifest;
+    const base = buildDefaultState([defaultChatProvider, persistedMemoryProvider]);
+    const legacy = { ...base };
+    delete (legacy as Partial<ResonantShellState>).activeSystemSlotProviderIds;
+
+    const rebasedLegacy = rebaseStateOnManifests(legacy as ResonantShellState, [defaultChatProvider], []);
+    const rebasedPersisted = rebaseStateOnManifests(
+      {
+        ...base,
+        activeSystemSlotProviderIds: { "memory-system": "addon.missing-from-catalog" },
+      },
+      [defaultChatProvider, persistedMemoryProvider],
+      [],
+    );
+
+    expect(rebasedLegacy.activeSystemSlotProviderIds).toEqual({ "chat-interface": "addon.default-chat" });
+    expect(rebasedPersisted.activeSystemSlotProviderIds).toEqual({
+      "chat-interface": "addon.default-chat",
+      "memory-system": "addon.missing-from-catalog",
+    });
+  });
 });

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -91,7 +91,7 @@ import type {
   TrustKernelAdvisory,
 } from "./contracts";
 import type { BrowserToolResult } from "./browser-tools";
-import { buildDefaultState } from "./defaults";
+import { buildDefaultState, selectRecommendedDefaultSystemSlotProviderIds } from "./defaults";
 import { renderDelegationTaskMarkdown, validateDelegationPacket } from "./delegation";
 import { normalizeGoalWorkspaces } from "./goal-workspace";
 import { providerNeedsStoredCredential } from "./provider-credentials";
@@ -1518,6 +1518,10 @@ export const rebaseStateOnManifests = (
   sideloadedIds: string[],
 ): ResonantShellState => {
   const installations = { ...state.installations };
+  const activeSystemSlotProviderIds = selectRecommendedDefaultSystemSlotProviderIds(
+    manifests,
+    state.activeSystemSlotProviderIds ?? {},
+  );
   for (const manifest of manifests) {
     const snapshot = createInstallationSnapshot(
       manifest,
@@ -1545,7 +1549,9 @@ export const rebaseStateOnManifests = (
     }
   }
 
-  return { ...state, installations };
+  // If a selected provider is absent from the current catalog, keep the selection;
+  // replacement policy for absent selected providers belongs to a later task.
+  return { ...state, installations, activeSystemSlotProviderIds };
 };
 
 export const applyProviderCredentialStatuses = (
@@ -1891,6 +1897,10 @@ export const normalizeState = (state: ResonantShellState, base: ResonantShellSta
   return {
     ...base,
     ...state,
+    activeSystemSlotProviderIds: {
+      ...base.activeSystemSlotProviderIds,
+      ...(state.activeSystemSlotProviderIds ?? {}),
+    },
     strategistIdentity: { ...base.strategistIdentity, ...state.strategistIdentity },
     uiPreferences: {
       ...base.uiPreferences,

--- a/src/modules/addons/controller.test.ts
+++ b/src/modules/addons/controller.test.ts
@@ -33,6 +33,7 @@ import {
   runAddonLogicianScript,
   toggleAddonCapabilityGrant,
   toggleAddonInstallation,
+  uninstallAddon,
   updateAddonConfig,
 } from "./controller";
 
@@ -109,6 +110,30 @@ const createMinimalInstallation = (addonId: string, installed: boolean, enabled:
   recommendedGrantPresetIds: [],
   privateProviderProfileIds: [],
   notes: [],
+});
+
+const createSystemSlotManifest = (
+  id: string,
+  role: NonNullable<AddOnManifest["systemSlots"]>[number]["role"] = "default-provider",
+  recommended = true,
+): AddOnManifest => ({
+  ...createMinimalManifest(id, id),
+  requestedCapabilities: [capability("agent-delegation"), capability("chat-interface")],
+  systemSlots: [
+    { id: "primary-agent", role, replaceable: true, recommended },
+    { id: "chat-interface", role: "default-provider", replaceable: true, recommended: true },
+  ],
+});
+
+const uninstallDeps = (
+  getState: () => ResonantShellState,
+  updateRuntimeState: (updater: (current: ResonantShellState) => ResonantShellState) => void,
+  stopRunningWork?: (input: { addonId: string }) => Promise<{ stopped: boolean; detail?: string }>,
+) => ({
+  getState,
+  updateRuntimeState,
+  stopRunningWork,
+  now: () => new Date("2026-09-07T12:00:00.000Z"),
 });
 
 describe("toggleAddonInstallation", () => {
@@ -261,6 +286,389 @@ describe("toggleAddonCapabilityGrant", () => {
     });
 
     expect(state.installations["addon.nonexistent"]).toBeUndefined();
+  });
+});
+
+describe("uninstallAddon", () => {
+  it("clears grants provider profiles and config", async () => {
+    const manifest = createMinimalManifest("addon.test", "Test Addon");
+    let state = buildDefaultState([manifest]);
+    state.installations[manifest.id] = {
+      ...createMinimalInstallation(manifest.id, true, true, "enabled"),
+      grantedCapabilities: [
+        { ...capability("network"), granted: true },
+        { ...capability("archive-read"), granted: false },
+      ],
+      privateProviderProfileIds: ["profile-a", "profile-b"],
+      config: { secret: "do-not-log" },
+    };
+
+    const result = await uninstallAddon(
+      manifest,
+      uninstallDeps(
+        () => state,
+        (updater) => {
+          state = updater(state);
+        },
+      ),
+    );
+
+    expect(result.outcome).toBe("uninstalled");
+    expect(state.installations[manifest.id].grantedCapabilities).toEqual([]);
+    expect(state.installations[manifest.id].privateProviderProfileIds).toEqual([]);
+    expect("config" in state.installations[manifest.id]).toBe(false);
+    expect(result.audit?.clearedCapabilities).toEqual(["network"]);
+    expect(result.audit?.clearedPrivateProviderProfileIds).toBe(2);
+    expect(result.audit?.configDeleted).toBe(true);
+  });
+
+  it("disables enabled add-ons and records an uninstall note", async () => {
+    const manifest = createMinimalManifest("addon.test", "Test Addon");
+    let state = buildDefaultState([manifest]);
+    state.installations[manifest.id] = createMinimalInstallation(manifest.id, true, true, "enabled");
+
+    await uninstallAddon(
+      manifest,
+      uninstallDeps(
+        () => state,
+        (updater) => {
+          state = updater(state);
+        },
+      ),
+    );
+
+    expect(state.installations[manifest.id]).toMatchObject({
+      installed: false,
+      enabled: false,
+      status: "uninstalled",
+      notes: ["Uninstalled; capability grants and add-on config were cleared. User data was retained."],
+    });
+  });
+
+  it("disables the Hermes channel in the same mutation", async () => {
+    const manifest = createHermesManifest();
+    let state = buildDefaultState([manifest]);
+    state.channels.find((channel) => channel.id === "desktop-hermes")!.enabled = true;
+    state.installations[manifest.id] = createMinimalInstallation(manifest.id, true, true, "enabled");
+
+    await uninstallAddon(
+      manifest,
+      uninstallDeps(
+        () => state,
+        (updater) => {
+          state = updater(state);
+        },
+      ),
+    );
+
+    expect(state.channels.find((channel) => channel.id === "desktop-hermes")?.enabled).toBe(false);
+  });
+
+  it("is a no-op for available add-ons and missing records", async () => {
+    const manifest = createMinimalManifest("addon.test", "Test Addon");
+    let availableState = buildDefaultState([manifest]);
+    const missingState = buildDefaultState([]);
+    const availableBefore = structuredClone(availableState);
+    const missingBefore = structuredClone(missingState);
+
+    const available = await uninstallAddon(
+      manifest,
+      uninstallDeps(
+        () => availableState,
+        (updater) => {
+          availableState = updater(availableState);
+        },
+      ),
+    );
+    const missing = await uninstallAddon(
+      manifest,
+      uninstallDeps(
+        () => missingState,
+        () => {
+          throw new Error("missing records should not mutate");
+        },
+      ),
+    );
+
+    expect(available).toEqual({ outcome: "blocked", blockReason: "not-installed" });
+    expect(missing).toEqual({ outcome: "blocked", blockReason: "not-installed" });
+    expect(availableState).toEqual(availableBefore);
+    expect(missingState).toEqual(missingBefore);
+  });
+
+  it("is idempotent for already-uninstalled add-ons", async () => {
+    const manifest = createMinimalManifest("addon.test", "Test Addon");
+    let state = buildDefaultState([manifest]);
+    state.installations[manifest.id] = createMinimalInstallation(manifest.id, false, false, "uninstalled");
+    const before = structuredClone(state);
+
+    const result = await uninstallAddon(
+      manifest,
+      uninstallDeps(
+        () => state,
+        (updater) => {
+          state = updater(state);
+        },
+      ),
+    );
+
+    expect(result).toEqual({ outcome: "blocked", blockReason: "already-uninstalled" });
+    expect(result.audit).toBeUndefined();
+    expect(state).toEqual(before);
+  });
+
+  it("is allowed from disabled, degraded, update-available and incompatible", async () => {
+    for (const status of ["disabled", "degraded", "update-available", "incompatible"] as const) {
+      const manifest = createMinimalManifest(`addon.${status}`, status);
+      let state = buildDefaultState([manifest]);
+      state.installations[manifest.id] = createMinimalInstallation(manifest.id, true, false, status);
+
+      const result = await uninstallAddon(
+        manifest,
+        uninstallDeps(
+          () => state,
+          (updater) => {
+            state = updater(state);
+          },
+        ),
+      );
+
+      expect(result.outcome).toBe("uninstalled");
+      expect(result.audit?.previousStatus).toBe(status);
+      expect(state.installations[manifest.id].status).toBe("uninstalled");
+    }
+  });
+
+  it("blocks a bundled default that is the selected provider for one of its slots", async () => {
+    const manifest = createSystemSlotManifest("addon.default");
+    let state = buildDefaultState([manifest]);
+    state.activeSystemSlotProviderIds = { "primary-agent": manifest.id };
+    state.installations[manifest.id] = createMinimalInstallation(manifest.id, true, true, "enabled");
+    const before = structuredClone(state);
+
+    const result = await uninstallAddon(
+      manifest,
+      uninstallDeps(
+        () => state,
+        (updater) => {
+          state = updater(state);
+        },
+      ),
+    );
+
+    expect(result).toEqual({
+      outcome: "blocked",
+      blockReason: "active-system-slot-provider",
+      blockDetail: "primary-agent",
+    });
+    expect(state).toEqual(before);
+  });
+
+  it("ignores non-recommended and non-default-provider slots", async () => {
+    const notRecommended = createSystemSlotManifest("addon.not-recommended", "default-provider", false);
+    const alternative = createSystemSlotManifest("addon.alternative", "alternative-provider", true);
+
+    for (const manifest of [notRecommended, alternative]) {
+      let state = buildDefaultState([manifest]);
+      state.activeSystemSlotProviderIds = { "primary-agent": manifest.id };
+      state.installations[manifest.id] = createMinimalInstallation(manifest.id, true, true, "enabled");
+
+      const result = await uninstallAddon(
+        manifest,
+        uninstallDeps(
+          () => state,
+          (updater) => {
+            state = updater(state);
+          },
+        ),
+      );
+
+      expect(result.outcome).toBe("uninstalled");
+    }
+  });
+
+  it("allows sideloaded system-slot providers", async () => {
+    const manifest = createSystemSlotManifest("addon.sideloaded");
+    let state = buildDefaultState([manifest]);
+    state.activeSystemSlotProviderIds = { "primary-agent": manifest.id };
+    state.installations[manifest.id] = {
+      ...createMinimalInstallation(manifest.id, true, true, "enabled"),
+      source: "sideload",
+    };
+
+    const result = await uninstallAddon(
+      manifest,
+      uninstallDeps(
+        () => state,
+        (updater) => {
+          state = updater(state);
+        },
+      ),
+    );
+
+    expect(result.outcome).toBe("uninstalled");
+  });
+
+  it("allows a bundled default once another provider is selected for all its slots", async () => {
+    const manifest = createSystemSlotManifest("addon.default");
+    let state = buildDefaultState([manifest]);
+    state.activeSystemSlotProviderIds = {
+      "primary-agent": "addon.replacement",
+      "chat-interface": "addon.replacement",
+    };
+    state.installations[manifest.id] = createMinimalInstallation(manifest.id, true, true, "enabled");
+
+    const result = await uninstallAddon(
+      manifest,
+      uninstallDeps(
+        () => state,
+        (updater) => {
+          state = updater(state);
+        },
+      ),
+    );
+
+    expect(result.outcome).toBe("uninstalled");
+  });
+
+  it("blocks when running work cannot be stopped", async () => {
+    const manifest = createMinimalManifest("addon.test", "Test Addon");
+    for (const stopRunningWork of [
+      vi.fn(async () => ({ stopped: false, detail: "still running" })),
+      vi.fn(async () => {
+        throw new Error("runtime unavailable");
+      }),
+    ]) {
+      let state = buildDefaultState([manifest]);
+      state.installations[manifest.id] = createMinimalInstallation(manifest.id, true, true, "enabled");
+      const before = structuredClone(state);
+
+      const result = await uninstallAddon(
+        manifest,
+        uninstallDeps(
+          () => state,
+          (updater) => {
+            state = updater(state);
+          },
+          stopRunningWork,
+        ),
+      );
+
+      expect(result.outcome).toBe("blocked");
+      expect(result.blockReason).toBe("running-work-not-stopped");
+      expect(result.audit).toBeUndefined();
+      expect(state).toEqual(before);
+    }
+  });
+
+  it("proceeds when no stop hook is provided", async () => {
+    const manifest = createMinimalManifest("addon.test", "Test Addon");
+    let state = buildDefaultState([manifest]);
+    state.installations[manifest.id] = createMinimalInstallation(manifest.id, true, true, "enabled");
+
+    const result = await uninstallAddon(
+      manifest,
+      uninstallDeps(
+        () => state,
+        (updater) => {
+          state = updater(state);
+        },
+      ),
+    );
+
+    expect(result.outcome).toBe("uninstalled");
+  });
+
+  it("awaits the stop hook before mutating", async () => {
+    const manifest = createMinimalManifest("addon.test", "Test Addon");
+    let state = buildDefaultState([manifest]);
+    state.installations[manifest.id] = createMinimalInstallation(manifest.id, true, true, "enabled");
+    const observedStatuses: InstallationStatus[] = [];
+
+    const result = await uninstallAddon(
+      manifest,
+      uninstallDeps(
+        () => state,
+        (updater) => {
+          state = updater(state);
+        },
+        async () => {
+          observedStatuses.push(state.installations[manifest.id].status);
+          return { stopped: true };
+        },
+      ),
+    );
+
+    expect(result.outcome).toBe("uninstalled");
+    expect(observedStatuses).toEqual(["enabled"]);
+  });
+
+  it("does not call the stop hook when already blocked", async () => {
+    const manifest = createMinimalManifest("addon.test", "Test Addon");
+    const state = buildDefaultState([manifest]);
+    const stopRunningWork = vi.fn(async () => ({ stopped: true }));
+
+    const result = await uninstallAddon(
+      manifest,
+      uninstallDeps(
+        () => state,
+        () => {
+          throw new Error("blocked uninstall should not mutate");
+        },
+        stopRunningWork,
+      ),
+    );
+
+    expect(result.blockReason).toBe("not-installed");
+    expect(stopRunningWork).not.toHaveBeenCalled();
+  });
+
+  it("decides inside the updater", async () => {
+    const manifest = createMinimalManifest("addon.test", "Test Addon");
+    const getStateSnapshot = buildDefaultState([manifest]);
+    getStateSnapshot.installations[manifest.id] = createMinimalInstallation(manifest.id, true, true, "enabled");
+    let draft = buildDefaultState([manifest]);
+    draft.installations[manifest.id] = createMinimalInstallation(manifest.id, false, false, "uninstalled");
+    const before = structuredClone(draft);
+
+    const result = await uninstallAddon(manifest, {
+      ...uninstallDeps(
+        () => getStateSnapshot,
+        (updater) => {
+          draft = updater(draft);
+        },
+      ),
+    });
+
+    expect(result).toEqual({ outcome: "blocked", blockReason: "already-uninstalled" });
+    expect(draft).toEqual(before);
+  });
+
+  it("returns a counts-only audit record", async () => {
+    const manifest = createMinimalManifest("addon.test", "Test Addon");
+    let state = buildDefaultState([manifest]);
+    state.installations[manifest.id] = {
+      ...createMinimalInstallation(manifest.id, true, true, "enabled"),
+      grantedCapabilities: [{ ...capability("network"), granted: true }],
+      privateProviderProfileIds: ["private-profile-123"],
+      config: { apiKey: "secret-config-value" },
+    };
+
+    const result = await uninstallAddon(
+      manifest,
+      uninstallDeps(
+        () => state,
+        (updater) => {
+          state = updater(state);
+        },
+      ),
+    );
+    const auditJson = JSON.stringify(result.audit);
+
+    expect(result.audit?.clearedCapabilities).toEqual(["network"]);
+    expect(result.audit?.clearedPrivateProviderProfileIds).toBe(1);
+    expect(auditJson).not.toContain("private-profile-123");
+    expect(auditJson).not.toContain("secret-config-value");
   });
 });
 

--- a/src/modules/addons/controller.ts
+++ b/src/modules/addons/controller.ts
@@ -8,11 +8,13 @@ import type {
   AddOnManifest,
   AddOnScriptDefinition,
   CapabilityGrant,
+  InstallationStatus,
   LogicianExecutionArtifact,
   ResonantShellState,
 } from "../../core/contracts";
 import { executeLogicianHook, executeLogicianScript } from "../../core/logician";
 import { applyProviderCredentialStatuses, hydrateState, loadProviderCredentialStatuses, sideloadManifest } from "../../core/runtime";
+import { selectedSystemSlotProviderId } from "../shell/system-slots";
 
 type SideloadControllerInput = {
   sideloadPath: string;
@@ -92,6 +94,157 @@ export const toggleAddonInstallation = (
     }
     return draft;
   });
+};
+
+export type UninstallAddonBlockReason =
+  | "not-installed"
+  | "already-uninstalled"
+  | "active-system-slot-provider"
+  | "running-work-not-stopped";
+
+export interface UninstallAddonAuditRecord {
+  at: string;
+  event: "addonUninstalled";
+  addonId: string;
+  source: AddOnInstallation["source"];
+  previousStatus: InstallationStatus;
+  previousInstalled: boolean;
+  previousEnabled: boolean;
+  clearedCapabilities: CapabilityGrant["capability"][];
+  clearedPrivateProviderProfileIds: number;
+  configDeleted: boolean;
+  userDataRetained: true;
+  alsoDeleteUserDataOffered: boolean;
+  actor: "human";
+}
+
+export interface UninstallAddonResult {
+  outcome: "uninstalled" | "blocked";
+  blockReason?: UninstallAddonBlockReason;
+  blockDetail?: string;
+  audit?: UninstallAddonAuditRecord;
+}
+
+export interface UninstallAddonDependencies {
+  getState: () => ResonantShellState;
+  updateRuntimeState: (updater: (current: ResonantShellState) => ResonantShellState) => void;
+  stopRunningWork?: (input: { addonId: string }) => Promise<{ stopped: boolean; detail?: string }>;
+  now?: () => Date;
+}
+
+type UninstallDecision =
+  | { ok: true; installation: AddOnInstallation }
+  | { ok: false; blockReason: UninstallAddonBlockReason; blockDetail?: string };
+
+const decideUninstall = (state: ResonantShellState, manifest: AddOnManifest): UninstallDecision => {
+  const installation = state.installations[manifest.id];
+  if (!installation || (!installation.installed && installation.status !== "uninstalled")) {
+    return { ok: false, blockReason: "not-installed" };
+  }
+  if (installation.status === "uninstalled") {
+    return { ok: false, blockReason: "already-uninstalled" };
+  }
+  const activeDefaultSlotIds =
+    installation.source === "bundled"
+      ? (manifest.systemSlots ?? [])
+          .filter(
+            (slot) =>
+              slot.role === "default-provider" &&
+              slot.recommended === true &&
+              selectedSystemSlotProviderId(state, slot.id) === manifest.id,
+          )
+          .map((slot) => slot.id)
+      : [];
+  if (activeDefaultSlotIds.length > 0) {
+    return {
+      ok: false,
+      blockReason: "active-system-slot-provider",
+      blockDetail: activeDefaultSlotIds.join(", "),
+    };
+  }
+  return { ok: true, installation };
+};
+
+const runningWorkBlockDetail = (error: unknown): string =>
+  error instanceof Error ? error.message : typeof error === "string" ? error : "Running add-on work could not be stopped.";
+
+export const uninstallAddon = async (
+  manifest: AddOnManifest,
+  deps: UninstallAddonDependencies,
+): Promise<UninstallAddonResult> => {
+  const initialDecision = decideUninstall(deps.getState(), manifest);
+  if (!initialDecision.ok) {
+    return { outcome: "blocked", blockReason: initialDecision.blockReason, blockDetail: initialDecision.blockDetail };
+  }
+
+  if (deps.stopRunningWork) {
+    try {
+      const stopResult = await deps.stopRunningWork({ addonId: manifest.id });
+      if (!stopResult.stopped) {
+        return {
+          outcome: "blocked",
+          blockReason: "running-work-not-stopped",
+          blockDetail: stopResult.detail,
+        };
+      }
+    } catch (error) {
+      return {
+        outcome: "blocked",
+        blockReason: "running-work-not-stopped",
+        blockDetail: runningWorkBlockDetail(error),
+      };
+    }
+  }
+
+  let result: UninstallAddonResult = {
+    outcome: "blocked",
+    blockReason: "not-installed",
+  };
+  deps.updateRuntimeState((draft) => {
+    const draftDecision = decideUninstall(draft, manifest);
+    if (!draftDecision.ok) {
+      result = { outcome: "blocked", blockReason: draftDecision.blockReason, blockDetail: draftDecision.blockDetail };
+      return draft;
+    }
+
+    const installation = draftDecision.installation;
+    const audit: UninstallAddonAuditRecord = {
+      at: (deps.now ?? (() => new Date()))().toISOString(),
+      event: "addonUninstalled",
+      addonId: manifest.id,
+      source: installation.source,
+      previousStatus: installation.status,
+      previousInstalled: installation.installed,
+      previousEnabled: installation.enabled,
+      clearedCapabilities: installation.grantedCapabilities
+        .filter((grant) => grant.granted)
+        .map((grant) => grant.capability),
+      clearedPrivateProviderProfileIds: installation.privateProviderProfileIds.length,
+      configDeleted: installation.config !== undefined,
+      userDataRetained: true,
+      alsoDeleteUserDataOffered: false,
+      actor: "human",
+    };
+
+    installation.status = "uninstalled";
+    installation.installed = false;
+    installation.enabled = false;
+    installation.grantedCapabilities = [];
+    installation.privateProviderProfileIds = [];
+    delete installation.config;
+    installation.notes = ["Uninstalled; capability grants and add-on config were cleared. User data was retained."];
+    if (manifest.id === "addon.hermes") {
+      const hermesChannel = draft.channels.find((channel) => channel.id === "desktop-hermes");
+      if (hermesChannel) {
+        hermesChannel.enabled = false;
+      }
+    }
+
+    result = { outcome: "uninstalled", audit };
+    return draft;
+  });
+
+  return result;
 };
 
 export const toggleAddonCapabilityGrant = (

--- a/src/modules/shell/system-slots.test.ts
+++ b/src/modules/shell/system-slots.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import type { AddOnManifest, CapabilityGrant, SystemSlotId } from "../../core/contracts";
 import { buildDefaultState } from "../../core/defaults";
 import { applyFirstRunRecommendedAddOns } from "./controller";
-import { activeSystemSlotProvider, systemSlotAvailable } from "./system-slots";
+import { activeSystemSlotProvider, selectedSystemSlotProviderId, systemSlotAvailable } from "./system-slots";
 
 const grant = (capability: CapabilityGrant["capability"]): CapabilityGrant => ({
   capability,
@@ -117,5 +117,113 @@ describe("system slot replacement runtime", () => {
     expect(activeSystemSlotProvider(granted, manifests, "memory-system")?.manifest.id).toBe(memoryManifest.id);
     expect(systemSlotAvailable(granted, manifests, "chat-interface")).toBe(true);
     expect(systemSlotAvailable(granted, manifests, "memory-system")).toBe(true);
+  });
+
+  it("activeSystemSlotProvider prefers the selected provider when it is enabled and granted", () => {
+    const first = manifestForSlot("addon.first", "memory-system", "memory-provider");
+    const selected = manifestForSlot("addon.selected", "memory-system", "memory-provider");
+    const state = {
+      ...buildDefaultState([first, selected]),
+      activeSystemSlotProviderIds: { "memory-system": selected.id },
+      installations: {
+        [first.id]: {
+          ...buildDefaultState([first]).installations[first.id],
+          installed: true,
+          enabled: true,
+          grantedCapabilities: [{ ...grant("memory-provider"), granted: true }],
+        },
+        [selected.id]: {
+          ...buildDefaultState([selected]).installations[selected.id],
+          installed: true,
+          enabled: true,
+          grantedCapabilities: [{ ...grant("memory-provider"), granted: true }],
+        },
+      },
+    };
+
+    expect(selectedSystemSlotProviderId(state, "memory-system")).toBe(selected.id);
+    expect(activeSystemSlotProvider(state, [first, selected], "memory-system")?.manifest.id).toBe(selected.id);
+  });
+
+  it("falls back to the first eligible provider when the selection is disabled or ungranted", () => {
+    const first = manifestForSlot("addon.first", "chat-interface", "chat-interface");
+    const disabled = manifestForSlot("addon.disabled", "chat-interface", "chat-interface");
+    const ungranted = manifestForSlot("addon.ungranted", "chat-interface", "chat-interface");
+    const base = buildDefaultState([first, disabled, ungranted]);
+    const eligibleInstallation = {
+      ...base.installations[first.id],
+      installed: true,
+      enabled: true,
+      grantedCapabilities: [{ ...grant("chat-interface"), granted: true }],
+    };
+
+    expect(
+      activeSystemSlotProvider(
+        {
+          ...base,
+          activeSystemSlotProviderIds: { "chat-interface": disabled.id },
+          installations: {
+            ...base.installations,
+            [first.id]: eligibleInstallation,
+            [disabled.id]: {
+              ...base.installations[disabled.id],
+              installed: true,
+              enabled: false,
+              grantedCapabilities: [{ ...grant("chat-interface"), granted: true }],
+            },
+          },
+        },
+        [first, disabled, ungranted],
+        "chat-interface",
+      )?.manifest.id,
+    ).toBe(first.id);
+
+    expect(
+      activeSystemSlotProvider(
+        {
+          ...base,
+          activeSystemSlotProviderIds: { "chat-interface": ungranted.id },
+          installations: {
+            ...base.installations,
+            [first.id]: eligibleInstallation,
+            [ungranted.id]: {
+              ...base.installations[ungranted.id],
+              installed: true,
+              enabled: true,
+              grantedCapabilities: [{ ...grant("chat-interface"), granted: false }],
+            },
+          },
+        },
+        [first, disabled, ungranted],
+        "chat-interface",
+      )?.manifest.id,
+    ).toBe(first.id);
+  });
+
+  it("ignores a selection naming a manifest that does not declare the slot", () => {
+    const first = manifestForSlot("addon.first", "memory-system", "memory-provider");
+    const selected = manifestForSlot("addon.selected-chat", "chat-interface", "chat-interface");
+    const base = buildDefaultState([first, selected]);
+    const state = {
+      ...base,
+      activeSystemSlotProviderIds: { "memory-system": selected.id },
+      installations: {
+        ...base.installations,
+        [first.id]: {
+          ...base.installations[first.id],
+          installed: true,
+          enabled: true,
+          grantedCapabilities: [{ ...grant("memory-provider"), granted: true }],
+        },
+        [selected.id]: {
+          ...base.installations[selected.id],
+          installed: true,
+          enabled: true,
+          grantedCapabilities: [{ ...grant("chat-interface"), granted: true }],
+        },
+      },
+    };
+
+    expect(activeSystemSlotProvider(state, [first, selected], "memory-system")?.manifest.id).toBe(first.id);
   });
 });

--- a/src/modules/shell/system-slots.ts
+++ b/src/modules/shell/system-slots.ts
@@ -39,21 +39,47 @@ export const capabilityForSlot = (slotId: SystemSlotId): CapabilityGrant["capabi
   }
 };
 
+export const selectedSystemSlotProviderId = (state: ResonantShellState, slotId: SystemSlotId): string | undefined =>
+  state.activeSystemSlotProviderIds?.[slotId];
+
+const eligibleSystemSlotProvider = (
+  state: ResonantShellState,
+  manifest: AddOnManifest,
+  slotId: SystemSlotId,
+): SystemSlotProvider | null => {
+  if (!manifest.systemSlots?.some((slot) => slot.id === slotId)) {
+    return null;
+  }
+  const installation = state.installations[manifest.id];
+  if (!installation?.enabled) {
+    return null;
+  }
+  const requiredCapability = capabilityForSlot(slotId);
+  if (!installation.grantedCapabilities.some((grant) => grant.capability === requiredCapability && grant.granted)) {
+    return null;
+  }
+  return { manifest, installation };
+};
+
 export const activeSystemSlotProvider = (
   state: ResonantShellState,
   manifests: AddOnManifest[],
   slotId: SystemSlotId,
 ): SystemSlotProvider | null => {
+  const selectedManifestId = selectedSystemSlotProviderId(state, slotId);
+  const selectedManifest = selectedManifestId ? manifests.find((manifest) => manifest.id === selectedManifestId) : undefined;
+  if (selectedManifest) {
+    const selectedProvider = eligibleSystemSlotProvider(state, selectedManifest, slotId);
+    if (selectedProvider) {
+      return selectedProvider;
+    }
+  }
+
   for (const manifest of manifestsForSystemSlot(manifests, slotId)) {
-    const installation = state.installations[manifest.id];
-    if (!installation?.enabled) {
-      continue;
+    const provider = eligibleSystemSlotProvider(state, manifest, slotId);
+    if (provider) {
+      return provider;
     }
-    const requiredCapability = capabilityForSlot(slotId);
-    if (!installation.grantedCapabilities.some((grant) => grant.capability === requiredCapability && grant.granted)) {
-      continue;
-    }
-    return { manifest, installation };
   }
 
   return null;


### PR DESCRIPTION
## Summary

Build-plan **task 2** of the uninstall design note (#180), on the release owner's answers of 2026-09-07 (Q2: stop running work first, block if it cannot stop; Q3: a typed field for system-slot ownership).

- **Typed system-slot ownership.** `ResonantShellState.activeSystemSlotProviderIds` records which add-on currently provides each system slot. Defaults come from the bundled manifests' recommended default providers (first manifest wins), legacy persisted state gains the defaults on load, and explicit selections survive rebase.
- **`uninstallAddon` mutation.** Order: read the record (not installed → blocked; already uninstalled → idempotent no-op with no duplicate audit) → kernel-adjacent check (a **bundled** add-on that is the **active** recommended default provider for a slot is blocked; sideloaded add-ons never are; a bundled default whose slots another provider now owns is allowed) → **await the stop hook** (a `stopped: false` or a throw blocks with no mutation) → one atomic updater that re-validates against the draft and then sets `uninstalled`, clears grants, private provider links and config, appends the uninstall note, and disables the Hermes channel for that add-on → returns a **counts-only audit record** built from the pre-mutation values. The record is returned for the host to persist (task 4), not written here.
- No UI, no App wiring, no host route, no user-data deletion — tasks 3 to 5.

## Evidence

Head `c433aace` (1 commit on `ca896bf7`). Gates run outside the executor sandbox, mirroring every verify-alpha step:

| Gate | Result |
|---|---|
| `vitest run` | **462 / 462** (dev: 440; +22 from this PR) |
| `npm run test:browser-first` | 1220 / 1220 |
| `tsc --noEmit`, `docs:check`, `test:docs` (233/233), `test:module-ownership`, `test:security-pipeline` (46/46), `repo:hygiene`, release-scope audit `--committed --strict` | clean |

Anti-false-green — six mutations via `rig-mutate`, each restored byte-identical, each **red**: the kernel-adjacent predicate ignores the selection; the stop hook's result is ignored; the updater reuses the early decision instead of re-deciding on the draft; the selection-first branch of `activeSystemSlotProvider` is removed; first-manifest-wins in the defaults is broken; the audit exposes private profile ids instead of a count.

Every new test was observed red before its implementation (executor's red runs are in the report; the 16 controller tests all failed with `uninstallAddon is not a function`, the four state and slot tests with the specific missing behaviour).

## Process

Spec derived from the merged design note and the release owner's answers; single-reviewer spec check (Grok) before execution; fleet executor (codex); maintainer read the full handback; independent correctness review (DeepSeek, vendor ≠ author) — verdict in the PR comments.

Refs #180 (stays open for tasks 3–6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
