### PR TITLE
ci(security): gate PRs on the repository hygiene guard

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -62,3 +62,24 @@ jobs:
         run: node --test scripts/security-pipeline/checks/committed-private-key-material.test.mjs
       - name: Run committed private key material check
         run: node scripts/security-pipeline/run-check.mjs --config .github/security-pipeline/checks.yml --check committed-private-key-material
+
+  repo-hygiene:
+    name: "repository hygiene: workflow allowlist (gating)"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        # pin: full 40-char commit SHA per sha-pin-policy.md.
+        # NOTE: verify this SHA at the commit gate before merge.
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup Node.js
+        # pin: full 40-char commit SHA per sha-pin-policy.md.
+        # NOTE: verify this SHA at the commit gate before merge.
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version-file: .nvmrc
+      - name: Test repository hygiene guard
+        run: node --test scripts/check-repo-hygiene.test.mjs
+      - name: Run repository hygiene guard
+        run: npm run -s repo:hygiene

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -79,6 +79,8 @@ jobs:
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version-file: .nvmrc
+      - name: Install dependencies (no lifecycle scripts)
+        run: npm ci --ignore-scripts
       - name: Test repository hygiene guard
         run: node --test scripts/check-repo-hygiene.test.mjs
       - name: Run repository hygiene guard


### PR DESCRIPTION
## Correction (2026-09-10, after merge)
The original description claimed the hygiene guard was never executed in CI and that a PR adding a rogue workflow file would have passed. **That was wrong.** `alpha-build.yml` runs `npm run verify:alpha`, and `scripts/verify-alpha.mjs` runs `npm run repo:hygiene`; "Build Chrome extension alpha" was already a required check. A rogue workflow file was already blocked (confirmed by fixture PR #439, which fails both checks on the identical finding).

## What this PR actually adds
A **separately named** gating job, `repo-hygiene` → check "repository hygiene: workflow allowlist (gating)", that:
- makes a hygiene failure attributable by name instead of surfacing as a generic build failure;
- runs the guard's own unit tests (`scripts/check-repo-hygiene.test.mjs`, 87 tests) before the guard — `verify-alpha` does not, so a PR that weakened the checker could previously pass;
- runs in ~10 s without building the extension, so it is independent of build flakiness.

Installs dependencies with `npm ci --ignore-scripts` (the test file imports `yaml`; no lifecycle scripts run).

## Validation (actual)
| Command | Result |
| --- | --- |
| `npm run -s repo:hygiene` on a clean worktree of `dev` | exit 0, 0 violations |
| same, with a planted non-allowlisted workflow present | exit 1; all four rules fire |
| `git ls-tree origin/dev .github/workflows` vs `WORKFLOW_ALLOWLIST` | identical |
| this check on its own PR (run 2) | install → tests → guard all success |
| this check on the `dev` push after merge (run 34440052765) | success |
| fixture PR #439 (inert non-allowlisted workflow) | this check **fails**, merge **blocked** |

Now a required status check on the `dev` ruleset alongside the two existing ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)