### PR TITLE
feat(bridge): uninstall-audit and running-work routes for the add-on lifecycle (#180 task 4)

### DIFF
--- a/browser-first/host/addon-delegation-host-service.mjs
+++ b/browser-first/host/addon-delegation-host-service.mjs
@@ -154,6 +154,18 @@ export function createAddonDelegationHostService(handlers = {}) {
       },
       {
         method: "POST",
+        path: "/addons/uninstall-audit",
+        requiredCapability: "addon-record-write",
+        handler: required("executeAddonUninstallAudit"),
+      },
+      {
+        method: "POST",
+        path: "/addons/running-work",
+        requiredCapability: "addon-record-read",
+        handler: required("executeAddonRunningWork"),
+      },
+      {
+        method: "POST",
         path: "/goals",
         requiredCapability: "addon-record-write",
         handler: required("executeGoalRecord"),

--- a/browser-first/host/addon-delegation-service.mjs
+++ b/browser-first/host/addon-delegation-service.mjs
@@ -498,6 +498,101 @@ export function createAddonDelegationService(dependencies) {
     return match ? match[1].trim() : "";
   }
 
+  function isPlainObject(value) {
+    return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+  }
+
+  const addonIdPattern = /^[a-z0-9][a-z0-9._-]{0,119}$/i;
+  const addonCapabilityPattern = /^[a-z0-9][a-z0-9._-]{0,63}$/i;
+  const uninstallAuditKeys = Object.freeze([
+    "actor",
+    "addonId",
+    "alsoDeleteUserDataOffered",
+    "at",
+    "clearedCapabilities",
+    "clearedPrivateProviderProfileIds",
+    "configDeleted",
+    "event",
+    "previousEnabled",
+    "previousInstalled",
+    "previousStatus",
+    "source",
+    "userDataRetained",
+  ]);
+  const installationStatuses = new Set([
+    "available",
+    "installed",
+    "enabled",
+    "disabled",
+    "degraded",
+    "update-available",
+    "incompatible",
+    "uninstalled",
+  ]);
+
+  function rejectUninstallAudit(reason) {
+    throw new Error(`Uninstall audit record rejected: ${reason}`);
+  }
+
+  function rejectRunningWork(reason) {
+    throw new Error(`Running-work query rejected: ${reason}`);
+  }
+
+  function hasExactKeys(payload, allowedKeys) {
+    const keys = Object.keys(payload);
+    const allowed = new Set(allowedKeys);
+    if (keys.some((key) => !allowed.has(key))) return "unexpected-keys";
+    if (allowedKeys.some((key) => !Object.hasOwn(payload, key))) return "missing-keys";
+    return "";
+  }
+
+  function validateCanonicalIsoTimestamp(value) {
+    if (typeof value !== "string") return false;
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) return false;
+    return parsed.toISOString() === value;
+  }
+
+  function validateUninstallAuditRecord(payload) {
+    if (!isPlainObject(payload)) rejectUninstallAudit("not-an-object");
+    const keyError = hasExactKeys(payload, uninstallAuditKeys);
+    if (keyError) rejectUninstallAudit(keyError);
+    if (payload.event !== "addonUninstalled") rejectUninstallAudit("event");
+    if (typeof payload.addonId !== "string" || !addonIdPattern.test(payload.addonId)) {
+      rejectUninstallAudit("addonId");
+    }
+    if (!["bundled", "sideload"].includes(payload.source)) rejectUninstallAudit("source");
+    if (!installationStatuses.has(payload.previousStatus)) rejectUninstallAudit("previousStatus");
+    if (
+      typeof payload.previousInstalled !== "boolean" ||
+      typeof payload.previousEnabled !== "boolean" ||
+      typeof payload.configDeleted !== "boolean" ||
+      typeof payload.alsoDeleteUserDataOffered !== "boolean"
+    ) {
+      rejectUninstallAudit("booleans");
+    }
+    if (payload.userDataRetained !== true) rejectUninstallAudit("userDataRetained");
+    if (payload.actor !== "human") rejectUninstallAudit("actor");
+    if (
+      !Array.isArray(payload.clearedCapabilities) ||
+      payload.clearedCapabilities.length > 64 ||
+      payload.clearedCapabilities.some((capability) => (
+        typeof capability !== "string" || !addonCapabilityPattern.test(capability)
+      ))
+    ) {
+      rejectUninstallAudit("clearedCapabilities");
+    }
+    if (
+      !Number.isInteger(payload.clearedPrivateProviderProfileIds) ||
+      payload.clearedPrivateProviderProfileIds < 0 ||
+      payload.clearedPrivateProviderProfileIds > 10_000
+    ) {
+      rejectUninstallAudit("clearedPrivateProviderProfileIds");
+    }
+    if (!validateCanonicalIsoTimestamp(payload.at)) rejectUninstallAudit("at");
+    return Object.fromEntries(uninstallAuditKeys.map((key) => [key, payload[key]]));
+  }
+
   function sectionFromMarkdown(content, heading) {
     const normalizedContent = String(content ?? "").replace(/\r\n?/g, "\n");
     const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -596,6 +691,68 @@ export function createAddonDelegationService(dependencies) {
     }
     delegations.sort((left, right) => String(right.updatedAt).localeCompare(String(left.updatedAt)));
     return { root: path.relative(userRoot(), delegationRoot()), delegations: delegations.slice(0, limit) };
+  }
+
+  async function executeAddonUninstallAudit(payload) {
+    const record = validateUninstallAuditRecord(payload);
+    const recordedAt = new Date().toISOString();
+    await appendAddonGovernanceAuditEntry({
+      ...record,
+      recordedAt,
+      recordedVia: "bridge",
+    });
+    return { recorded: true, addonId: record.addonId, recordedAt };
+  }
+
+  async function executeAddonRunningWork(payload) {
+    if (!isPlainObject(payload)) rejectRunningWork("not-an-object");
+    const keyError = hasExactKeys(payload, ["addonId"]);
+    if (keyError) rejectRunningWork(keyError);
+    if (typeof payload.addonId !== "string" || !addonIdPattern.test(payload.addonId)) {
+      rejectRunningWork("addonId");
+    }
+
+    const targetMap = new Map([
+      ["addon.hermes", ["hermes"]],
+      ["addon.opencode", ["opencode"]],
+    ]);
+    const targets = targetMap.get(payload.addonId) ?? [];
+    const running = [];
+    let queuedCount = 0;
+
+    for (const target of targets) {
+      const root = path.join(delegationRoot(), target);
+      const files = await listFilesRecursive(root, (filePath) => filePath.endsWith(".md"), 300);
+      for (const filePath of files) {
+        const [details, content] = await Promise.all([
+          stat(filePath).catch(() => null),
+          readFile(filePath, "utf8").catch(() => ""),
+        ]);
+        const status = (fieldFromMarkdown(content, "status") || "queued").toLowerCase();
+        if (status === "queued") {
+          queuedCount += 1;
+        }
+        if (status === "running") {
+          running.push({
+            id: fieldFromMarkdown(content, "id") || path.basename(filePath, ".md"),
+            target,
+            updatedAt: details?.mtime?.toISOString?.() ?? "",
+          });
+        }
+      }
+    }
+
+    const stopped = running.length === 0;
+    return {
+      addonId: payload.addonId,
+      targets,
+      running,
+      queuedCount,
+      stopped,
+      detail: stopped
+        ? "No running delegations for this add-on on the bridge."
+        : `${running.length} running delegation(s) for this add-on; cancel them or wait for them to finish before uninstalling.`,
+    };
   }
 
   async function executeHermesStatus(payload = {}) {
@@ -2395,6 +2552,8 @@ except BaseException as exc:
     executeAddonsStatus,
     executeAddonExecutionSettingsGet,
     executeAddonExecutionSettingsUpdate,
+    executeAddonUninstallAudit,
+    executeAddonRunningWork,
     executeHermesDashboardStatus,
     executeHermesDashboardStart,
     executeHermesDashboardStop,

--- a/browser-first/resonantos-side-panel-extension/src/lib/bridge-client.js
+++ b/browser-first/resonantos-side-panel-extension/src/lib/bridge-client.js
@@ -113,6 +113,8 @@ const BRIDGE_ROUTE_CAPABILITIES = Object.freeze({
   "POST /addons/draft/handoff": "addon-record-write",
   "POST /addons/delegate": "addon-record-write",
   "POST /addons/delegate/list": "addon-record-read",
+  "POST /addons/uninstall-audit": "addon-record-write",
+  "POST /addons/running-work": "addon-record-read",
   "POST /goals": "addon-record-write",
   "GET /settings/extension-prefs": "extension-prefs-read",
   "POST /settings/extension-prefs": "extension-prefs-write",

--- a/browser-first/test/addon-delegation-host-service.test.mjs
+++ b/browser-first/test/addon-delegation-host-service.test.mjs
@@ -27,6 +27,8 @@ const requiredHandlers = [
   "executeAddonDraftProviderHandoff",
   "executeDelegationRecord",
   "executeDelegationList",
+  "executeAddonUninstallAudit",
+  "executeAddonRunningWork",
   "executeGoalRecord",
 ];
 
@@ -63,6 +65,8 @@ test("add-on delegation host service owns add-on, delegation, draft, and goal ro
     "POST /addons/draft/handoff",
     "POST /addons/delegate",
     "POST /addons/delegate/list",
+    "POST /addons/uninstall-audit",
+    "POST /addons/running-work",
     "POST /goals",
   ]);
   assert.equal(routes.get("POST /addons/execution-settings").requiredCapability, "addon-execution-settings-write");
@@ -86,6 +90,8 @@ test("add-on delegation host service owns add-on, delegation, draft, and goal ro
   assert.equal(routes.get("POST /addons/draft/handoff").requiredCapability, "addon-record-write");
   assert.equal(routes.get("POST /addons/delegate").requiredCapability, "addon-record-write");
   assert.equal(routes.get("POST /addons/delegate/list").requiredCapability, "addon-record-read");
+  assert.equal(routes.get("POST /addons/uninstall-audit").requiredCapability, "addon-record-write");
+  assert.equal(routes.get("POST /addons/running-work").requiredCapability, "addon-record-read");
   assert.equal(routes.get("POST /goals").requiredCapability, "addon-record-write");
 });
 

--- a/browser-first/test/addon-delegation-service-error-handling.test.mjs
+++ b/browser-first/test/addon-delegation-service-error-handling.test.mjs
@@ -7,6 +7,7 @@ import path from "node:path";
 import test from "node:test";
 
 import { createAddonDelegationService } from "../host/addon-delegation-service.mjs";
+import { listFilesRecursive } from "../host/browser-first-host-utils.mjs";
 import {
   hermesPythonRuntimeDiagnostics,
   hermesRuntimeDiagnostics,
@@ -40,7 +41,7 @@ function createService(root, overrides = {}) {
     hermesCommand: overrides.hermesCommand ?? (() => null),
     hermesHome: overrides.hermesHome ?? (() => path.join(root, "HermesHome")),
     hermesPythonRuntime: overrides.hermesPythonRuntime ?? (() => null),
-    listFilesRecursive: async () => [],
+    listFilesRecursive: overrides.listFilesRecursive ?? (async () => []),
     memoryRoot: () => path.join(root, "Memory"),
     opencodeCommand: overrides.opencodeCommand ?? (() => null),
     opencodeRuntimeDiagnostics: overrides.opencodeRuntimeDiagnostics ?? (() => ({ installed: false, command: null })),
@@ -116,6 +117,32 @@ async function readAuditEntries(root) {
     .split("\n")
     .filter(Boolean)
     .map((line) => JSON.parse(line));
+}
+
+function validUninstallAuditRecord(overrides = {}) {
+  return {
+    actor: "human",
+    addonId: "addon.hermes",
+    alsoDeleteUserDataOffered: false,
+    at: "2026-09-07T00:00:00.000Z",
+    clearedCapabilities: ["agent-delegation", "archive-read"],
+    clearedPrivateProviderProfileIds: 2,
+    configDeleted: true,
+    event: "addonUninstalled",
+    previousEnabled: true,
+    previousInstalled: true,
+    previousStatus: "enabled",
+    source: "bundled",
+    userDataRetained: true,
+    ...overrides,
+  };
+}
+
+async function rewriteDelegationStatus(root, delegation, statusValue) {
+  const filePath = path.join(root, delegation.path);
+  const content = await readFile(filePath, "utf8");
+  await writeFile(filePath, content.replace(/^- status:\s*.+$/mi, `- status: ${statusValue}`));
+  return filePath;
 }
 
 async function withTempService(fn) {
@@ -232,6 +259,184 @@ test("add-on execution setting updates append an operator audit trail only for r
     ]);
     assert.deepEqual(entries.map((entry) => entry.addonId), ["opencode", "opencode", "opencode"]);
     assert.ok(entries.every((entry) => entry.field === "localCliExecution"));
+  });
+});
+
+test("add-on uninstall appends governance audit entry without secrets", async () => {
+  await withTempService(async (service, root) => {
+    const record = validUninstallAuditRecord();
+
+    const result = await service.executeAddonUninstallAudit(record);
+
+    assert.equal(result.recorded, true);
+    assert.equal(result.addonId, "addon.hermes");
+    assert.doesNotThrow(() => new Date(result.recordedAt).toISOString());
+    const [entry] = await readAuditEntries(root);
+    assert.deepEqual(Object.keys(entry).sort(), [
+      "actor",
+      "addonId",
+      "alsoDeleteUserDataOffered",
+      "at",
+      "clearedCapabilities",
+      "clearedPrivateProviderProfileIds",
+      "configDeleted",
+      "event",
+      "previousEnabled",
+      "previousInstalled",
+      "previousStatus",
+      "recordedAt",
+      "recordedVia",
+      "source",
+      "userDataRetained",
+    ].sort());
+    assert.deepEqual(entry, {
+      ...record,
+      recordedAt: result.recordedAt,
+      recordedVia: "bridge",
+    });
+    const serialized = JSON.stringify(entry);
+    assert.doesNotMatch(serialized, /\/[A-Za-z0-9._-]+/);
+    assert.doesNotMatch(serialized, /sk-[a-z0-9_-]+/i);
+    assert.doesNotMatch(serialized, /api[_-]?key|token|secret/i);
+  });
+});
+
+test("uninstall audit rejects malformed records and appends nothing", async () => {
+  await withTempService(async (service, root) => {
+    const cases = [
+      ["extra key", { ...validUninstallAuditRecord(), configValues: { secret: "sk-extra" } }, ["configValues", "sk-extra"]],
+      ["missing actor", (() => {
+        const record = validUninstallAuditRecord();
+        delete record.actor;
+        return record;
+      })(), ["actor"]],
+      ["path addon id", validUninstallAuditRecord({ addonId: "../x" }), ["../x"]],
+      ["path capability", validUninstallAuditRecord({ clearedCapabilities: ["/tmp/x"] }), ["/tmp/x"]],
+      ["too many capabilities", validUninstallAuditRecord({ clearedCapabilities: Array.from({ length: 65 }, (_, index) => `cap-${index}`) }), ["cap-64"]],
+      ["profile ids array", validUninstallAuditRecord({ clearedPrivateProviderProfileIds: ["id-1"] }), ["id-1"]],
+      ["profile ids float", validUninstallAuditRecord({ clearedPrivateProviderProfileIds: 1.5 }), ["1.5"]],
+      ["user data deleted", validUninstallAuditRecord({ userDataRetained: false }), ["false"]],
+      ["agent actor", validUninstallAuditRecord({ actor: "agent" }), ["agent"]],
+      ["wrong event", validUninstallAuditRecord({ event: "delegationExecuted" }), ["delegationExecuted"]],
+      ["garbage date", validUninstallAuditRecord({ at: "yesterday" }), ["yesterday"]],
+      ["path date", validUninstallAuditRecord({ at: "/Users/x" }), ["/Users/x"]],
+      ["non-canonical date", validUninstallAuditRecord({ at: "2026-09-07T00:00:00Z" }), ["2026-09-07T00:00:00Z"]],
+      ["array payload", [validUninstallAuditRecord()], ["addon.hermes"]],
+    ];
+
+    for (const [name, payload, forbiddenValues] of cases) {
+      await assert.rejects(
+        () => service.executeAddonUninstallAudit(payload),
+        (error) => {
+          assert.match(error.message, /^Uninstall audit record rejected: /, name);
+          for (const value of forbiddenValues) {
+            assert.equal(error.message.includes(value), false, `${name} leaked ${value}`);
+          }
+          return true;
+        },
+      );
+    }
+
+    const auditPath = path.join(root, "BrowserFirst", "Settings", "addon-governance-audit.jsonl");
+    await assert.rejects(() => access(auditPath), /ENOENT/);
+  });
+});
+
+test("running-work reports running delegations per add-on", async () => {
+  await withTempService(async (_service, root) => {
+    const service = createService(root, { listFilesRecursive });
+    const running = await service.executeDelegationRecord({
+      target: "hermes",
+      mission: "Keep one Hermes delegation marked as running.",
+    });
+    const queued = await service.executeDelegationRecord({
+      target: "hermes",
+      mission: "Keep one Hermes delegation queued.",
+    });
+    const completed = await service.executeDelegationRecord({
+      target: "hermes",
+      mission: "Keep one Hermes delegation completed.",
+    });
+    await rewriteDelegationStatus(root, running, "running");
+    await rewriteDelegationStatus(root, queued, "queued");
+    await rewriteDelegationStatus(root, completed, "completed");
+
+    const hermes = await service.executeAddonRunningWork({ addonId: "addon.hermes" });
+    const opencode = await service.executeAddonRunningWork({ addonId: "addon.opencode" });
+    const obsidian = await service.executeAddonRunningWork({ addonId: "addon.obsidian" });
+
+    assert.equal(hermes.addonId, "addon.hermes");
+    assert.deepEqual(hermes.targets, ["hermes"]);
+    assert.equal(hermes.running.length, 1);
+    assert.equal(hermes.running[0].id, running.id);
+    assert.equal(hermes.running[0].target, "hermes");
+    assert.doesNotThrow(() => new Date(hermes.running[0].updatedAt).toISOString());
+    assert.equal(JSON.stringify(hermes.running).includes(root), false);
+    assert.equal(JSON.stringify(hermes.running).includes("/BrowserFirst/Delegations"), false);
+    assert.equal(hermes.queuedCount, 1);
+    assert.equal(hermes.stopped, false);
+    assert.equal(hermes.detail, "1 running delegation(s) for this add-on; cancel them or wait for them to finish before uninstalling.");
+    assert.deepEqual(opencode.running, []);
+    assert.equal(opencode.stopped, true);
+    assert.deepEqual(obsidian.targets, []);
+    assert.deepEqual(obsidian.running, []);
+    assert.equal(obsidian.stopped, true);
+  });
+});
+
+test("running-work sees an old running packet behind newer ones", async () => {
+  await withTempService(async (_service, root) => {
+    const service = createService(root, { listFilesRecursive });
+    const oldRunning = await service.executeDelegationRecord({
+      target: "hermes",
+      mission: "Keep the old Hermes packet running behind newer packets.",
+    });
+    await rewriteDelegationStatus(root, oldRunning, "running");
+
+    for (let index = 0; index < 45; index += 1) {
+      const completed = await service.executeDelegationRecord({
+        target: "hermes",
+        mission: `Create newer completed Hermes packet ${index}.`,
+      });
+      await rewriteDelegationStatus(root, completed, "completed");
+    }
+
+    const result = await service.executeAddonRunningWork({ addonId: "addon.hermes" });
+
+    assert.equal(result.stopped, false);
+    assert.equal(result.running.length, 1);
+    assert.equal(result.running[0].id, oldRunning.id);
+  });
+});
+
+test("running-work does not treat blocked or cancelled as running", async () => {
+  await withTempService(async (_service, root) => {
+    const service = createService(root, { listFilesRecursive });
+    const blocked = await service.executeDelegationRecord({
+      target: "opencode",
+      mission: "Keep one OpenCode delegation blocked.",
+    });
+    const cancelled = await service.executeDelegationRecord({
+      target: "opencode",
+      mission: "Keep one OpenCode delegation cancelled.",
+    });
+    await rewriteDelegationStatus(root, blocked, "blocked");
+    await rewriteDelegationStatus(root, cancelled, "cancelled");
+
+    const result = await service.executeAddonRunningWork({ addonId: "addon.opencode" });
+
+    assert.deepEqual(result.running, []);
+    assert.equal(result.queuedCount, 0);
+    assert.equal(result.stopped, true);
+  });
+});
+
+test("running-work rejects unknown keys", async () => {
+  await withTempService(async (service) => {
+    await assert.rejects(
+      () => service.executeAddonRunningWork({ addonId: "addon.hermes", target: "hermes" }),
+      /^Error: Running-work query rejected: unexpected-keys$/,
+    );
   });
 });
 

--- a/browser-first/test/addon-delegation-service-error-handling.test.mjs
+++ b/browser-first/test/addon-delegation-service-error-handling.test.mjs
@@ -322,6 +322,12 @@ test("uninstall audit rejects malformed records and appends nothing", async () =
       ["path date", validUninstallAuditRecord({ at: "/Users/x" }), ["/Users/x"]],
       ["non-canonical date", validUninstallAuditRecord({ at: "2026-09-07T00:00:00Z" }), ["2026-09-07T00:00:00Z"]],
       ["array payload", [validUninstallAuditRecord()], ["addon.hermes"]],
+      ["bad source", validUninstallAuditRecord({ source: "marketplace" }), ["marketplace"]],
+      ["bad previous status", validUninstallAuditRecord({ previousStatus: "installing" }), ["installing"]],
+      ["non-boolean previousInstalled", validUninstallAuditRecord({ previousInstalled: "yes" }), ["yes"]],
+      ["non-boolean configDeleted", validUninstallAuditRecord({ configDeleted: 1 }), []],
+      ["negative profile count", validUninstallAuditRecord({ clearedPrivateProviderProfileIds: -1 }), ["-1"]],
+      ["oversized profile count", validUninstallAuditRecord({ clearedPrivateProviderProfileIds: 10_001 }), ["10001"]],
     ];
 
     for (const [name, payload, forbiddenValues] of cases) {
@@ -357,9 +363,14 @@ test("running-work reports running delegations per add-on", async () => {
       target: "hermes",
       mission: "Keep one Hermes delegation completed.",
     });
+    const failed = await service.executeDelegationRecord({
+      target: "hermes",
+      mission: "Keep one Hermes delegation failed.",
+    });
     await rewriteDelegationStatus(root, running, "running");
     await rewriteDelegationStatus(root, queued, "queued");
     await rewriteDelegationStatus(root, completed, "completed");
+    await rewriteDelegationStatus(root, failed, "failed");
 
     const hermes = await service.executeAddonRunningWork({ addonId: "addon.hermes" });
     const opencode = await service.executeAddonRunningWork({ addonId: "addon.opencode" });
@@ -436,6 +447,18 @@ test("running-work rejects unknown keys", async () => {
     await assert.rejects(
       () => service.executeAddonRunningWork({ addonId: "addon.hermes", target: "hermes" }),
       /^Error: Running-work query rejected: unexpected-keys$/,
+    );
+    await assert.rejects(
+      () => service.executeAddonRunningWork(["addon.hermes"]),
+      /^Error: Running-work query rejected: not-an-object$/,
+    );
+    await assert.rejects(
+      () => service.executeAddonRunningWork({ addonId: "../hermes" }),
+      (error) => {
+        assert.match(error.message, /^Running-work query rejected: addonId$/);
+        assert.equal(error.message.includes("../"), false);
+        return true;
+      },
     );
   });
 });

--- a/browser-first/test/bridge-get-routes-require-capability.test.mjs
+++ b/browser-first/test/bridge-get-routes-require-capability.test.mjs
@@ -125,6 +125,8 @@ function createRoutes(root) {
     executeAddonDraftProviderHandoff: async () => ({}),
     executeDelegationRecord: async () => ({}),
     executeDelegationList: async () => ({}),
+    executeAddonUninstallAudit: async () => ({}),
+    executeAddonRunningWork: async () => ({}),
     executeGoalRecord: async () => ({}),
   });
   const prefs = createExtensionPrefsHostService({ userRoot: () => root });

--- a/browser-first/test/bridge-route-capability-audit.test.mjs
+++ b/browser-first/test/bridge-route-capability-audit.test.mjs
@@ -76,6 +76,8 @@ const addonHandlers = [
   "executeAddonDraftProviderHandoff",
   "executeDelegationRecord",
   "executeDelegationList",
+  "executeAddonUninstallAudit",
+  "executeAddonRunningWork",
   "executeGoalRecord",
 ];
 

--- a/docs/addons/addon-lifecycle-uninstall-design.md
+++ b/docs/addons/addon-lifecycle-uninstall-design.md
@@ -188,6 +188,11 @@ The controller-level mutation should return enough structured detail for the
 bridge/UI caller to append this audit entry without putting secrets or raw user
 content into the log.
 
+The bridge exposes `POST /addons/uninstall-audit` with `addon-record-write` to
+persist the shell's audit record and `POST /addons/running-work` with
+`addon-record-read` to report persisted running delegation packets before
+uninstall.
+
 ## Kernel-adjacent add-ons (ADR-026)
 
 ADR-026 says the minimal kernel owns add-on registry, installer, lifecycle,
@@ -239,6 +244,12 @@ when the sideloaded add-on provides a system slot.
    Recommended default: yes, attempt a best-effort stop before the state
    mutation and block uninstall if the runtime cannot reach a safe stopped
    state. **Answered 2026-09-07 (release owner): yes — implemented in task 2.** Scope of the stop hook in task 3: the desktop shell has no delegation-cancel primitive, and task workspaces are listable but carry no run status; the in-flight registry covers Logician script and hook runs, browser engine install, and Hermes install. The Hermes dashboard, OpenCode service start/stop, OpenCode task execution from the Delegation workspace, task-workspace creation from chat, and browser sessions are not stopped by uninstall in task 3; the host-side running-delegation check lands with task 4.
+   The bridge's running-delegation signal is the persisted packet status, not
+   process liveness: a crash after a packet is marked running and before it is
+   finalised leaves it running, the route keeps reporting it, and uninstall
+   stays blocked until a human cancels it through the existing Hermes or
+   OpenCode cancel routes. Packets are never auto-expired. Engineer delegations
+   have no catalog add-on and never block an uninstall.
 3. Which surface owns active system-slot provider selection?
    Recommended default: add an explicit typed field under shared runtime state
    before enforcing kernel-adjacent uninstall blocking. **Answered 2026-09-07 (release owner): yes — implemented in task 2.**
@@ -286,7 +297,10 @@ when the sideloaded add-on provides a system slot.
    - TDD first: add `add-on uninstall appends governance audit entry without secrets` and `uninstall audit route requires addon-record-write`.
    - Implementation: add a narrow audit-write route or reuse an existing
      add-on record-write path to append `addonUninstalled` entries to
-     `addon-governance-audit.jsonl`.
+     `addon-governance-audit.jsonl`. **Implemented in task 4 (2026-09-07):
+     bridge routes only. Persisting the shell's record and consulting the
+     running-delegation check from the desktop shell depend on #374 (the
+     web-mode shell sends no capability tokens).**
 
 5. Optional user-data deletion flow (M)
    - Files: `src/modules/addons/AddOnsWorkspace.tsx`,


### PR DESCRIPTION
## Summary

Build-plan **task 4** of the uninstall design note (#180): the bridge side of audit persistence and the running-delegation check the desktop shell cannot make itself.

- **`POST /addons/uninstall-audit`** (capability `addon-record-write`) accepts the counts-only uninstall record produced by the shell's `uninstallAddon` and appends it to the add-on governance audit log with the server's timestamp and `recordedVia: "bridge"`. Validation is strict and fail-closed: every field is checked against its allowed shape, arrays are bounded, and any extra key is rejected, so no path, config value, or identifier can ride into the log. Rejected bodies are never logged.
- **`POST /addons/running-work`** (capability `addon-record-read`) maps an add-on id to its delegation targets and reports running delegations from the bridge's own records, with a queued count and a plain-language detail. This is the host-side half of the stop-before-uninstall rule.
- **Dependency, stated in the design note:** the desktop shell's web transport sends no capability tokens (#374, in the beta.2 milestone). Until #374 lands, the shell cannot call either route; nothing in `src/` changes here.

## Evidence

Head `1e3288cb` (2 commits on `3fac77b6`: the change `42c71910`, then a test-only commit closing the review's coverage gaps). Full gate outside the executor sandbox on `42c71910`, mirroring every verify-alpha step; the four route/service suites re-ran on `1e3288cb`:

| Gate | Result |
|---|---|
| `npm run test:browser-first` | **1226 / 1226** (dev: 1220; +6 from this PR) |
| `vitest run` | 484 / 484 |
| `tsc --noEmit`, `docs:check`, `test:docs` (233/233), `test:module-ownership`, `test:security-pipeline` (46/46), `repo:hygiene`, release-scope audit `--committed --strict` | clean |
| focused route/service suites on `1e3288cb` | green |

Anti-false-green — seven mutations via `rig-mutate`, each restored byte-identical, each **red**: the key allowlist check is removed; the canonical-timestamp check is weakened; `blocked` packets count as running; the audit route's capability is swapped to read; the `recordedVia` marker is dropped; `stopped` is forced true; the `source` enum check is dropped (added with the review's coverage fix).

Executor's TDD red runs are in the report; the two CLI smoke tests that a nested sandbox blocks pass in the full suite here (1226/1226).

## Process

Spec derived from the merged design note and tasks 1–3; single-reviewer spec check (Grok) before execution; fleet executor (codex); maintainer read the full handback; independent security + correctness review (DeepSeek, vendor ≠ author) — verdict in the PR comments. Host code: deploy = bridge restart, then a live probe of both routes with a capability token.

Refs #180 (stays open for tasks 5–6 and the #374-dependent shell wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
