### PR TITLE
security(dev): deny the generated bridge config and user data in the Vite dev server (#429 part 1)

### DIFF
--- a/docs/browser-first-bridge-setup-runbook.md
+++ b/docs/browser-first-bridge-setup-runbook.md
@@ -25,6 +25,11 @@ Chrome (extension side panel)  --HTTPS/h1-->  Caddy :19443  --HTTP-->  bridge :4
 - The bridge can bind to `0.0.0.0` for LAN/Tailscale (`RESONANTOS_BRIDGE_HOST`);
   gate clients with `RESONANTOS_BRIDGE_ALLOWED_IPS` (e.g. `192.168.0.0/16,100.64.0.0/10`).
 
+## Dev server hardening (#429)
+
+The dev server refuses to serve `bridge-config.generated.js` and anything under `ResonantOS_User/`.
+The exposure only existed while `npm run dev` was running.
+
 ## The five first-run bug classes
 
 | # | Symptom | Root cause | Fix / status |

--- a/src/dev-server-policy.test.ts
+++ b/src/dev-server-policy.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { DEV_SERVER_FS_DENY } from "./dev-server-policy";
+
+describe("dev server filesystem policy", () => {
+  it("denies generated bridge credentials and local user data", () => {
+    expect(DEV_SERVER_FS_DENY).toEqual(expect.arrayContaining([
+      "**/bridge-config.generated.js",
+      "**/ResonantOS_User/**",
+    ]));
+  });
+
+  it("preserves all four Vite default deny patterns", () => {
+    expect(DEV_SERVER_FS_DENY).toEqual(expect.arrayContaining([
+      ".env",
+      ".env.*",
+      "*.{crt,pem}",
+      "**/.git/**",
+    ]));
+  });
+
+  it("wires the deny list into a strict Vite server fs block", () => {
+    const source = readFileSync(resolve(process.cwd(), "vite.config.ts"), "utf8");
+    const fsBlock = source.match(/\bserver\s*:\s*\{\s*[^{}]*\bfs\s*:\s*\{([^{}]*)\}/)?.[1];
+
+    expect(fsBlock).toBeDefined();
+    expect(fsBlock).toMatch(/\bdeny\s*:\s*DEV_SERVER_FS_DENY\b/);
+    expect(fsBlock).toMatch(/\bstrict\s*:\s*true\b/);
+  });
+});

--- a/src/dev-server-policy.ts
+++ b/src/dev-server-policy.ts
@@ -1,0 +1,9 @@
+// Keep Vite's default deny patterns alongside the local-state protections (#429).
+export const DEV_SERVER_FS_DENY: string[] = [
+  "**/bridge-config.generated.js",
+  "**/ResonantOS_User/**",
+  ".env",
+  ".env.*",
+  "*.{crt,pem}",
+  "**/.git/**",
+];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
+import { DEV_SERVER_FS_DENY } from "./src/dev-server-policy";
 
 export default defineConfig({
   plugins: [react()],
@@ -31,6 +32,10 @@ export default defineConfig({
     host: "127.0.0.1",
     port: 1430,
     strictPort: true,
+    fs: {
+      strict: true,
+      deny: DEV_SERVER_FS_DENY,
+    },
     watch: {
       ignored: [
         "**/dist/**",


### PR DESCRIPTION
## Summary

Part 1 of #429. While `npm run dev` is running, the Vite dev server served `browser-first/resonantos-side-panel-extension/src/bridge-config.generated.js` (bridge token and capability-bootstrap token) to any local process, both by path and through `/@fs`, defeating the file's 0600 mode. Loopback is machine-wide, so this reached other local OS users.

- `vite.config.ts` now sets `server.fs.strict` and a deny list that adds `**/bridge-config.generated.js` and `**/ResonantOS_User/**` to Vite's defaults (kept explicitly so nothing is lost).
- The deny list lives in `src/dev-server-policy.ts` so a Vitest test pins it, and a source-contract test pins that `vite.config.ts` actually uses it under `fs:` with `strict: true`.
- Runbook note in the web-mode shell section.

Part 2 of #429 (CSP-compatible, opt-in delivery of the config to the shell page) stays open.

## Evidence

Gate on `7ebe3f16` (rebased onto `4aa67237`), mirroring `scripts/verify-alpha.mjs`: vitest 487 / 487 (44 files), tsc clean, `npm run build` ok, `test:browser-first` 1240 / 1240, `docs:check` + `test:docs` 233 / 233, module-ownership, security-pipeline, `repo:hygiene`, security run-check, release-scope audit `--committed --strict` all green.

Anti-false-green: three guard mutations, each proven non-vacuous with `rig-mutate` and restored byte-identical: deny entries removed, `strict` flipped to false, deny list not wired.

Independent review (Grok, security + correctness lenses): **CONFIRM**. Verified against the installed Vite 6.4.3 that `server.fs.deny` matches absolute paths for both the plain URL and the `/@fs` form, that setting `deny` replaces the default array (so the four defaults must be, and are, kept), and that the source-contract pin is deliberately strict. One nit accepted as designed.

Live proof (dev server started from the branch with the real generated config staged, then removed):

```
PASS  (1) dev server answered on 127.0.0.1:1430
PASS  (2) generated config by path -> HTTP 403, secret keys in body: false
PASS  (3) generated config via /@fs -> HTTP 403, secret keys in body: false
PASS  (4) ResonantOS_User via /@fs -> HTTP 403 (denied or outside root)
PASS  (5) app module still served -> HTTP 200
```

Before the change the same two requests returned HTTP 200 with both token keys in the body (verified 2026-09-08, recorded on #429).

## Process

Resonant-Rig standard tier (security-adjacent, small): executor codex (gpt-6-astra); deterministic gates mirroring `verify-alpha`; guard mutations; one independent reviewer (Grok) with security + correctness lenses; live proof that starts the dev server and gets HTTP 403 for both request forms while the app module still serves.

Refs #374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
