### PR TITLE
fix(shell): bootstrap capability tokens in the web-mode transport (#374)

### DIFF
--- a/docs/browser-first-bridge-setup-runbook.md
+++ b/docs/browser-first-bridge-setup-runbook.md
@@ -140,6 +140,29 @@ Residuals:
 - The Hermes dashboard server and OpenCode server are not confined.
 - Cross-platform isolation is a separate ADR.
 
+## Web-mode shell transport (#374)
+
+The shell transport (`src/core/web-transport.ts`) requests only
+`provider-diagnostics-read` and `provider-model-invoke` from
+`POST /api/capability-tokens`, using the bridge token and capability-bootstrap
+token in `globalThis.__RESONANTOS_BRIDGE_CONFIG__`. It memoizes the scoped tokens,
+shares an in-flight bootstrap between concurrent calls, and attaches the token
+required by each route. Failed bootstraps are not cached.
+
+A capability-missing 403 triggers exactly one re-bootstrap and route retry.
+This recovers from capability-token rotation while the bridge and bootstrap
+tokens remain valid. After a full bridge restart, the caller must refresh
+`globalThis.__RESONANTOS_BRIDGE_CONFIG__` from the regenerated config; the
+transport reads it on every call and a changed URL or either credential triggers
+a fresh bootstrap. Other 403s and 401s do not trigger retries. Tokens never appear
+in transport-generated error messages.
+
+Nothing delivers `__RESONANTOS_BRIDGE_CONFIG__` to a browser page yet. Browser
+use also requires the operator's CORS opt-in at the bridge through
+`RESONANTOS_BRIDGE_ALLOWED_ORIGINS`. Config delivery and browser-origin setup
+are tracked in #429, together with the dev-server exposure warning: while
+`npm run dev` runs, the generated config file is served to local processes.
+
 ## Live SDK lane
 
 `npm run test:browser-first:live-sdk` proves the browser-first bridge and SDK-facing add-on routes work together in an isolated live run: capability bootstrap covers the extension allowlist, OpenCode serve uses a credentialed ephemeral loopback port, execution settings gate local CLI execution, public add-on manifests remain structurally valid, and the Settings Overview cards call capability-mapped bridge routes without 403s.

--- a/src/core/web-transport.test.ts
+++ b/src/core/web-transport.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as transport from "./web-transport";
+
+const baseUrl = "http://127.0.0.1:47773";
+const diagnostics = "provider_diagnostics";
+const chat = "provider_service_chat_completion";
+const capabilityHeader = "X-ResonantOS-Bridge-Capability-Token";
+const capabilityError = "Bridge route requires provider-diagnostics-read capability.";
+const issuedTokens = {
+  "provider-diagnostics-read": "diagnostics-token-test",
+  "provider-model-invoke": "model-token-test",
+};
+const secrets = ["bridge-token-test", "bootstrap-token-test", ...Object.values(issuedTokens), "fresh-token-test"];
+type Config = { bridgeUrl?: string; httpsBridgeUrl?: string; bridgeToken?: string; capabilityBootstrapToken?: string };
+const globals = globalThis as typeof globalThis & { __RESONANTOS_BRIDGE_CONFIG__?: Config };
+let config: Config;
+const fetchMock = vi.fn<typeof fetch>();
+const response = (payload: unknown, status = 200) => new Response(JSON.stringify(payload), { status });
+const bootstrap = (tokens: unknown = issuedTokens) => response({ ok: true, capabilityTokens: tokens });
+const calls = () => fetchMock.mock.calls;
+const bootstrapCalls = () => calls().filter(([url]) => String(url).endsWith("/api/capability-tokens"));
+const routeCalls = () => calls().filter(([url]) => !String(url).endsWith("/api/capability-tokens"));
+const headers = (call: (typeof fetchMock.mock.calls)[number]) => new Headers(call[1]?.headers);
+const paths = () => calls().map(([url]) => new URL(String(url)).pathname);
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => { resolve = done; });
+  return { promise, resolve };
+};
+
+async function expectSafeError(promise: Promise<unknown>, message: string) {
+  const error = await promise.then(() => undefined, (reason: unknown) => reason);
+  expect(error).toBeInstanceOf(Error);
+  expect((error as Error).message).toBe(message);
+  for (const secret of secrets) expect((error as Error).message).not.toContain(secret);
+}
+
+beforeEach(() => {
+  config = { bridgeUrl: baseUrl, bridgeToken: "bridge-token-test", capabilityBootstrapToken: "bootstrap-token-test" };
+  vi.stubGlobal("__RESONANTOS_BRIDGE_CONFIG__", config);
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+  transport.__resetWebTransportForTests();
+  fetchMock.mockImplementation(async (url) => String(url).endsWith("/api/capability-tokens")
+    ? bootstrap() : response({ ok: true }));
+});
+afterEach(() => vi.unstubAllGlobals());
+
+describe("web-mode capability transport", () => {
+  it("D1 bootstraps once and reuses scoped diagnostics tokens", async () => {
+    await transport.webInvoke(diagnostics);
+    await transport.webInvoke(diagnostics);
+    expect(bootstrapCalls()).toHaveLength(1);
+    const call = bootstrapCalls()[0];
+    expect(call[0]).toBe(`${baseUrl}/api/capability-tokens`);
+    expect(call[1]?.method).toBe("POST");
+    expect(Object.fromEntries(headers(call))).toEqual({
+      "content-type": "application/json",
+      "x-resonantos-bridge-token": "bridge-token-test",
+      "x-resonantos-capability-bootstrap-token": "bootstrap-token-test",
+    });
+    expect(JSON.parse(String(call[1]?.body))).toEqual({ capabilities: transport.WEB_TRANSPORT_CAPABILITIES });
+    expect(routeCalls()).toHaveLength(2);
+    for (const route of routeCalls()) {
+      expect(headers(route).get(capabilityHeader)).toBe(issuedTokens["provider-diagnostics-read"]);
+      expect(headers(route).get("X-ResonantOS-Bridge-Token")).toBe("bridge-token-test");
+    }
+  });
+
+  it("D2 D17 preserves chat mapping and uses only the model token", async () => {
+    const args = { model: "test-model", reasoningEffort: "high", systemPrompt: "test prompt", messages: [{ role: "user", content: "hi" }] };
+    fetchMock.mockImplementation(async (url) => String(url).endsWith("/api/capability-tokens")
+      ? bootstrap() : response({ ok: true, reply: "test reply" }));
+    expect(await transport.webInvoke(chat, args)).toBe("test reply");
+    const call = routeCalls()[0];
+    expect(headers(call).get(capabilityHeader)).toBe(issuedTokens["provider-model-invoke"]);
+    expect(headers(call).get("Content-Type")).toBe("application/json");
+    expect(call[0]).toBe(`${baseUrl}/augmentor/chat`);
+    expect(call[1]?.method).toBe("POST");
+    expect(JSON.parse(String(call[1]?.body))).toEqual({ workload: "augmentor-chat", surface: "react-shell", model: args.model, thinkingDepth: "high", systemPrompt: args.systemPrompt, messages: args.messages });
+  });
+
+  it("D3 D7 omits bootstrap without its secret and throws the bridge error verbatim", async () => {
+    delete config.capabilityBootstrapToken;
+    fetchMock.mockImplementation(async () => response({ ok: false, error: capabilityError }, 403));
+    await expectSafeError(transport.webInvoke(diagnostics), capabilityError);
+    expect(bootstrapCalls()).toHaveLength(0);
+    for (const call of routeCalls()) expect(headers(call).has(capabilityHeader)).toBe(false);
+    expect(routeCalls()).toHaveLength(2);
+  });
+
+  it("D4 D18 does not cache a 500 bootstrap or expose its failure details", async () => {
+    fetchMock.mockImplementation(async (url) => String(url).endsWith("/api/capability-tokens")
+      ? response({ ok: false, error: secrets.join(" ") }, 500)
+      : response({ ok: false, error: "Provider unavailable." }, 500));
+    await expectSafeError(transport.webInvoke(diagnostics), "Provider unavailable.");
+    await expectSafeError(transport.webInvoke(diagnostics), "Provider unavailable.");
+    expect(bootstrapCalls()).toHaveLength(2);
+    expect(routeCalls()).toHaveLength(2);
+    for (const call of routeCalls()) expect(headers(call).has(capabilityHeader)).toBe(false);
+  });
+
+  it("D5 recovers capability-token rotation with one bootstrap and route retry", async () => {
+    fetchMock.mockResolvedValueOnce(bootstrap())
+      .mockResolvedValueOnce(response({ ok: false, error: capabilityError }, 403))
+      .mockResolvedValueOnce(bootstrap({ "provider-diagnostics-read": "fresh-token-test" }))
+      .mockResolvedValueOnce(response({ ok: true, status: "ready" }));
+    expect(await transport.webInvoke(diagnostics)).toEqual({ ok: true, status: "ready" });
+    expect(paths()).toEqual(["/api/capability-tokens", "/providers/status", "/api/capability-tokens", "/providers/status"]);
+    expect(headers(routeCalls()[0]).get(capabilityHeader)).toBe(issuedTokens["provider-diagnostics-read"]);
+    expect(headers(routeCalls()[1]).get(capabilityHeader)).toBe("fresh-token-test");
+  });
+
+  it("D6 D7 stops after the second capability 403 without leaking any token", async () => {
+    fetchMock.mockImplementation(async (url) => String(url).endsWith("/api/capability-tokens")
+      ? bootstrap() : response({ ok: false, error: capabilityError }, 403));
+    await expectSafeError(transport.webInvoke(diagnostics), capabilityError);
+    expect(bootstrapCalls()).toHaveLength(2);
+    expect(routeCalls()).toHaveLength(2);
+  });
+
+  it("D8 rejects an unknown command before any network access", async () => {
+    await expectSafeError(transport.webInvoke("x"), "Runtime command 'x' is not available in the browser-first Chrome extension alpha.");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("D9 derives sorted unique capabilities from a copied route map", () => {
+    expect(transport.WEB_TRANSPORT_CAPABILITIES).toEqual(["provider-diagnostics-read", "provider-model-invoke"]);
+    const routes = transport.__webTransportRoutesForTests();
+    expect(transport.WEB_TRANSPORT_CAPABILITIES).toEqual([...new Set(routes.map((route) => route.capability))].sort());
+    expect(routes).toEqual([
+      { command: diagnostics, method: "GET", path: "/providers/status", capability: "provider-diagnostics-read" },
+      { command: chat, method: "POST", path: "/augmentor/chat", capability: "provider-model-invoke" },
+    ]);
+    routes[0].capability = "changed-copy";
+    expect(transport.__webTransportRoutesForTests()[0].capability).toBe("provider-diagnostics-read");
+  });
+
+  it("D10 shares an in-flight bootstrap between concurrent commands", async () => {
+    const pending = deferred<Response>();
+    fetchMock.mockImplementation(async (url) => String(url).endsWith("/api/capability-tokens") ? pending.promise : response({ ok: true }));
+    const first = transport.webInvoke(diagnostics);
+    const second = transport.webInvoke(diagnostics);
+    await vi.waitFor(() => expect(bootstrapCalls()).toHaveLength(1));
+    expect(routeCalls()).toHaveLength(0);
+    pending.resolve(bootstrap());
+    await Promise.all([first, second]);
+    expect(bootstrapCalls()).toHaveLength(1);
+    expect(routeCalls()).toHaveLength(2);
+    for (const call of routeCalls()) expect(headers(call).get(capabilityHeader)).toBe(issuedTokens["provider-diagnostics-read"]);
+  });
+
+  it("D11 does not bootstrap when only the bootstrap secret is present", async () => {
+    delete config.bridgeToken;
+    await transport.webInvoke(diagnostics);
+    expect(bootstrapCalls()).toHaveLength(0);
+    expect(routeCalls()).toHaveLength(1);
+    expect(headers(routeCalls()[0]).has(capabilityHeader)).toBe(false);
+    expect(headers(routeCalls()[0]).has("X-ResonantOS-Bridge-Token")).toBe(false);
+  });
+
+  it.each(["", 42])("D12 filters extraneous and invalid capability tokens (%j)", async (invalid) => {
+    fetchMock.mockImplementation(async (url) => String(url).endsWith("/api/capability-tokens")
+      ? bootstrap({ ...issuedTokens, "provider-model-invoke": invalid, "extra-capability": "extra-token-test" }) : response({ ok: true }));
+    await transport.webInvoke(diagnostics);
+    await transport.webInvoke(chat);
+    expect(headers(routeCalls()[0]).get(capabilityHeader)).toBe(issuedTokens["provider-diagnostics-read"]);
+    expect(headers(routeCalls()[1]).has(capabilityHeader)).toBe(false);
+    for (const call of routeCalls()) expect([...headers(call).values()]).not.toContain("extra-token-test");
+    expect(bootstrapCalls()).toHaveLength(1);
+  });
+
+  it.each(["capabilityBootstrapToken", "bridgeToken", "bridgeUrl"] as const)("D13 re-bootstraps only when config key %s changes", async (key) => {
+    await transport.webInvoke(diagnostics);
+    await transport.webInvoke(diagnostics);
+    expect(bootstrapCalls()).toHaveLength(1);
+    globals.__RESONANTOS_BRIDGE_CONFIG__ = { ...config, [key]: key === "bridgeUrl" ? "http://127.0.0.1:47774" : "changed-test-token" };
+    await transport.webInvoke(diagnostics);
+    await transport.webInvoke(diagnostics);
+    expect(bootstrapCalls()).toHaveLength(2);
+    expect(routeCalls()).toHaveLength(4);
+    if (key === "bridgeUrl") expect(bootstrapCalls()[1][0]).toBe("http://127.0.0.1:47774/api/capability-tokens");
+    else expect(headers(bootstrapCalls()[1]).get(key === "bridgeToken" ? "X-ResonantOS-Bridge-Token" : "X-ResonantOS-Capability-Bootstrap-Token")).toBe("changed-test-token");
+  });
+
+  it.each(["rejection", "ok false", "non-JSON", "missing tokens", "array tokens", "null tokens", "null payload", "truthy ok"])("D14 D18 does not cache malformed bootstrap: %s", async (mode) => {
+    fetchMock.mockImplementation(async (url) => {
+      if (!String(url).endsWith("/api/capability-tokens")) return response({ ok: false, error: "Provider unavailable." }, 500);
+      switch (mode) {
+        case "rejection": throw new Error(secrets.join(" "));
+        case "ok false": return response({ ok: false, capabilityTokens: issuedTokens });
+        case "non-JSON": return new Response("not json");
+        case "missing tokens": return response({ ok: true });
+        case "array tokens": return bootstrap([]);
+        case "null tokens": return bootstrap(null);
+        case "null payload": return response(null);
+        default: return response({ ok: "true", capabilityTokens: issuedTokens });
+      }
+    });
+    await expectSafeError(transport.webInvoke(diagnostics), "Provider unavailable.");
+    await expectSafeError(transport.webInvoke(diagnostics), "Provider unavailable.");
+    expect(bootstrapCalls()).toHaveLength(2);
+    expect(routeCalls()).toHaveLength(2);
+    for (const call of routeCalls()) expect(headers(call).has(capabilityHeader)).toBe(false);
+  });
+
+  it.each([
+    [401, "Unauthorized browser-first bridge request."],
+    [403, "Bridge client IP not allowed."],
+    [403, "Client IP not allowlisted for browser-first bridge."],
+    [403, `prefix ${capabilityError}`],
+    [403, `${capabilityError} suffix`],
+  ])("D15 D16 D18 does not retry unrelated denial %s %s", async (status, error) => {
+    fetchMock.mockImplementation(async (url) => String(url).endsWith("/api/capability-tokens")
+      ? bootstrap() : response({ ok: false, error }, Number(status)));
+    await expectSafeError(transport.webInvoke(diagnostics), String(error));
+    expect(bootstrapCalls()).toHaveLength(1);
+    expect(routeCalls()).toHaveLength(1);
+  });
+
+  it("D17 preserves GET payload mapping without body or Content-Type", async () => {
+    expect(await transport.webInvoke(diagnostics)).toEqual({ ok: true });
+    const call = routeCalls()[0];
+    expect(call[1]?.method).toBe("GET");
+    expect(call[1]?.body).toBeUndefined();
+    expect(headers(call).has("Content-Type")).toBe(false);
+  });
+
+  it("A4 keeps a newer bootstrap when an older concurrent request gets a 403", async () => {
+    const staleResponse = deferred<Response>();
+    let routeCount = 0;
+    fetchMock.mockImplementation(async (url) => {
+      if (String(url).endsWith("/api/capability-tokens")) return bootstrap({ "provider-diagnostics-read": bootstrapCalls().length === 1 ? issuedTokens["provider-diagnostics-read"] : "fresh-token-test" });
+      routeCount += 1;
+      if (routeCount === 1) return staleResponse.promise;
+      if (routeCount === 2) return response({ ok: false, error: capabilityError }, 403);
+      return response({ ok: true });
+    });
+    const first = transport.webInvoke(diagnostics);
+    await vi.waitFor(() => expect(routeCalls()).toHaveLength(1));
+    await transport.webInvoke(diagnostics);
+    staleResponse.resolve(response({ ok: false, error: capabilityError }, 403));
+    await first;
+    expect(bootstrapCalls()).toHaveLength(2);
+    expect(routeCalls()).toHaveLength(4);
+    expect(headers(routeCalls()[3]).get(capabilityHeader)).toBe("fresh-token-test");
+  });
+
+  it("A3 keeps a newer memo when an older bootstrap fails", async () => {
+    const oldBootstrap = deferred<Response>();
+    fetchMock.mockImplementation(async (url) => {
+      if (String(url).endsWith("/api/capability-tokens")) return bootstrapCalls().length === 1 ? oldBootstrap.promise : bootstrap();
+      return response({ ok: true });
+    });
+    const old = transport.webInvoke(diagnostics);
+    await vi.waitFor(() => expect(bootstrapCalls()).toHaveLength(1));
+    globals.__RESONANTOS_BRIDGE_CONFIG__ = { ...config, capabilityBootstrapToken: "changed-test-token" };
+    await transport.webInvoke(diagnostics);
+    oldBootstrap.resolve(response({ ok: false }, 500));
+    await old;
+    await transport.webInvoke(diagnostics);
+    expect(bootstrapCalls()).toHaveLength(2);
+    expect(headers(routeCalls()[2]).get(capabilityHeader)).toBe(issuedTokens["provider-diagnostics-read"]);
+  });
+});

--- a/src/core/web-transport.test.ts
+++ b/src/core/web-transport.test.ts
@@ -170,16 +170,17 @@ describe("web-mode capability transport", () => {
     expect(bootstrapCalls()).toHaveLength(1);
   });
 
-  it.each(["capabilityBootstrapToken", "bridgeToken", "bridgeUrl"] as const)("D13 re-bootstraps only when config key %s changes", async (key) => {
+  it.each(["capabilityBootstrapToken", "bridgeToken", "bridgeUrl", "httpsBridgeUrl"] as const)("D13 re-bootstraps only when config key %s changes", async (key) => {
     await transport.webInvoke(diagnostics);
     await transport.webInvoke(diagnostics);
     expect(bootstrapCalls()).toHaveLength(1);
-    globals.__RESONANTOS_BRIDGE_CONFIG__ = { ...config, [key]: key === "bridgeUrl" ? "http://127.0.0.1:47774" : "changed-test-token" };
+    globals.__RESONANTOS_BRIDGE_CONFIG__ = { ...config, [key]: key === "bridgeUrl" ? "http://127.0.0.1:47774" : key === "httpsBridgeUrl" ? "https://127.0.0.1:47775" : "changed-test-token" };
     await transport.webInvoke(diagnostics);
     await transport.webInvoke(diagnostics);
     expect(bootstrapCalls()).toHaveLength(2);
     expect(routeCalls()).toHaveLength(4);
     if (key === "bridgeUrl") expect(bootstrapCalls()[1][0]).toBe("http://127.0.0.1:47774/api/capability-tokens");
+    else if (key === "httpsBridgeUrl") expect(bootstrapCalls()[1][0]).toBe("https://127.0.0.1:47775/api/capability-tokens");
     else expect(headers(bootstrapCalls()[1]).get(key === "bridgeToken" ? "X-ResonantOS-Bridge-Token" : "X-ResonantOS-Capability-Bootstrap-Token")).toBe("changed-test-token");
   });
 
@@ -206,6 +207,7 @@ describe("web-mode capability transport", () => {
 
   it.each([
     [401, "Unauthorized browser-first bridge request."],
+    [401, capabilityError],
     [403, "Bridge client IP not allowed."],
     [403, "Client IP not allowlisted for browser-first bridge."],
     [403, `prefix ${capabilityError}`],
@@ -216,6 +218,26 @@ describe("web-mode capability transport", () => {
     await expectSafeError(transport.webInvoke(diagnostics), String(error));
     expect(bootstrapCalls()).toHaveLength(1);
     expect(routeCalls()).toHaveLength(1);
+  });
+
+  it("D16b does not retry a capability 403 whose body lacks ok:false", async () => {
+    fetchMock.mockImplementation(async (url) => String(url).endsWith("/api/capability-tokens")
+      ? bootstrap() : response({ error: capabilityError }, 403));
+    await expectSafeError(transport.webInvoke(diagnostics), capabilityError);
+    expect(bootstrapCalls()).toHaveLength(1);
+    expect(routeCalls()).toHaveLength(1);
+  });
+
+  it("D18b fallback error text carries no token when the bridge answers without a body", async () => {
+    fetchMock.mockImplementation(async (url) => String(url).endsWith("/api/capability-tokens")
+      ? bootstrap() : new Response("", { status: 500 }));
+    await expectSafeError(transport.webInvoke(diagnostics), `Bridge request failed for ${diagnostics}.`);
+  });
+
+  it("A3b module never logs", async () => {
+    const { readFileSync } = await import("node:fs");
+    const source = readFileSync(new URL("./web-transport.ts", import.meta.url), "utf8");
+    expect(/console\./.test(source)).toBe(false);
   });
 
   it("D17 preserves GET payload mapping without body or Content-Type", async () => {

--- a/src/core/web-transport.ts
+++ b/src/core/web-transport.ts
@@ -2,20 +2,23 @@ type BridgeConfig = {
   bridgeUrl?: string;
   httpsBridgeUrl?: string;
   bridgeToken?: string;
+  capabilityBootstrapToken?: string;
 };
 
 type CommandRoute = {
   method: "GET" | "POST";
   path: string;
+  capability: string;
   body?: (args: Record<string, unknown>) => unknown;
   result?: (payload: Record<string, unknown>) => unknown;
 };
 
 const commandRouteMap: Record<string, CommandRoute> = {
-  provider_diagnostics: { method: "GET", path: "/providers/status" },
+  provider_diagnostics: { method: "GET", path: "/providers/status", capability: "provider-diagnostics-read" },
   provider_service_chat_completion: {
     method: "POST",
     path: "/augmentor/chat",
+    capability: "provider-model-invoke",
     body: (args) => ({
       workload: "augmentor-chat",
       surface: "react-shell",
@@ -27,6 +30,64 @@ const commandRouteMap: Record<string, CommandRoute> = {
     result: (payload) => payload.reply,
   },
 };
+
+export const WEB_TRANSPORT_CAPABILITIES: readonly string[] = [...new Set(
+  Object.values(commandRouteMap).map((route) => route.capability),
+)].sort();
+
+let bootstrapState: { key: string; promise: Promise<Record<string, string>> } | null = null;
+
+const bootstrapKey = (config: BridgeConfig, baseUrl: string): string =>
+  JSON.stringify([baseUrl, config.bridgeToken ?? "", config.capabilityBootstrapToken ?? ""]);
+
+const ensureCapabilityTokens = (config: BridgeConfig, baseUrl: string): Promise<Record<string, string>> => {
+  if (!config.bridgeToken || !config.capabilityBootstrapToken) {
+    return Promise.resolve({});
+  }
+  const key = bootstrapKey(config, baseUrl);
+  if (bootstrapState?.key === key) {
+    return bootstrapState.promise;
+  }
+
+  // Defer the request until the in-flight promise has been published to all callers.
+  const promise: Promise<Record<string, string>> = Promise.resolve().then(async () => {
+    try {
+      const response = await fetch(`${baseUrl}/api/capability-tokens`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-ResonantOS-Bridge-Token": config.bridgeToken!,
+          "X-ResonantOS-Capability-Bootstrap-Token": config.capabilityBootstrapToken!,
+        },
+        body: JSON.stringify({ capabilities: WEB_TRANSPORT_CAPABILITIES }),
+      });
+      const payload = await response.json();
+      const tokens: unknown = payload?.capabilityTokens;
+      if (response.ok && payload?.ok === true && tokens !== null && typeof tokens === "object" &&
+          (Object.getPrototypeOf(tokens) === Object.prototype || Object.getPrototypeOf(tokens) === null)) {
+        return Object.fromEntries(Object.entries(tokens).filter(([capability, token]) =>
+          WEB_TRANSPORT_CAPABILITIES.includes(capability) && typeof token === "string" && token.length > 0,
+        ));
+      }
+    } catch {
+      // Bootstrap failures fall through to the route's existing error handling.
+    }
+    if (bootstrapState?.promise === promise) {
+      bootstrapState = null;
+    }
+    return {};
+  });
+  bootstrapState = { key, promise };
+  return promise;
+};
+
+export const __resetWebTransportForTests = (): void => { bootstrapState = null; };
+
+export const __webTransportRoutesForTests = (): ReadonlyArray<{
+  command: string; method: string; path: string; capability: string;
+}> => Object.entries(commandRouteMap).map(([command, { method, path, capability }]) =>
+  ({ command, method, path, capability }),
+);
 
 const bridgeConfig = (): BridgeConfig => {
   if (typeof globalThis === "undefined") {
@@ -47,12 +108,23 @@ const bridgeBaseUrl = (): string => {
 export const isWebMode = (): boolean => true;
 
 export const webInvoke = async <T>(command: string, args: Record<string, unknown> = {}): Promise<T> => {
+  return performInvoke<T>(command, args, { retried: false });
+};
+
+const performInvoke = async <T>(
+  command: string,
+  args: Record<string, unknown>,
+  { retried }: { retried: boolean },
+): Promise<T> => {
   const route = commandRouteMap[command];
   if (!route) {
     throw new Error(`Runtime command '${command}' is not available in the browser-first Chrome extension alpha.`);
   }
 
   const config = bridgeConfig();
+  const baseUrl = bridgeBaseUrl();
+  const tokenPromise = ensureCapabilityTokens(config, baseUrl);
+  const tokens = await tokenPromise;
   const headers: Record<string, string> = {};
   if (config.bridgeToken) {
     headers["X-ResonantOS-Bridge-Token"] = config.bridgeToken;
@@ -60,13 +132,24 @@ export const webInvoke = async <T>(command: string, args: Record<string, unknown
   if (route.method === "POST") {
     headers["Content-Type"] = "application/json";
   }
+  if (typeof tokens[route.capability] === "string" && tokens[route.capability].length > 0) {
+    headers["X-ResonantOS-Bridge-Capability-Token"] = tokens[route.capability];
+  }
 
-  const response = await fetch(`${bridgeBaseUrl()}${route.path}`, {
+  const response = await fetch(`${baseUrl}${route.path}`, {
     method: route.method,
     headers,
     body: route.method === "POST" ? JSON.stringify(route.body ? route.body(args) : args) : undefined,
   });
   const payload = (await response.json().catch(() => ({}))) as { ok?: boolean; error?: string } & T;
+  if (response.status === 403 && payload.ok === false && typeof payload.error === "string" &&
+      /^Bridge route requires .+ capability\.$/.test(payload.error) && !retried) {
+    // A late response must not discard a newer bootstrap from another command.
+    if (bootstrapState?.promise === tokenPromise) {
+      bootstrapState = null;
+    }
+    return performInvoke<T>(command, args, { retried: true });
+  }
   if (!response.ok || payload.ok === false) {
     throw new Error(payload.error || `Bridge request failed for ${command}.`);
   }


### PR DESCRIPTION
## Summary

Closes #374. The shell transport (`src/core/web-transport.ts`) now bootstraps the capability tokens the bridge has required since the capability system landed, so `provider_diagnostics` and `provider_service_chat_completion` no longer answer 403 from the `src/` shell.

- **Bootstrap once, per config:** reads `capabilityBootstrapToken` from `__RESONANTOS_BRIDGE_CONFIG__`, POSTs `/api/capability-tokens` for exactly the capabilities the command map declares (`provider-diagnostics-read`, `provider-model-invoke`; derived, not hand-written), keeps only those tokens, and memoizes the in-flight promise so concurrent commands share one bootstrap. A changed bridge URL or token yields a new memo key; failures are never cached.
- **Per-route header:** `X-ResonantOS-Bridge-Capability-Token` is attached only for the route's capability; GET requests stay body-less.
- **One bounded retry on capability-token rotation:** a 403 carrying the bridge's exact "Bridge route requires … capability." sentence triggers one re-bootstrap and one retry (same-promise guard, so a concurrent fresh bootstrap is never dropped). IP-allowlist 403s, 401s, and a second capability 403 are thrown as before. After a full bridge restart the caller must refresh the config, which the transport reads on every call.
- **No token ever reaches an error message**, and the module never logs.
- **Out of scope, stated in the runbook:** browser delivery of the config (nothing injects it into the page today; CSP `script-src 'self'`) and the operator CORS opt-in are tracked in #429, together with the dev-server exposure that certification uncovered. The #180 shell routes are not added here; only the derived capability list is the hook they will use.

## Decision basis

Release-owner decision 2026-09-08: #374 promoted from "dispositioned" to a beta.2 gate (issue comment; epic #402 line 21) because the shell wiring of #180 tasks 3–5 cannot proceed while the shell gets 403 on every gated route.

## Evidence

Two commits: `b37098e7` (transport + 31 tests + runbook) and `14708cf3` (five pinning tests from the correctness review). Gate on the final head, mirroring `scripts/verify-alpha.mjs`: vitest 520 / 520 (44 files), tsc clean, `npm run build` ok, `test:browser-first` 1240 / 1240, `docs:check` + `test:docs` 233 / 233, module-ownership, security-pipeline, `repo:hygiene`, security run-check, release-scope audit `--committed --strict` all green.

Anti-false-green: **13 guard mutations**, each proven non-vacuous with `rig-mutate` (files restored byte-identical): capability header removed, memo key ignores config, no retry, retry on any 403, failures cached, both token guards removed together (a single-layer mutation is unobservable, so the pair is pinned), in-flight bootstrap not shared, retry clears a newer bootstrap, memo key ignores the https URL, retry on 401, retry ignores `ok:false`, fallback message leaks a token, console call in the module.

Panel by lens, reviewer ≠ author: security (DeepSeek) **CONFIRM**, two nits accepted as designed; correctness (Grok) **CONFIRM**, six unpinned rules → pinned in `14708cf3`; docs (Gemini) **CONFIRM**, no findings. Plan certified at rev-2 by Grok and DeepSeek after round 1 REVISE (the dropped Vite-injection section became #429, whose exposure claim was verified live and fixed in #432).

Live proof from Node against the deployed bridge (after merge; posted on #374): bridge token alone → capability refusal with no token text; with the bootstrap token → `provider_diagnostics` answers; second call reuses the memo; reset → exactly one bootstrap; a forged stale-token 403 → one re-bootstrap and a successful retry; declared capabilities are exactly the two the shell needs.

Pre-merge run of the same proof, module loaded from the branch worktree, against the deployed bridge (pid 98760):

```
PASS  (1) bridge token only -> gated route refused with a capability error
PASS  (2) refusal message carries no token value
PASS  (3) with bootstrap -> provider_diagnostics answers 200 (keys: ok,vault,providers)
PASS  (4) payload carries no token value
PASS  (5) second call reuses memoized tokens (no re-bootstrap)
PASS  (6) after reset: exactly one bootstrap, then success
PASS  (7) stale-token 403 -> one re-bootstrap (2 bootstraps) -> retry succeeds
PASS  (8) declared capabilities are exactly provider-diagnostics-read + provider-model-invoke

LIVE PROOF 374 PASSED
```

## Process

Resonant-Rig full tier. Plan certified at rev-2 by Grok and DeepSeek (round 1: both REVISE; the Vite-page injection section was dropped and became #429 after the reviewers' exposure claim was verified live). Executor: codex (gpt-6-astra). Panel by lens, reviewer ≠ author: security (DeepSeek), correctness (Grok), docs (Gemini). Live proof from Node against the deployed bridge.

Refs #180, #346, #429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
