### PR TITLE
security(ci): default-branch drift monitor (#431)

### DIFF
--- a/.github/workflows/security-drift.yml
+++ b/.github/workflows/security-drift.yml
@@ -1,0 +1,24 @@
+name: security-drift
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    permissions: { contents: read, actions: read }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version-file: .nvmrc
+      - name: Check dev branch drift
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/default-branch-drift.mjs

--- a/docs/release/ALPHA_DISTRIBUTION.md
+++ b/docs/release/ALPHA_DISTRIBUTION.md
@@ -97,7 +97,7 @@ workflow rules as part of `verify:alpha`:
 
 1. Every file under `.github/workflows/` must be listed in the exported
    `WORKFLOW_ALLOWLIST`: `agent-control-live.yml`, `alpha-build.yml`,
-   `project-issue-sync.yml`, and `security.yml`.
+   `project-issue-sync.yml`, `security-drift.yml`, and `security.yml`.
 2. A secret-bearing `run:` block must not send secrets to an IP literal or a
    host outside `WORKFLOW_ALLOWED_HOSTS`. The check also follows secret values
    assigned through `env:` and referenced by a run in the same job. GitHub
@@ -123,6 +123,39 @@ filenames in secret-bearing network commands. Review remains necessary.
 During token rotation, until a maintainer re-creates `PROJECT_SYNC_TOKEN` as a
 `project-sync` environment secret, the workflow's `HAS_PROJECT_SYNC_TOKEN` guard
 sees it as absent and synchronization no-ops. This is intended during rotation.
+
+### Periodic dev-branch drift check
+
+`security-drift.yml` runs every six hours and through `workflow_dispatch`, using
+only `GITHUB_TOKEN` with contents/actions read permissions. It runs
+`node scripts/default-branch-drift.mjs` without installing dependencies. The
+script reads `GITHUB_REPOSITORY` (default `ResonantOS/2.0.0-alpha`) and checks:
+
+- Seven days of `dev` commits for non-merge commits with no associated merged PR.
+- Current `.github/workflows/` paths on `dev` against `WORKFLOW_ALLOWLIST`.
+- `dev` runs concluded `action_required`, or queued/waiting for over one hour.
+  Run `updated_at` (falling back to `created_at`) approximates status age; GitHub
+  does not expose an exact transition timestamp in the run object.
+- Effective rules from `/repos/{owner}/{repo}/rules/branches/dev` for pull
+  requests, non-fast-forward updates, deletion, and required status checks
+  including `Build Chrome extension alpha`. A ruleset inventory entry with an
+  empty branch include list is not evidence that `dev` is protected.
+
+Findings or unavailable checks fail the job and name the affected checks in the
+log. HTTP errors (including 403/404), malformed responses, and pagination limits
+cannot produce an all-clear. Commit/rule/PR/run queries read up to ten pages of
+100 entries; a reached limit is reported as unavailable. The contents endpoint's
+1,000-entry limit is also treated as incomplete. PR association lookup may require
+`pull-requests: read`, which this workflow deliberately does not request; a denied
+lookup fails visibly. The commit window is a heuristic, not a push audit log,
+and existing workflow content changes are covered by the separate policy guard.
+
+GitHub schedules run only from the repository's default branch, so this workflow
+must be present there to become active. Scheduled notifications go to the user
+who last changed the cron syntax, subject to notification settings; owner email
+delivery is not guaranteed. See the
+[GitHub schedule documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule).
+The workflow itself supplies the failed-job alert; no external message is sent.
 
 ## Secret And State Boundary
 

--- a/scripts/check-repo-hygiene.mjs
+++ b/scripts/check-repo-hygiene.mjs
@@ -11,7 +11,7 @@ import { isIP } from "node:net";
 // Adding a workflow is a deliberate reviewed change: update this allowlist,
 // its tests, and docs/release/ALPHA_DISTRIBUTION.md together.
 export const WORKFLOW_ALLOWLIST = Object.freeze([
-  "agent-control-live.yml", "alpha-build.yml", "project-issue-sync.yml", "security.yml",
+  "agent-control-live.yml", "alpha-build.yml", "project-issue-sync.yml", "security-drift.yml", "security.yml",
 ]);
 export const WORKFLOW_ALLOWED_HOSTS = Object.freeze([
   "github.com", "api.github.com", "uploads.github.com", "objects.githubusercontent.com",

--- a/scripts/check-repo-hygiene.test.mjs
+++ b/scripts/check-repo-hygiene.test.mjs
@@ -35,7 +35,7 @@ function workflowRules(text, options) {
 test("workflow policy accepts the reviewed allowlist", () => {
   assert.deepEqual(workflowPolicy(workflowJob("    steps:\n      - run: echo safe")), { ok: true, violations: [] });
   assert.deepEqual(hygiene.WORKFLOW_ALLOWLIST, [
-    "agent-control-live.yml", "alpha-build.yml", "project-issue-sync.yml", "security.yml",
+    "agent-control-live.yml", "alpha-build.yml", "project-issue-sync.yml", "security-drift.yml", "security.yml",
   ]);
   assert.deepEqual(hygiene.WORKFLOW_ALLOWED_HOSTS, [
     "github.com", "api.github.com", "uploads.github.com", "objects.githubusercontent.com",

--- a/scripts/default-branch-drift.mjs
+++ b/scripts/default-branch-drift.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+// Intent: docs/release/ALPHA_DISTRIBUTION.md#workflow-policy-incident-2026-09-04
+import { pathToFileURL } from "node:url";
+import { WORKFLOW_ALLOWLIST } from "./check-repo-hygiene.mjs";
+
+const HOUR_MS = 60 * 60 * 1000;
+const REQUIRED_BUILD = "Build Chrome extension alpha";
+
+export function findUnreviewedCommits(commits, pullsBySha) {
+  return commits.filter((commit) => commit.parents.length < 2
+    && !(pullsBySha[commit.sha] ?? []).some((pull) => Boolean(pull.merged_at)));
+}
+
+export function findUnknownWorkflows(paths, allowlist = WORKFLOW_ALLOWLIST) {
+  const allowed = new Set(allowlist);
+  return paths.filter((path) => !allowed.has(path.replace(/^\.github\/workflows\//, "")));
+}
+
+// updated_at is GitHub's available approximation of time in the current status;
+// the REST run object does not expose the exact status-transition timestamp.
+export function findStalledRuns(runs, { now, thresholdMs }) {
+  return runs.filter((run) => run.conclusion === "action_required"
+    || (["queued", "waiting"].includes(run.status)
+      && now - Date.parse(run.updated_at ?? run.created_at) > thresholdMs));
+}
+
+export function checkBranchProtection(rules) {
+  // The incident spec records a June 2026 ruleset with an EMPTY branch include
+  // list, protecting nothing. Inspect /rules/branches/dev (effective rules),
+  // never flatten the ruleset inventory into evidence of protection.
+  const types = new Set(rules.map((rule) => rule.type));
+  const missing = ["pull_request", "non_fast_forward", "deletion", "required_status_checks"]
+    .filter((type) => !types.has(type));
+  if (!rules.some((rule) => rule.type === "required_status_checks"
+    && rule.parameters?.required_status_checks?.some((check) => check.context === REQUIRED_BUILD))) {
+    missing.push(REQUIRED_BUILD);
+  }
+  return missing;
+}
+
+export function summarize(findings) {
+  const { unreviewedCommits = [], unknownWorkflows = [], stalledRuns = [],
+    missingProtection = [], unavailable = [] } = findings;
+  const count = unreviewedCommits.length + unknownWorkflows.length + stalledRuns.length + missingProtection.length;
+  const ok = count === 0 && unavailable.length === 0;
+  // Quote external identifiers and prefix every line, keeping control characters
+  // and Actions workflow-command syntax out of executable log positions.
+  const quote = (value) => JSON.stringify(String(value));
+  const text = [
+    `Drift: ${count} finding(s); ${unavailable.length} unavailable check(s). ${ok ? "OK" : "ATTENTION"}`,
+    ...unreviewedCommits.map((commit) => `- unreviewed commit: ${quote(commit.sha)}`),
+    ...unknownWorkflows.map((path) => `- unknown workflow: ${quote(path)}`),
+    ...stalledRuns.map((run) => `- stalled run: ${quote(run.id)} (${quote(run.conclusion ?? run.status)})`),
+    ...missingProtection.map((rule) => `- missing protection: ${quote(rule)}`),
+    ...unavailable.map(({ check, reason }) => `- unavailable: ${quote(check)}: ${quote(reason)}`),
+  ].join("\n");
+  return { ok, count, text };
+}
+
+// Read-only driver, injectable for offline API fixtures. No I/O occurs on import.
+export async function runDrift({ env = process.env, fetchImpl = globalThis.fetch, now = Date.now() } = {}) {
+  const findings = { unreviewedCommits: [], unknownWorkflows: [], stalledRuns: [], missingProtection: [], unavailable: [] };
+  const unavailable = (check, reason) => findings.unavailable.push({ check, reason });
+  const finish = () => {
+    const summary = summarize(findings);
+    return { ...summary, findings, exitCode: summary.ok ? 0 : 1 };
+  };
+  const repository = env.GITHUB_REPOSITORY || "ResonantOS/2.0.0-alpha";
+  if (!env.GITHUB_TOKEN || !/^[\w.-]+\/[\w.-]+$/.test(repository)) {
+    for (const check of ["commits", "workflows", "runs", "protection"]) {
+      unavailable(check, !env.GITHUB_TOKEN ? "GITHUB_TOKEN is missing" : "GITHUB_REPOSITORY is invalid");
+    }
+    return finish();
+  }
+  const base = `https://api.github.com/repos/${repository}`;
+
+  async function read(path, check) {
+    try {
+      const response = await fetchImpl(`${base}${path}`, {
+        method: "GET",
+        headers: { Accept: "application/vnd.github+json", Authorization: `Bearer ${env.GITHUB_TOKEN}`,
+          "X-GitHub-Api-Version": "2022-11-28" },
+        redirect: "error",
+        signal: AbortSignal.timeout(30_000),
+      });
+      if (!response.ok) {
+        unavailable(check, `HTTP ${response.status}`);
+        return null;
+      }
+      const body = await response.json();
+      if (body === null) unavailable(check, "unexpected null API response");
+      return body;
+    } catch {
+      // Never log headers, response bodies, or raw errors that might contain secrets.
+      unavailable(check, "request or JSON response failed");
+      return null;
+    }
+  }
+
+  async function list(path, check, valid, { runs = false, paginated = true } = {}) {
+    const items = [];
+    for (let page = 1; page <= 10; page += 1) {
+      const query = paginated ? `${path.includes("?") ? "&" : "?"}per_page=100&page=${page}` : "";
+      const body = await read(`${path}${query}`, check);
+      if (body === null) return null;
+      const batch = runs ? body.workflow_runs : body;
+      if (!Array.isArray(batch) || !batch.every((item) => item && valid(item))
+        || (runs && (!Number.isInteger(body.total_count) || body.total_count < 0))) {
+        unavailable(check, "unexpected API response shape");
+        return null;
+      }
+      items.push(...batch);
+      if ((!paginated && items.length >= 1000) || (runs && body.total_count > 1000)) {
+        unavailable(check, "API result limit prevents a complete check");
+        return null;
+      }
+      if (!paginated || batch.length < 100) {
+        if (runs && body.total_count > items.length) {
+          unavailable(check, "incomplete API pagination");
+          return null;
+        }
+        return items;
+      }
+    }
+    unavailable(check, "pagination limit prevents a complete check");
+    return null;
+  }
+
+  // Seven days overlap scheduled runs and cover the four-day incident delay.
+  // This is a recent-commit heuristic, not an audit log of push events.
+  const since = encodeURIComponent(new Date(now - 7 * 24 * HOUR_MS).toISOString());
+  const commits = await list(`/commits?sha=dev&since=${since}`, "commits",
+    (item) => typeof item.sha === "string" && Array.isArray(item.parents));
+  if (commits) {
+    const checked = [];
+    const pullsBySha = Object.create(null);
+    for (const commit of commits.filter((item) => item.parents.length < 2)) {
+      const pulls = await list(`/commits/${encodeURIComponent(commit.sha)}/pulls`, `commits: PR association ${commit.sha}`,
+        (item) => item.merged_at === null || typeof item.merged_at === "string");
+      if (pulls !== null) {
+        checked.push(commit);
+        pullsBySha[commit.sha] = pulls;
+      }
+    }
+    findings.unreviewedCommits = findUnreviewedCommits(checked, pullsBySha);
+  }
+
+  const workflows = await list("/contents/.github/workflows?ref=dev", "workflows",
+    (item) => typeof item.path === "string", { paginated: false });
+  if (workflows) findings.unknownWorkflows = findUnknownWorkflows(workflows.map((item) => item.path));
+
+  const stalled = new Map();
+  for (const status of ["action_required", "queued", "waiting"]) {
+    const runs = await list(`/actions/runs?branch=dev&status=${status}`, `runs: ${status}`,
+      (item) => Number.isInteger(item.id) && typeof item.status === "string"
+        && (item.conclusion === "action_required" || Number.isFinite(Date.parse(item.updated_at ?? item.created_at))),
+      { runs: true });
+    if (runs) for (const run of findStalledRuns(runs, { now, thresholdMs: HOUR_MS })) stalled.set(run.id, run);
+  }
+  findings.stalledRuns = [...stalled.values()];
+
+  const rules = await list("/rules/branches/dev", "protection", (item) => typeof item.type === "string"
+    && (item.type !== "required_status_checks"
+      || (Array.isArray(item.parameters?.required_status_checks)
+        && item.parameters.required_status_checks.every((check) => typeof check?.context === "string"))));
+  if (rules) findings.missingProtection = checkBranchProtection(rules);
+  return finish();
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const result = await runDrift();
+  console.log(result.text);
+  process.exitCode = result.exitCode;
+}

--- a/scripts/default-branch-drift.test.mjs
+++ b/scripts/default-branch-drift.test.mjs
@@ -1,0 +1,260 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import test from "node:test";
+import {
+  findUnreviewedCommits, findUnknownWorkflows, findStalledRuns,
+  checkBranchProtection, summarize, runDrift,
+} from "./default-branch-drift.mjs";
+import { WORKFLOW_ALLOWLIST } from "./check-repo-hygiene.mjs";
+
+const now = Date.parse("2026-09-08T12:00:00Z");
+const thresholdMs = 60 * 60 * 1000;
+const commit = (sha, parents = [{ sha: "parent" }]) => ({ sha, parents });
+const completeRules = [
+  { type: "pull_request" }, { type: "non_fast_forward" }, { type: "deletion" },
+  { type: "required_status_checks", parameters: {
+    required_status_checks: [{ context: "Build Chrome extension alpha" }],
+  } },
+];
+const emptyFindings = () => ({
+  unreviewedCommits: [], unknownWorkflows: [], stalledRuns: [], missingProtection: [], unavailable: [],
+});
+const response = (body, status = 200) => ({ ok: status === 200, status, json: async () => body });
+function fixtureFetch(overrides = {}, calls = []) {
+  return async (input, options) => {
+    const url = new URL(input);
+    calls.push({ url, options });
+    const route = url.pathname.replace(/^\/repos\/[^/]+\/[^/]+/, "");
+    if (overrides[route]) return overrides[route](url, options);
+    if (route === "/commits") return response([commit("reviewed")]);
+    if (route === "/commits/reviewed/pulls") return response([{ merged_at: "2026-09-08T00:00:00Z" }]);
+    if (route === "/contents/.github/workflows") return response(
+      WORKFLOW_ALLOWLIST.map((name) => ({ path: `.github/workflows/${name}`, type: "file" })),
+    );
+    if (route === "/actions/runs") return response({ total_count: 0, workflow_runs: [] });
+    if (route === "/rules/branches/dev") return response(completeRules);
+    throw new Error(`Unexpected fixture route ${route}`);
+  };
+}
+const driverOptions = (fetchImpl) => ({
+  env: { GITHUB_TOKEN: "fixture-token", GITHUB_REPOSITORY: "example/project" }, now, fetchImpl,
+});
+
+test("direct pushes are detected while merged PR commits are ignored", () => {
+  const commits = [commit("direct"), commit("reviewed"), commit("open-pr")];
+  assert.deepEqual(findUnreviewedCommits(commits, {
+    direct: [], reviewed: [{ merged_at: "2026-09-07T00:00:00Z" }],
+    "open-pr": [{ state: "closed", merged_at: null }],
+  }), [commits[0], commits[2]]);
+});
+
+test("merge commits are ignored without requiring a PR association", () => {
+  assert.deepEqual(findUnreviewedCommits([commit("merge", [{ sha: "a" }, { sha: "b" }])], {}), []);
+});
+
+test("both incident commits and the added attacker workflow are flagged", () => {
+  // Git objects verify ancestry/paths; empty PR associations are inline fixtures.
+  const first = "fa42023d1a9d3169f5ea9b37a3827ff816bcd5ec";
+  const second = "cc53f498c49de670e7e5d3d9e9f415c7d8d03b83";
+  const commits = [commit(second, [{ sha: first }]), commit(first)];
+  assert.deepEqual(findUnreviewedCommits(commits, { [first]: [], [second]: [] }), commits);
+  assert.deepEqual(findUnknownWorkflows([
+    ".github/workflows/alpha-build.yml", ".github/workflows/github_actions_security.yml",
+  ], WORKFLOW_ALLOWLIST), [".github/workflows/github_actions_security.yml"]);
+});
+
+test("workflow paths use the shared allowlist and flag unknown filenames", () => {
+  const allowed = WORKFLOW_ALLOWLIST.map((name) => `.github/workflows/${name}`);
+  assert.deepEqual(findUnknownWorkflows([...allowed, ".github/workflows/unknown.yaml"], WORKFLOW_ALLOWLIST),
+    [".github/workflows/unknown.yaml"]);
+  assert.deepEqual(findUnknownWorkflows(allowed), []);
+});
+
+test("action_required runs are flagged regardless of their age", () => {
+  const blocked = { id: 1, status: "completed", conclusion: "action_required" };
+  assert.deepEqual(findStalledRuns([blocked, { id: 2, status: "completed", conclusion: "success" }],
+    { now, thresholdMs }), [blocked]);
+});
+
+test("queued and waiting runs must exceed the injected age threshold", () => {
+  const runs = [
+    { id: 1, status: "queued", updated_at: "2026-09-08T10:59:59Z" },
+    { id: 2, status: "waiting", updated_at: "2026-09-08T10:00:00Z" },
+    { id: 3, status: "queued", updated_at: "2026-09-08T11:00:00Z" },
+    { id: 4, status: "waiting", updated_at: "2026-09-08T11:59:00Z" },
+    { id: 5, status: "in_progress", updated_at: "2026-09-07T00:00:00Z" },
+    { id: 6, status: "queued", created_at: "2026-09-07T00:00:00Z" },
+  ];
+  assert.deepEqual(findStalledRuns(runs, { now, thresholdMs }), [runs[0], runs[1], runs[5]]);
+});
+
+test("protection reports a missing PR rule and accepts complete effective rules", () => {
+  assert.deepEqual(checkBranchProtection(completeRules.slice(1)), ["pull_request"]);
+  assert.deepEqual(checkBranchProtection(completeRules), []);
+});
+
+test("protection requires all rule types and the exact alpha build context", () => {
+  assert.deepEqual(checkBranchProtection([]), [
+    "pull_request", "non_fast_forward", "deletion", "required_status_checks", "Build Chrome extension alpha",
+  ]);
+  assert.deepEqual(checkBranchProtection(completeRules.map((rule) => rule.type === "required_status_checks"
+    ? { type: rule.type, parameters: { required_status_checks: [{ context: "other" }] } } : rule)),
+  ["Build Chrome extension alpha"]);
+});
+
+test("an empty-include ruleset inventory is not effective protection", () => {
+  const inventory = [{ enforcement: "active", conditions: { ref_name: { include: [], exclude: [] } }, rules: completeRules }];
+  assert.deepEqual(checkBranchProtection(inventory), [
+    "pull_request", "non_fast_forward", "deletion", "required_status_checks", "Build Chrome extension alpha",
+  ]);
+});
+
+test("summary returns false and the correct finding count with useful identifiers", () => {
+  const result = summarize({ ...emptyFindings(), unreviewedCommits: [commit("direct")],
+    unknownWorkflows: [".github/workflows/unknown.yml"], stalledRuns: [{ id: 42 }], missingProtection: ["pull_request"] });
+  assert.ok(result, "summary must return a report");
+  assert.equal(result.ok, false);
+  assert.equal(result.count, 4);
+  for (const expected of ["4 finding", "direct", "unknown.yml", "42", "pull_request"]) assert.ok(result.text.includes(expected));
+  assert.equal(summarize(emptyFindings()).ok, true);
+});
+
+test("summary explicitly names unavailable checks and never reports all-clear", () => {
+  const result = summarize({ ...emptyFindings(), unavailable: [{ check: "workflows", reason: "HTTP 403" }] });
+  assert.ok(result, "summary must return a report");
+  assert.equal(result.ok, false);
+  assert.match(result.text, /unavailable.*workflows.*HTTP 403/i);
+});
+
+test("driver performs authenticated read-only dev checks and returns a clean report", async () => {
+  const calls = [];
+  const result = await runDrift(driverOptions(fixtureFetch({}, calls)));
+  assert.ok(result, "driver must return findings and summary");
+  assert.equal(result.ok, true);
+  assert.equal(result.exitCode, 0);
+  assert.deepEqual(result.findings, emptyFindings());
+  assert.ok(calls.some(({ url }) => url.pathname.endsWith("/rules/branches/dev")));
+  assert.ok(calls.some(({ url }) => url.searchParams.get("sha") === "dev" && url.searchParams.has("since")));
+  assert.ok(calls.some(({ url }) => url.searchParams.get("ref") === "dev"));
+  assert.deepEqual(calls.filter(({ url }) => url.pathname.endsWith("/actions/runs"))
+    .map(({ url }) => url.searchParams.get("status")).sort(), ["action_required", "queued", "waiting"]);
+  for (const { url, options } of calls) {
+    assert.equal(url.origin, "https://api.github.com");
+    assert.ok(url.pathname.startsWith("/repos/example/project/"));
+    assert.equal(options.method, "GET");
+    assert.equal(options.headers.Authorization, "Bearer fixture-token");
+    assert.equal(options.redirect, "error");
+    assert.ok(options.signal instanceof AbortSignal);
+    if (url.pathname.endsWith("/actions/runs")) assert.equal(url.searchParams.get("branch"), "dev");
+  }
+});
+
+for (const status of [403, 404, 500]) {
+  test(`driver records HTTP ${status} at every API check and continues other checks`, async () => {
+    for (const route of ["/commits", "/commits/reviewed/pulls", "/contents/.github/workflows", "/actions/runs", "/rules/branches/dev"]) {
+      const calls = [];
+      const result = await runDrift(driverOptions(fixtureFetch({ [route]: () => response({}, status) }, calls)));
+      assert.ok(result, "driver must return an unavailable report");
+      assert.equal(result.ok, false, route);
+      assert.equal(result.exitCode, 1);
+      assert.match(result.text, new RegExp(`unavailable.*HTTP ${status}`, "i"));
+      assert.ok(result.findings.unavailable.length > 0);
+      assert.deepEqual(result.findings.unreviewedCommits, [], "unknown PR associations are not confirmed direct pushes");
+      assert.ok(calls.some(({ url }) => url.pathname.endsWith("/rules/branches/dev")), "continue independent checks");
+    }
+  });
+}
+
+test("driver contains transport and malformed API failures without leaking error text", async () => {
+  for (const failure of [() => { throw new Error("private diagnostic"); }, () => response({ unexpected: true }),
+    () => ({ ok: true, status: 200, json: async () => { throw new Error("private diagnostic"); } })]) {
+    const result = await runDrift(driverOptions(fixtureFetch({ "/commits": failure })));
+    assert.ok(result, "driver must return an unavailable report");
+    assert.equal(result.ok, false);
+    assert.match(result.text, /unavailable.*commits/i);
+    assert.doesNotMatch(result.text, /private diagnostic/);
+  }
+});
+
+test("driver follows pagination so later direct pushes and PR associations are checked", async () => {
+  const result = await runDrift(driverOptions(fixtureFetch({
+    "/commits": (url) => response(url.searchParams.get("page") === "1"
+      ? Array.from({ length: 100 }, (_, i) => commit(`merge-${i}`, [{ sha: "a" }, { sha: "b" }]))
+      : [commit("direct"), commit("reviewed")]),
+    "/commits/direct/pulls": () => response([]),
+    "/commits/reviewed/pulls": (url) => response(url.searchParams.get("page") === "1"
+      ? Array.from({ length: 100 }, () => ({ merged_at: null })) : [{ merged_at: "2026-09-08T00:00:00Z" }]),
+  })));
+  assert.ok(result, "driver must return paginated findings");
+  assert.deepEqual(result.findings.unreviewedCommits.map(({ sha }) => sha), ["direct"]);
+  assert.equal(result.exitCode, 1);
+});
+
+test("driver reports API result caps and partial pagination as unavailable", async () => {
+  for (const overrides of [
+    { "/actions/runs": () => response({ total_count: 1001, workflow_runs: [] }) },
+    { "/commits": (url) => url.searchParams.get("page") === "1"
+      ? response(Array.from({ length: 100 }, () => commit("merge", [{ sha: "a" }, { sha: "b" }]))) : response({}, 403) },
+    { "/contents/.github/workflows": () => response(Array.from({ length: 1000 }, () => ({ path: ".github/workflows/alpha-build.yml", type: "file" }))) },
+  ]) {
+    const result = await runDrift(driverOptions(fixtureFetch(overrides)));
+    assert.ok(result, "driver must return an unavailable report");
+    assert.equal(result.ok, false);
+    assert.ok(result.findings.unavailable.length > 0);
+  }
+});
+
+test("driver defaults the repository and makes missing credentials an explicit failure", async () => {
+  const calls = [];
+  const result = await runDrift({ env: { GITHUB_TOKEN: "fixture-token" }, now, fetchImpl: fixtureFetch({}, calls) });
+  assert.ok(result, "driver must return a report");
+  assert.equal(result.ok, true);
+  assert.ok(calls.every(({ url }) => url.pathname.startsWith("/repos/ResonantOS/2.0.0-alpha/")));
+  const missing = await runDrift({ env: {}, fetchImpl: () => assert.fail("must not request without a token") });
+  assert.equal(missing.exitCode, 1);
+  for (const check of ["commits", "workflows", "runs", "protection"]) assert.ok(missing.text.includes(check));
+});
+
+test("scheduled drift workflow has the specified triggers, permissions, pins, and token", () => {
+  const path = new URL("../.github/workflows/security-drift.yml", import.meta.url);
+  assert.ok(existsSync(path), "security-drift.yml must exist");
+  const text = readFileSync(path, "utf8");
+  assert.match(text, /cron: ['"]0 \*\/6 \* \* \*['"]/);
+  assert.match(text, /workflow_dispatch:/);
+  assert.match(text, /  drift:/);
+  assert.match(text, /contents: read/);
+  assert.match(text, /actions: read/);
+  assert.match(text, /run: node scripts\/default-branch-drift\.mjs/);
+  assert.deepEqual([...text.matchAll(/secrets\.([A-Z_]+)/g)].map((match) => match[1]), ["GITHUB_TOKEN"]);
+  const uses = [...text.matchAll(/uses: (\S+)/g)].map((match) => match[1]);
+  assert.equal(uses.length, 2);
+  for (const action of uses) assert.match(action, /@[0-9a-f]{40}$/);
+  assert.doesNotMatch(text, /continue-on-error|\bpush:|\bpull_request:/);
+});
+
+test("successful HTTP responses containing null cannot silently skip a check", async () => {
+  for (const route of ["/commits", "/commits/reviewed/pulls", "/contents/.github/workflows", "/actions/runs", "/rules/branches/dev"]) {
+    const result = await runDrift(driverOptions(fixtureFetch({ [route]: () => response(null) })));
+    assert.equal(result.ok, false, `${route} must be unavailable for a null response`);
+    assert.ok(result.findings.unavailable.length > 0);
+  }
+});
+
+test("malformed status-check parameters are unavailable rather than crashing", async () => {
+  await assert.doesNotReject(async () => {
+    const result = await runDrift(driverOptions(fixtureFetch({ "/rules/branches/dev": () => response([
+      ...completeRules.slice(0, 3), { type: "required_status_checks", parameters: { required_status_checks: {} } },
+    ]) })));
+    assert.equal(result.ok, false);
+    assert.ok(result.findings.unavailable.some(({ check }) => check === "protection"));
+  });
+});
+
+test("incomplete PR pagination does not mislabel an unverified commit as a direct push", async () => {
+  const result = await runDrift(driverOptions(fixtureFetch({
+    "/commits/reviewed/pulls": () => response(Array.from({ length: 100 }, () => ({ merged_at: null }))),
+  })));
+  assert.deepEqual(result.findings.unreviewedCommits, []);
+  assert.equal(result.ok, false);
+  assert.match(result.text, /unavailable.*PR association/);
+});


### PR DESCRIPTION
Adds the missing watchdog from the 2026-09-04 incident (#431). CI proves a change is clean; nothing was watching the branch itself, and the original attack went unnoticed for four days.

`scripts/default-branch-drift.mjs` reports:

- **Direct pushes** to `dev` with no associated merged pull request
- **Workflow files** outside the reviewed allowlist
- **Runs stuck in `action_required`** or queued past a threshold — the public repo accumulated 43 of these on 2026-09-04 and nobody was told
- **Missing branch protection**, read from `dev` effective rules rather than the ruleset inventory. This repository already carried a ruleset whose branch include list was empty, so it appeared protective and protected nothing. That is the specific failure this check exists to catch.

Every check degrades to a recorded `unavailable` when the token cannot read an endpoint, so a permission gap can never render as an all-clear.

## One manual step

`.github/workflows/security-drift.yml` is **not** in this push. The maintainer machine token deliberately lost `workflow` scope after the incident, and GitHub correctly refuses to let it create workflow files. That refusal is the control working, so rather than re-granting the scope, the workflow file is added to this branch through the web editor. It is already allowlisted by the hygiene guard in this PR.

## Evidence

`node --test scripts/default-branch-drift.test.mjs` 23 / 23; hygiene suite 87 / 87; `repo:hygiene`, `docs:check`, `test:docs`, security run-check all pass.

Anti-false-green: five mutations, each proven non-vacuous and restored byte-identical — direct pushes ignored, any workflow allowed, `action_required` ignored, protection always reported healthy, and `unavailable` counted as OK.

Refs #431.

🤖 Generated with [Claude Code](https://claude.com/claude-code)