### PR TITLE
feat(addons): Uninstall action, confirmation copy, and running-work guard (#180 task 3)

### DIFF
--- a/docs/addons/addon-lifecycle-uninstall-design.md
+++ b/docs/addons/addon-lifecycle-uninstall-design.md
@@ -238,7 +238,7 @@ when the sideloaded add-on provides a system slot.
 2. Should uninstall stop or cancel currently running local add-on work first?
    Recommended default: yes, attempt a best-effort stop before the state
    mutation and block uninstall if the runtime cannot reach a safe stopped
-   state. **Answered 2026-09-07 (release owner): yes — implemented in task 2.**
+   state. **Answered 2026-09-07 (release owner): yes — implemented in task 2.** Scope of the stop hook in task 3: the desktop shell has no delegation-cancel primitive, and task workspaces are listable but carry no run status; the in-flight registry covers Logician script and hook runs, browser engine install, and Hermes install. The Hermes dashboard, OpenCode service start/stop, OpenCode task execution from the Delegation workspace, task-workspace creation from chat, and browser sessions are not stopped by uninstall in task 3; the host-side running-delegation check lands with task 4.
 3. Which surface owns active system-slot provider selection?
    Recommended default: add an explicit typed field under shared runtime state
    before enforcing kernel-adjacent uninstall blocking. **Answered 2026-09-07 (release owner): yes — implemented in task 2.**
@@ -272,8 +272,8 @@ when the sideloaded add-on provides a system slot.
 
 3. UI control and confirmation (M)
    - Files: `src/modules/addons/AddOnsWorkspace.tsx`,
-     `src/modules/addons/AddOnsWorkspace.test.tsx`, `src/App.tsx`.
-   - TDD first: add `shows Uninstall for installed add-ons`, `confirmation copy states config is deleted and user data retained`, `does not show Uninstall for blocked active bundled defaults`, and `calls uninstall handler only after confirmation`.
+     `src/modules/addons/AddOnsWorkspace.test.tsx`, `src/App.tsx`. **Implemented in task 3 (2026-09-07).**
+   - TDD first: add `shows Uninstall for installed add-ons`, `confirmation copy states config is deleted and user data retained`, `shows a disabled Uninstall with the slot reason for blocked active bundled defaults`, and `calls uninstall handler only after confirmation`.
    - Implementation: add an Uninstall secondary action in the detail panel,
      show the warning copy from this design, and wire the handler through
      `App.tsx`.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,14 +59,17 @@ import {
   subscribeRuntimeStateUpdates,
 } from "./core/runtime";
 import {
+  describeUninstallBlock,
   executeSideloadManifest,
   grantAddonCapabilities,
   runAddonLogicianHook,
   runAddonLogicianScript,
   toggleAddonCapabilityGrant,
   toggleAddonInstallation,
+  uninstallAddon,
   updateAddonConfig,
 } from "./modules/addons/controller";
+import { addonWorkRegistry, withAddonWork } from "./modules/addons/running-work";
 import {
   executeArchiveIngestProbe,
   executeArchiveSearch,
@@ -2422,6 +2425,7 @@ export function App() {
                 installations={state.installations}
                 selectedManifest={selectedManifest}
                 selectedInstallation={selectedInstallation}
+                uninstallBlock={selectedManifest ? describeUninstallBlock(state, selectedManifest) : null}
                 onSearchChange={(value) => {
                   startTransition(() => setSearch(value));
                 }}
@@ -2436,11 +2440,28 @@ export function App() {
                   grantAddonCapabilities(manifestId, capabilities, requestedCapabilities, updateRuntimeState)
                 }
                 onUpdateAddonConfig={(manifestId, config) => updateAddonConfig(manifestId, config, updateRuntimeState)}
-                onRunLogicianScript={(manifest, installation, script) =>
-                  runAddonLogicianScript(manifest, installation, script, updateRuntimeState)
+                onUninstallAddon={(manifest) =>
+                  uninstallAddon(manifest, {
+                    getState: () => {
+                      const readyState = currentReadyStateRef.current;
+                      if (!readyState) {
+                        throw new Error("Runtime state is not ready.");
+                      }
+                      return readyState;
+                    },
+                    updateRuntimeState,
+                    stopRunningWork: addonWorkRegistry.stopRunningWork,
+                  })
                 }
-                onRunLogicianHook={(manifest, installation, hook) =>
-                  runAddonLogicianHook(manifest, installation, hook, updateRuntimeState)
+                onRunLogicianScript={async (manifest, installation, script) =>
+                  withAddonWork(addonWorkRegistry, manifest.id, () =>
+                    runAddonLogicianScript(manifest, installation, script, updateRuntimeState),
+                  )
+                }
+                onRunLogicianHook={async (manifest, installation, hook) =>
+                  withAddonWork(addonWorkRegistry, manifest.id, () =>
+                    runAddonLogicianHook(manifest, installation, hook, updateRuntimeState),
+                  )
                 }
                 onAskAugmentor={async (message) => {
                   await sendStrategistMessage(message);

--- a/src/modules/addons/AddOnsWorkspace.test.tsx
+++ b/src/modules/addons/AddOnsWorkspace.test.tsx
@@ -1,10 +1,18 @@
 // @vitest-environment jsdom
 
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
-import type { AddOnManifest, CapabilityGrant, LogicianExecutionArtifact } from "../../core/contracts";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  AddOnInstallation,
+  AddOnManifest,
+  CapabilityGrant,
+  InstallationStatus,
+  LogicianExecutionArtifact,
+} from "../../core/contracts";
 import { buildDefaultState } from "../../core/defaults";
 import { AddOnsWorkspace } from "./AddOnsWorkspace";
+import type { UninstallAddonResult } from "./controller";
 
 vi.mock("../../core/runtime", () => ({
   requestBrowserEngineStatus: vi.fn(async () => ({
@@ -61,6 +69,89 @@ const createHermesManifest = (): AddOnManifest => ({
     shellVersion: "^0.1.0",
     platforms: ["macOS"],
   },
+});
+
+const createMinimalManifest = (id: string, name: string): AddOnManifest => ({
+  id,
+  name,
+  version: "0.1.0",
+  author: "test",
+  category: "tool",
+  description: `${name} manifest`,
+  runtimeType: "ui-module",
+  surfaces: [],
+  requestedCapabilities: [],
+  providerRequirements: {
+    sharedProfiles: [],
+    supportsPrivateCredentials: false,
+  },
+  archiveIntegration: {
+    readScopes: [],
+    intakeWriteScopes: [],
+    canRequestIngest: false,
+    canWriteKnowledgePages: false,
+  },
+  health: {
+    strategy: "none",
+  },
+  installHooks: {},
+  compatibility: {
+    shellVersion: "^0.1.0",
+    platforms: ["macOS"],
+  },
+});
+
+type AddOnsWorkspaceRenderProps = ComponentProps<typeof AddOnsWorkspace>;
+
+const renderWorkspaceProps = (overrides: Partial<AddOnsWorkspaceRenderProps> = {}): AddOnsWorkspaceRenderProps => {
+  const fallbackManifest = createMinimalManifest("addon.test", "Test Addon");
+  const manifests = overrides.filteredManifests ?? [overrides.selectedManifest ?? fallbackManifest];
+  const state = buildDefaultState(manifests);
+  const selectedManifest = overrides.selectedManifest ?? manifests[0] ?? null;
+  const selectedInstallation =
+    overrides.selectedInstallation ?? (selectedManifest ? state.installations[selectedManifest.id] : null);
+  return {
+    search: "",
+    sideloadPath: "",
+    filteredManifests: manifests,
+    installations: state.installations,
+    selectedManifest,
+    selectedInstallation,
+    uninstallBlock: null,
+    onSearchChange: vi.fn(),
+    onSideloadPathChange: vi.fn(),
+    onSideload: vi.fn(),
+    onSelectManifest: vi.fn(),
+    onToggleAddonInstall: vi.fn(),
+    onToggleGrant: vi.fn(),
+    onGrantCapabilities: vi.fn(),
+    onUpdateAddonConfig: vi.fn(),
+    onUninstallAddon: vi.fn(async (): Promise<UninstallAddonResult> => ({ outcome: "blocked", blockReason: "not-installed" })),
+    onRunLogicianScript: vi.fn(),
+    onRunLogicianHook: vi.fn(),
+    onAskAugmentor: vi.fn(async () => undefined),
+    onOpenArchiveReview: vi.fn(),
+    onOpenSurface: vi.fn(),
+    ...overrides,
+  };
+};
+
+const renderWorkspace = (overrides: Partial<AddOnsWorkspaceRenderProps> = {}) =>
+  render(<AddOnsWorkspace {...renderWorkspaceProps(overrides)} />);
+
+const setInstallationStatus = (installation: AddOnInstallation, status: InstallationStatus): AddOnInstallation => {
+  installation.status = status;
+  installation.installed = status !== "available" && status !== "uninstalled";
+  installation.enabled = status === "enabled";
+  return installation;
+};
+
+const confirmationCopy =
+  "Uninstall clears this add-on's grants, private provider links, and settings. It keeps source files, Living Archive intake/review records, delegation packets, drafts, and result artifacts. Review those records separately before deleting them.";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
 });
 
 describe("AddOnsWorkspace Hermes grants", () => {
@@ -121,6 +212,7 @@ describe("AddOnsWorkspace Hermes grants", () => {
         installations={state.installations}
         selectedManifest={null}
         selectedInstallation={null}
+        uninstallBlock={null}
         onSearchChange={vi.fn()}
         onSideloadPathChange={vi.fn()}
         onSideload={vi.fn()}
@@ -129,6 +221,7 @@ describe("AddOnsWorkspace Hermes grants", () => {
         onToggleGrant={vi.fn()}
         onGrantCapabilities={vi.fn()}
         onUpdateAddonConfig={vi.fn()}
+        onUninstallAddon={vi.fn()}
         onRunLogicianScript={vi.fn()}
         onRunLogicianHook={vi.fn()}
         onAskAugmentor={vi.fn(async () => undefined)}
@@ -155,6 +248,7 @@ describe("AddOnsWorkspace Hermes grants", () => {
         installations={state.installations}
         selectedManifest={null}
         selectedInstallation={null}
+        uninstallBlock={null}
         onSearchChange={vi.fn()}
         onSideloadPathChange={vi.fn()}
         onSideload={vi.fn()}
@@ -163,6 +257,7 @@ describe("AddOnsWorkspace Hermes grants", () => {
         onToggleGrant={vi.fn()}
         onGrantCapabilities={onGrantCapabilities}
         onUpdateAddonConfig={vi.fn()}
+        onUninstallAddon={vi.fn()}
         onRunLogicianScript={vi.fn()}
         onRunLogicianHook={vi.fn()}
         onAskAugmentor={vi.fn(async () => undefined)}
@@ -248,6 +343,7 @@ describe("AddOnsWorkspace Hermes grants", () => {
         installations={state.installations}
         selectedManifest={hermesManifest}
         selectedInstallation={state.installations[hermesManifest.id]}
+        uninstallBlock={null}
         onSearchChange={vi.fn()}
         onSideloadPathChange={vi.fn()}
         onSideload={vi.fn()}
@@ -256,6 +352,7 @@ describe("AddOnsWorkspace Hermes grants", () => {
         onToggleGrant={vi.fn()}
         onGrantCapabilities={vi.fn()}
         onUpdateAddonConfig={vi.fn()}
+        onUninstallAddon={vi.fn()}
         onRunLogicianScript={vi.fn(async (): Promise<LogicianExecutionArtifact> => ({
           id: "test-artifact",
           addonId: hermesManifest.id,
@@ -376,6 +473,7 @@ describe("AddOnsWorkspace Hermes grants", () => {
         installations={state.installations}
         selectedManifest={hermesManifest}
         selectedInstallation={state.installations[hermesManifest.id]}
+        uninstallBlock={null}
         onSearchChange={vi.fn()}
         onSideloadPathChange={vi.fn()}
         onSideload={vi.fn()}
@@ -384,6 +482,7 @@ describe("AddOnsWorkspace Hermes grants", () => {
         onToggleGrant={vi.fn()}
         onGrantCapabilities={vi.fn()}
         onUpdateAddonConfig={vi.fn()}
+        onUninstallAddon={vi.fn()}
         onRunLogicianScript={vi.fn()}
         onRunLogicianHook={vi.fn()}
         onAskAugmentor={vi.fn(async () => undefined)}
@@ -396,5 +495,291 @@ describe("AddOnsWorkspace Hermes grants", () => {
     expect(screen.getByText(/Hermes profile requires review/i)).toBeTruthy();
     expect(screen.getByText(/host-reported: 1/i)).toBeTruthy();
     expect(screen.getByText(/command-degraded/i)).toBeTruthy();
+  });
+});
+
+describe("AddOnsWorkspace uninstall lifecycle", () => {
+  it.each(["installed", "enabled", "disabled", "degraded", "update-available", "incompatible"] as const)(
+    "shows Uninstall for installed add-ons in %s status",
+    (status) => {
+      const manifest = createMinimalManifest(`addon.${status}`, `${status} Addon`);
+      const state = buildDefaultState([manifest]);
+      setInstallationStatus(state.installations[manifest.id], status);
+
+      renderWorkspace({
+        filteredManifests: [manifest],
+        installations: state.installations,
+        selectedManifest: manifest,
+        selectedInstallation: state.installations[manifest.id],
+      });
+
+      const button = screen.getByRole("button", { name: `Uninstall ${manifest.name}` }) as HTMLButtonElement;
+      expect(button.disabled).toBe(false);
+    },
+  );
+
+  it("hides Uninstall for available and uninstalled add-ons", () => {
+    for (const status of ["available", "uninstalled"] as const) {
+      const manifest = createMinimalManifest(`addon.${status}`, `${status} Addon`);
+      const state = buildDefaultState([manifest]);
+      setInstallationStatus(state.installations[manifest.id], status);
+      const view = renderWorkspace({
+        filteredManifests: [manifest],
+        installations: state.installations,
+        selectedManifest: manifest,
+        selectedInstallation: state.installations[manifest.id],
+      });
+
+      expect(screen.queryByRole("button", { name: `Uninstall ${manifest.name}` })).toBeNull();
+      view.unmount();
+    }
+  });
+
+  it("disables Uninstall for a blocked active bundled default and shows the slot reason", () => {
+    const manifest = createMinimalManifest("addon.default", "Default Agent");
+    const state = buildDefaultState([manifest]);
+    setInstallationStatus(state.installations[manifest.id], "enabled");
+
+    renderWorkspace({
+      filteredManifests: [manifest],
+      installations: state.installations,
+      selectedManifest: manifest,
+      selectedInstallation: state.installations[manifest.id],
+      uninstallBlock: { blockReason: "active-system-slot-provider", blockDetail: "primary-agent, chat-interface" },
+    });
+
+    const button = screen.getByRole("button", { name: "Uninstall Default Agent" }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(
+      screen.getByText(
+        "Default Agent currently provides the primary-agent, chat-interface slot(s). Select another provider for those slots before uninstalling.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("confirmation copy states config is deleted and user data retained", () => {
+    const manifest = createMinimalManifest("addon.confirm", "Confirm Addon");
+    const state = buildDefaultState([manifest]);
+    setInstallationStatus(state.installations[manifest.id], "enabled");
+    const onUninstallAddon = vi.fn();
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    renderWorkspace({
+      filteredManifests: [manifest],
+      installations: state.installations,
+      selectedManifest: manifest,
+      selectedInstallation: state.installations[manifest.id],
+      onUninstallAddon,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Uninstall Confirm Addon" }));
+
+    expect(confirm).toHaveBeenCalledWith(confirmationCopy);
+    expect(onUninstallAddon).not.toHaveBeenCalled();
+    confirm.mockRestore();
+  });
+
+  it("calls the uninstall handler after confirmation and shows the counts-only result", async () => {
+    const manifest = createMinimalManifest("addon.clean", "Clean Addon");
+    const state = buildDefaultState([manifest]);
+    setInstallationStatus(state.installations[manifest.id], "enabled");
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    const onUninstallAddon = vi.fn(async (): Promise<UninstallAddonResult> => ({
+      outcome: "uninstalled",
+      audit: {
+        at: "2026-09-07T12:00:00.000Z",
+        event: "addonUninstalled",
+        addonId: manifest.id,
+        source: "bundled",
+        previousStatus: "enabled",
+        previousInstalled: true,
+        previousEnabled: true,
+        clearedCapabilities: ["network", "shell"],
+        clearedPrivateProviderProfileIds: 2,
+        configDeleted: true,
+        userDataRetained: true,
+        alsoDeleteUserDataOffered: false,
+        actor: "human",
+      },
+    }));
+
+    renderWorkspace({
+      filteredManifests: [manifest],
+      installations: state.installations,
+      selectedManifest: manifest,
+      selectedInstallation: state.installations[manifest.id],
+      onUninstallAddon,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Uninstall Clean Addon" }));
+
+    await waitFor(() => expect(screen.getByRole("status").textContent).toContain("2 grant(s) cleared"));
+    expect(screen.getByRole("status").textContent).toContain("settings deleted");
+    expect(screen.getByRole("status").textContent).toContain("user data retained");
+    expect(screen.queryByText(/private-profile|secret-config-value/i)).toBeNull();
+    confirm.mockRestore();
+  });
+
+  it('shows "settings were not set" when configDeleted is false', async () => {
+    const manifest = createMinimalManifest("addon.no-config", "No Config Addon");
+    const state = buildDefaultState([manifest]);
+    setInstallationStatus(state.installations[manifest.id], "enabled");
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    renderWorkspace({
+      filteredManifests: [manifest],
+      installations: state.installations,
+      selectedManifest: manifest,
+      selectedInstallation: state.installations[manifest.id],
+      onUninstallAddon: vi.fn(async (): Promise<UninstallAddonResult> => ({
+        outcome: "uninstalled",
+        audit: {
+          at: "2026-09-07T12:00:00.000Z",
+          event: "addonUninstalled",
+          addonId: manifest.id,
+          source: "bundled",
+          previousStatus: "enabled",
+          previousInstalled: true,
+          previousEnabled: true,
+          clearedCapabilities: [],
+          clearedPrivateProviderProfileIds: 0,
+          configDeleted: false,
+          userDataRetained: true,
+          alsoDeleteUserDataOffered: false,
+          actor: "human",
+        },
+      })),
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Uninstall No Config Addon" }));
+
+    await waitFor(() => expect(screen.getByRole("status").textContent).toContain("settings were not set"));
+    confirm.mockRestore();
+  });
+
+  it("shows the block reason when the handler reports running work", async () => {
+    const manifest = createMinimalManifest("addon.running", "Running Addon");
+    const state = buildDefaultState([manifest]);
+    setInstallationStatus(state.installations[manifest.id], "enabled");
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    renderWorkspace({
+      filteredManifests: [manifest],
+      installations: state.installations,
+      selectedManifest: manifest,
+      selectedInstallation: state.installations[manifest.id],
+      onUninstallAddon: vi.fn(async (): Promise<UninstallAddonResult> => ({
+        outcome: "blocked",
+        blockReason: "running-work-not-stopped",
+        blockDetail: "Work is still running.",
+      })),
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Uninstall Running Addon" }));
+
+    await waitFor(() => expect(screen.getByRole("status").textContent).toBe("Work is still running."));
+    confirm.mockRestore();
+  });
+
+  it("keeps the pending state on the add-on that was uninstalled when the selection changes", async () => {
+    const first = createMinimalManifest("addon.first", "First Addon");
+    const second = createMinimalManifest("addon.second", "Second Addon");
+    const state = buildDefaultState([first, second]);
+    setInstallationStatus(state.installations[first.id], "enabled");
+    setInstallationStatus(state.installations[second.id], "enabled");
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    let resolveUninstall: (result: UninstallAddonResult) => void = () => undefined;
+    const uninstallPromise = new Promise<UninstallAddonResult>((resolve) => {
+      resolveUninstall = resolve;
+    });
+    const onUninstallAddon = vi.fn(() => uninstallPromise);
+    const props = {
+      filteredManifests: [first, second],
+      installations: state.installations,
+      onUninstallAddon,
+    };
+    const view = renderWorkspace({
+      ...props,
+      selectedManifest: first,
+      selectedInstallation: state.installations[first.id],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Uninstall First Addon" }));
+    expect((screen.getByRole("button", { name: "Uninstalling…" }) as HTMLButtonElement).disabled).toBe(true);
+
+    view.rerender(
+      <AddOnsWorkspace
+        {...(renderWorkspaceProps({
+          ...props,
+          selectedManifest: second,
+          selectedInstallation: state.installations[second.id],
+        }))}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Uninstalling…" })).toBeNull();
+    expect((screen.getByRole("button", { name: "Uninstall Second Addon" }) as HTMLButtonElement).disabled).toBe(false);
+
+    await act(async () => {
+      resolveUninstall({ outcome: "blocked", blockReason: "running-work-not-stopped", blockDetail: "still running" });
+      await uninstallPromise;
+    });
+    confirm.mockRestore();
+  });
+
+  it("discards an uninstall result that arrives for a different add-on than the selection", async () => {
+    const first = createMinimalManifest("addon.first", "First Addon");
+    const second = createMinimalManifest("addon.second", "Second Addon");
+    const state = buildDefaultState([first, second]);
+    setInstallationStatus(state.installations[first.id], "enabled");
+    setInstallationStatus(state.installations[second.id], "enabled");
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    let resolveUninstall: (result: UninstallAddonResult) => void = () => undefined;
+    const uninstallPromise = new Promise<UninstallAddonResult>((resolve) => {
+      resolveUninstall = resolve;
+    });
+    const props = {
+      filteredManifests: [first, second],
+      installations: state.installations,
+      onUninstallAddon: vi.fn(() => uninstallPromise),
+    };
+    const view = renderWorkspace({
+      ...props,
+      selectedManifest: first,
+      selectedInstallation: state.installations[first.id],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Uninstall First Addon" }));
+    view.rerender(
+      <AddOnsWorkspace
+        {...(renderWorkspaceProps({
+          ...props,
+          selectedManifest: second,
+          selectedInstallation: state.installations[second.id],
+        }))}
+      />,
+    );
+
+    await act(async () => {
+      resolveUninstall({
+        outcome: "blocked",
+        blockReason: "running-work-not-stopped",
+        blockDetail: "First add-on is still running.",
+      });
+      await uninstallPromise;
+    });
+
+    expect(screen.queryByRole("status")).toBeNull();
+    view.rerender(
+      <AddOnsWorkspace
+        {...(renderWorkspaceProps({
+          ...props,
+          selectedManifest: first,
+          selectedInstallation: state.installations[first.id],
+        }))}
+      />,
+    );
+    expect(screen.queryByRole("status")).toBeNull();
+    confirm.mockRestore();
   });
 });

--- a/src/modules/addons/AddOnsWorkspace.test.tsx
+++ b/src/modules/addons/AddOnsWorkspace.test.tsx
@@ -550,11 +550,13 @@ describe("AddOnsWorkspace uninstall lifecycle", () => {
 
     const button = screen.getByRole("button", { name: "Uninstall Default Agent" }) as HTMLButtonElement;
     expect(button.disabled).toBe(true);
-    expect(
-      screen.getByText(
-        "Default Agent currently provides the primary-agent, chat-interface slot(s). Select another provider for those slots before uninstalling.",
-      ),
-    ).toBeTruthy();
+    const reason = screen.getByText(
+      "Default Agent currently provides the primary-agent, chat-interface slot(s). Select another provider for those slots before uninstalling.",
+    );
+    expect(reason).toBeTruthy();
+    // The disabled button must point screen readers at its reason.
+    expect(reason.id).toBeTruthy();
+    expect(button.getAttribute("aria-describedby")).toBe(reason.id);
   });
 
   it("confirmation copy states config is deleted and user data retained", () => {
@@ -595,7 +597,7 @@ describe("AddOnsWorkspace uninstall lifecycle", () => {
         previousInstalled: true,
         previousEnabled: true,
         clearedCapabilities: ["network", "shell"],
-        clearedPrivateProviderProfileIds: 2,
+        clearedPrivateProviderProfileIds: 3,
         configDeleted: true,
         userDataRetained: true,
         alsoDeleteUserDataOffered: false,

--- a/src/modules/addons/AddOnsWorkspace.tsx
+++ b/src/modules/addons/AddOnsWorkspace.tsx
@@ -329,6 +329,7 @@ function AddOnDetailPanel(props: AddOnDetailPanelProps) {
     }
   };
   const currentUninstallPending = uninstallPending?.addonId === props.selectedManifest.id;
+  const uninstallBlockId = `uninstall-block-${props.selectedManifest.id}`;
   const currentUninstallResult =
     uninstallResult?.addonId === props.selectedManifest.id ? uninstallResult.result : null;
   const runUninstall = async () => {
@@ -425,12 +426,13 @@ function AddOnDetailPanel(props: AddOnDetailPanelProps) {
                 type="button"
                 className="button-secondary touch-action"
                 disabled={currentUninstallPending || props.uninstallBlock !== null}
+                aria-describedby={props.uninstallBlock ? uninstallBlockId : undefined}
                 onClick={() => void runUninstall()}
               >
                 {currentUninstallPending ? "Uninstalling…" : `Uninstall ${props.selectedManifest.name}`}
               </button>
               {props.uninstallBlock ? (
-                <p className="muted-copy">
+                <p className="muted-copy" id={uninstallBlockId}>
                   {uninstallBlockMessage(
                     props.selectedManifest.name,
                     props.uninstallBlock.blockReason,

--- a/src/modules/addons/AddOnsWorkspace.tsx
+++ b/src/modules/addons/AddOnsWorkspace.tsx
@@ -1,6 +1,6 @@
 // Intent citation: docs/architecture/ADR-002-modular-codebase.md
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type {
   AddOnInstallation,
   AddOnHookDefinition,
@@ -21,6 +21,8 @@ import { createAddOnRegistryEntry } from "../../sdk/addons";
 import { HermesAddonPanel } from "./HermesAddonPanel";
 import { ObsidianAddonPanel } from "./ObsidianAddonPanel";
 import { TelegramAddonPanel } from "./TelegramAddonPanel";
+import { addonWorkRegistry, withAddonWork } from "./running-work";
+import type { UninstallAddonBlockReason, UninstallAddonResult } from "./controller";
 
 type AddOnsWorkspaceProps = {
   search: string;
@@ -41,6 +43,8 @@ type AddOnsWorkspaceProps = {
     requestedCapabilities: CapabilityGrant[],
   ) => void;
   onUpdateAddonConfig: (manifestId: string, config: Record<string, unknown>) => void;
+  uninstallBlock: { blockReason: UninstallAddonBlockReason; blockDetail?: string } | null;
+  onUninstallAddon: (manifest: AddOnManifest) => Promise<UninstallAddonResult>;
   onRunLogicianScript: (
     manifest: AddOnManifest,
     installation: AddOnInstallation,
@@ -116,6 +120,39 @@ const addonPrimaryActionLabel = (manifest: AddOnManifest, installation: AddOnIns
     return "Install";
   }
   return installation.enabled ? "Disable" : "Enable";
+};
+
+const UNINSTALL_CONFIRMATION_COPY =
+  "Uninstall clears this add-on's grants, private provider links, and settings. It keeps source files, Living Archive intake/review records, delegation packets, drafts, and result artifacts. Review those records separately before deleting them.";
+
+const uninstallBlockMessage = (
+  manifestName: string,
+  reason: UninstallAddonBlockReason | undefined,
+  detail?: string,
+): string => {
+  if (reason === "active-system-slot-provider") {
+    return `${manifestName} currently provides the ${detail ?? "selected"} slot(s). Select another provider for those slots before uninstalling.`;
+  }
+  if (reason === "already-uninstalled") {
+    return `${manifestName} is already uninstalled.`;
+  }
+  if (reason === "not-installed") {
+    return `${manifestName} is not installed.`;
+  }
+  if (reason === "running-work-not-stopped") {
+    return detail ?? "Work for this add-on is still running in the desktop shell. Wait for it to finish, then uninstall.";
+  }
+  return "This add-on cannot be uninstalled right now.";
+};
+
+const uninstallResultMessage = (manifestName: string, result: UninstallAddonResult): string => {
+  if (result.outcome === "uninstalled") {
+    const audit = result.audit;
+    const clearedGrantCount = audit?.clearedCapabilities.length ?? 0;
+    const settingsText = audit?.configDeleted ? "settings deleted" : "settings were not set";
+    return `Uninstalled. ${clearedGrantCount} grant(s) cleared; ${settingsText}; user data retained.`;
+  }
+  return uninstallBlockMessage(manifestName, result.blockReason, result.blockDetail);
 };
 
 export function AddOnsWorkspace(props: AddOnsWorkspaceProps) {
@@ -231,6 +268,8 @@ export function AddOnsWorkspace(props: AddOnsWorkspaceProps) {
           onToggleGrant={props.onToggleGrant}
           onGrantCapabilities={props.onGrantCapabilities}
           onUpdateAddonConfig={props.onUpdateAddonConfig}
+          uninstallBlock={props.uninstallBlock}
+          onUninstallAddon={props.onUninstallAddon}
           onRunLogicianScript={props.onRunLogicianScript}
           onRunLogicianHook={props.onRunLogicianHook}
           onAskAugmentor={props.onAskAugmentor}
@@ -250,6 +289,8 @@ type AddOnDetailPanelProps = Pick<
   | "onRunLogicianScript"
   | "onToggleGrant"
   | "onUpdateAddonConfig"
+  | "onUninstallAddon"
+  | "uninstallBlock"
 > & {
   selectedManifest: AddOnManifest;
   selectedInstallation: AddOnInstallation;
@@ -259,6 +300,10 @@ type AddOnDetailPanelProps = Pick<
 function AddOnDetailPanel(props: AddOnDetailPanelProps) {
   const [logicianBusyId, setLogicianBusyId] = useState<string | null>(null);
   const [logicianNotice, setLogicianNotice] = useState("");
+  const [uninstallPending, setUninstallPending] = useState<{ addonId: string } | null>(null);
+  const [uninstallResult, setUninstallResult] = useState<{ addonId: string; result: UninstallAddonResult } | null>(null);
+  const selectedAddonIdRef = useRef(props.selectedManifest.id);
+  selectedAddonIdRef.current = props.selectedManifest.id;
   const runScript = async (script: AddOnScriptDefinition) => {
     setLogicianBusyId(script.id);
     setLogicianNotice("");
@@ -281,6 +326,25 @@ function AddOnDetailPanel(props: AddOnDetailPanelProps) {
       setLogicianNotice(error instanceof Error ? error.message : "Logician hook failed.");
     } finally {
       setLogicianBusyId(null);
+    }
+  };
+  const currentUninstallPending = uninstallPending?.addonId === props.selectedManifest.id;
+  const currentUninstallResult =
+    uninstallResult?.addonId === props.selectedManifest.id ? uninstallResult.result : null;
+  const runUninstall = async () => {
+    const addonId = props.selectedManifest.id;
+    if (!window.confirm(UNINSTALL_CONFIRMATION_COPY)) {
+      return;
+    }
+    setUninstallPending({ addonId });
+    setUninstallResult(null);
+    try {
+      const result = await props.onUninstallAddon(props.selectedManifest);
+      if (selectedAddonIdRef.current === addonId) {
+        setUninstallResult({ addonId, result });
+      }
+    } finally {
+      setUninstallPending((current) => (current?.addonId === addonId ? null : current));
     }
   };
 
@@ -350,6 +414,39 @@ function AddOnDetailPanel(props: AddOnDetailPanelProps) {
               </button>
             ))}
           </div>
+        </div>
+        <div className="detail-card">
+          <span className="eyebrow">Lifecycle</span>
+          {props.selectedInstallation.status === "uninstalled" ? (
+            <p className="muted-copy">Uninstalled. Reinstalling starts a fresh grant flow.</p>
+          ) : props.selectedInstallation.installed ? (
+            <>
+              <button
+                type="button"
+                className="button-secondary touch-action"
+                disabled={currentUninstallPending || props.uninstallBlock !== null}
+                onClick={() => void runUninstall()}
+              >
+                {currentUninstallPending ? "Uninstalling…" : `Uninstall ${props.selectedManifest.name}`}
+              </button>
+              {props.uninstallBlock ? (
+                <p className="muted-copy">
+                  {uninstallBlockMessage(
+                    props.selectedManifest.name,
+                    props.uninstallBlock.blockReason,
+                    props.uninstallBlock.blockDetail,
+                  )}
+                </p>
+              ) : null}
+            </>
+          ) : (
+            <p className="muted-copy">Not installed.</p>
+          )}
+          {currentUninstallResult ? (
+            <p className="muted-copy" role="status">
+              {uninstallResultMessage(props.selectedManifest.name, currentUninstallResult)}
+            </p>
+          ) : null}
         </div>
         <div className="detail-card">
           <span className="eyebrow">Archive contract</span>
@@ -683,7 +780,7 @@ function BrowserAddonSetupPanel({
     setEngineError("");
     setEngineLog("");
     try {
-      const result = await requestBrowserInstallEngine();
+      const result = await withAddonWork(addonWorkRegistry, "addon.browser", () => requestBrowserInstallEngine());
       setEngineLog(result.log);
       setEngineStatus({
         installed: result.installed,

--- a/src/modules/addons/HermesAddonPanel.tsx
+++ b/src/modules/addons/HermesAddonPanel.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import type { AddOnInstallation, CapabilityGrant, HermesInstallStatus } from "../../core/contracts";
 import { requestHermesInstall, requestHermesStatus } from "../../core/runtime";
+import { addonWorkRegistry, withAddonWork } from "./running-work";
 
 type HermesAddonPanelProps = {
   installation: AddOnInstallation;
@@ -76,10 +77,12 @@ export function HermesAddonPanel({
     setInstallNotice("");
     setInstallLog("");
     try {
-      const result = await requestHermesInstall({
-        profileHome: profileHome.trim() || undefined,
-        branch: "main",
-      });
+      const result = await withAddonWork(addonWorkRegistry, "addon.hermes", () =>
+        requestHermesInstall({
+          profileHome: profileHome.trim() || undefined,
+          branch: "main",
+        }),
+      );
       setStatus(result.status);
       setInstallLog(result.log);
       setInstallNotice(

--- a/src/modules/addons/controller.test.ts
+++ b/src/modules/addons/controller.test.ts
@@ -314,6 +314,22 @@ describe("uninstallAddon", () => {
       blockReason: "active-system-slot-provider",
       blockDetail: "primary-agent",
     });
+
+    // Two selected slots are both named in the detail, comma-separated.
+    const twoSlotManifest = {
+      ...createSystemSlotManifest("addon.two-slots"),
+      systemSlots: [
+        { id: "primary-agent" as const, role: "default-provider" as const, replaceable: true, recommended: true },
+        { id: "chat-interface" as const, role: "default-provider" as const, replaceable: true, recommended: true },
+      ],
+    };
+    const twoSlotState = buildDefaultState([twoSlotManifest]);
+    twoSlotState.installations[twoSlotManifest.id] = createMinimalInstallation(twoSlotManifest.id, true, true, "enabled");
+    twoSlotState.activeSystemSlotProviderIds = { "primary-agent": twoSlotManifest.id, "chat-interface": twoSlotManifest.id };
+    expect(describeUninstallBlock(twoSlotState, twoSlotManifest)).toEqual({
+      blockReason: "active-system-slot-provider",
+      blockDetail: "primary-agent, chat-interface",
+    });
   });
 
   it("describeUninstallBlock never blocks sideloaded providers", () => {

--- a/src/modules/addons/controller.test.ts
+++ b/src/modules/addons/controller.test.ts
@@ -27,6 +27,7 @@ const logicianMocks = vi.hoisted(() => ({
 
 vi.mock("../../core/logician", () => logicianMocks);
 import {
+  describeUninstallBlock,
   executeSideloadManifest,
   grantAddonCapabilities,
   runAddonLogicianHook,
@@ -290,6 +291,43 @@ describe("toggleAddonCapabilityGrant", () => {
 });
 
 describe("uninstallAddon", () => {
+  it("describeUninstallBlock mirrors decideUninstall for allowed, not-installed, uninstalled and active-slot cases", () => {
+    const allowedManifest = createMinimalManifest("addon.allowed", "Allowed");
+    const missingManifest = createMinimalManifest("addon.missing", "Missing");
+    const uninstalledManifest = createMinimalManifest("addon.removed", "Removed");
+    const activeSlotManifest = createSystemSlotManifest("addon.default");
+    const state = buildDefaultState([allowedManifest, missingManifest, uninstalledManifest, activeSlotManifest]);
+    state.installations[allowedManifest.id] = createMinimalInstallation(allowedManifest.id, true, true, "enabled");
+    state.installations[uninstalledManifest.id] = createMinimalInstallation(
+      uninstalledManifest.id,
+      false,
+      false,
+      "uninstalled",
+    );
+    state.installations[activeSlotManifest.id] = createMinimalInstallation(activeSlotManifest.id, true, true, "enabled");
+    state.activeSystemSlotProviderIds = { "primary-agent": activeSlotManifest.id };
+
+    expect(describeUninstallBlock(state, allowedManifest)).toBeNull();
+    expect(describeUninstallBlock(state, missingManifest)).toEqual({ blockReason: "not-installed" });
+    expect(describeUninstallBlock(state, uninstalledManifest)).toEqual({ blockReason: "already-uninstalled" });
+    expect(describeUninstallBlock(state, activeSlotManifest)).toEqual({
+      blockReason: "active-system-slot-provider",
+      blockDetail: "primary-agent",
+    });
+  });
+
+  it("describeUninstallBlock never blocks sideloaded providers", () => {
+    const manifest = createSystemSlotManifest("addon.sideloaded");
+    const state = buildDefaultState([manifest]);
+    state.activeSystemSlotProviderIds = { "primary-agent": manifest.id };
+    state.installations[manifest.id] = {
+      ...createMinimalInstallation(manifest.id, true, true, "enabled"),
+      source: "sideload",
+    };
+
+    expect(describeUninstallBlock(state, manifest)).toBeNull();
+  });
+
   it("clears grants provider profiles and config", async () => {
     const manifest = createMinimalManifest("addon.test", "Test Addon");
     let state = buildDefaultState([manifest]);

--- a/src/modules/addons/controller.ts
+++ b/src/modules/addons/controller.ts
@@ -165,6 +165,17 @@ const decideUninstall = (state: ResonantShellState, manifest: AddOnManifest): Un
   return { ok: true, installation };
 };
 
+export const describeUninstallBlock = (
+  state: ResonantShellState,
+  manifest: AddOnManifest,
+): { blockReason: UninstallAddonBlockReason; blockDetail?: string } | null => {
+  const decision = decideUninstall(state, manifest);
+  if (decision.ok) {
+    return null;
+  }
+  return { blockReason: decision.blockReason, blockDetail: decision.blockDetail };
+};
+
 const runningWorkBlockDetail = (error: unknown): string =>
   error instanceof Error ? error.message : typeof error === "string" ? error : "Running add-on work could not be stopped.";
 

--- a/src/modules/addons/running-work.test.ts
+++ b/src/modules/addons/running-work.test.ts
@@ -1,0 +1,142 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createAddonWorkRegistry, withAddonWork } from "./running-work";
+
+const matchingCloseParen = (source: string, callIndex: number): number => {
+  const openIndex = source.indexOf("(", callIndex);
+  let depth = 0;
+  for (let index = openIndex; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === "(") {
+      depth += 1;
+    } else if (char === ")") {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+  return -1;
+};
+
+const occurrenceIndexes = (source: string, needle: string): number[] => {
+  const indexes: number[] = [];
+  let index = source.indexOf(needle);
+  while (index !== -1) {
+    indexes.push(index);
+    index = source.indexOf(needle, index + needle.length);
+  }
+  return indexes;
+};
+
+describe("createAddonWorkRegistry", () => {
+  it("counts independent work per add-on", () => {
+    const registry = createAddonWorkRegistry();
+    const endA1 = registry.begin("addon.a");
+    const endA2 = registry.begin("addon.a");
+    const endB = registry.begin("addon.b");
+
+    expect(registry.inFlight("addon.a")).toBe(2);
+    expect(registry.inFlight("addon.b")).toBe(1);
+
+    endA1();
+    expect(registry.inFlight("addon.a")).toBe(1);
+    expect(registry.inFlight("addon.b")).toBe(1);
+
+    endA2();
+    endB();
+    expect(registry.inFlight("addon.a")).toBe(0);
+    expect(registry.inFlight("addon.b")).toBe(0);
+  });
+
+  it("reports running work until the matching end function is called", async () => {
+    const registry = createAddonWorkRegistry();
+    const end = registry.begin("addon.a");
+
+    await expect(registry.stopRunningWork({ addonId: "addon.a" })).resolves.toEqual({
+      stopped: false,
+      detail: "Work for this add-on is still running in the desktop shell. Wait for it to finish, then uninstall.",
+    });
+
+    end();
+    await expect(registry.stopRunningWork({ addonId: "addon.a" })).resolves.toEqual({ stopped: true });
+  });
+
+  it("keeps double end calls safe", () => {
+    const registry = createAddonWorkRegistry();
+    const end = registry.begin("addon.a");
+
+    end();
+    end();
+
+    expect(registry.inFlight("addon.a")).toBe(0);
+  });
+});
+
+describe("withAddonWork", () => {
+  it("keeps the count raised until a resolving promise settles", async () => {
+    const registry = createAddonWorkRegistry();
+    let settle: (value: string) => void = () => undefined;
+    const promise = withAddonWork(
+      registry,
+      "addon.a",
+      () =>
+        new Promise<string>((resolvePromise) => {
+          settle = resolvePromise;
+        }),
+    );
+
+    expect(registry.inFlight("addon.a")).toBe(1);
+    settle("ok");
+    await expect(promise).resolves.toBe("ok");
+    expect(registry.inFlight("addon.a")).toBe(0);
+  });
+
+  it("keeps the count raised until a rejecting promise settles and rethrows", async () => {
+    const registry = createAddonWorkRegistry();
+    let reject: (error: Error) => void = () => undefined;
+    const promise = withAddonWork(
+      registry,
+      "addon.a",
+      () =>
+        new Promise<string>((_, rejectPromise) => {
+          reject = rejectPromise;
+        }),
+    );
+
+    expect(registry.inFlight("addon.a")).toBe(1);
+    reject(new Error("boom"));
+    await expect(promise).rejects.toThrow("boom");
+    expect(registry.inFlight("addon.a")).toBe(0);
+  });
+});
+
+describe("add-on work source contract", () => {
+  it("keeps every wrapped add-on starter inside withAddonWork", () => {
+    const files = [
+      "src/App.tsx",
+      "src/modules/addons/AddOnsWorkspace.tsx",
+      "src/modules/addons/HermesAddonPanel.tsx",
+    ];
+    const scanned = files
+      .map((file) => readFileSync(resolve(process.cwd(), file), "utf8"))
+      .join("\n");
+    const wrappedNames = [
+      "runAddonLogicianScript(",
+      "runAddonLogicianHook(",
+      "requestBrowserInstallEngine(",
+      "requestHermesInstall(",
+    ];
+
+    for (const name of wrappedNames) {
+      const indexes = occurrenceIndexes(scanned, name);
+      expect(indexes.length, `${name} occurs in scanned source`).toBeGreaterThan(0);
+      for (const index of indexes) {
+        const wrapperIndex = scanned.lastIndexOf("withAddonWork(", index);
+        expect(wrapperIndex, `${name} has a preceding withAddonWork call`).toBeGreaterThanOrEqual(0);
+        expect(index, `${name} is inside withAddonWork`).toBeLessThan(matchingCloseParen(scanned, wrapperIndex));
+      }
+    }
+  });
+});

--- a/src/modules/addons/running-work.ts
+++ b/src/modules/addons/running-work.ts
@@ -1,0 +1,55 @@
+export interface AddonWorkRegistry {
+  begin(addonId: string): () => void;
+  inFlight(addonId: string): number;
+  stopRunningWork(input: { addonId: string }): Promise<{ stopped: boolean; detail?: string }>;
+}
+
+const runningWorkDetail =
+  "Work for this add-on is still running in the desktop shell. Wait for it to finish, then uninstall.";
+
+export const createAddonWorkRegistry = (): AddonWorkRegistry => {
+  const counts = new Map<string, number>();
+
+  return {
+    begin(addonId) {
+      counts.set(addonId, (counts.get(addonId) ?? 0) + 1);
+      let ended = false;
+      return () => {
+        if (ended) {
+          return;
+        }
+        ended = true;
+        const nextCount = Math.max(0, (counts.get(addonId) ?? 0) - 1);
+        if (nextCount === 0) {
+          counts.delete(addonId);
+        } else {
+          counts.set(addonId, nextCount);
+        }
+      };
+    },
+    inFlight(addonId) {
+      return counts.get(addonId) ?? 0;
+    },
+    async stopRunningWork({ addonId }) {
+      if ((counts.get(addonId) ?? 0) > 0) {
+        return { stopped: false, detail: runningWorkDetail };
+      }
+      return { stopped: true };
+    },
+  };
+};
+
+export const addonWorkRegistry: AddonWorkRegistry = createAddonWorkRegistry();
+
+export const withAddonWork = async <T>(
+  registry: AddonWorkRegistry,
+  addonId: string,
+  fn: () => Promise<T>,
+): Promise<T> => {
+  const end = registry.begin(addonId);
+  try {
+    return await fn();
+  } finally {
+    end();
+  }
+};


### PR DESCRIPTION
## Summary

Build-plan **task 3** of the uninstall design note (#180): the user-facing action.

- **Uninstall control** in the add-on detail panel's new "Lifecycle" card, for installed add-ons in any state. It is disabled with a plain-language reason when the mutation would block — for a bundled add-on that currently provides a system slot, the reason names the slots and says to select another provider first. The disabled state comes from the same decision function the mutation uses, so the two cannot disagree.
- **Confirmation copy** is the design note's, verbatim: grants, private provider links and settings are cleared; source files, Living Archive intake and review records, delegation packets, drafts and result artifacts are kept. Declining does nothing.
- **Result line** after the action is counts-only: how many grants were cleared, whether settings were deleted, that user data was retained. No ids, no values.
- **Stop-running-work hook (Q2).** The shell tracks the add-on work it starts itself — Logician checks and hooks — in a small in-flight registry; while one runs for that add-on, uninstall is blocked with a reason. The desktop shell cannot see or cancel bridge-side delegations, and the note now says so; the host-side running-delegation check lands with task 4.
- App wiring uses the synchronous state updater and the latest committed state; the returned audit record is displayed as counts and not yet persisted (task 4).

## Evidence

Head `b8ce1723` (2 commits on `47a610f5`: the change `44e376e2`, then a small commit for three review nits — an `aria-describedby` link and two test tightenings). The full gate ran outside the executor sandbox on `44e376e2`, mirroring every verify-alpha step; the focused suites and `tsc` re-ran on `b8ce1723`:

| Gate | Result |
|---|---|
| `vitest run` | **484 / 484** (dev: 462; +22 from this PR) |
| `npm run test:browser-first` | 1220 / 1220 |
| `tsc --noEmit`, `docs:check`, `test:docs` (233/233), `test:module-ownership`, `test:security-pipeline` (46/46), `repo:hygiene`, release-scope audit `--committed --strict` | clean |
| focused `vitest run src/modules/addons src/core` + `tsc` on `b8ce1723` | 206 / 206, clean |

Anti-false-green — seven mutations via `rig-mutate`, each restored byte-identical, each **red**: `withAddonWork` stops awaiting (count drops before the work settles); `stopRunningWork` always reports stopped; the confirmation gate is removed; the button ignores the block; `describeUninstallBlock` always allows; the App's Logician handler is unwrapped (caught by the source-contract test); a stale result is rendered for the wrong add-on.

Every new test was observed red before its implementation (executor's red runs are in the report), and the confirmation copy was verified equal to the design note's text after whitespace normalization.

## Process

Spec derived from the merged design note and the two prior tasks; single-reviewer spec check (Grok) before execution; fleet executor (codex); maintainer read the full handback; independent correctness review (DeepSeek, vendor ≠ author) — verdict in the PR comments.

Refs #180 (stays open for tasks 4–6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
