### PR TITLE
docs(adr): deferred ADR-055/056 + Resonant Extension Framework package (resubmit of #327 docs slice)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -72,10 +72,17 @@ review, promotion, or trusted-memory writes.
 ## Change An Add-On
 
 Read [ADR-006: Add-On Runtime SDK](architecture/ADR-006-addon-runtime-sdk.md),
+[ADR-018: Add-on SDK V0](architecture/ADR-018-addon-sdk-v0.md),
+[ADR-055: Resonant Extension Framework](architecture/ADR-055-resonant-extension-framework.md)
+(extends ADR-006/018 toward public/third-party add-ons), and
+[ADR-056: Provider Fabric Boundary for External Agent Runtimes](architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md)
+(boundary for third-party agent runtimes like DeepSeek Harness or Agent Zero),
 [ADR-023: Add-On Repository And Registry](architecture/ADR-023-addon-repository-registry-model.md),
 [Add-On Lifecycle Uninstall Design](addons/addon-lifecycle-uninstall-design.md),
-and [Module Ownership](architecture/MODULE-OWNERSHIP.md). For the separate
-controlled Chromium package, use its
+and [Module Ownership](architecture/MODULE-OWNERSHIP.md). The Resonant
+Extension Framework package lives at
+[Framework package README](addons/resonant-extension-framework/README.md).
+For the separate controlled Chromium package, use its
 [component README](../addons/resonant-browser-host/README.md).
 
 ## Change Documentation

--- a/docs/addons/resonant-extension-framework/ADDON_CERTIFICATION_AND_SIGNING_V0.1.md
+++ b/docs/addons/resonant-extension-framework/ADDON_CERTIFICATION_AND_SIGNING_V0.1.md
@@ -1,0 +1,306 @@
+# Resonant Add-on Certification and Signing V0.1
+
+## Purpose
+
+This document defines how an add-on moves from local development to trusted ResonantOS distribution.
+
+Certification exists to protect users without turning the ecosystem into a closed execution model.
+
+## Core Rule
+
+An add-on may be technically valid without being officially approved.
+
+The states are distinct:
+
+```text
+VALID != VERIFIED != APPROVED != GRANTED
+```
+
+- **Valid**: conforms to SDK contracts.
+- **Verified**: release identity/signature and required automated checks are valid.
+- **Approved**: ResonantOS review accepted this exact release for official distribution.
+- **Granted**: the current user or authorized policy allowed a requested capability on this machine.
+
+## REF Vocabulary (C9)
+
+The Resonant Extension Framework uses three named fields that must
+not be confused. Per `OPEN_DESIGN_CONFLICTS_V0.1.md` C9 and
+`RESOLUTIONS_V0.1.md` C9, the rename applies **in REF only** — the
+existing runtime field `agents[].trustTier` stays untouched.
+
+| REF name | Field meaning | Allowed values |
+| --- | --- | --- |
+| `releaseTrustTier` | Distribution trust level granted to a specific release by ResonantOS after certification | `developer`, `verified`, `approved` |
+| `capabilityRiskClass` | Risk class assigned to a capability by the certification pipeline; drives streamlined vs manual review and gates approval | `low`, `moderate`, `high`, `critical` |
+| `agents[].trustTier` *(legacy, unchanged)* | Existing trust label inside the agent subsystem, used by the alpha runtime | unchanged |
+
+The two REF names are the canonical names in this document and in
+the SDK Certification Report. Existing implementation fields
+(`provenance.tier`, etc.) may carry the same value set for V0.1; the
+formal field rename lands when the SDK is extracted to
+`packages/addon-sdk/` (Phase 1 of the implementation roadmap).
+
+The inline "risk class" and "trust tier" prose in this document refers
+to `capabilityRiskClass` and `releaseTrustTier` respectively.
+
+**See also:**
+
+- [`REGISTRY_METADATA_SCHEMA_V0.1.md`](REGISTRY_METADATA_SCHEMA_V0.1.md) —
+  the canonical approved-release index JSON schema and verifier behavior
+  (C10).
+- [`SIGNING_ARCHITECTURE_V0.1.md`](SIGNING_ARCHITECTURE_V0.1.md) — the
+  canonical ed25519 signing envelope and verification behavior (C11).
+- [`CAPABILITY_SEPARATION_V1.md`](CAPABILITY_SEPARATION_V1.md) — the
+  deferred V1 design record for splitting `PublicCapability` from
+  `InternalCapability` (no V0.1 contract change).
+
+## Submission Pipeline
+
+```text
+Developer
+   |
+   v
+SDK Validation
+   |
+   v
+Local Test Suite
+   |
+   v
+Package
+   |
+   v
+Submission
+   |
+   v
+Automated Certification
+   |
+   +--> FAIL -> developer report
+   |
+   v
+Risk Classification
+   |
+   +--> low risk -> streamlined review
+   |
+   +--> sensitive -> manual security/capability review
+   |
+   v
+Functional Review
+   |
+   v
+Approval Decision
+   |
+   +--> reject / changes requested
+   |
+   v
+Bind Review to Digest
+   |
+   v
+Resonant Signature
+   |
+   v
+Official Registry
+```
+
+## Automated Certification Gates
+
+Minimum V0.1 gates:
+
+### Manifest
+
+- schema valid;
+- stable add-on id;
+- valid semantic version;
+- supported SDK range;
+- supported runtime type;
+- all tool capabilities appear in requested capabilities;
+- no unknown privileged capability;
+- no duplicate tool ids;
+- no invalid system-slot claims.
+
+### Package Integrity
+
+- package structure valid;
+- no path traversal;
+- normalized digest reproducible;
+- no secret-like files in prohibited locations;
+- no unsigned mutation after submission.
+
+### Dependencies
+
+- dependency inventory produced;
+- lockfile present when applicable;
+- known critical vulnerabilities flagged;
+- prohibited dependency classes flagged by policy;
+- bundled executable/native assets identified.
+
+### Capability Audit
+
+Certification produces a machine-readable capability report:
+
+```text
+requested
+granted-by-default: none
+risk class
+scope
+reason
+tools requiring capability
+hooks requiring capability
+connectors requiring capability
+```
+
+### Runtime Tests
+
+- install in clean test profile;
+- enable;
+- health check;
+- execute deterministic smoke test;
+- disable;
+- re-enable;
+- remove;
+- verify no unauthorized host calls.
+
+### Compatibility
+
+- supported ResonantOS range;
+- supported SDK range;
+- manifest schema version;
+- runtime protocol support;
+- deprecated API warnings.
+
+## Human Review Triggers
+
+Manual review is required when a release:
+
+- requests a high-risk or critical capability;
+- expands sensitive capabilities from the prior approved version;
+- launches or installs a local service;
+- bundles native executable code;
+- controls a browser;
+- accesses microphone/camera/device integrations;
+- performs external account mutation;
+- requests shell-mediated commands;
+- participates in identity signing;
+- handles credentials beyond approved host references;
+- supplies self-updating code;
+- changes publisher signing identity;
+- requests a broad filesystem scope;
+- modifies installation behavior.
+
+## Review Outcomes
+
+- `approved`
+- `approved-with-constraints`
+- `changes-requested`
+- `rejected`
+- `suspended`
+- `revoked`
+
+Constraints are machine-readable where possible.
+
+## Review Record
+
+Recommended fields:
+
+```json
+{
+  "reviewId": "ROS-ADDON-2026-0042",
+  "addonId": "addon.example.notes",
+  "version": "1.0.0",
+  "packageSha256": "<digest>",
+  "publisherId": "example-developer",
+  "automatedCertification": "pass",
+  "capabilityRisk": "moderate",
+  "decision": "approved",
+  "reviewedAt": "2026-08-24T00:00:00Z",
+  "approvedCapabilities": [
+    "archive-read",
+    "archive-intake-write"
+  ]
+}
+```
+
+## Signing Model
+
+V0.1 should distinguish at least:
+
+1. publisher signature;
+2. Resonant verification/approval signature.
+
+A package may have both.
+
+The official registry must not distribute a release as Resonant Approved unless the package digest matches the approved review record and signature.
+
+## Key Management
+
+Production signing keys must not live in the source repository.
+
+Recommended separation:
+
+- offline or protected root trust key;
+- rotating release-signing keys;
+- publisher keys;
+- revocation metadata.
+
+A key rotation must not invalidate historical package records when the old key remains trusted for its valid time window.
+
+## Revocation
+
+Revocation may target:
+
+- exact add-on release;
+- publisher key;
+- publisher identity;
+- signing key;
+- add-on id in exceptional cases.
+
+Reasons may include:
+
+- compromised publisher key;
+- malicious update;
+- severe undisclosed behavior;
+- supply-chain compromise;
+- critical vulnerability;
+- policy violation.
+
+The client should surface:
+
+- severity;
+- affected release;
+- recommended action;
+- whether execution is blocked.
+
+## Transparency
+
+The user-facing install screen should display:
+
+- publisher;
+- trust tier;
+- version;
+- capabilities requested;
+- sensitive permission explanation;
+- whether code launches local services;
+- whether network access is required;
+- current certification state;
+- signature state.
+
+Approval must not be presented as a guarantee of security.
+
+## Re-Review Rules
+
+A release must be re-certified every version.
+
+Manual re-review is mandatory when:
+
+- capability risk increases;
+- publisher changes;
+- runtime isolation weakens;
+- native code is introduced;
+- installer behavior changes materially;
+- external account write scopes are added;
+- critical security policy changes apply.
+
+## Emergency Security Action
+
+The ResonantOS team may revoke distribution immediately for critical threats.
+
+The runtime still owns the final local enforcement behavior, but the registry may publish high-severity revocation metadata that causes compatible clients to quarantine the release.

--- a/docs/addons/resonant-extension-framework/ADDON_DEVELOPER_WORKFLOW_AND_CLI_V0.1.md
+++ b/docs/addons/resonant-extension-framework/ADDON_DEVELOPER_WORKFLOW_AND_CLI_V0.1.md
@@ -1,0 +1,261 @@
+# Resonant Add-on Developer Workflow and CLI V0.1
+
+## Objective
+
+Make the safe path the easiest path.
+
+A developer should not need to learn ResonantOS kernel internals to produce a compliant add-on.
+
+## Developer Journey
+
+```text
+npm create resonant-addon
+        |
+        v
+choose add-on template
+        |
+        v
+edit resonant.addon.json
+        |
+        v
+implement SDK-facing code
+        |
+        v
+resonant addon validate
+        |
+        v
+resonant addon test
+        |
+        v
+resonant addon audit
+        |
+        v
+resonant addon package
+        |
+        +--> sideload in developer mode
+        |
+        v
+resonant addon submit
+        |
+        v
+certification / review
+```
+
+## Scaffolded Project
+
+```text
+my-addon/
+|
++-- resonant.addon.json
++-- package.json
++-- src/
+|   +-- index.ts
+|
++-- skills/
++-- tests/
+|   +-- manifest.test.ts
+|   +-- smoke.test.ts
+|
++-- README.md
++-- LICENSE
+```
+
+## CLI Commands
+
+### Create
+
+```bash
+resonant addon create
+```
+
+Responsibilities:
+
+- select runtime template;
+- generate manifest;
+- generate tests;
+- pin compatible SDK;
+- create example capability declaration.
+
+### Validate
+
+```bash
+resonant addon validate
+```
+
+Checks:
+
+- manifest schema;
+- capability references;
+- tool/connector/hook references;
+- compatibility;
+- package identity;
+- required fields.
+
+### Test
+
+```bash
+resonant addon test
+```
+
+Runs:
+
+- SDK contract tests;
+- deterministic add-on tests;
+- smoke tests against a mock host;
+- lifecycle tests.
+
+### Audit
+
+```bash
+resonant addon audit
+```
+
+Produces a human-readable and machine-readable report.
+
+Example:
+
+```text
+Resonant Add-on Audit
+
+Add-on: Example Notes
+Version: 1.0.0
+SDK: ^0.1.0
+
+Manifest: PASS
+Compatibility: PASS
+Smoke tests: 12/12 PASS
+
+Capabilities
+------------
+archive-read          MODERATE
+archive-intake-write  MODERATE
+
+Network access: none
+Shell access: none
+Native executables: none
+
+Certification readiness: PASS
+```
+
+### Package
+
+```bash
+resonant addon package
+```
+
+Responsibilities:
+
+- build add-on assets;
+- normalize package;
+- generate checksums;
+- generate provenance metadata;
+- produce `.rpkg`;
+- optionally create publisher signature.
+
+### Submit
+
+```bash
+resonant addon submit
+```
+
+V0.1 may initially output a submission bundle rather than talking to a live registry.
+
+The submission bundle should include:
+
+- `.rpkg`;
+- audit report;
+- test report;
+- provenance;
+- publisher metadata;
+- requested certification tier.
+
+## Mock Host
+
+`@resonantos/addon-sdk-testing` should expose a mock host.
+
+Example:
+
+```ts
+const host = createMockResonantHost({
+  grants: ["archive-read"]
+});
+```
+
+The mock host must reject undeclared and ungranted operations.
+
+This is essential: tests should prove that add-ons handle denied capabilities correctly.
+
+## Reference Add-ons
+
+M0 should ship three deliberately small reference add-ons.
+
+### Hello Resonant
+
+Tests:
+
+- manifest;
+- UI surface;
+- lifecycle;
+- enable/disable.
+
+### Local Files
+
+Tests:
+
+- bounded filesystem read;
+- denied filesystem write;
+- scope enforcement;
+- audit output.
+
+### Local AI
+
+Tests:
+
+- provider/inference request;
+- local vs host-selected provider abstraction;
+- cancellation;
+- no raw provider credential exposure.
+
+## Error Model
+
+SDK-facing errors should be stable and machine-readable.
+
+Candidate codes:
+
+```text
+REF_MANIFEST_INVALID
+REF_CAPABILITY_NOT_DECLARED
+REF_CAPABILITY_NOT_GRANTED
+REF_SCOPE_DENIED
+REF_ADDON_DISABLED
+REF_ADDON_REVOKED
+REF_SDK_INCOMPATIBLE
+REF_HOST_UNAVAILABLE
+REF_HUMAN_APPROVAL_REQUIRED
+REF_SERVICE_UNHEALTHY
+```
+
+## Documentation Requirements
+
+Every public SDK API must document:
+
+- purpose;
+- authority boundary;
+- capability requirement;
+- input/output contract;
+- error behavior;
+- version stability;
+- minimal example.
+
+## Developer Mode
+
+Developer mode may allow unsigned sideloading.
+
+It must clearly indicate:
+
+- unverified publisher;
+- unsigned or locally signed package;
+- capabilities requested;
+- elevated risk if applicable.
+
+Developer mode must not disable capability enforcement.

--- a/docs/addons/resonant-extension-framework/ADDON_PACKAGE_AND_MANIFEST_SPEC_V0.1.md
+++ b/docs/addons/resonant-extension-framework/ADDON_PACKAGE_AND_MANIFEST_SPEC_V0.1.md
@@ -1,0 +1,248 @@
+# Resonant Add-on Package and Manifest Specification V0.1
+
+## Purpose
+
+This specification defines the portable package submitted, reviewed, signed, and installed by the Resonant Extension Framework.
+
+## Recommended Extension
+
+Use `.rpkg` for the packaged artifact.
+
+The format may initially be a deterministic ZIP container.
+
+## Package Layout
+
+```text
+example-notes-1.0.0.rpkg
+|
++-- resonant.addon.json
++-- package/
+|   +-- compiled add-on assets
+|   +-- UI assets
+|   +-- service assets
+|
++-- skills/
++-- docs/
++-- tests/
++-- provenance/
+|   +-- checksums.json
+|   +-- build.json
+|
++-- signatures/
+    +-- publisher.sig
+    +-- resonant-approval.sig   # official releases only
+```
+
+Not every directory is mandatory.
+
+## Required Package Properties
+
+A package must be:
+
+- deterministic enough to produce a stable package digest;
+- self-describing;
+- immutable after signing;
+- version-specific;
+- verifiable before install;
+- unpackable without executing add-on code.
+
+## Required Manifest Fields
+
+```json
+{
+  "schemaVersion": "0.1",
+  "id": "addon.example.notes",
+  "name": "Example Notes",
+  "version": "1.0.0",
+  "author": "Example Developer",
+  "description": "Example note integration.",
+  "category": "knowledge",
+  "runtimeType": "local-service",
+  "sdkVersion": "^0.1.0",
+  "surfaces": [],
+  "requestedCapabilities": [],
+  "providerRequirements": [],
+  "archiveIntegration": {},
+  "health": {},
+  "installHooks": {},
+  "compatibility": {
+    "resonantOS": ">=2.0.0-alpha <3.0.0",
+    "sdk": "^0.1.0"
+  }
+}
+```
+
+The example identifier `addon.example.notes` follows the Add-on SDK V0
+identifier rule (`addon.` reverse-domain), so V0.1 manifests remain valid
+against the current validator.
+
+The implementation may retain existing Add-on SDK fields while normalizing names over time.
+
+## Publisher Block
+
+Recommended:
+
+```json
+{
+  "publisher": {
+    "id": "example-developer",
+    "displayName": "Example Developer",
+    "keyId": "publisher-key-2026-01"
+  }
+}
+```
+
+Publisher identity must not be inferred solely from a display name.
+
+## Optional Manifest Sections
+
+The current Add-on SDK concepts remain supported:
+
+- `provenance`
+- `runtimeIsolation`
+- `grantPresets`
+- `service`
+- `tools`
+- `delegation`
+- `agents`
+- `workflowBoundaries`
+- `skills`
+- `connectors`
+- `scripts`
+- `hooks`
+- `engineerSetup`
+- `augmentorSkills`
+- `install`
+- `audit`
+- `embeddedWorkspace`
+- `agentRuntime`
+- `memoryAccess`
+- `smokeTests`
+
+## Package Digest
+
+Certification binds to a cryptographic digest of the normalized package.
+
+Recommended V0.1 algorithm:
+
+```text
+SHA-256
+```
+
+Example review identity:
+
+```text
+addonId: addon.example.notes
+version: 1.0.0
+packageSha256: <digest>
+manifestSha256: <digest>
+publisherKeyId: publisher-key-2026-01
+reviewId: ROS-ADDON-2026-0042
+```
+
+## Signature Envelope
+
+Illustrative:
+
+```json
+{
+  "algorithm": "ed25519",
+  "keyId": "resonant-release-2026-01",
+  "addonId": "addon.example.notes",
+  "version": "1.0.0",
+  "packageSha256": "<digest>",
+  "signedAt": "2026-08-24T00:00:00Z",
+  "reviewId": "ROS-ADDON-2026-0042"
+}
+```
+
+The exact cryptographic implementation should receive a dedicated security review before production use.
+
+## Installation Verification Order
+
+The installer must verify data before executing add-on code.
+
+```text
+read package
+   |
+   v
+validate archive structure
+   |
+   v
+read manifest
+   |
+   v
+validate manifest schema
+   |
+   v
+calculate digests
+   |
+   v
+verify signatures
+   |
+   v
+check revocation
+   |
+   v
+check compatibility
+   |
+   v
+display capabilities
+   |
+   v
+obtain user grants
+   |
+   v
+install
+```
+
+## Package Safety Rules
+
+Packages must not:
+
+- write files during inspection;
+- launch processes during inspection;
+- contact networks during inspection;
+- execute install hooks before authorization;
+- contain credentials;
+- claim capabilities not present in the manifest;
+- replace files belonging to another add-on;
+- overwrite kernel-owned files.
+
+## Updates
+
+An update is a new package and a new release identity.
+
+The updater must compare:
+
+- requested capabilities;
+- scopes;
+- runtime type;
+- service definitions;
+- connector scopes;
+- native/runtime requirements;
+- publisher key;
+- compatibility range.
+
+Permission expansion must be surfaced to the user.
+
+Sensitive permission expansion must return the release to manual review for official distribution.
+
+## Removal
+
+Removal must:
+
+- disable the add-on first;
+- stop host-managed services;
+- revoke active capability grants;
+- remove package-owned runtime files;
+- preserve user data unless the user explicitly elects deletion;
+- record an audit event.
+
+## Revocation
+
+The registry may mark a signed release revoked.
+
+A revoked release must not be newly installed.
+
+Existing installations should be disabled or quarantined according to severity and local policy, with a clear explanation to the user.

--- a/docs/addons/resonant-extension-framework/ADDON_PACKAGE_AND_MANIFEST_SPEC_V0.1.md
+++ b/docs/addons/resonant-extension-framework/ADDON_PACKAGE_AND_MANIFEST_SPEC_V0.1.md
@@ -61,13 +61,25 @@ A package must be:
   "sdkVersion": "^0.1.0",
   "surfaces": [],
   "requestedCapabilities": [],
-  "providerRequirements": [],
-  "archiveIntegration": {},
-  "health": {},
-  "installHooks": {},
+  "providerRequirements": {
+    "sharedProfiles": [],
+    "supportsPrivateCredentials": false,
+    "preferredRuntimeKinds": []
+  },
+  "archiveIntegration": {
+    "readScopes": [],
+    "intakeWriteScopes": [],
+    "canRequestIngest": false,
+    "canWriteKnowledgePages": false
+  },
+  "health": {
+    "strategy": "host-command",
+    "command": "noop"
+  },
+  "installHooks": { "onInstall": "noop", "onEnable": "noop" },
   "compatibility": {
-    "resonantOS": ">=2.0.0-alpha <3.0.0",
-    "sdk": "^0.1.0"
+    "shellVersion": "^0.1.0",
+    "platforms": ["macOS", "linux"]
   }
 }
 ```

--- a/docs/addons/resonant-extension-framework/ADDON_PERSONAL_PLUGIN_GOVERNANCE.md
+++ b/docs/addons/resonant-extension-framework/ADDON_PERSONAL_PLUGIN_GOVERNANCE.md
@@ -1,0 +1,180 @@
+# Personal / Local Add-on Governance
+
+## Status
+
+- Decision status: Proposed fork policy
+- Alpha applicability: Development / sideload path
+- Owner: Add-on SDK
+- Date: 2026-08-24
+- Related: ADR-006, ADR-018, ADR-023, ADR-026
+
+## Purpose
+
+ResonantOS should support user sovereignty without weakening the SDK boundary. A user may create a plugin/add-on for their own ResonantOS installation and accept more responsibility for breakage, maintenance, and update incompatibility. That freedom does **not** permit bypassing the ResonantOS add-on SDK, manifest, capability, lifecycle, or host-mediation contracts.
+
+> **The SDK is the technical admission protocol. ResonantOS approval is the trust, compatibility, distribution, and support protocol.**
+
+## Core Rule
+
+Every add-on that plugs into ResonantOS must use the supported SDK contract, including personal/local add-ons.
+
+A personal/local add-on may run without ResonantOS development-team approval when all of the following are true:
+
+- the manifest validates against a supported SDK version;
+- requested capabilities are declared explicitly;
+- privileged behavior remains behind ResonantOS host mediation;
+- the human explicitly enables or sideloads the add-on;
+- the human explicitly accepts the unreviewed status and requested capabilities;
+- the add-on does not impersonate an approved publisher or ResonantOS-signed release.
+
+ResonantOS approval is required for an add-on to claim official compatibility, verified update support, curated distribution, or ResonantOS development-team support.
+
+## Two Independent Axes
+
+Technical compliance and ecosystem trust are separate.
+
+| Class | SDK required | ResonantOS review | Official compatibility/update guarantee | Official distribution |
+| --- | --- | --- | --- | --- |
+| Personal / local | Yes | No | No | No |
+| Community unverified | Yes | No | No | No |
+| Verified publisher | Yes | Automated and/or limited review | Limited, policy-defined | Optional curated channel |
+| Resonant Approved | Yes | Yes | Yes, within declared compatibility policy | Yes |
+
+Passing SDK validation means the package follows the technical contract. It does not mean ResonantOS reviewed or endorsed the package.
+
+## Personal / Local Provenance
+
+Recommended future provenance tier:
+
+```text
+personal-local
+```
+
+Until that tier is implemented, personal/local add-ons should remain fail-closed under the existing unverified/sideloaded trust behavior. `personal-local` communicates provenance only; it must not grant capabilities or bypass runtime checks.
+
+## User Responsibility
+
+When a user installs or creates a personal/local add-on, ResonantOS should make clear that the user accepts responsibility for application instability, broken workflows, incompatibility after ResonantOS updates, data loss or corruption within granted scopes, unsupported interaction with other add-ons, and maintaining the add-on as SDK contracts evolve.
+
+This increased responsibility does not turn developer mode into unrestricted execution.
+
+## Non-Bypassable Boundaries
+
+Personal/local add-ons must still obey:
+
+- SDK manifest validation;
+- SDK compatibility rules;
+- capability declaration;
+- explicit human grants;
+- capability revocation;
+- system-slot capability gates;
+- host-mediated provider access;
+- host-mediated filesystem/process/device access;
+- trusted-memory write boundaries;
+- audit requirements for privileged actions;
+- runtime disable/remove lifecycle.
+
+Developer mode may relax **distribution trust requirements**. It must not disable **kernel/runtime authority checks**.
+
+## Suggested User-Facing Warning
+
+> This add-on uses the ResonantOS SDK but has not been reviewed or approved by the ResonantOS development team. It may cause instability, data loss, or incompatibility after updates. You are responsible for enabling and maintaining it. ResonantOS capability and host-security boundaries still apply.
+
+## Official Approval Path
+
+A developer who wants ResonantOS compatibility guarantees, curated distribution, or development-team support must submit the add-on through the approval process.
+
+The approval path should include, at minimum:
+
+1. SDK validation;
+2. deterministic tests and smoke tests;
+3. capability/risk analysis;
+4. package integrity/provenance checks;
+5. compatibility testing against supported ResonantOS versions;
+6. development/security review when policy requires it;
+7. release-specific approval and signing;
+8. re-certification for updates, especially capability changes.
+
+Approval applies to a specific release, not permanently to a plugin name.
+
+## Update Compatibility
+
+Personal/local add-ons receive no automatic compatibility promise across ResonantOS or SDK updates.
+
+Resonant Approved add-ons may receive a compatibility promise only for the version ranges explicitly declared and tested by the approval process.
+
+If an approved add-on update expands sensitive capabilities, changes its runtime boundary, changes publisher identity, or introduces new privileged behavior, the new release must return to the applicable review path.
+
+## Support Posture
+
+The ResonantOS development team may distinguish between bugs in the SDK/runtime boundary, which remain ResonantOS concerns, and breakage caused by an unreviewed personal/local add-on, which remains the add-on author's/user's responsibility unless the failure demonstrates an SDK or host-security defect.
+
+## Architectural Summary
+
+```text
+                     Resonant Add-on SDK
+                            |
+               +------------+------------+
+               |                         |
+        Personal / Local            Submitted Add-on
+               |                         |
+        SDK validation             SDK validation
+               |                         |
+        User sideloads            Certification
+               |                         |
+        User accepts risk          Dev-team review
+               |                         |
+        Host enforces              Signing / approval
+        capabilities                    |
+               |                  Curated distribution
+               |                         |
+         Runs locally              Supported add-on
+```
+
+```text
+SDK compliance is mandatory.
+Official approval is optional for personal use.
+Official trust, compatibility, updates, distribution, and support require approval.
+Host capability enforcement is never optional.
+```
+
+## Cross-References
+
+This document proposes the governance policy shape for explicit support
+of personal/local add-ons.
+
+The two-axis table (SDK required × Resonant review) extends the
+provenance work in `RESOLUTIONS_V0.1.md` C1, which currently maps the
+three REF trust tiers (Developer / Verified / Resonant Approved) onto
+the existing `AddOnProvenanceTier` enum. The proposed `personal-local`
+trust tier would require **adding a new enum value** to
+`AddOnProvenanceTier`, which is a different kind of change from the
+C1 mapping work — it is a new design decision, not a refactor.
+
+Cross-cuts with the framework package:
+
+- `RESONANT_ADDON_SDK_SPEC_V0.1.md` — the technical contract every
+  add-on (including personal/local) must satisfy.
+- `OPEN_DESIGN_CONFLICTS_V0.1.md` — C8 (sideload enablement) is the
+  runtime gate; this document argues it must be fail-closed against
+  bypassing capability checks, even when sideload is enabled.
+- `RESOLUTIONS_V0.1.md` — C8 was deferred ("enable + harden" with the
+  security pipeline as its gate). This document is the policy
+  position to apply when C8 lands.
+- `EXTERNAL_REVIEW_FEEDBACK_V0.1.md` — the prior review's verification
+  record confirms the existing trust-tier enum, which is what this
+  document proposes to extend with `personal-local`.
+
+## Disposition
+
+This is a proposed fork policy, not an accepted decision. Carry into:
+
+1. The ADR-055 draft: the `personal-local` provenance tier (if
+   accepted) becomes an additional enum value with the same fail-closed
+   guarantees as the others.
+2. `RESOLUTIONS_V0.1.md` — when C8 is reopened (sideload enablement), the
+   non-bypassable-boundaries list in this document becomes the
+   acceptance criteria, alongside the security-pipeline review.
+3. `IMPLEMENTATION_ROADMAP_V0.1.md` Phase 3.5 — the user-facing warning
+   wording proposed here is the chip-UI copy for the personal/local
+   tier, once implemented.

--- a/docs/addons/resonant-extension-framework/CAPABILITY_SEPARATION_V1.md
+++ b/docs/addons/resonant-extension-framework/CAPABILITY_SEPARATION_V1.md
@@ -1,0 +1,104 @@
+# Capability Separation V1 (deferred)
+
+## Status
+
+**Deferred to a future ADR.** This document captures the design intent
+so the V1 separation work can be picked up without rediscovery. It does
+**not** modify any V0.1 contract.
+
+Per `ADR-055-resonant-extension-framework.md` §12.3 (Resonant-OS vs
+Third-Party SDK capability separation row) and `RESOLUTIONS_V0.1.md`
+C10 deferred work, the V1 separation is out of scope for V0.1 but
+must be planned.
+
+## Why this is deferred from V0.1
+
+V0.1 ships 13 manifest capabilities plus the two V0.1 additions
+(`channel.send`, `channel.account-write`). The validation, certification,
+and signing pipeline treat all of them uniformly. The runtime and the
+SDK package expose internal types alongside the public surface.
+
+Two reasons V1 needs a real split:
+
+1. **Privilege-not-directory boundary.** The C3 resolution says the
+   boundary is what the host *enforces*, not which directory the code
+   lives in. Today, internal ResonantOS subsystems reach privileged
+   state via the same `Capability` enum that third-party add-ons
+   request. A V1 split gives the host a way to express "this
+   capability is for first-party subsystem use only" without inventing
+   a new enum value for every internal.
+2. **Public SDK surface.** `packages/addon-sdk/` (Phase 1) ships a
+   public type for `Capability`. Whatever values the SDK package
+   exports become part of the public API. Internal-only capabilities
+   (e.g. those that exist purely to wire the bridge to native services)
+   must not leak into the public type.
+
+## Proposed V1 shape
+
+The V1 proposal, recorded here so a future ADR can pick it up without
+rediscovery:
+
+```text
+Capability =
+  | PublicCapability       // 13 + V0.1 channel additions, declared in packages/addon-sdk
+  | InternalCapability     // first-party subsystem use; not exported from packages/addon-sdk
+```
+
+Two parallel enums:
+
+- `PublicCapability` — declared in `packages/addon-sdk/src/capabilities.ts`.
+  Used by add-on manifests and grant records.
+- `InternalCapability` — declared in `src/core/contracts.ts` (current
+  location). Used by the host runtime and first-party subsystems.
+
+The host runtime maps `PublicCapability` to `InternalCapability` (or to
+no capability at all, if the request cannot be satisfied) at the bridge
+boundary. The mapping is the SDK-owned data file from C5.
+
+### V1 manifest shape
+
+The `requestedCapabilities[].capability` field uses
+`PublicCapability` exclusively. A manifest that references an
+`InternalCapability` is rejected at validation with
+`unknown-capability`.
+
+### V1 grant shape
+
+Grants issued by the host carry an `InternalCapability` for runtime
+enforcement; the `PublicCapability` is the visible label to the user.
+
+### V1 certifier shape
+
+The capability audit report (per
+`ADDON_CERTIFICATION_AND_SIGNING_V0.1.md` Capability Audit) describes
+the *requested* capabilities in `PublicCapability` form and reports
+the host-side mapping outcome (`allowed` / `denied-by-mapping` /
+`requires-internal-grant`).
+
+## Out of scope for this deferred record
+
+- Concrete enum values for `InternalCapability`. These are
+  implementation-dependent and depend on the first-party subsystem
+  inventory at the time the V1 ADR is written.
+- Migration of existing V0.1 manifests. V0.1 manifests continue to
+  work; the V1 cutover is opt-in via a `sdkVersion` bump.
+- Removal of any V0.1 capability. The V1 split is additive; the V0.1
+  set is a strict subset of the `PublicCapability` enum.
+
+## ADR pointer
+
+When this work is picked up, it lands as ADR-057 (or whichever number
+is next in the architecture sequence). The ADR should:
+
+1. Confirm the public SDK surface and what stays internal.
+2. Lock the mapping table ownership (per C5: SDK-owned data).
+3. Record the V1 manifest validation rules.
+4. Record the runtime grant migration plan.
+5. Update ADR-055 §12.3 to remove this deferral row.
+
+## Source
+
+- `ADR-055-resonant-extension-framework.md` §12.3 (Resonant-OS vs
+  Third-Party SDK capability separation row)
+- `RESOLUTIONS_V0.1.md` C5 (mapping table ownership)
+- `RESOLUTIONS_V0.1.md` C3 (privilege-not-directory boundary)

--- a/docs/addons/resonant-extension-framework/EXTERNAL_REVIEW_FEEDBACK_V0.1.md
+++ b/docs/addons/resonant-extension-framework/EXTERNAL_REVIEW_FEEDBACK_V0.1.md
@@ -1,0 +1,135 @@
+# External Review Feedback V0.1
+
+First external review of this documentation package, captured as a design
+resource. The reviewer examined both this package and the fork
+(`vonstegen/2.0.0-alpha`), including the existing add-on architecture.
+
+## Source and Status
+
+- Source: independent AI review session (ChatGPT), 2026-08-24, requested by
+  the package author as feedback on `OPEN_DESIGN_CONFLICTS_V0.1.md` and the
+  overall framework direction.
+- Status: feedback for design consideration. Not an accepted decision. Every
+  factual claim the review made about this repository was verified against
+  the fork on 2026-08-24; see "Verification Record" below.
+
+## Core Recommendation
+
+**Do not ship the Resonant Extension Framework as a second, competing add-on
+architecture. Present it as the evolution of the architecture that already
+exists.**
+
+The review found that ADR-006 (Add-on Runtime & SDK) and ADR-018 (Add-on SDK
+V0) already establish most of what this package proposes: a capability-gated,
+host-mediated add-on runtime with provenance trust tiers, manifest contracts,
+and lifecycle rules. The package's real contribution is the missing external
+half. The review's proposed framing:
+
+```text
+ADR-006 Add-on Runtime & SDK
+    ↓
+ADR-018 Add-on SDK V0  (binding internal standard, src/sdk/addons)
+    ↓
+Public / Third-Party SDK  ("Add-on SDK V1")
+    ↓
+Certification + Packaging + Signing
+    ↓
+Official Extension Ecosystem
+```
+
+ADR-018 itself names the gap this package addresses:
+
+> The SDK is not a public marketplace SDK yet.
+
+Suggested naming from the review: "Resonant Add-on SDK V1 — Public /
+Third-Party Extension Framework", rather than an unrelated framework name.
+This independently matches the terminology decision already made for this
+package (the unit is an **add-on**; "Resonant Extension Framework" names the
+governance architecture, not a second artifact type).
+
+## Alignment Map (Review Claims, Verified)
+
+| This package | Existing repository asset |
+|---|---|
+| Developer / Sideloaded trust | ADR-006 `sideloaded-unverified` |
+| Verified trust | ADR-006 `curated-signed` |
+| Resonant Approved trust | ADR-006 `bundled-core`; future `enterprise-signed` |
+| Capability / permission model | ADR-006 capability grants; `src/sdk/addons` |
+| Host-mediated execution | ADR-006; authenticated Node bridge |
+| Manifest standard | ADR-018 `AddOnManifest` contract |
+| "Not a marketplace SDK yet" gap | ADR-018, stated verbatim |
+
+The review also identified branch `sdk/p1b-p1e-slots-provenance` as relevant
+prior art: it gates add-on `systemSlots` behind capabilities and stops
+treating bundled add-ons without provenance as trusted (they default to
+`sideloaded-unverified` / unreviewed).
+
+## What the Review Says This Package Adds
+
+The parts judged to add real value beyond the existing system — keep these:
+
+- external package boundary and `.rpkg` artifact;
+- deterministic package hashing;
+- version-specific certification (approval never inherited across versions);
+- publisher signing plus Resonant approval signing;
+- formal review records;
+- revocation;
+- developer CLI;
+- the External Add-on M0 Test (create, validate, package, sideload,
+  permission, execute, disable, and remove one add-on from outside the
+  ResonantOS source tree, using only the public SDK).
+
+## Fork Strategy Guidance
+
+- Build the framework **beside** the current SDK; do not rewrite the Alpha
+  core first. Adapt `src/sdk/addons` contracts into the public package;
+  change host/runtime code only when an M0 test proves a specific need.
+- Mark the work clearly as fork-owned and experimental, with the upstream
+  dependency stated (`ResonantOS 2.0.0-alpha`), so it is never confused with
+  upstream ResonantOS.
+- Keep an `UPSTREAM_DELTA.md` alongside the framework: record every change
+  the fork makes to an upstream contract, so future rebases show exactly
+  where the fork diverges.
+- Suggested progression: document → extract public SDK → external add-on
+  fixture → sideload lifecycle → capability enforcement → certification →
+  signing → registry.
+
+## Review Cautions
+
+- **Do not promote the proposal to an ADR as written.** The original draft
+  (ADR-031 numbering) risked duplicating decisions already made by ADR-006
+  and ADR-018. The revision path is to reframe explicitly as
+  "Add-on SDK V0 → Public Third-Party SDK V1", extending ADR-006/ADR-018
+  rather than restating them. This package's staging at `docs/design/`
+  (pending acceptance as ADR-055) already avoids premature promotion; the
+  reframing still needs to happen before any ADR-055 draft.
+- The main long-term engineering risk the review flags matches this
+  package's own guiding rule: the public SDK contract must not couple back
+  into private core implementation types. Keep "do not move privilege into
+  the SDK" as a hard architectural rule.
+
+## Verification Record
+
+Claims checked against the fork on 2026-08-24:
+
+- `docs/architecture/ADR-006-addon-runtime-sdk.md` exists; trust tiers at
+  lines 60–63 are `bundled-core`, `curated-signed`, `sideloaded-unverified`,
+  optional future `enterprise-signed`. Confirmed.
+- `docs/architecture/ADR-018-addon-sdk-v0.md` exists; line 17 reads "The SDK
+  is not a public marketplace SDK yet." Confirmed verbatim.
+- Branch `sdk/p1b-p1e-slots-provenance` exists on the fork at `ca8ff57`
+  ("sdk: Gate add-on systemSlots and mark missing provenance as
+  unreviewed"). Confirmed.
+- The review stated the fork's `dev` branch still pointed at a July commit.
+  Stale at time of writing: `dev` was fast-forwarded to upstream `530b753`
+  (2.0.0-beta.1 release prep) earlier on 2026-08-24.
+
+## Disposition
+
+Route this feedback into the resolution of `OPEN_DESIGN_CONFLICTS_V0.1.md`:
+
+1. Reframe the package as the public evolution of ADR-006/ADR-018 before any
+   ADR-055 draft.
+2. Carry the "keep" list above into `IMPLEMENTATION_ROADMAP_V0.1.md` as the
+   external-layer scope.
+3. Add `UPSTREAM_DELTA.md` to the roadmap's fork-hygiene deliverables.

--- a/docs/addons/resonant-extension-framework/IMPLEMENTATION_ROADMAP_V0.1.md
+++ b/docs/addons/resonant-extension-framework/IMPLEMENTATION_ROADMAP_V0.1.md
@@ -1,0 +1,296 @@
+# Resonant Extension Framework Implementation Roadmap V0.1
+
+## Objective
+
+Turn the current internal Add-on SDK V0 into an externally consumable, governed add-on system without destabilizing the Alpha runtime.
+
+## Guiding Rule
+
+Do not move privilege into the SDK.
+
+The SDK defines contracts.
+
+The Alpha bridge, capability broker, and named host services remain the privileged execution boundary.
+
+## Phase 0 — Freeze Current Contract Surface
+
+### Deliverables
+
+- inventory all exports from `src/sdk/addons/`;
+- inventory all Add-on manifest fields in use;
+- inventory bundled manifests in `public/addons/`;
+- inventory bridge capabilities and add-on delegation routes;
+- record unsupported/deferred fields;
+- identify imports from `src/core/contracts.ts` that block external packaging.
+
+### Exit Gate
+
+A machine-readable list exists for:
+
+- current public candidates;
+- internal-only contracts;
+- capability names;
+- service protocols;
+- manifest fields;
+- compatibility assumptions.
+
+## Phase 1 — Extract Public SDK Package
+
+### Target structure
+
+```text
+packages/
++-- addon-sdk/
+|   +-- src/
+|   +-- test/
+|   +-- package.json
+|
++-- addon-sdk-testing/
+    +-- src/
+    +-- test/
+    +-- package.json
+```
+
+If the Alpha repo is not yet ready for workspaces, the package can first live under:
+
+```text
+src/sdk/addon-public/
+```
+
+but it must be testable as if imported externally.
+
+### Deliverables
+
+- public manifest types;
+- public capability constants;
+- validation;
+- compatibility parser;
+- stable error codes;
+- no private relative imports from add-on projects.
+
+### Exit Gate
+
+An external fixture project compiles and validates while importing only the SDK package.
+
+## Phase 2 — Add-on Package Format
+
+### Deliverables
+
+- `.rpkg` archive format;
+- deterministic normalization rules;
+- checksum generation;
+- package reader that does not execute code;
+- manifest extraction;
+- package digest;
+- path traversal protection.
+
+### Exit Gate
+
+A package can be built, inspected, hashed, and rejected safely before installation.
+
+## Phase 3 — Developer CLI
+
+### Deliverables
+
+- `create`;
+- `validate`;
+- `test`;
+- `audit`;
+- `package`.
+
+`submit` may remain local/export-only at first.
+
+### Exit Gate
+
+
+## Phase 3.5 — Caller-Attributed Capability Tokens
+
+**Gate phase.** Hard-pinned before Phase 4 and before any M0 reference test that exercises enforcement (Tests B and C). Closes C2.
+
+### Deliverables
+
+- extend `isAuthorizedCapabilityRequest` (`browser-first/host/bridge-server.mjs`) from a static route→token map to a grant store keyed `(callerId, capability, scope)`;
+- mint per-add-on tokens at grant time using the existing requested/granted/denied record shape;
+- remove bootstrap-derived credential set from `lib/addon-iframe.js`; iframes receive only the per-caller, scope-bounded token;
+- audit-trail hook that records callerId on every authorised request.
+
+### Exit Gate
+
+
+## Phase 4 — Host Install and Lifecycle (gated on 3.5)
+
+### Deliverables
+
+- install;
+- enable;
+- disable;
+- health;
+- update;
+- remove;
+- capability grant display;
+- audit records.
+
+### Exit Gate
+
+The Hello Resonant reference add-on completes the full lifecycle.
+
+## Phase 5 — Certification Harness
+
+
+### Deliverables
+
+- automated manifest checks;
+- package-integrity checks;
+- dependency inventory;
+- capability-risk report;
+- compatibility checks;
+- clean-profile runtime test;
+- smoke-test execution;
+- machine-readable certification report.
+
+### Exit Gate
+
+The same release produces the same certification identity and digest when built through the supported path.
+
+## Phase 6 — Signing and Trust
+
+### Deliverables
+
+- publisher signature format;
+- Resonant approval signature format;
+- trusted key store;
+- verification;
+- revocation metadata;
+- trust-tier UI.
+
+### Exit Gate
+
+The host differentiates:
+
+- unsigned sideload;
+- verified publisher release;
+- Resonant Approved release;
+- revoked release.
+
+## Phase 7 — Review Workflow
+
+### Deliverables
+
+- submission bundle;
+- review record schema;
+- automated risk classification;
+- manual-review trigger rules;
+- approval decision;
+- digest-bound approval.
+
+### Exit Gate
+
+A release can move from developer package to officially approved artifact without changing bytes after approval.
+
+## Phase 8 — Registry
+
+### Deliverables
+
+- registry metadata format;
+- approved release index;
+- compatibility filtering;
+- revocation feed;
+- update lookup.
+
+### Non-Goal
+
+Do not add marketplace commerce in this phase.
+
+## M0 Reference Tests
+
+**Order:** Test B → Test C → Test A.
+
+Test A is deferred past V0.1 (see C4 resolution: V0.1 is declarative-only; no third-party code runs in the shell). Tests B and C are gated on Phase 3.5.
+
+### Test A — Hello Resonant (deferred past V0.1)
+
+Must prove, *when revisited after the post-V0.1 sandbox surface ships*:
+
+- external scaffold;
+- manifest validation;
+- package;
+- sideload;
+- install;
+- enable;
+- UI surface;
+- disable;
+- remove.
+
+
+### Test B — Local Files
+
+Must prove:
+
+- capability declaration;
+- user grant;
+- scope restriction;
+- denied unauthorized action;
+- audit record.
+
+### Test C — Local AI
+
+Must prove:
+
+- add-on asks for inference capability;
+- host chooses authorized provider/runtime;
+- add-on never receives raw provider credentials;
+- cancellation and failure are bounded;
+- audit remains attributable to add-on id/version.
+
+## Suggested Repository Additions
+
+```text
+docs/
++-- architecture/
+|   +-- ADR-055-resonant-extension-framework.md
+|
++-- add-ons/
+    +-- RESONANT_ADDON_SDK_SPEC_V0.1.md
+    +-- ADDON_PACKAGE_AND_MANIFEST_SPEC_V0.1.md
+    +-- ADDON_CERTIFICATION_AND_SIGNING_V0.1.md
+    +-- ADDON_DEVELOPER_WORKFLOW_AND_CLI_V0.1.md
+    +-- IMPLEMENTATION_ROADMAP_V0.1.md
+
+packages/
++-- addon-sdk/
++-- addon-sdk-testing/
+
+examples/
++-- add-ons/
+    +-- hello-resonant/
+    +-- local-files/
+    +-- local-ai/
+```
+
+## Recommended First Engineering Commit
+
+Documentation only:
+
+```text
+docs: define Resonant Extension Framework V0.1
+```
+
+Do not change runtime behavior in the same commit.
+
+## Recommended Second Engineering Commit
+
+Contract extraction only:
+
+```text
+sdk: extract public add-on contracts and validation
+```
+
+## Recommended Third Engineering Commit
+
+External fixture:
+
+```text
+test: prove external add-on SDK consumption
+```
+
+This sequence makes regressions easy to identify and avoids mixing policy, API extraction, and runtime authority changes.

--- a/docs/addons/resonant-extension-framework/MAINTAINER_ALIGNMENT_ROADMAP.md
+++ b/docs/addons/resonant-extension-framework/MAINTAINER_ALIGNMENT_ROADMAP.md
@@ -1,0 +1,51 @@
+# Maintainer-Alignment Roadmap — REF/SDK Contribution
+
+## Status
+
+- Date: 2026-08-31
+- Updated: 2026-09-10 — Tom reviewed the full stack in the 2026-09-10 closeout (per-PR blockers plus a resubmission path: docs-only ADR PR first, then the SDK relocation PR). Issue states re-verified: #109 OPEN, #137 OPEN, #180 OPEN (task 1 landed in `dev`), #215 CLOSED. #327–#331 closed automatically when the fork was deleted and re-created; resubmission follows the closeout order.
+- Source: external review of Tom's *indirect* maintainer feedback (ChatGPT, 2026-08-31), verified against the upstream issue record.
+- Verdict: the architecture is aligned (~8/10); the disagreement is **release-scope timing** (Alpha/beta.1 vs beta.2), not design. Remaining work is decision hygiene and decomposition, not redesign.
+- As of 2026-08-31 Tom had **not reviewed** the REF PRs; every maintainer signal below is a release-scope disposition on issues (#109, #180, #215, #137), each drafted via Claude Code and read from the issue comment record on 2026-08-31. Superseded by the 2026-09-10 closeout (see Updated note).
+
+## Principle
+
+REF is the governed evolution of the existing Add-on SDK (ADR-006/ADR-018), not a replacement. It splits into two planes:
+
+- **REF Core / Add-on SDK V0.1** — manifests, capability declarations, validation, delegation contracts, external-runtime boundary, host-owned authority, negative-test infrastructure. Moves now.
+- **REF Distribution & Lifecycle (beta.2)** — `.rpkg` install, remote registry, third-party sideload, signature/hash enforcement, certification, update/uninstall/revocation, marketplace. Gated on a third-party install path existing.
+
+Security requirements become mandatory at the boundary where third-party code actually becomes installable (Tom, #109).
+
+## Completed
+
+| # | Recommendation | State | Evidence |
+|---|---|---|---|
+| 0 | Verify Tom's feedback rather than trust the sweep | Done | GitHub API read of #109/#180/#215/#137; zero reviews/comments from `tompennington` on #327–#331 as of 2026-08-31 (superseded by the 2026-09-10 closeout) |
+| 1 | Reframe ADR-055 as evolution, not replacement | Done | ADR-055 §1: "extension of, not replacement for, ADR-006 and ADR-018" |
+| 2 | Divide SDK Core V0.1 from Distribution/Lifecycle beta.2 | Done (status) | ADR-055 §15.2 re-classifies C6/C7/C8/C10/C11 as beta.2 distribution deferrals |
+| 3 | Gate signing/.rpkg/registry/sideload behind "activates when third-party install exists" | Done (documented) | ADR-055 §15.2 cites #109: "becomes gating the moment a remote/marketplace registry or extension-side sideload lands" |
+| 4 | Uninstall/revocation/re-consent as a first-class contract (#180) | Done | ADR-055 §16 — four-transition lifecycle contract (disable/enable/uninstall/update), grounded in the #180 audit |
+| 5 | PR #327 too large — decompose | Done | Split into #327 (REF) + #334 (tab-referencing); original history on `backup/tab-referencing-pre-split` |
+| 6 | "Maintainer-alignment patch" as the next move | Done | ADR-055 §15 reconciliation + §15.2 re-classification + split |
+| 7 | Keep the DeepSeek/external-runtime experiment | Intact | ADR-056 lives in #327; external-runtime PRs #329–#331 unaffected |
+| 8 | Resolve the ADR double-claim (fork hygiene) | Done | REF renumbered ADR-038→055 and ADR-040→056 (153 refs + 2 file renames) |
+
+## Remaining
+
+### Phase 1 — blocked on Tom
+
+1. **Review the resubmitted ADR PRs** (#327 was closed by the fork re-creation and is resubmitted per the 2026-09-10 closeout; #334 is closed), and answer ADR-055 §15.3:
+   - REF-vs-"Add-on SDK V1" terminology;
+   - `packages/addon-sdk/` as the long-term public boundary;
+   - which V0.1 subset to accept now;
+   - the Deferred → Accepted transition path.
+
+### Phase 2 — parallel CP workstream
+
+2. CP-7 redaction/export/retention/deletion tests; CP-5 assistant-only output-filtering parity; CP-6 executor UI; CP-9 "declare stable" (blocked on live harness validation + OpenClaw key).
+
+## Sequencing
+
+1. Tom reviews the resubmitted ADR PRs and answers ADR-055 §15.3 → Deferred → Accepted.
+2. In parallel: CP-7 tests, CP-5 filtering, CP-6 UI → CP-9 stable.

--- a/docs/addons/resonant-extension-framework/OPEN_DESIGN_CONFLICTS_V0.1.md
+++ b/docs/addons/resonant-extension-framework/OPEN_DESIGN_CONFLICTS_V0.1.md
@@ -1,0 +1,573 @@
+# Resonant Extension Framework V0.1 — Open Design Conflicts for External Review
+
+## Purpose of This Document
+
+This document lists the unresolved design conflicts discovered when the
+Resonant Extension Framework (REF) V0.1 proposal was reviewed against the
+actual ResonantOS `2.0.0-alpha` codebase (state: 2026-08-24, version
+2.0.0-beta.1).
+
+It is written for external review (ChatGPT and the ResonantOS development
+team). It is self-contained: all evidence needed to evaluate each conflict
+is included inline. File paths and symbol names refer to the
+`2.0.0-alpha` repository so the team can verify claims against the source.
+
+### How to review
+
+For each conflict (C1–C13):
+
+1. State whether you agree with the framing. If not, reframe it.
+2. Pick one of the options, or propose a better one, with reasoning.
+3. Flag anything that makes the conflict more or less urgent than stated.
+
+After the conflicts:
+
+4. Identify conflicts this document misses.
+5. Re-order the priority list if you disagree with it.
+
+## Background in Sixty Seconds
+
+REF is a proposal to evolve the existing internal **Add-on SDK V0** into a
+governed add-on ecosystem: trust tiers (Developer / Verified / Resonant
+Approved), a signed `.rpkg` package format, an automated certification
+pipeline, a developer CLI, and a plugin registry.
+
+Core principle:
+
+```text
+Manifest declares.
+Certification evaluates.
+Signature identifies.
+User grants.
+Host enforces.
+```
+
+Terminology note: the unit of the ecosystem is an **add-on** (matching
+existing repo vocabulary: `AddOnManifest`, `src/sdk/addons/`, ADR-018).
+Earlier drafts used the word "plugin"; the concepts are identical.
+"Resonant Extension Framework" names the governance architecture, not a
+second artifact type.
+
+The full proposal lives beside this document:
+
+- `PROPOSAL-resonant-extension-framework.md` (draft for ADR-055)
+- `RESONANT_ADDON_SDK_SPEC_V0.1.md`
+- `ADDON_PACKAGE_AND_MANIFEST_SPEC_V0.1.md`
+- `ADDON_CERTIFICATION_AND_SIGNING_V0.1.md`
+- `ADDON_DEVELOPER_WORKFLOW_AND_CLI_V0.1.md`
+- `IMPLEMENTATION_ROADMAP_V0.1.md`
+
+## Grounding: What the Repo Actually Has Today
+
+### The Alpha runtime
+
+Exactly two privileged components:
+
+1. a Chrome Manifest V3 extension
+   (`browser-first/resonantos-side-panel-extension/`);
+2. an authenticated loopback Node bridge (`browser-first/host/`), HTTP port
+   47773 / HTTPS 47774, bound to 127.0.0.1.
+
+The only privileged path is: extension → bridge-token-authenticated request
+→ per-route capability-token check in `bridge-server.mjs` → named host
+service → provider endpoint / local filesystem / local service.
+
+### The existing Add-on SDK V0 (ADR-018)
+
+- Typed manifests (`AddOnManifest`, `src/core/contracts.ts`), validated by
+  `validateAddOnManifest` (`src/sdk/addons/validation.ts`, ~1,180 lines).
+- Manifests are **declarative only** — shell add-ons carry no executable
+  code. UI surfaces are hand-written per-add-on React panels
+  (`src/modules/addons/`). Effects happen through host-mediated services,
+  declared tools, and scripts/hooks.
+- Capability coherence is enforced: every capability referenced by any
+  sub-contract must be declared in `requestedCapabilities`.
+- Trust vocabulary already exists as types:
+
+```text
+AddOnProvenanceTier        = bundled-core | curated-signed |
+                             enterprise-signed | sideloaded-unverified
+ManifestVerificationState  = verified | unverified | not-applicable | failed
+AddOnRegistryReviewState   = unreviewed | reviewed | approved |
+                             blocked | deprecated
+```
+
+- The registry already implements "no trust by omission": a bundled
+  manifest without provenance is downgraded to
+  `sideloaded-unverified / unverified / unreviewed`
+  (`src/sdk/addons/registry.ts`).
+- Signing fields exist (`provenance.signed`, `signer`, `signatureRef`,
+  `AddOnArtifactReference.sha256`) but are **self-asserted — nothing
+  verifies them**.
+- `sdkVersion` exists (`ADDON_SDK_VERSION = "0.1.0"`) but is **never
+  validated**; `compatibility.shellVersion` is only checked as a non-empty
+  string.
+
+### Three capability vocabularies coexist
+
+1. **Manifest capabilities** (13, coarse): `filesystem`, `archive-read`,
+   `archive-intake-write`, `chat-interface`, `memory-provider`,
+   `providers`, `shell`, `network`, `ui-embedding`, `browser-control`,
+   `agent-delegation`, `notifications`, `device-integration`
+   (`ADDON_CAPABILITIES`, `src/sdk/addons/contracts.ts`).
+2. **Bridge route capabilities** (23, fine-grained):
+   `BRIDGE_CAPABILITY_TOKEN_SPECS`
+   (`browser-first/host/bridge-capability-tokens.mjs`) — e.g.
+   `provider-model-invoke`, `agent-control-plan`, `archive-read`,
+   `archive-write`, `memory-source-*`, `browser-download-action`,
+   `addon-runtime-control`. A consistency test locks this list to the
+   extension-side allowlist.
+3. **Browser-first add-on capabilities** (informal): a second, untyped
+   manifest format (`browser-first/addons/*/addon.json`) with its own
+   `capabilities` field.
+
+### The second add-on system
+
+`browser-first/addons/resonant-context/addon.json` and
+`resonator/addon.json` use an untyped schema (`mode`, `trust`, `entry`,
+`contentScripts`, `commands`, `messageChannel`, `capabilities`,
+`requires`, `boundary`) and **do carry executable JavaScript**, injected as
+Chrome content scripts. Their dashboards render through
+`lib/addon-iframe.js`: bridge-proxied HTML inlined into a sandboxed
+`srcdoc` iframe.
+
+### The enforcement gap (most important single fact)
+
+- Bridge capability tokens are minted per extension session
+  (`POST /api/capability-tokens`, gated by a bootstrap token) and are
+  **not caller-attributed**: any holder of a scoped token is
+  indistinguishable from the extension itself.
+- `lib/addon-iframe.js` passes `bridgeUrl` and the `bridgeToken` into
+  sandboxed iframes. Today's de-facto add-on channel therefore hands every
+  add-on extension-grade authority.
+- Per-add-on `requestedCapabilities / grantedCapabilities /
+  deniedCapabilities` records exist
+  (`browser-first/host/addon-delegation-service.mjs`) but are **descriptive
+  only**. The code states this explicitly: "Capability enforcement happens
+  at the bridge via per-route tokens; these chips describe the add-on
+  contract."
+- The sideload path exists in `src/core/runtime.ts` but
+  `hasCommandHost()` is hardcoded `false` — sideloading is disabled in
+  this build.
+
+### Governance gates any change must pass
+
+`npm run verify:alpha` sequences 16 checks including: repo hygiene (no
+`*.zip`, no symlinks, no >10 MiB files, multi-encoding secret scans), docs
+validation (link reachability, ADR index parity, command truthfulness),
+build, vitest + `node --test` suites, security-pipeline certification, and
+a release scope audit that fails strict mode on any unregistered path.
+
+---
+
+## C1 — Trust tiers: three new tiers vs. the existing enum stack
+
+**Conflict.** The proposal defines three tiers (Developer / Verified /
+Resonant Approved). The repo already models four provenance tiers, four
+verification states, and five review states (see Grounding). Inventing a
+parallel vocabulary would fork the domain model; ignoring the proposal
+loses the ecosystem semantics.
+
+**Plausible mapping:**
+
+| REF tier | Existing enums |
+|---|---|
+| Developer | `sideloaded-unverified` + `unverified` + `unreviewed` |
+| Verified | `curated-signed` + `verified` + `reviewed` |
+| Resonant Approved | `curated-signed` + `verified` + `approved` (bound to package digest) |
+
+**Open:** what happens to `bundled-core` (first-party, trusted by
+bundling, not signature) and `enterprise-signed` (no enterprise flow
+exists yet)? Does "Verified" require a new provenance tier value, or is it
+`curated-signed` with a verification state?
+
+**Options:**
+
+- **(a) Map only.** Keep existing enums; ADR-055 documents the mapping.
+  Cheapest; no migration; but "Verified vs Approved" distinction lives
+  only in review state, which is registry-derived today, not stored per
+  release.
+- **(b) Extend.** Add explicit tier values and a per-(addonId, version)
+  approval record. More invasive; matches the proposal's
+  version-specific approval requirement.
+- **(c) Replace.** New REF trust model supersedes the old enums with a
+  migration. Cleanest end state; highest churn across validation,
+  registry, and UI.
+
+**Question for reviewer:** which option, and what is the fate of
+`bundled-core` / `enterprise-signed`?
+
+## C2 — Capability tokens are not caller-attributed (highest priority)
+
+**Conflict.** REF's promise — "User grants. Host enforces." — cannot be
+implemented on the current bridge. Enforcement is a static route→token
+map; any token holder has the extension's authority; the add-on iframe
+channel is handed the bridge URL and bridge token directly.
+
+**Consequence:** every runtime phase of the roadmap (install, lifecycle,
+certification runtime tests) inherits this hole. Per-add-on grants are UI
+decoration until tokens carry caller identity.
+
+**Options:**
+
+- **(a) Per-caller grant store at the dispatcher.** Extend
+  `isAuthorizedCapabilityRequest` (`bridge-server.mjs`) from a static map
+  lookup to a grant store keyed `(callerId, capability, scope)`. Mint
+  per-add-on tokens at grant time; stop passing the bootstrap-derived
+  credential set into iframes. Reuse the existing
+  requested/granted/denied record shape as the schema.
+- **(b) Full mediation.** Add-on iframes get no bridge credentials at
+  all; they call a `postMessage` API surfaced by the shell, which
+  authorizes and forwards. Strongest isolation; requires building the
+  message API surface.
+- **(c) Hybrid.** (a) now for local-service add-ons; (b) as the target
+  for any UI-embedded third-party code.
+
+**Question for reviewer:** which mediation shape, and should this become
+an explicit roadmap phase (proposed: "Phase 3.5 — caller-attributed
+capability tokens") gating all later runtime phases?
+
+## C3 — Two manifest systems, one proposal
+
+**Conflict.** The proposal assumes a single manifest contract. The repo
+has two: the typed, declarative shell SDK v0, and the informal,
+code-carrying browser-first `addon.json` (see Grounding).
+
+**Options:**
+
+- **(a) Subsume.** Type the browser-first fields into the SDK manifest
+  (content scripts, message channel, boundary) and migrate
+  `resonant-context` / `resonator`. One contract; real migration cost.
+- **(b) Bridge.** Keep both; write an adapter that projects browser-first
+  manifests into SDK records. Two contracts forever; adapter drift risk.
+- **(c) Scope-exclude.** Declare browser-first add-ons "extension-internal
+  modules," out of REF scope. Honest but leaves executable code outside
+  the governance model REF claims to own.
+
+**Question for reviewer:** which — and if (c), how is the boundary
+worded so third-party code cannot route around REF through the
+browser-first path?
+
+## C4 — No executable surface exists for third-party add-on code
+
+**Conflict.** Shell add-ons today are declarative JSON plus hand-written
+React panels. M0 Test A in the roadmap ("Hello Resonant" with a UI
+surface) implicitly requires a sandboxed execution/rendering surface for
+third-party code that does not exist in the shell. This is the largest
+hidden work item in the proposal; no roadmap phase builds it.
+
+**Options:**
+
+- **(a) V0.1 is declarative-only.** Add-ons = manifest + host-mediated
+  tools + local services; no shipped code runs in the shell. Defers the
+  problem; severely limits what ecosystem add-ons can be.
+- **(b) Extend the browser-first iframe model** to shell surfaces — but
+  only after C2 is fixed, since that model currently leaks bridge
+  credentials.
+- **(c) Build a dedicated sandboxed module runner** (isolated JS realm,
+  SDK API only). Most work; cleanest end state.
+
+**Question for reviewer:** is code-carrying add-ons in V0.1 scope at all?
+If not, say so explicitly in the spec and adjust M0 Test A.
+
+## C5 — Three capability vocabularies with no mapping layer
+
+**Conflict.** The proposal wants fine-grained capabilities
+(`network.http`, `filesystem.read`, …). The repo has 13 coarse manifest
+capabilities, 23 bridge route capabilities, and the informal browser-first
+set — with no declared mapping between a manifest request and the bridge
+tokens an operation actually requires. That mapping **is** the
+developer-facing contract; it is currently unwritten.
+
+**Options:**
+
+- **(a) Mapping table owned by the SDK package**, consumed by validation
+  (warn when a requested capability maps to nothing) and by the bridge
+  (authorize at route granularity). Single source of truth.
+- **(b) Collapse to one vocabulary.** Migrate manifest capabilities to
+  the bridge's finer set with a deprecation window. More honest; touches
+  every bundled manifest.
+- **(c) Two-layer model, documented:** coarse "product capabilities" for
+  users, fine "route capabilities" for enforcement, mapping shipped as
+  data.
+
+**Question for reviewer:** who owns the mapping, and what migration order
+avoids breaking the 16 bundled manifests in `public/addons/`?
+
+## C6 — `.rpkg` container format vs. repository hygiene rules
+
+**Conflict.** The proposal suggests a deterministic ZIP container. The
+repo forbids `*.zip` files anywhere (`scripts/check-repo-hygiene.mjs`),
+and the supply-chain conventions treat archives as hostile until scanned.
+Test fixtures of a zip-based `.rpkg` would collide with that posture.
+
+**Options:**
+
+- **(a) ZIP with explicit allowlist.** Keep the proposal; add a hygiene
+  allowlist entry for `*.rpkg` fixtures under test paths. Least spec
+  churn; weakens a blanket rule.
+- **(b) Deterministic tar (`.tar.zst`)**. No zip ban collision; equally
+  reproducible; slightly less familiar tooling.
+- **(c) Custom manifest-first bundle** (canonical JSON + content-addressed
+  blob tree). Best determinism story; most tooling to build.
+
+**Question for reviewer:** which container, given that deterministic
+digest reproducibility is a certification requirement?
+
+## C7 — `sdkVersion` and `compatibility` are never evaluated
+
+**Conflict.** The proposal makes compatibility ranges load-bearing
+(`compatibility.resonantOS`, `compatibility.sdk`). Today `sdkVersion` is
+unchecked and `compatibility.shellVersion` is a non-empty-string check.
+Nobody evaluates a semver range anywhere in the host.
+
+**Options:**
+
+- **(a) Enforce at validation time only** (`validateAddOnManifest`
+  rejects out-of-range manifests). Simple; but a host upgrade can strand
+  already-installed add-ons with no signal.
+- **(b) Enforce at install + evaluate at launch.** Install-time rejection
+  plus launch-time degrade/quarantine when the host no longer matches.
+  Safer; needs a runtime state (`degraded`) the lifecycle model already
+  names.
+
+**Question for reviewer:** install-time only, or install + launch? And is
+range evaluation an SDK-package export or host-internal?
+
+## C8 — Sideload is disabled in the current build
+
+**Conflict.** REF Tier 1 (Developer) requires sideloading. The runtime
+sideload path exists but is disabled (`hasCommandHost()` hardcoded
+`false`). Enabling it is a security-relevant runtime change, not a docs
+change: ADR-018 already requires sideloaded add-ons to be treated as
+unverified, and validation runs before trust — but the disabled path has
+never been exercised as an attack surface.
+
+**Options:**
+
+- **(a) Enable + harden in Alpha scope.** Required for any developer
+  ecosystem; adds a reviewable privileged path.
+- **(b) Defer sideload; developer mode = bundled dev catalog**
+  (`dev-index.json` exists). Zero new attack surface; no real third-party
+  story.
+
+**Question for reviewer:** is enabling sideload in scope for the Alpha
+timeline, and what hardening does the security pipeline require first?
+
+## C9 — Naming collisions: "trust tier" and "risk class"
+
+**Conflict.** Manifests already have `agents[].trustTier` — a trust label
+for *agent personas*, unrelated to add-on release trust. The proposal uses
+"trust tier" for releases and "risk class" for capabilities. Three similar
+terms for three different axes invites confusion in validation messages,
+UI, and docs.
+
+**Options:**
+
+- **(a) Rename in REF:** `releaseTrustTier` (Developer/Verified/Approved)
+  and `capabilityRiskClass` (low/moderate/high/critical); leave
+  `agents[].trustTier` alone. Document all three in the spec glossary.
+- **(b) Rename the agent field** to `agentPersonaTrust` at next SDK
+  major. Cleaner long-term; migration cost now.
+
+**Question for reviewer:** is (a) sufficient, or is the agent field worth
+migrating?
+
+## C10 — Registry plans vs. existing deferrals (ADR-023 / ADR-024)
+
+**Conflict.** ADR-023 (add-on repository/registry) and ADR-024 (store)
+are explicitly deferred. REF Phase 8 proposes a registry metadata format,
+approved-release index, revocation feed, and update lookup. The
+relationship between REF and those deferrals is unstated.
+
+**Options:**
+
+- **(a) Inherit the deferral.** REF specifies the metadata *format* and
+  review-record schema now; the live registry *service* remains deferred
+  per ADR-023/024. Approved-release index lives as a signed JSON document
+  in a git repository until a service exists.
+- **(b) Supersede.** ADR-055 declares the registry in-scope and
+  un-defers ADR-023. Larger commitment; needs staffing reality check.
+
+**Question for reviewer:** (a) or (b)? If (a), what is the minimal signed
+index format that a future service can adopt without breaking clients?
+
+## C11 — Signing key architecture and first-party signing
+
+**Conflict.** The proposal specifies ed25519 publisher + approval
+signatures, an offline root, rotating release keys, and revocation. Open
+implementation questions the spec defers:
+
+- ed25519 exists in the repo only via openssl shell-out for bridge TLS
+  (`bridge-tls.mjs`). The security pipeline's runtime-hardening family
+  gates new subprocess-spawning code; Node's native `crypto.sign`/
+  `crypto.verify` (ed25519) avoids that entirely for the verifier path.
+- Key custody for the Resonant release-signing key is undecided (offline
+  vs. CI KMS/HSM). Repo hygiene scans make "keys in repo" a non-starter,
+  which the spec already states.
+- **First-party add-ons are currently trusted by bundling, not
+  signature.** Does REF change that (sign the 16 bundled manifests too),
+  or does `bundled-core` remain a separate trust root?
+
+**Question for reviewer:** native-crypto verification (recommended), key
+custody model, and whether first-party bundles get signatures in V0.1.
+
+## C12 — SDK package location and its governance cost
+
+**Conflict.** The roadmap proposes `packages/addon-sdk/`. The repo is a
+single npm package with no workspaces; the one sub-package precedent
+(`addons/resonant-browser-host/`) requires registration in ~5 places:
+root `package.json` scripts, CI install/audit blocks, the release scope
+audit classifier, docs links, and module ownership docs.
+
+**Options:**
+
+- **(a) `packages/addon-sdk/` from the start.** True external packaging
+  (exports map, no deep imports) from day one; pays the registration cost
+  once, up front.
+- **(b) `src/sdk/addon-public/` first** (the roadmap's own fallback).
+  Free vitest coverage and zero CI changes, but "importable as an
+  external package" is only simulated until extraction.
+- **(c) Stay in `src/sdk/addons/`** and treat the existing barrel
+  (`index.ts`) as the public surface with an explicit export-boundary
+  test. Cheapest; weakest external-consumption proof.
+
+**Question for reviewer:** which option, and is "an external fixture
+project compiles against only the SDK" (the roadmap's Phase 1 exit gate)
+worth the `packages/` cost in V0.1?
+
+## C13 — Roadmap sequencing: the missing phases and M0 order
+
+**Conflict.** The proposed Phase 0–8 sequence has three holes visible
+from the repo side:
+
+1. No phase delivers caller-attributed capability tokens (C2), yet every
+   runtime phase after packaging depends on enforcement being real.
+2. No phase reconciles the two manifest formats (C3); Phase 0
+   ("inventory") would discover the split but has no decision gate for
+   it.
+3. Phase 4's exit gate ("Hello Resonant completes the full lifecycle"
+   with a UI surface) assumes an executable surface (C4) that no phase
+   builds.
+
+Also: M0 Test B (Local Files: grants, scope restriction, audit) exercises
+the capability model without needing a UI surface; Test A needs C4.
+Running B first de-risks the sequence.
+
+**Proposed revision:**
+
+```text
+Phase 0   inventory (+ explicit decision: C3 manifest reconciliation)
+Phase 1   extract public SDK contracts
+Phase 2   package format
+Phase 3   developer CLI
+Phase 3.5 caller-attributed capability tokens + iframe credential
+          containment (C2) — NEW, gates everything below
+Phase 4   host install + lifecycle (surface scope depends on C4 decision)
+Phase 5–8 certification, signing, review, registry (unchanged)
+M0 order: Test B (Local Files) → Test C (Local AI) → Test A (UI surface)
+```
+
+**Question for reviewer:** agree with the revised order? Is 3.5 correctly
+placed, or should it precede Phase 2?
+
+---
+
+## Priority Summary (proposed)
+
+| Priority | Conflict | Why |
+|---|---|---|
+| 1 | C2 caller attribution | REF's core promise is unimplementable without it |
+| 2 | C4 executable surface | Determines what V0.1 add-ons can even be |
+| 3 | C1 trust tiers | Vocabulary decision that touches every later artifact |
+| 4 | C3 manifest reconciliation | One-contract claim is currently false |
+| 5 | C5 capability mapping | The actual developer-facing contract |
+| 6 | C13 sequencing | Cheap to fix now, expensive to fix later |
+| 7 | C7 compatibility evaluation | Small, early, load-bearing |
+| 8 | C8 sideload enablement | Security review needed before Tier 1 exists |
+| 9 | C10 registry deferral | Scope honesty for ADR-055 |
+| 10 | C11 signing architecture | Needed by Phase 6, not before |
+| 11 | C6 container format | Needed by Phase 2, low risk either way |
+| 12 | C12 package location | Reversible decision |
+| 13 | C9 naming collisions | Cosmetic but cheap |
+
+## Already Resolved (for reviewer context)
+
+- **Terminology:** the unit is an **add-on**; "plugin" is retired.
+  Proposed API names (`defineAddon`, `validateAddOnManifest`,
+  `assertValidAddOnManifest`) intentionally match existing code.
+- **ADR numbering:** the proposal targets **ADR-055** (ADR-031 is taken).
+- **Staging:** this package lives at
+  `docs/addons/resonant-extension-framework/` and passes the repo's docs
+  and release-scope gates as a design-stage proposal.
+
+## Requested Output From the Reviewer
+
+1. Per conflict C1–C13: agree/reframe, chosen option, reasoning.
+2. Conflicts missing from this list.
+3. A revised priority order, if different.
+4. Any conflict where the honest answer is "do not build this in V0.1."
+
+---
+
+## Resolutions (2026-08-24, fork author)
+
+Decisions on the six conflicts the roadmap depends on. Recorded for traceable carry into the ADR-055 draft.
+
+### C1 — Trust tiers: option (a) Map only + a per-(addonId, version) approval record
+
+**Decision:** (a) for vocabulary; layer per-version approval records on top so the "Verified vs Approved" distinction survives.
+
+Keep the existing `AddOnProvenanceTier`, `ManifestVerificationState`, and `AddOnRegistryReviewState` enums. Map REF tiers onto them per the table in C1. Add a per-(addonId, version) approval record stored alongside the add-on in the registry: presence of a record with status `approved` and `packageDigest` equal to the package's digest is what distinguishes Resonant Approved from Verified. This honours the version-specific-approval invariant from the proposal without forking the domain model.
+
+`bundled-core` stays as a separate trust root (signed by bundling, not signature) and is documented as such. `enterprise-signed` remains a future value; no work in V0.1.
+
+### C2 — Capability tokens: option (a) Per-caller grant store at the dispatcher, as Phase 3.5
+
+**Decision:** (a) for V0.1; record (b) as the target for any UI-embedded third-party code.
+
+Extend `isAuthorizedCapabilityRequest` (`browser-first/host/bridge-server.mjs`) from a static route→token map to a grant store keyed `(callerId, capability, scope)`. Mint per-add-on tokens at grant time using the existing requested/granted/denied record shape. Stop passing the bootstrap-derived credential set into iframes; iframes receive only the per-caller, scope-bounded token.
+
+Phase 3.5 is hard-pinned *before* Phase 4 (host install + lifecycle) and *before* any M0 reference test that exercises enforcement (Tests B and C). Phase 3.5 is the gate.
+
+### C3 — Manifest systems: option (c) Scope-exclude browser-first from REF, with an explicit boundary
+
+**Decision:** (c) for V0.1; document the boundary so it cannot be routed around.
+
+`browser-first/addons/*` are declared *extension-internal modules* — first-party code shipped inside the Chrome extension — and are out of REF scope. The boundary is the privilege boundary, not the directory boundary: anything reachable from extension content scripts without going through the Phase 3.5 bridge-caller-token machinery is first-party and may be unreachable to third-party add-ons. This is the only option that does not require migrating the existing `resonant-context` and `resonator` add-ons in V0.1.
+
+The boundary clause to put in ADR-055: *third-party add-on code cannot invoke any bridge route that is not gated by a caller-attributed token minted under Phase 3.5; the browser-first executable content scripts remain first-party because they are not in the add-on loader path.*
+
+### C4 — Executable surface: option (a) V0.1 is declarative-only
+
+**Decision:** (a). M0 Test A is deferred past V0.1.
+
+V0.1 add-ons are manifest + host-mediated tools + local services; no shipped third-party code runs in the shell. M0 Test A (Hello Resonant with a UI surface) is removed from the M0 milestone and renamed to "post-V0.1 sandbox surface" in the roadmap. Options (b) and (c) — extending the iframe model or building a sandboxed module runner — both depend on a Phase 3.5 that doesn't exist yet. Building C4 before C2 would require rolling back the iframe-credential containment from C2.
+
+The V0.1 cut is honest: it delivers the external ecosystem's *enforcement* half (trust tiers, capability model, lifecycle, certification, signing, registry) without its *code-running* half.
+
+### C5 — Capability mapping: option (a) Single mapping table owned by the SDK package
+
+**Decision:** (a). The mapping table is an SDK export, consumed by both validation and the bridge.
+
+Ship the manifest-capability → bridge-route-capability mapping as a versioned data file inside the public SDK package. Validation warns when a requested manifest capability maps to nothing. The bridge authorises at route granularity using the same data. This makes the mapping the developer-facing contract instead of an unwritten assumption.
+
+Migration order to avoid breaking the 16 bundled manifests in `public/addons/`: introduce the mapping in Phase 1 alongside the SDK extraction; back-fill existing manifests in Phase 0's inventory deliverable; deprecation window starts after M0.
+
+### C13 — Sequencing: revised order adopted
+
+**Decision:** Insert Phase 3.5 *between* Phase 3 and Phase 4 (not before Phase 2; the SDK extraction and packaging work does not depend on it). Re-order M0 tests: **Test B (Local Files) → Test C (Local AI) → Test A (UI surface, deferred past V0.1)**.
+
+Phase 3.5 gates Tests B and C; Test A drops out of V0.1 entirely (see C4). Keeping Phase 3.5 after Phase 2 lets `.rpkg` packaging and the developer CLI land in parallel with the security work.
+
+### Deferred (no decision needed today)
+
+- **C6** container format: chosen git-tarball-with-deterministic-permissions unless the security pipeline vetoes; defer until Phase 2 starts.
+- **C7** compatibility evaluation: install + launch (option b); small, fold into Phase 1.
+- **C8** sideload enablement: option (a), enabled + hardened; security-pipeline review is its own gate before any Tier 1 exists.
+- **C9** naming: option (a) — rename in REF only (`releaseTrustTier`, `capabilityRiskClass`); leave `agents[].trustTier` alone.
+- **C10** registry deferral: option (a) — inherit the deferral; metadata format and signed approved-release index now, live service later per ADR-023/024.
+- **C11** signing architecture: native `crypto.sign` / `crypto.verify` ed25519 (no subprocess); first-party bundles remain trust-by-bundling in V0.1; key custody decision deferred to security pipeline.
+- **C12** package location: `packages/addon-sdk/` from the start (option a); pay the registration cost once.
+
+These are recorded so the ADR-055 draft carries them as "acknowledged, deferred to Phase N" rather than rediscovery work.

--- a/docs/addons/resonant-extension-framework/OPEN_DESIGN_CONFLICTS_V0.1.md
+++ b/docs/addons/resonant-extension-framework/OPEN_DESIGN_CONFLICTS_V0.1.md
@@ -562,7 +562,7 @@ Phase 3.5 gates Tests B and C; Test A drops out of V0.1 entirely (see C4). Keepi
 
 ### Deferred (no decision needed today)
 
-- **C6** container format: chosen git-tarball-with-deterministic-permissions unless the security pipeline vetoes; defer until Phase 2 starts.
+- **C6** container format: chosen git-tarball-with-deterministic-permissions unless the security pipeline vetoes; defer until Phase 2 starts. *(Superseded by ADR-055 §12.1 C6 which proposes `.rpkg` — a deterministic ZIP container internally. The git-tarball proposal remains in the C6 conflict record for historical reference; the proposal that lands with the maintainer's review is the one named in ADR-055.)*
 - **C7** compatibility evaluation: install + launch (option b); small, fold into Phase 1.
 - **C8** sideload enablement: option (a), enabled + hardened; security-pipeline review is its own gate before any Tier 1 exists.
 - **C9** naming: option (a) — rename in REF only (`releaseTrustTier`, `capabilityRiskClass`); leave `agents[].trustTier` alone.

--- a/docs/addons/resonant-extension-framework/PROPOSAL-resonant-extension-framework.md
+++ b/docs/addons/resonant-extension-framework/PROPOSAL-resonant-extension-framework.md
@@ -1,0 +1,353 @@
+# Proposal: Resonant Extension Framework (draft for ADR-055)
+
+## Decision Metadata
+
+- Decision status: Proposed
+- Alpha applicability: Applies incrementally
+- Superseded by: None
+- Owner: Add-on SDK / Core / Security
+- Decision date: 2026-08-24
+- Target: ResonantOS Alpha fork
+- Staging: design-stage proposal at `docs/addons/resonant-extension-framework/`;
+  on acceptance this becomes `docs/architecture/ADR-055-resonant-extension-framework.md`
+
+## Decision
+
+ResonantOS will formalize its existing add-on architecture as the **Resonant Extension Framework (REF)**.
+
+REF is the governed system by which third-party and first-party add-ons are defined, validated, tested, reviewed, signed, distributed, installed, granted capabilities, executed, updated, disabled, and removed.
+
+The existing `src/sdk/addons/` contracts remain the starting point. The new framework does not replace the Alpha capability model or authenticated host bridge. It packages and hardens those boundaries into a stable developer-facing contract.
+
+An add-on that wants to operate inside ResonantOS must:
+
+1. declare itself using the Resonant Add-on SDK manifest contract;
+2. request all capabilities explicitly;
+3. pass SDK validation;
+4. execute privileged operations only through host-mediated APIs;
+5. pass the applicable automated certification suite;
+6. be cryptographically signed for verified or approved distribution;
+7. receive explicit user grants before using requested capabilities.
+
+Official catalog distribution additionally requires ResonantOS review and approval for the specific add-on version.
+
+## Architectural Principle
+
+The framework separates four questions that must never be conflated:
+
+1. **What is the add-on?** — declared by the manifest.
+2. **What does the add-on request?** — declared capabilities.
+3. **What may the add-on do on this machine?** — decided by the ResonantOS host and user grants.
+4. **What does the ResonantOS project trust and distribute?** — decided by certification and signing policy.
+
+The trust flow is therefore:
+
+```text
+Add-on Declaration
+        |
+        v
+Capability Request
+        |
+        v
+SDK Validation
+        |
+        v
+Certification / Review
+        |
+        v
+Signature / Distribution Trust
+        |
+        v
+User Installation
+        |
+        v
+User Capability Grant
+        |
+        v
+Host-Mediated Execution
+```
+
+Approval is never a substitute for runtime authorization.
+
+## Framework Components
+
+```text
+Resonant Extension Framework
+|
++-- Resonant Add-on SDK
+|   +-- manifest contracts
+|   +-- capability constants
+|   +-- lifecycle contracts
+|   +-- service/tool contracts
+|   +-- validation
+|   +-- compatibility rules
+|
++-- Add-on CLI
+|   +-- create
+|   +-- validate
+|   +-- test
+|   +-- audit
+|   +-- package
+|   +-- submit
+|
++-- Add-on Runtime
+|   +-- discovery
+|   +-- installation
+|   +-- lifecycle
+|   +-- capability broker
+|   +-- host IPC mediation
+|   +-- enable/disable/remove
+|
++-- Certification Pipeline
+|   +-- manifest validation
+|   +-- dependency checks
+|   +-- capability analysis
+|   +-- static checks
+|   +-- sandbox/runtime checks
+|   +-- smoke tests
+|   +-- compatibility tests
+|
++-- Trust and Signing
+|   +-- publisher identity
+|   +-- package digest
+|   +-- release signature
+|   +-- revocation
+|   +-- provenance
+|
++-- Add-on Registry
+    +-- approved releases
+    +-- publisher metadata
+    +-- compatibility metadata
+    +-- review state
+    +-- revocation state
+```
+
+## Trust Tiers
+
+REF defines three initial trust tiers.
+
+### 1. Sideloaded / Developer
+
+- May be installed manually in developer mode.
+- May be unsigned.
+- Must still pass manifest validation.
+- Is visibly marked unverified.
+- Does not receive sensitive capabilities merely because it is installed.
+- May be subject to tighter runtime restrictions.
+- Must not impersonate an approved publisher or package.
+
+### 2. Verified
+
+A verified add-on:
+
+- has an identified publisher;
+- is built against a supported SDK version;
+- passes automated certification;
+- is packaged reproducibly enough to bind review to a digest;
+- is signed by an accepted publisher or Resonant verification key;
+- has not been revoked.
+
+Verified means the release and publisher identity are known and the package passed the required checks. It does not mean the ResonantOS team endorses every behavior or external service.
+
+### 3. Resonant Approved
+
+A Resonant Approved add-on:
+
+- satisfies all Verified requirements;
+- has passed the required ResonantOS development/security review;
+- has an approved capability profile;
+- has an approved version-specific package digest;
+- is signed for official distribution;
+- may appear in the official ResonantOS add-on catalog.
+
+Approval is version-specific.
+
+## Version-Specific Approval
+
+Approval binds to a release identity:
+
+```text
+add-on id
++ add-on version
++ manifest digest
++ package digest
++ publisher identity
++ review record
++ signature
+```
+
+A new version must be certified again.
+
+A release that adds or materially broadens sensitive capabilities automatically returns to human review.
+
+Example:
+
+```diff
+ requestedCapabilities:
+   - archive-read
++  - shell
++  - network
+```
+
+The newer release cannot inherit the prior approval.
+
+## Capability Governance
+
+REF keeps the current ResonantOS rule that manifests request authority but do not possess authority.
+
+A manifest may request:
+
+```json
+{
+  "requestedCapabilities": [
+    "archive-read",
+    "network"
+  ]
+}
+```
+
+The host must independently verify:
+
+- the add-on is installed and enabled;
+- the requested capability exists in the current SDK;
+- the add-on manifest requested it;
+- certification policy permits the release to request it;
+- the user or enterprise policy granted it;
+- the current operation is within the granted scope;
+- required approvals are satisfied.
+
+## Capability Risk Classes
+
+Certification should classify capabilities at least as:
+
+### Low risk
+
+Examples:
+
+- UI surface registration
+- non-sensitive notifications
+- bounded metadata reads
+
+### Moderate risk
+
+Examples:
+
+- network access
+- archive read
+- provider-backed inference
+- external connectors with read-only scopes
+
+### High risk
+
+Examples:
+
+- filesystem writes
+- browser control
+- microphone/camera access
+- local service launch
+- shell-mediated commands
+- external account mutation
+
+### Critical
+
+Examples:
+
+- cryptographic identity signing
+- credential export
+- administrative system mutation
+- arbitrary native-code execution outside approved mediation
+
+Critical capabilities should require explicit manual review and may be prohibited entirely in Alpha.
+
+## Runtime Boundary
+
+REF does not allow third-party code to call privileged local resources directly.
+
+For Alpha:
+
+```text
+Add-on / Extension UI
+        |
+        v
+Resonant SDK API
+        |
+        v
+Authenticated Resonant Bridge
+        |
+        v
+Capability Broker / Policy
+        |
+        v
+Named Host Service
+        |
+        v
+Local privileged resource
+```
+
+The bridge and named host services remain the authority boundary.
+
+Provider secrets, raw credential values, protected user state, trusted archive promotion, unrestricted process launch, and other privileged resources remain host-side.
+
+## Replaceability
+
+REF preserves the minimal-kernel model.
+
+Add-ons may provide replaceable system slots such as:
+
+- `primary-agent`
+- `chat-interface`
+- `memory-system`
+- `communication-channel`
+
+Certification does not make an add-on mandatory core.
+
+## Distribution Policy
+
+The official catalog should contain only releases that are:
+
+- certified;
+- signed;
+- compatible with the running ResonantOS/SDK range;
+- not revoked;
+- approved for official distribution.
+
+Developer mode may expose additional sideloaded or experimental releases.
+
+## Non-Goals for V0.1
+
+REF V0.1 does not require:
+
+- a commercial marketplace;
+- add-on payments;
+- ratings/reviews;
+- revenue sharing;
+- cross-device license management;
+- arbitrary native binaries;
+- remote code execution;
+- automatic approval of sensitive permission changes.
+
+## Consequences
+
+- Third-party developers receive a stable target.
+- The ResonantOS team gains a repeatable review and signing process.
+- Users can distinguish installed, verified, and approved software.
+- Add-ons remain modular and replaceable.
+- Privileged authority remains with the host, not with signatures or manifests.
+- The existing Add-on SDK can evolve toward a public package without rewriting the kernel architecture.
+
+## Initial Implementation References
+
+Existing source to evolve:
+
+- `src/sdk/addons/`
+- `src/core/contracts.ts`
+- `src/core/runtime.ts`
+- `public/addons/`
+- `browser-first/host/bridge-server.mjs`
+- `browser-first/host/*-host-service.mjs`
+- `browser-first/test/`
+
+Related decisions:
+
+- ADR-018: Add-on SDK V0
+- ADR-026: Minimal Kernel And Replaceable Default Add-ons

--- a/docs/addons/resonant-extension-framework/README.md
+++ b/docs/addons/resonant-extension-framework/README.md
@@ -22,8 +22,7 @@ This package contains a proposed architecture and implementation specification f
 - [`MAINTAINER_ALIGNMENT_ROADMAP.md`](MAINTAINER_ALIGNMENT_ROADMAP.md) — status/sequencing roadmap tracking the maintainer-alignment work (done vs remaining)
 
 The framework's V0.1 SDK contracts live today at
-[`src/sdk/addons/`](../../../src/sdk/addons/); the `packages/addon-sdk/`
-public boundary (ADR-055 §12.1 C12) is proposed as its own follow-up PR.
+`packages/addon-sdk/src/` — the V0.1 public boundary (ADR-055 §12.1 C12), landed in `dev` via PR #441 (merged 2026-09-11). The `src/sdk/addons/*.ts` files are re-export shims pointing at this location; `src/sdk/addons/contracts.ts:62-75` resolves to the same `ADDON_CAPABILITIES` enum as `packages/addon-sdk/src/contracts.ts:62-75`.
 
 ## Staging
 

--- a/docs/addons/resonant-extension-framework/README.md
+++ b/docs/addons/resonant-extension-framework/README.md
@@ -1,0 +1,74 @@
+# Resonant Extension Framework V0.1 — Documentation Package
+
+This package contains a proposed architecture and implementation specification for turning the current ResonantOS Alpha Add-on SDK into a governed external add-on ecosystem.
+
+## Files
+
+- [`PROPOSAL-resonant-extension-framework.md`](PROPOSAL-resonant-extension-framework.md) — framework proposal (draft for ADR-055)
+- [`RESONANT_ADDON_SDK_SPEC_V0.1.md`](RESONANT_ADDON_SDK_SPEC_V0.1.md) — Add-on SDK specification
+- [`ADDON_PACKAGE_AND_MANIFEST_SPEC_V0.1.md`](ADDON_PACKAGE_AND_MANIFEST_SPEC_V0.1.md) — `.rpkg` package and manifest contract
+- [`ADDON_CERTIFICATION_AND_SIGNING_V0.1.md`](ADDON_CERTIFICATION_AND_SIGNING_V0.1.md) — certification pipeline, trust tiers, signing
+- [`ADDON_DEVELOPER_WORKFLOW_AND_CLI_V0.1.md`](ADDON_DEVELOPER_WORKFLOW_AND_CLI_V0.1.md) — developer workflow and CLI
+- [`IMPLEMENTATION_ROADMAP_V0.1.md`](IMPLEMENTATION_ROADMAP_V0.1.md) — phased implementation plan
+- [`OPEN_DESIGN_CONFLICTS_V0.1.md`](OPEN_DESIGN_CONFLICTS_V0.1.md) — 13 unresolved design conflicts, prepared for external review
+- [`RESOLUTIONS_V0.1.md`](RESOLUTIONS_V0.1.md) — fork-author decisions on the conflicts, carried forward into ADR-055
+- [`EXTERNAL_REVIEW_FEEDBACK_V0.1.md`](EXTERNAL_REVIEW_FEEDBACK_V0.1.md) — first external review of this package, with verification record and disposition
+- [`ADDON_PERSONAL_PLUGIN_GOVERNANCE.md`](ADDON_PERSONAL_PLUGIN_GOVERNANCE.md) — fork policy proposal for personal/local add-ons (SDK required, Resonant review optional)
+- [`SDK_REVIEWER_AGENT_V0.1.md`](SDK_REVIEWER_AGENT_V0.1.md) — Augmentor/Logician agent that reviews add-on submissions and drafts certification decisions
+- [`REGISTRY_METADATA_SCHEMA_V0.1.md`](REGISTRY_METADATA_SCHEMA_V0.1.md) — C10 approved-release index schema (canonical JSON shape, verifier behavior, rotation)
+- [`SIGNING_ARCHITECTURE_V0.1.md`](SIGNING_ARCHITECTURE_V0.1.md) — C11 ed25519 signing envelope, key ids, and verification behavior
+- [`CAPABILITY_SEPARATION_V1.md`](CAPABILITY_SEPARATION_V1.md) — deferred V1 design for splitting Public vs Internal capabilities (no V0.1 contract change)
+- [`REF_HARDENING_NOTES_V0.1.md`](REF_HARDENING_NOTES_V0.1.md) — Phase 3.5 caller-attributed bridge hardening (threat model and H1–H3 design; source for ADR-055 §8)
+- [`MAINTAINER_ALIGNMENT_ROADMAP.md`](MAINTAINER_ALIGNMENT_ROADMAP.md) — status/sequencing roadmap tracking the maintainer-alignment work (done vs remaining)
+
+The framework's V0.1 SDK contracts live today at
+[`src/sdk/addons/`](../../../src/sdk/addons/); the `packages/addon-sdk/`
+public boundary (ADR-055 §12.1 C12) is proposed as its own follow-up PR.
+
+## Staging
+
+This package was staged at `docs/design/resonant-extension-framework/`
+during the design phase. When ADR-055 was drafted, the proposal became
+`docs/architecture/ADR-055-resonant-extension-framework.md` and the
+specifications moved to this folder (`docs/addons/resonant-extension-framework/`)
+as described in `IMPLEMENTATION_ROADMAP_V0.1.md`.
+
+## Terminology
+
+The unit of the ecosystem is an **add-on**, matching existing ResonantOS
+vocabulary (`AddOnManifest`, `src/sdk/addons/`, ADR-018). Earlier drafts of
+this package used the word "plugin"; the concepts are identical. Proposed
+public API names (`defineAddon`, `validateAddOnManifest`,
+`assertValidAddOnManifest`) intentionally align with the existing validators
+in `src/sdk/addons/validation.ts`. "Resonant Extension Framework" names the
+governance architecture, not a second artifact type.
+
+## Intended Repository Target
+
+The documents are written for a fork of the ResonantOS `2.0.0-alpha` repository and are designed to extend—not replace—the existing:
+
+- Add-on SDK V0;
+- capability-grant model;
+- authenticated Node bridge;
+- host-mediated service architecture;
+- minimal-kernel / replaceable-add-on philosophy.
+
+## Suggested First Commit
+
+```text
+docs: define Resonant Extension Framework V0.1
+```
+
+Keep this first commit documentation-only.
+
+## Core Principle
+
+```text
+Manifest declares.
+Certification evaluates.
+Signature identifies.
+User grants.
+Host enforces.
+```
+
+An approved add-on never gains direct privileged authority merely because it is signed.

--- a/docs/addons/resonant-extension-framework/REF_HARDENING_NOTES_V0.1.md
+++ b/docs/addons/resonant-extension-framework/REF_HARDENING_NOTES_V0.1.md
@@ -1,0 +1,233 @@
+# REF Bridge Hardening Notes — V0.1
+
+Status: design-stage proposal at the framework level, with hardening
+landed at the runtime level on the spike branch.
+
+This document is the security companion to
+`docs/addons/resonant-extension-framework/`, and the
+applied-runtime companion to `RESOLUTIONS_V0.1.md` items C2 and C5
+(see the open-design-conflicts document for the full set). It is read
+alongside the framework package, not in place of it.
+
+## Where the live code lives
+
+All hardening lives on branch `spike/caller-attributed-tokens` in the
+author's fork (preserved in the fork-cleanup backup after the 2026-09
+fork re-creation). The branch contains four commits in
+this order:
+
+```
+92659c1  bridge: redaction, rotation, allowlist, fail-fast, boot log (H3)
+779f16d  bridge: denied audit emission with reason codes (H2)
+0d5f7ae  bridge: callerId-bound HMAC tokens (Phase 3.5 hardening H1)
+6617a63  bridge: caller-attributed grants store + audit ledger (hook-up B)
+ 9e28f3f  bridge: thread perCallerGrants + auditSink through handler (hook-up A)
+ 60c0129  spike: caller-attributed bridge capability tokens (kernel)
+```
+
+It is not yet merged into `feat/tab-referencing` or `dev`. ADR-055
+acceptance is the natural moment to surface a single squashed or
+cherry-picked "Phase 3.5 implementation" commit on the framework
+branch.
+
+## Threat model addressed
+
+The original Phase 3.5 kernel (commit `410e508` "docs: define
+Resonant Extension Framework V0.1") describes caller attribution as
+`X-ResonantOS-Bridge-Caller-Id` alongside `X-ResonantOS-Bridge-
+Capability-Token`. That data shape is honest about its limitations:
+
+- `callerId` is whatever the client claims.
+- `capabilityToken` is a static per-bridge opaque string.
+
+The kernel proves the *data shape* of per-caller attribution. It does
+not bind `callerId` to the holder of the token. Combined, an adversary
+who possesses any capability token (legitimately or by stealing) can
+forge the `callerId` header and the bridge accepts the request as if it
+came from any caller. H1-H3 close that gap and several adjacent ones.
+
+### What an adversary on the loopback bridge interface can do today
+
+Loopback-only, but attacker code does not need the extension:
+
+1. **Token replay** — the static capability tokens minted at bridge
+   startup are reusable until bridge restart. Combined with #2, this
+   is the dominant attack.
+
+2. **Caller-id spoofing** — `X-ResonantOS-Bridge-Caller-Id` is
+   unauthenticated in the kernel. Without H1, an attacker holding one
+   valid token can claim to be any caller.
+
+3. **Forged tokens** — `capabilityToken` was a `randomBytes` string
+   with no integrity. An adversary who guessed any of 23 strings
+   (one per capability type) got the capability.
+
+4. **Audit blindness on denial** — denial paths (401/403/404/500) did
+   not write audit records, so the chip UI couldn't triage probing.
+
+5. **No redaction** — the audit trail could carry URL secrets, header
+   secrets, or token-shaped values verbatim.
+
+6. **Disk DoS via unbounded growth** — audit ledger wrote with no
+   rotation, no cap.
+
+7. **No callerId allowlist** — `mintGrant` would mint for any string,
+   including `"../etc/passwd"`-shape strings.
+
+8. **Smuggle callerId via shape** — the caller-id regex was loose; a
+   caller could send whitespace or slashes that survived serialization.
+
+9. **Boot had no observability** — misconfigured launchers shipped with
+   no add-ons authorised, silently.
+
+## What H1-H3 change
+
+### H1 — caller-attributed HMAC tokens (commit `0d5f7ae`)
+
+- New `bridge-attributed-token.mjs`: tokens are now
+  `<base64url(payload)>.<base64url(signature)>` where:
+  - `payload = { callerId, capability, expiresAt, nonce }` as JSON
+  - `signature = HMAC-SHA256(tokenKey, rawPayloadBytes)`
+- New `bridge-token-key.mjs`: per-bridge-process 32-byte HMAC key,
+  regenerated on every bridge restart. Tokens minted in a previous run
+  become unverifiable on next start (matches the in-memory grants
+  store's lifetime; see RESOLUTIONS_V0.1 C2 option (a)).
+- `bridge-grants-store.mjs`: `verifyCallerGrant` consults the live
+  bucket before letting the HMAC verifier run, so revocation is
+  immediate. `mintGrant` no longer accepts a forgeable string.
+- `bridge-server.mjs`: every launcher-func accepts and threads
+  `tokenKey` and `callerGrantVerifier` through to
+  `evaluateBridgeRequestForSelfTest`. A callerGrantVerifier callback
+  from the live store is the bridge's primary auth path; the snapshot
+  map (still accepted) is the legacy fallback for launchers that
+  haven't opted in.
+
+Adversary case closed: forging the caller-id header no longer
+matters; the callerId comes from the verified HMAC payload inside
+the token. TokenForgery closes because the signature is constant-time
+compared against a per-process secret an attacker cannot read.
+
+### H2 — denied-audit emission with reason codes (commit `779f16d`)
+
+Every deny path inside `evaluateBridgeRequestForSelfTest` now emits a
+JSONL record through the auditSink:
+
+| HTTP | Reason              | CallerId logged        |
+| ---- | ------------------- | ---------------------- |
+| 401  | `bridge-token`      | `anonymous`            |
+| 404  | `unknown-route`      | `anonymous`            |
+| 403  | `bootstrap-missing`  | `anonymous` (or header) |
+| 403  | `capability-denied`  | header value if present |
+| 500  | `internal-error`     | `internal`              |
+| 200  | `authorized`         | verified callerId      |
+
+Audit records never carry the supplied capability token. The supplied
+callerId is logged only when present in the request shape — it does
+not authenticate, only attribute.
+
+### H3 — redaction, rotation, allowlist, fail-fast, boot log
+(commit `92659c1`)
+
+- `bridge-redact-audit.mjs`: walks each string field of the record
+  through the existing `redactTraceText` scrubber. URL parameters
+  matching `(token|key|secret|password|...)` are replaced with
+  `REDACTED`. Hex-shaped tokens are replaced with `[REDACTED-TOKEN]`.
+- `bridge-audit-ledger.mjs`: append-only is no longer the only mode.
+  When a write crosses `maxBytes` (default 10 MiB), the file rotates
+  to `<filePath>.1`, `.2`, ..., `.<maxFiles-1>`. Beyond that, the
+  oldest is best-effort dropped. Path sanitation rejects NUL bytes and
+  `..` path components.
+- `bridge-grants-store.mjs`: optional `callerIdAllowlist` rejects
+  mintGrant for callerIds outside a hard-coded list. The minimal
+  launcher passes `["hermes", "opencode", "resonant-context",
+  "resonator"]`, so the bundled add-ons are the entire known keyspace.
+- `run-bridge-minimal.mjs`: wraps `createBridgeAuditLedger` in a
+  try/catch and exits non-zero if init throws — a misconfigured audit
+  surface can no longer go unnoticed.
+- `run-bridge-minimal.mjs`: prints a `caller_grants_ready` JSON line
+  at boot with caller count, grant count, the allowlist, the audit
+  path, and an 8-character SHA-256 fingerprint of the per-process
+  tokenKey.
+- `bridge-server.mjs`: `callerIdFromHeaders` now uses the same regex
+  as the mint layer (`/^[a-z0-9][a-z0-9._-]{0,80}$/`) so a caller-id
+  header can't smuggle whitespace or path components.
+
+## How to read this against RESOLUTIONS_V0.1.md
+
+- C2 / Phase 3.5 (caller attribution, capability tokens): **closed**.
+  H1-H3 deliver the runtime against which ADR-055 was drafted.
+- C5 (capability mapping): still open. The capability vocabulary at
+  the bridge layer is 23 fine-grained tokens; the manifest vocabulary
+  is 13 coarse entries. The H1 + H3 design does not collapse this; an
+  explicit mapping table is the next step.
+- C4 (executable surface): still deferred. V0.1 add-ons remain
+  declarative. M0 Test A is still deferred past V0.1.
+- C1, C6, C7, C8, C9, C10, C11, C12, C13: unchanged from the
+  resolutions doc. None of H1-H3 close them.
+
+## What is not yet addressed (deferred from the hardening review)
+
+- **C2 option (b)** — full mediation where add-on iframes have no
+  bridge credentials and call a `postMessage` API. This is the
+  long-term direction; H1 is the local ground-truth that we will
+  re-enter when iframes are next touched.
+- **On-disk HMAC key** — the per-process key is regenerated on
+  restart, so tokens die with the bridge. Persisting the key across
+  restarts requires key custody (HSM/CI KMS), which is the C11
+  signing-architecture decision that was deferred to the security
+  pipeline.
+- **Bridge-side enforcement of Test B's "denied unauthorized action"
+  half** — M0 Test B refers to a real Local Files reference add-on that
+  does not yet exist. The kernel of Test B is enforced (H1's
+  verifyCallerGrant rejects revoked grants; H3's allowlist rejects
+  rogue callers). The full integration with a sample add-on is a
+  separate effort.
+- **Production launcher wiring** — `resonantos-bridge-full.mjs`
+  (when the file lands in this fork) needs the same H1-H3 wiring as
+  the minimal launcher. The wiring is a copy of `run-bridge-
+  minimal.mjs`'s grant-store + audit + tokenKey dance.
+- **Extension-side `X-ResonantOS-Bridge-Caller-Id` plumbing in
+  `bridge-client.js`** — H1 makes the header redundant as the source
+  of attribution (it's now in the token), but production code still
+  needs to pass the header so the call site is recognisable in
+  legacy logs. A future commit flips bridge-client.js to *only* send
+  the token and drop the caller-id header; H1 already supports that
+  path (the legacy-fallback static-token path).
+
+## Test surface
+
+The hardening pass added or extended the following test files; all
+green at HEAD:
+
+- `browser-first/test/bridge-attributed-token.test.mjs` — 9 cases.
+  Mint/verify round-trip, expiry, signature tampering, caller-id
+  mismatch, capability mismatch, malformed input, shape regex
+  enforcement, unsafe-input rejection.
+- `browser-first/test/bridge-grants-store.test.mjs` — 11 cases.
+  H1 token verification through the store; H3 allowlist honour;
+  malformed-allowlist rejection; revocation observability.
+- `browser-first/test/bridge-audit-ledger.test.mjs` — 8 cases.
+  H3 redaction pipeline; redact:false opt-out; rotation under
+  maxBytes; path sanitation (NUL, `..`); bad `maxBytes`/`maxFiles`
+  rejection.
+- `browser-first/test/bridge-caller-attributed-integration.test.mjs`
+  — 2 cases. End-to-end through `createBridgeRequestHandler` with a
+  real grants store + audit ledger.
+- `browser-first/test/bridge-denied-audit.test.mjs` — 6 cases. H2
+  reason-code emission per deny path; no-token-leak invariant.
+
+Together: 36 hardening-related tests, all green at HEAD.
+
+## Reviewer checklist
+
+1. The `bridgeAudit.sink` reference in `run-bridge-minimal.mjs`
+   lines 446 ish must continue to resolve. If a refactor removes the
+   `bridgeAudit` const, the launcher crashes silently at startup.
+   The fail-fast in H3 should make this obvious in CI.
+2. The `tokenKey` and `callerGrantVerifier` parameters must remain
+   optional in every launcher-func signature. Removing `= undefined`
+   would break any downstream consumer who calls these with positional
+   arguments.
+3. Audit-record consumers in the chip UI should now filter on
+   `reason` (string) plus `status` (numeric), not just `status`.
+   Reason code values are stable across H1-H3.

--- a/docs/addons/resonant-extension-framework/REGISTRY_METADATA_SCHEMA_V0.1.md
+++ b/docs/addons/resonant-extension-framework/REGISTRY_METADATA_SCHEMA_V0.1.md
@@ -1,0 +1,131 @@
+# Approved-Release Registry Metadata Schema V0.1
+
+## Purpose
+
+Per `RESOLUTIONS_V0.1.md` C10 and `ADR-055` §12.1 (C10 row), REF V0.1
+ships a **metadata format and signed approved-release index** as a
+versioned JSON document. The live registry service is deferred to
+ADR-023 / ADR-024.
+
+This document defines the canonical JSON schema for that index. When
+the SDK is extracted to `packages/addon-sdk/` (Phase 1 of the
+implementation roadmap), this schema becomes the SDK package's
+`registry-metadata.schema.json` plus a typed loader.
+
+## File Layout
+
+The approved-release index ships alongside the SDK package as:
+
+```text
+registry/
+  index.schema.json          # this document, in JSON Schema form
+  approved-releases.json     # signed list of approved releases
+  approved-releases.sig      # ed25519 detached signature
+```
+
+The signature file uses the signing architecture defined in
+`SIGNING_ARCHITECTURE_V0.1.md` (C11). The schema and the index carry a
+top-level `schemaVersion: "0.1"` field; future versions may add
+fields but must not remove or rename existing fields without a major
+version bump.
+
+## Top-Level Shape
+
+```json
+{
+  "$schema": "https://resonantos.dev/schemas/registry-metadata/v0.1.json",
+  "schemaVersion": "0.1",
+  "generatedAt": "2026-08-24T00:00:00Z",
+  "publisherKeyId": "resonant-approval-2026",
+  "signerKeyId": "resonant-approval-2026",
+  "releases": [
+    /* ApprovedReleaseRecord entries, see below */
+  ]
+}
+```
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `$schema` | string | The canonical schema URL. Tooling may pin to a specific minor. |
+| `schemaVersion` | string | "0.1" for this version. |
+| `generatedAt` | string | ISO-8601 timestamp; the moment the index was last signed. |
+| `publisherKeyId` | string | The publisher key id that vouches for the entries. |
+| `signerKeyId` | string | The signing key id (see C11). |
+| `releases` | array | ApprovedReleaseRecord entries (see below). |
+
+## ApprovedReleaseRecord
+
+One entry per approved (`addonId`, `version`):
+
+```json
+{
+  "addonId": "addon.example.notes",
+  "version": "1.0.0",
+  "packageDigest": "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+  "manifestDigest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "publisherKeyId": "developer-alice-2026",
+  "reviewId": "ROS-ADDON-2026-0042",
+  "signerKeyId": "resonant-approval-2026",
+  "signedAt": "2026-08-24T00:00:00Z",
+  "approvedCapabilities": ["archive-read", "archive-intake-write"],
+  "releaseTrustTier": "approved",
+  "riskClasses": ["low"]
+}
+```
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `addonId` | string | yes | Matches the manifest `id` pattern `^addon\.[a-z0-9][a-z0-9-]*(?:\.[a-z0-9][a-z0-9-]*)*$`. |
+| `version` | string | yes | Strict semver. |
+| `packageDigest` | string | yes | `sha256:` + lowercase hex; the normalized `.rpkg` digest. |
+| `manifestDigest` | string | yes | `sha256:` + lowercase hex; the canonical manifest JSON digest. |
+| `publisherKeyId` | string | yes | Key id that signed the publisher signature on the package. |
+| `reviewId` | string | yes | Pointer back to the certification review record. |
+| `signerKeyId` | string | yes | Key id that signed this index entry. |
+| `signedAt` | string | yes | ISO-8601 timestamp. |
+| `approvedCapabilities` | array of string | yes | Capability ids approved for this release. |
+| `releaseTrustTier` | enum | yes | `developer` / `verified` / `approved` (see C9). |
+| `riskClasses` | array of enum | yes | `low` / `moderate` / `high` / `critical` per capability (see C9). |
+
+## Verifier Behavior
+
+A V0.1 verifier performs, in order:
+
+1. Load `approved-releases.json` and `approved-releases.sig`.
+2. Verify the signature using `signerKeyId`'s public key (C11).
+3. For each candidate package, compute the normalized package digest
+   in the same way as the index.
+4. Look up `(addonId, version)` in the index `releases` array.
+5. Compare package digest, manifest digest, and signer key id.
+6. Reject if any mismatch, if the entry is absent, or if any required
+   field is missing or malformed.
+
+A release removed from the index is no longer installable; existing
+installations follow the revocation flow in
+`ADDON_PACKAGE_AND_MANIFEST_SPEC_V0.1.md`.
+
+## Rotation
+
+Index rotation: when a new index is published, the previous index
+remains verifiable for a grace window. After the grace window, only
+the new index is honored by verifiers. The grace window length is set
+by the ResonantOS release process; it is not part of the V0.1 schema.
+
+## Compatibility Notes
+
+- The schema is forward-compatible: future minor versions may add
+  fields. Consumers must ignore unknown fields.
+- `releaseTrustTier` and `riskClasses` are the REF Vocabulary names
+  (C9). Runtime fields `provenance.tier` and `agents[].trustTier`
+  carry equivalent values for V0.1 backward compat.
+- This schema is the metadata format only; the live registry service
+  (search, browse, ratings, commerce) is out of scope per ADR-023 /
+  ADR-024.
+
+## Source
+
+- `RESOLUTIONS_V0.1.md` C10
+- `OPEN_DESIGN_CONFLICTS_V0.1.md` C10
+- `ADR-055-resonant-extension-framework.md` §12.1 (C10 row)
+- `ADDON_PACKAGE_AND_MANIFEST_SPEC_V0.1.md`
+- `ADDON_CERTIFICATION_AND_SIGNING_V0.1.md`

--- a/docs/addons/resonant-extension-framework/RESOLUTIONS_V0.1.md
+++ b/docs/addons/resonant-extension-framework/RESOLUTIONS_V0.1.md
@@ -1,0 +1,133 @@
+# Conflict Resolutions V0.1
+
+Decisions recorded 2026-08-24 by the fork author on the six conflicts the
+roadmap depends on. Each cites the chosen option, the reasoning, and the
+specific files or symbols affected. Carried into the ADR-055 draft.
+
+The same resolutions also appear as an appendix in
+`OPEN_DESIGN_CONFLICTS_V0.1.md`. This document is the canonical record
+referenced by `IMPLEMENTATION_ROADMAP_V0.1.md`, ADR-055 drafts, and any
+later external review.
+
+## C1 — Trust tiers
+
+**Decision:** Option (a) Map only, layered with a per-(addonId, version)
+approval record.
+
+Map REF tiers onto the existing enums:
+
+| REF tier | Existing enums |
+|---|---|
+| Developer | `sideloaded-unverified` + `unverified` + `unreviewed` |
+| Verified | `curated-signed` + `verified` + `reviewed` |
+| Resonant Approved | `curated-signed` + `verified` + `approved`, with a per-(addonId, version) approval record whose `packageDigest` equals the package digest |
+
+`bundled-core` remains a separate trust root (trust-by-bundling, not
+signature). `enterprise-signed` is a future value with no V0.1 work.
+
+## C2 — Capability tokens
+
+**Decision:** Option (a) — Per-caller grant store at the dispatcher.
+Record option (b) as the target for any UI-embedded third-party code.
+
+Concrete change:
+
+- Extend `isAuthorizedCapabilityRequest`
+  (`browser-first/host/bridge-server.mjs`) from a static route→token map
+  to a grant store keyed `(callerId, capability, scope)`.
+- Mint per-add-on tokens at grant time using the existing
+  requested/granted/denied record shape.
+- Remove the bootstrap-derived credential set from
+  `lib/addon-iframe.js`; iframes receive only the per-caller,
+  scope-bounded token.
+- Audit-trail hook records `callerId` on every authorised request.
+
+This is Phase 3.5 in `IMPLEMENTATION_ROADMAP_V0.1.md` and is the hard
+gate before Phase 4 and before M0 Tests B and C.
+
+## C3 — Manifest systems
+
+**Decision:** Option (c) — Scope-exclude browser-first from REF V0.1,
+with an explicit privilege boundary.
+
+`browser-first/addons/*` is declared extension-internal. The boundary is
+privilege, not directory: anything reachable from extension content
+scripts without going through the Phase 3.5 bridge-caller-token
+machinery is first-party and out of REF scope.
+
+Boundary clause for ADR-055:
+
+> Third-party add-on code cannot invoke any bridge route that is not
+> gated by a caller-attributed token minted under Phase 3.5. The
+> browser-first executable content scripts remain first-party because
+> they are not in the add-on loader path.
+
+## C4 — Executable surface
+
+**Decision:** Option (a) — V0.1 is declarative-only.
+
+M0 Test A (Hello Resonant with a UI surface) is removed from the M0
+milestone and renamed to "post-V0.1 sandbox surface" in the roadmap.
+V0.1 add-ons are manifest + host-mediated tools + local services. No
+shipped third-party code runs in the shell.
+
+V0.1 still delivers the ecosystem's enforcement half (trust tiers,
+capability model, lifecycle, certification, signing, registry). It
+defers the code-running half until after Phase 3.5 is mature and a
+sandbox surface decision can be made with real evidence.
+
+## C5 — Capability mapping
+
+**Decision:** Option (a) — single mapping table owned by the SDK
+package.
+
+Ship the manifest-capability → bridge-route-capability mapping as a
+versioned data file inside the public SDK package. Validation warns
+when a requested manifest capability maps to nothing; the bridge
+authorises at route granularity using the same data.
+
+Migration order:
+
+1. Phase 0 — inventory the 16 bundled manifests in `public/addons/`
+   alongside existing deliverables.
+2. Phase 1 — introduce the mapping alongside the SDK extraction;
+   back-fill bundled manifests.
+3. After M0 — open deprecation window for any manifest capability that
+   becomes unrepresentable in the new vocabulary.
+
+## C13 — Sequencing
+
+**Decision:** Adopt the revised order from the conflicts document:
+
+```text
+Phase 0   inventory (+ explicit decision: C3 manifest reconciliation)
+Phase 1   extract public SDK contracts (introduces C5 mapping)
+Phase 2   package format
+Phase 3   developer CLI
+Phase 3.5 caller-attributed capability tokens + iframe credential
+          containment (C2) — NEW, gates everything below
+Phase 4   host install + lifecycle (surface scope depends on C4 decision)
+Phase 5–8 certification, signing, review, registry (unchanged)
+M0 order: Test B (Local Files) → Test C (Local AI) → Test A (deferred)
+```
+
+## Deferred without further decision needed now
+
+These are recorded so ADR-055 carries "acknowledged, deferred to Phase
+N" rather than rediscovery work.
+
+- **C6** container format: git-tarball with deterministic permissions;
+  security pipeline veto possible.
+- **C7** compatibility evaluation: install + launch (option b); fold
+  into Phase 1.
+- **C8** sideload enablement: enable + harden (option a); security
+  pipeline review is its own gate before Tier 1 exists.
+- **C9** naming: rename in REF only (`releaseTrustTier`,
+  `capabilityRiskClass`); leave `agents[].trustTier` alone.
+- **C10** registry deferral: option (a); metadata format and signed
+  approved-release index now, live service later per ADR-023/024.
+- **C11** signing architecture: native `crypto.sign` / `crypto.verify`
+  ed25519; first-party bundles remain trust-by-bundling in V0.1; key
+  custody deferred to security pipeline.
+- **C12** package location: `packages/addon-sdk/` from the start; pay
+  the registration cost once.

--- a/docs/addons/resonant-extension-framework/RESONANT_ADDON_SDK_SPEC_V0.1.md
+++ b/docs/addons/resonant-extension-framework/RESONANT_ADDON_SDK_SPEC_V0.1.md
@@ -348,8 +348,8 @@ Each add-on must declare supported ranges:
 ```json
 {
   "compatibility": {
-    "resonantOS": ">=2.0.0-alpha <3.0.0",
-    "sdk": "^0.1.0"
+    "shellVersion": "^0.1.0",
+    "platforms": ["macOS", "linux"]
   }
 }
 ```

--- a/docs/addons/resonant-extension-framework/RESONANT_ADDON_SDK_SPEC_V0.1.md
+++ b/docs/addons/resonant-extension-framework/RESONANT_ADDON_SDK_SPEC_V0.1.md
@@ -1,0 +1,433 @@
+# Resonant Add-on SDK Specification V0.1
+
+## Status
+
+Draft specification for implementation in the ResonantOS Alpha fork.
+
+## Purpose
+
+The Resonant Add-on SDK is the developer-facing contract of the Resonant Extension Framework.
+
+Its purpose is to let a developer build a ResonantOS add-on without importing private kernel implementation details or bypassing ResonantOS authority boundaries.
+
+The SDK must be usable outside the ResonantOS source tree.
+
+## Terminology
+
+The unit built with this SDK is an **add-on**, matching existing ResonantOS
+vocabulary (`AddOnManifest`, `src/sdk/addons/`, ADR-018). Earlier drafts used
+the word "plugin"; the concepts are identical. Public API names in this
+specification (`defineAddon`, `validateAddOnManifest`,
+`assertValidAddOnManifest`) intentionally align with the existing validators
+in `src/sdk/addons/validation.ts`.
+
+## Design Goals
+
+1. Stable, explicit contracts.
+2. Least-privilege capabilities.
+3. Host-mediated privileged operations.
+4. Deterministic validation.
+5. Versioned compatibility.
+6. Testability outside the main repository.
+7. Clear separation between declaration, grant, execution, and certification.
+8. Compatibility with first-party, curated, and sideloaded add-ons.
+
+## Proposed Packages
+
+```text
+@resonantos/addon-sdk
+@resonantos/addon-sdk-ui
+@resonantos/addon-sdk-agent
+@resonantos/addon-sdk-testing
+@resonantos/create-addon
+```
+
+V0.1 may ship only `@resonantos/addon-sdk` and `@resonantos/addon-sdk-testing` initially.
+
+## Public SDK Boundary
+
+The public package must not require imports like:
+
+```ts
+import type { AddOnManifest } from "../../core/contracts";
+```
+
+Instead, public contracts must be owned by the SDK or a deliberately public shared contract package.
+
+Preferred:
+
+```ts
+import {
+  defineAddon,
+  validateAddOnManifest,
+  capability,
+  tool,
+  service
+} from "@resonantos/addon-sdk";
+```
+
+## Proposed SDK Modules
+
+```text
+@resonantos/addon-sdk
+|
++-- manifest
++-- capabilities
++-- compatibility
++-- lifecycle
++-- services
++-- tools
++-- connectors
++-- skills
++-- hooks
++-- memory
++-- agents
++-- ui
++-- validation
++-- package
++-- provenance
+```
+
+## Add-on Definition API
+
+Illustrative API:
+
+```ts
+import {
+  defineAddon,
+  capabilities
+} from "@resonantos/addon-sdk";
+
+export default defineAddon({
+  id: "addon.example.notes",
+  name: "Example Notes",
+  version: "1.0.0",
+  sdkVersion: "^0.1.0",
+  category: "knowledge",
+  runtimeType: "local-service",
+  description: "Example note integration.",
+
+  requestedCapabilities: [
+    capabilities.archiveRead(),
+    capabilities.archiveIntakeWrite()
+  ],
+
+  surfaces: [],
+  tools: []
+});
+```
+
+The helper API is optional sugar. The normalized manifest remains the source of truth.
+
+## Runtime Types
+
+V0.1 retains the existing runtime categories:
+
+- `ui-module`
+- `embedded-module`
+- `local-service`
+- `agent-addon`
+- `channel-addon`
+
+Future runtime types require a versioned SDK decision.
+
+## Service Protocols
+
+V0.1 retains:
+
+- `stdio-json-rpc`
+- `http-json`
+- `websocket-json`
+- `host-command`
+
+A protocol declaration does not allow an add-on to open arbitrary privileged channels. The host determines how the service is launched and mediated.
+
+## Capability Model
+
+Existing V0 capabilities remain valid:
+
+- `filesystem`
+- `archive-read`
+- `archive-intake-write`
+- `chat-interface`
+- `memory-provider`
+- `providers`
+- `shell`
+- `network`
+- `ui-embedding`
+- `browser-control`
+- `agent-delegation`
+- `notifications`
+- `device-integration`
+
+V0.1 should begin a migration toward narrower capabilities where practical.
+
+Candidate future names:
+
+```text
+network.http
+filesystem.read
+filesystem.write
+archive.search
+archive.read
+archive.intake
+ai.inference
+ai.embedding
+ai.rerank
+ai.vision
+ai.audio
+browser.read
+browser.control
+device.camera
+device.microphone
+notifications.send
+identity.sign
+agent.delegate
+```
+
+The migration must remain backward-compatible until a major SDK version permits removal.
+
+## Scope Model
+
+Capabilities should support optional scopes.
+
+Illustrative:
+
+```json
+{
+  "capability": "filesystem.read",
+  "scopes": [
+    "${workspace}/notes/**"
+  ]
+}
+```
+
+A grant may be narrower than the add-on request.
+
+The host must reject attempts outside the grant.
+
+## Lifecycle
+
+An add-on may participate in these lifecycle states:
+
+```text
+discovered
+validated
+installed
+disabled
+enabled
+degraded
+updating
+revoked
+removed
+```
+
+Lifecycle hooks must be declarative and host-mediated.
+
+Candidate lifecycle events:
+
+- `beforeInstall`
+- `afterInstall`
+- `beforeEnable`
+- `afterEnable`
+- `beforeDisable`
+- `afterDisable`
+- `healthCheck`
+- `beforeUpdate`
+- `afterUpdate`
+- `beforeRemove`
+- `afterRemove`
+
+A hook does not grant authority.
+
+## Tools
+
+Every add-on tool must declare:
+
+- stable tool name;
+- description;
+- input schema;
+- output schema;
+- required capabilities;
+- audit requirement;
+- whether human approval is required.
+
+Example:
+
+```json
+{
+  "name": "notes.create",
+  "description": "Create a note through the configured note provider.",
+  "requiredCapabilities": [
+    "archive-intake-write"
+  ],
+  "inputSchema": {
+    "type": "object",
+    "required": ["title", "content"]
+  },
+  "outputSchema": {
+    "type": "object"
+  },
+  "audit": true,
+  "requiresHumanApproval": false
+}
+```
+
+## Connectors
+
+Connectors declare access to another system.
+
+They must never embed raw credentials in the add-on package.
+
+Credentials must be acquired through ResonantOS-mediated provider/account configuration.
+
+Connector manifests should declare:
+
+- connector id;
+- provider/service;
+- authentication mode;
+- required capabilities;
+- requested account scopes;
+- read/write semantics;
+- health check;
+- disconnect behavior.
+
+## Agent Add-ons
+
+Agent add-ons must explicitly declare:
+
+- invocation tool;
+- model-selection source of truth;
+- streaming support;
+- cancellation support;
+- output filtering;
+- memory access;
+- delegation ability;
+- smoke tests.
+
+Trusted memory writes remain intake-only unless a future policy explicitly expands the boundary.
+
+## REF Vocabulary
+
+The framework introduces two named REF fields that distinguish REF's
+distribution trust from the existing alpha runtime's `agents[].trustTier`:
+
+- `releaseTrustTier` — `developer` / `verified` / `approved`
+- `capabilityRiskClass` — `low` / `moderate` / `high` / `critical`
+
+These names are the canonical REF names per `OPEN_DESIGN_CONFLICTS_V0.1.md`
+C9 and `RESOLUTIONS_V0.1.md` C9. Existing fields (`provenance.tier`,
+`agents[].trustTier`) carry the same value set for V0.1 backward
+compat. Full field rename lands when the SDK is extracted to
+`packages/addon-sdk/`.
+
+See `ADDON_CERTIFICATION_AND_SIGNING_V0.1.md` "REF Vocabulary (C9)"
+for the canonical definition and allowed values.
+
+## SDK Validation
+
+The SDK must provide:
+
+```ts
+validateAddOnManifest(manifest)
+assertValidAddOnManifest(manifest)
+```
+
+Validation must be deterministic and callable in:
+
+- local development;
+- unit tests;
+- CI;
+- submission processing;
+- host installation.
+
+## Compatibility
+
+Each add-on must declare supported ranges:
+
+```json
+{
+  "compatibility": {
+    "resonantOS": ">=2.0.0-alpha <3.0.0",
+    "sdk": "^0.1.0"
+  }
+}
+```
+
+The host must reject or quarantine incompatible releases.
+
+## Developer CLI
+
+Target CLI:
+
+```text
+resonant addon create
+resonant addon validate
+resonant addon test
+resonant addon audit
+resonant addon package
+resonant addon submit
+```
+
+An npm initializer may provide:
+
+```bash
+npm create resonant-addon
+```
+
+## Local Development Workflow
+
+```text
+create
+  |
+  v
+implement
+  |
+  v
+validate
+  |
+  v
+test
+  |
+  v
+audit
+  |
+  v
+package
+  |
+  v
+sideload
+```
+
+No submission is required for local developer-mode testing.
+
+## Public API Stability
+
+SDK public exports must be intentional.
+
+Internal helpers must not be exported merely because they are convenient.
+
+Every public contract must have:
+
+- owner;
+- version behavior;
+- validation behavior;
+- tests;
+- migration policy.
+
+## M0 Success Criterion
+
+The SDK reaches M0 when a developer outside the ResonantOS source tree can:
+
+1. scaffold an add-on;
+2. declare a manifest;
+3. validate it;
+4. run SDK tests;
+5. package it;
+6. sideload it into ResonantOS;
+7. see requested permissions;
+8. grant a bounded capability;
+9. execute one host-mediated tool;
+10. disable and remove the add-on;
+
+without importing private ResonantOS source modules.

--- a/docs/addons/resonant-extension-framework/SDK_REVIEWER_AGENT_V0.1.md
+++ b/docs/addons/resonant-extension-framework/SDK_REVIEWER_AGENT_V0.1.md
@@ -1,0 +1,259 @@
+# SDK Reviewer Agent V0.1 — Augmentor/Logician Review Copilot for Add-on Certification
+
+## Status
+
+Design-stage proposal, part of the Resonant Extension Framework V0.1
+package at `docs/addons/resonant-extension-framework/`. Companion to
+`ADDON_CERTIFICATION_AND_SIGNING_V0.1.md`; does not amend it.
+
+## Purpose
+
+Define an agent — the **SDK Reviewer** — that operates inside the REF
+certification pipeline and helps the ResonantOS team review add-on
+submissions: extracting facts, applying review policy, and drafting
+review records with recommended decisions.
+
+The SDK Reviewer is built the ResonantOS way: it is itself an add-on,
+declared against the same SDK contracts it reviews others with.
+
+## Grounding: What Already Exists
+
+This design assembles existing, proven pieces rather than inventing a
+new subsystem:
+
+- **Augmentor** — the reasoning/strategist persona. Add-ons teach it
+  operating methods through the `augmentorSkills` manifest contract
+  (`docs/architecture/ADDON_AUGMENTOR_SKILL_TEMPLATE.md`): declared
+  workflow phases, approval gates, required tools, delegation packets,
+  audit logging.
+- **Logician** — the deterministic-verification workstream, already
+  shipped as `addon.logician` ("policy and reasoning rules engine",
+  `runtimeType: local-service`, archive read scopes `constitution` /
+  `protocols`, no provider credentials). ADR-018: "Deterministic
+  verification is owned by the Logician workstream. Add-ons declare the
+  checks and hooks; Logician or host-side services execute and report
+  them."
+- **Engineer runner** (`scripts/engineer-runner.mjs`, ADR-034) — the
+  prompt/verify precedent: an agent does work, then deterministic checks
+  verify the result.
+- **Certification spec** — the review record schema, review outcomes
+  (`approved` / `approved-with-constraints` / `changes-requested` /
+  `rejected` / `suspended` / `revoked`), human review triggers, and the
+  core state rule:
+
+```text
+VALID != VERIFIED != APPROVED != GRANTED
+```
+
+## The One Non-Negotiable Rule
+
+**The SDK Reviewer recommends. Humans approve.**
+
+- The agent may contribute to VALID and VERIFIED (automated checks).
+- The agent may *draft* an APPROVED review record.
+- The APPROVED transition and the release signature always require a
+  human (or explicit enterprise policy) decision. The agent's output is
+  an input to that decision, never a substitute for it.
+- A positive agent recommendation **never lowers** a manual-review
+  trigger defined in the certification spec. High/critical-risk releases
+  get human eyes regardless of what the agent says.
+- The certification spec's non-goal — "no automatic approval of
+  sensitive permission changes" — is retained unchanged.
+
+### Adversarial stance
+
+The agent's job is to argue **against** the submission: find reasons to
+reject, constrain, or request changes. A reviewer copilot that looks for
+reasons to approve amplifies automation bias; one that must cite
+evidence for every concern it raises (and explicitly states what it
+could not verify) strengthens the human decision.
+
+## Architecture
+
+Two halves, matching the repo's Augmentor/Logician split:
+
+```text
+Submission bundle (.rpkg + audit + provenance)
+        |
+        v
++--------------------------------------------------+
+| LOGICIAN HALF — deterministic, no LLM            |
+|                                                  |
+|  validate manifest (validateAddOnManifest)       |
+|  compute package + manifest digests              |
+|  diff requestedCapabilities vs prior approved    |
+|  dependency inventory + advisory scan            |
+|  run sandboxed smoke tests                       |
+|  evaluate policy rules (constitution)            |
+|    e.g. shell + network -> mandatory human       |
+|                                                  |
+|  output: EVIDENCE BUNDLE (machine-readable)      |
++--------------------------------------------------+
+        |
+        v
++--------------------------------------------------+
+| AUGMENTOR HALF — reasoning, advisory             |
+|                                                  |
+|  reviewer skill (augmentorSkills contract):      |
+|    1. read evidence bundle (never raw bytes)     |
+|    2. check policy findings against release type |
+|    3. adversarial analysis: what could this      |
+|       add-on do with each granted capability?    |
+|    4. draft review record:                       |
+|         recommendedDecision + evidenceRefs       |
+|         + mandatoryHumanTriggers                 |
+|         + unverifiableItems                      |
+|    5. prepare human decision packet              |
++--------------------------------------------------+
+        |
+        v
+Human reviewer approves / constrains / requests changes / rejects
+        |
+        v
+Signature service signs the exact approved digest
+```
+
+### Why the halves are separated
+
+Facts the decision rests on (digests, capability diffs, scan results,
+policy-rule hits) must be **reproducible and non-interpretive** — that is
+Logician work, executable in CI without any model. The LLM only
+*interprets* evidence that is already deterministic, which makes the
+agent's contribution auditable and its failure modes bounded: a wrong
+model can produce a bad recommendation, but it cannot fabricate a digest
+or hide a capability diff.
+
+## The Reviewer Is an Add-on (Dogfooding)
+
+```json
+{
+  "id": "addon.sdk-reviewer",
+  "name": "SDK Reviewer",
+  "category": "security",
+  "runtimeType": "local-service",
+  "requestedCapabilities": [
+    { "capability": "archive-read", "scope": "shared",
+      "revocationBehavior": "hard-stop" },
+    { "capability": "archive-intake-write", "scope": "intake-only",
+      "revocationBehavior": "hard-stop" },
+    { "capability": "providers", "scope": "shared",
+      "revocationBehavior": "degrade" }
+  ],
+  "tools": [
+    { "name": "review.extract_facts", "requiresHumanApproval": false },
+    { "name": "review.diff_capabilities", "requiresHumanApproval": false },
+    { "name": "review.classify_risk", "requiresHumanApproval": false },
+    { "name": "review.draft_record", "requiresHumanApproval": false },
+    { "name": "review.record_decision", "requiresHumanApproval": true }
+  ]
+}
+```
+
+Deliberate constraints:
+
+- **No `shell` capability.** Deterministic certification tooling runs
+  host-side (Logician/engineer-runner pattern); the reviewer calls
+  declared host-mediated tools. This follows the Hermes lesson: passive
+  audit must not run submission binaries, shell commands, or network
+  calls.
+- **Archive writes are intake-only.** Draft review records land in an
+  intake/review boundary; the trusted registry and the signing service
+  are written only after human decision.
+- **Provider access via shared profiles** — the reviewer never holds
+  raw credentials.
+- **Self-review rule:** updates to `addon.sdk-reviewer` itself go
+  through the same pipeline with mandatory human review. The reviewer
+  never touches its own release.
+
+## "Trained Within the SDK Framework"
+
+In ResonantOS vocabulary, agents are trained with **skills plus
+fixtures**, not weights:
+
+1. **Reviewer skill** — an `augmentorSkills` document (per the SDK
+   template) encoding the review operating method: intake checklist,
+   evidence requirements, capability-risk heuristics, adversarial
+   probes, delegation-packet output for the human decision, and explicit
+   "when not to recommend approval" conditions.
+2. **Golden fixture corpus** — deterministic review cases with expected
+   outcomes, replayed in CI (`node --test`):
+
+| Fixture | Expected recommendation |
+|---|---|
+| clean low-risk utility, no network/shell | `approved` (streamlined) |
+| calculator requesting `filesystem.write` + `shell` | `changes-requested` |
+| v1.3 adding `network` over approved v1.2 | `changes-requested` (re-review) |
+| package digest mismatch after submission | `rejected` |
+| secret-like file in package | `rejected` |
+| unsupported SDK range | `rejected` |
+| publisher key change between versions | escalate: mandatory human |
+
+3. **Measured agreement** — CI reports decision agreement and
+   evidence-citation coverage per fixture. Skill or model changes that
+   regress fixtures block the reviewer add-on's own release.
+
+## Prompt-Injection Containment
+
+Submission content (manifest text, README, code, skill docs) is
+**untrusted data**:
+
+- Facts reach the model only through deterministic extractors (the
+  evidence bundle), never by the model reading raw submission bytes for
+  ground truth.
+- Raw content may be quoted only as bounded evidence excerpts attached
+  to findings.
+- The reviewer executes nothing from the submission. Smoke tests run in
+  the Logician half's sandbox, host-side.
+- The skill instructs the reviewer to ignore instructions embedded in
+  submission content and to report their presence as a finding.
+
+## Auditability
+
+Every AI-assisted review record carries: model id, reviewer-skill
+version, evidence-bundle hash, prompt-template hash, and the human
+decision that followed. A disputed decision can therefore be replayed:
+same evidence bundle + same skill version + same model -> same
+recommendation, or a documented divergence.
+
+## Phasing
+
+### R1 — Deterministic facts, human-only decisions
+
+Logician half ships; evidence bundles attached to every submission; all
+decisions human. (Mostly already specified in the certification spec.)
+
+*Exit gate:* evidence bundle reproducible across runs for the same
+submission bytes.
+
+### R2 — Advisory drafting
+
+Augmentor half ships; agent drafts a recommendation on every submission;
+humans decide every release. Fixture corpus runs in CI.
+
+*Exit gate:* measured agreement on the golden corpus at or above a
+threshold the team sets; zero cases of the agent lowering a
+manual-review trigger.
+
+### R3 — Fast-track for low-risk only (optional, policy decision)
+
+After a fixture-proven track record: LOW-risk releases with a clean
+agent recommendation may use a streamlined human sign-off. Still
+human-signed, version-bound, revocable. Sensitive triggers untouched.
+
+*Exit gate:* explicit team policy decision recorded in an ADR; not
+implied by this document.
+
+## Open Questions for Review
+
+1. Should the reviewer's evidence bundle schema be the same document as
+   the certification spec's machine-readable capability report, or a
+   superset?
+2. What agreement threshold on the golden corpus qualifies R2 -> R3,
+   and who owns that threshold?
+3. Should the reviewer see the *previous* human review records for
+   earlier versions of the same add-on (continuity) — and does that risk
+   anchoring?
+4. Is a second, deliberately different model/skill as a
+   counter-reviewer worth the cost for HIGH/CRITICAL releases?
+5. Does `addon.sdk-reviewer` belong in the Resonant Approved tier by
+   definition once shipped, or does it earn the tier like everyone else?

--- a/docs/addons/resonant-extension-framework/SIGNING_ARCHITECTURE_V0.1.md
+++ b/docs/addons/resonant-extension-framework/SIGNING_ARCHITECTURE_V0.1.md
@@ -1,0 +1,145 @@
+# Signing Architecture V0.1
+
+## Purpose
+
+Per `RESOLUTIONS_V0.1.md` C11 and `ADR-055` §12.1 (C11 row), REF V0.1
+uses native `crypto.sign` / `crypto.verify` ed25519 via Node's built-in
+crypto module. First-party bundles remain trust-by-bundling in V0.1;
+key custody (offline root, rotating release-signing key, publisher
+keys, revocation metadata) is deferred to the security pipeline review.
+
+This document defines the canonical signing envelope, key ids, and
+verification behavior. When the SDK is extracted to `packages/addon-sdk/`
+(Phase 1 of the implementation roadmap), this becomes the SDK package's
+`sign.ts` helper plus typed verifier.
+
+## Algorithm
+
+- **Algorithm**: Ed25519 (edwards25519sha512no secret key wrapping).
+- **Library**: Node.js built-in `node:crypto` — `crypto.sign(null, data, key)`
+  and `crypto.verify(null, data, key, signature)`. The `null` digest
+  selects Ed25519 internally (no separate digest is required).
+- **Encoding**: raw 64-byte signature bytes, base64url-encoded in JSON
+  envelope files (no `-----BEGIN` PEM headers in V0.1 envelopes).
+
+## Key Identifiers
+
+Each key carries a stable string identifier (`keyId`). The format is:
+
+```text
+<role>-<owner>-<year>
+```
+
+Examples:
+
+- `resonant-approval-2026` — ResonantOS release-signing key (signs the
+  approved-release index).
+- `developer-alice-2026` — Alice's publisher key.
+- `bundled-core` — sentinel keyId for first-party bundles that do not
+  carry a publisher signature.
+
+The `keyId` is recorded in the index entry and in the package signature
+envelope. Verifiers fetch public keys by `keyId` from a trusted source
+(out-of-band for V0.1; the security pipeline review will define the
+distribution mechanism).
+
+## Signature Envelope
+
+A V0.1 package carries zero or more detached signatures in
+`signatures/*.sig`. Each signature is a JSON envelope:
+
+```json
+{
+  "schemaVersion": "0.1",
+  "addonId": "addon.example.notes",
+  "version": "1.0.0",
+  "packageDigest": "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+  "manifestDigest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "keyId": "developer-alice-2026",
+  "algorithm": "ed25519",
+  "signedAt": "2026-08-24T00:00:00Z",
+  "signature": "<base64url-encoded 64-byte Ed25519 signature>"
+}
+```
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `schemaVersion` | string | yes | "0.1" for this version. |
+| `addonId` | string | yes | Matches the manifest `id`. |
+| `version` | string | yes | Strict semver. |
+| `packageDigest` | string | yes | `sha256:` + lowercase hex; the normalized `.rpkg` digest. |
+| `manifestDigest` | string | yes | `sha256:` + lowercase hex; the canonical manifest JSON digest. |
+| `keyId` | string | yes | Stable key identifier (see above). |
+| `algorithm` | string | yes | Currently only `ed25519` is allowed in V0.1. |
+| `signedAt` | string | yes | ISO-8601 timestamp. |
+| `signature` | string | yes | base64url-encoded signature bytes. |
+
+The signature is over a canonical payload built from the envelope:
+
+```text
+payload = "${addonId}\n${version}\n${packageDigest}\n${manifestDigest}\n${keyId}\n${signedAt}"
+```
+
+The payload is then signed with the private key corresponding to
+`keyId`. Verification reconstructs the same payload and calls
+`crypto.verify`.
+
+## Trust Tiers and Required Signatures
+
+| `releaseTrustTier` | Required signatures |
+| --- | --- |
+| `developer` | publisher signature optional; no ResonantOS signature required |
+| `verified` | publisher signature required; ResonantOS verification signature required |
+| `approved` | publisher signature required; ResonantOS approval signature required |
+
+The `bundled-core` keyId is the sentinel for first-party bundles that
+do not carry a publisher signature (`developer` tier only). A bundled
+add-on may not claim `verified` or `approved` without a real publisher
+signature and a real ResonantOS signature.
+
+## Verification Behavior
+
+A V0.1 verifier performs, in order:
+
+1. Load each `signatures/*.sig` envelope.
+2. Look up the public key for `keyId`.
+3. Reject if `algorithm` is not `ed25519`.
+4. Reconstruct the canonical payload from the envelope fields.
+5. Call `crypto.verify(null, payload, publicKey, signatureBytes)`.
+6. Reject the signature on any failure; collect successful signatures
+   by `keyId`.
+7. Determine the effective `releaseTrustTier` from the highest tier
+   whose signature verifies successfully.
+8. Reject the package if the effective tier is below what the
+   installation channel requires.
+
+## Key Custody
+
+Per `RESOLUTIONS_V0.1.md` C11, detailed key custody is deferred to the
+security pipeline review. The V0.1 minimum:
+
+- Production signing keys MUST NOT live in the source repository.
+- The ResonantOS approval signing key MUST be offline or protected.
+- Release-signing keys SHOULD rotate annually; the previous key
+  remains valid for a grace window equal to the registry grace window
+  (see `REGISTRY_METADATA_SCHEMA_V0.1.md`).
+- Publisher keys are owned by the publisher; their revocation is the
+  publisher's responsibility, with an out-of-band channel to the
+  ResonantOS approval signer.
+
+## Compatibility Notes
+
+- The envelope is forward-compatible: future minor versions may add
+  fields. Consumers must ignore unknown fields.
+- A future V1 may add additional algorithms (e.g. `dilithium3` for
+  post-quantum). V0.1 verifiers must reject anything that is not
+  `ed25519`.
+
+## Source
+
+- `RESOLUTIONS_V0.1.md` C11
+- `OPEN_DESIGN_CONFLICTS_V0.1.md` C11
+- `ADR-055-resonant-extension-framework.md` §12.1 (C11 row)
+- `ADDON_PACKAGE_AND_MANIFEST_SPEC_V0.1.md`
+- `ADDON_CERTIFICATION_AND_SIGNING_V0.1.md`
+- `REGISTRY_METADATA_SCHEMA_V0.1.md`

--- a/docs/architecture/ADR-005-provider-fabric-routing.md
+++ b/docs/architecture/ADR-005-provider-fabric-routing.md
@@ -213,3 +213,5 @@ Routing still belongs to the provider fabric. The strategy profile is user-agree
 - Future provider UI, runtime health, and recovery UX must surface supported vs experimental distinctions clearly.
 - Chat UX must not assume streaming or abort support unless the chosen execution adapter explicitly declares it.
 - Contracts in `src/core/` should evolve toward `provider profile + runtime node + routing decision` instead of a single flattened provider concept.
+
+**See also:** [ADR-056: Provider Fabric Boundary for External Agent Runtimes](ADR-056-provider-fabric-boundary-external-agent-runtimes.md) — locks the boundary for third-party agent runtimes (DeepSeek Harness, Agent Zero) that want to use the provider fabric as consumers rather than providers.

--- a/docs/architecture/ADR-015-delegation-fabric-addon-catalog-native-tools.md
+++ b/docs/architecture/ADR-015-delegation-fabric-addon-catalog-native-tools.md
@@ -447,3 +447,5 @@ References:
 - Engineer gains structured repair delegation without bypassing audit controls.
 - OpenClaw compatibility is maintained through generated `TASK.md`, but ResonantOS owns the stronger structured packet.
 - LangGraph can be evaluated without making it foundational too early.
+
+**See also:** [ADR-056: Provider Fabric Boundary for External Agent Runtimes](ADR-056-provider-fabric-boundary-external-agent-runtimes.md) — extends the delegation-fabric policy to external agent runtimes by locking credential mediation, provider-routing authority, and capability enforcement at the bridge boundary.

--- a/docs/architecture/ADR-055-resonant-extension-framework.md
+++ b/docs/architecture/ADR-055-resonant-extension-framework.md
@@ -32,7 +32,10 @@ are defined, validated, tested, reviewed, signed, distributed, installed,
 granted capabilities, executed, updated, disabled, and removed. The
 existing `src/sdk/addons/` contracts remain the starting point; the
 framework packages and hardens those boundaries into a stable
-developer-facing contract.
+developer-facing contract. As of PR #441 (merged 2026-09-11) the
+source moved to `packages/addon-sdk/src/sdk/addons/`; the in-tree
+`src/sdk/addons/*.ts` re-export shims preserve backwards compatibility
+for in-flight imports.
 
 An add-on that wants to operate inside ResonantOS must:
 
@@ -119,8 +122,10 @@ ADR-023 / ADR-024 (registry / commerce — deferred per C10)
 
 ADR-006 establishes the Add-on Runtime & SDK with manifest validation,
 provenance, capabilities, and host mediation. ADR-018 establishes the
-binding internal standard at `src/sdk/addons/`. ADR-055 extends both
-toward a public, third-party-capable contract.
+binding internal standard at `src/sdk/addons/` (source moved to
+`packages/addon-sdk/src/sdk/addons/` by PR #441; `src/sdk/addons/*.ts`
+remain as re-export shims). ADR-055 extends both toward a public,
+third-party-capable contract.
 
 Future public/third-party work should extend the existing Add-on SDK
 decisions rather than introduce an unrelated extension framework that
@@ -146,19 +151,27 @@ VALID != VERIFIED != APPROVED != GRANTED
 `ADDON_CERTIFICATION_AND_SIGNING_V0.1.md` documents the rule in full. REF
 inherits it unchanged.
 
-REF's three trust tiers map onto the existing `AddOnProvenanceTier` enum
-(`bundled-core | curated-signed | enterprise-signed | sideloaded-unverified`)
-per `RESOLUTIONS_V0.1.md` C1 (option a — Map only). The mapping table:
+REF proposes three trust tiers. They are **proposed** in this ADR and
+do **not** correspond one-to-one to any single existing enum. The runtime
+carries `AddOnProvenanceTier` (`bundled-core | curated-signed |
+enterprise-signed | sideloaded-unverified` —
+`src/core/contracts.ts:113`) and `AddOnVerificationState`
+(`unverified | verified`, on `provenance.verificationState`) and
+`AddOnReviewState` (`unreviewed | reviewed | approved`). REF's proposed
+tiers are a *display/governance overlay*, not an extension of the
+runtime enum. The intended mapping (proposed per
+`RESOLUTIONS_V0.1.md` C1, option a — Map only):
 
-| REF tier | Existing enums |
+| REF tier (proposed) | Runtime enums (read-only, not equivalent) |
 |---|---|
-| Developer / Sideloaded | `sideloaded-unverified` + `unverified` + `unreviewed` |
-| Verified | `curated-signed` + `verified` + `reviewed` |
-| Resonant Approved | `curated-signed` + `verified` + `approved`, bound to per-`(addonId, version)` approval record |
+| Developer / Sideloaded | `provenance.tier = "sideloaded-unverified"` + `verificationState = "unverified"` + `reviewState = "unreviewed"` |
+| Verified | `provenance.tier = "curated-signed"` + `verificationState = "verified"` + `reviewState = "reviewed"` |
+| Resonant Approved | `provenance.tier = "curated-signed"` + `verificationState = "verified"` + `reviewState = "approved"`, bound to per-`(addonId, version)` approval record |
 
-`bundled-core` is first-party (trust-by-bundling, not signature). `enterprise-signed`
-is a future value with no V0.1 work. Per-version approval is mandatory — the
-package digest and manifest digest both bind to the approval record.
+`bundled-core` is first-party (trust-by-bundling, not signature).
+`enterprise-signed` is a future value with no V0.1 work. Per-version
+approval is mandatory — the package digest and manifest digest both
+bind to the approval record.
 
 ### User policy for personal / self-built add-ons
 
@@ -179,15 +192,18 @@ tier. Approval is never a substitute for runtime authorization.
 
 ## 5. Capability Model
 
-Three vocabularies coexist today:
-
-1. **Manifest capabilities** (13 coarse + 2 V0.1 additions; see
-   §12.1): `filesystem`, `archive-read`, `archive-intake-write`,
-   `chat-interface`, `memory-provider`, `providers`, `shell`, `network`,
-   `ui-embedding`, `browser-control`, `agent-delegation`,
-   `notifications`, `device-integration`, plus `channel.send` and
-   `channel.account-write` per the §12 commitment.
-2. **Bridge route capabilities** (23, fine-grained): the per-route
+1. **Manifest capabilities** (13, the
+   `ADDON_CAPABILITIES` enum at `packages/addon-sdk/src/sdk/addons/contracts.ts:62-75`
+(the original `src/sdk/addons/contracts.ts` now re-exports from
+`packages/addon-sdk/` after PR #441)):
+   `filesystem`, `archive-read`, `archive-intake-write`,
+   `chat-interface`, `memory-provider`, `providers`, `shell`,
+   `network`, `ui-embedding`, `browser-control`, `agent-delegation`,
+   `notifications`, `device-integration`. The §12 commitment to add
+   `channel.send` and `channel.account-write` alongside the existing
+   `notifications` is **proposed** in this ADR — they are not yet in
+   the `ADDON_CAPABILITIES` enum on `dev` (verified 2026-09-11).
+2. **Bridge route capabilities** (26, fine-grained): the per-route
    capability-token set at `browser-first/host/bridge-capability-tokens.mjs`.
    A consistency test locks this list to the extension-side allowlist.
 3. **Browser-first add-on capabilities** (informal): a second, untyped
@@ -196,7 +212,8 @@ Three vocabularies coexist today:
 
 `RESOLUTIONS_V0.1.md` C5 (option a) ships a single mapping table owned
 by the SDK package. The mapping is a versioned data file inside the
-public SDK (`packages/addon-sdk/`). Validation warns when a requested
+public SDK (`packages/addon-sdk/` — relocated from `src/sdk/addons/` by
+PR #441, merged 2026-09-11). Validation warns when a requested
 manifest capability maps to nothing; the bridge authorises at route
 granularity using the same data.
 
@@ -226,7 +243,7 @@ vocabularies coexist"; `RESOLUTIONS_V0.1.md` C5.
 
 The manifest is the developer-facing source of truth. V0.1 retains the
 existing `AddOnManifest` shape from `RESONANT_ADDON_SDK_SPEC_V0.1.md`
-and `src/sdk/addons/contracts.ts`:
+and `packages/addon-sdk/src/sdk/addons/contracts.ts` (post-PR #441):
 
 ```json
 {
@@ -241,22 +258,37 @@ and `src/sdk/addons/contracts.ts`:
   "sdkVersion": "^0.1.0",
   "surfaces": [],
   "requestedCapabilities": [],
-  "providerRequirements": [],
-  "archiveIntegration": {},
-  "health": {},
-  "installHooks": {},
+  "providerRequirements": {
+    "sharedProfiles": [],
+    "supportsPrivateCredentials": false,
+    "preferredRuntimeKinds": []
+  },
+  "archiveIntegration": {
+    "readScopes": [],
+    "intakeWriteScopes": [],
+    "canRequestIngest": false,
+    "canWriteKnowledgePages": false
+  },
+  "health": {
+    "strategy": "host-command",
+    "command": "noop"
+  },
+  "installHooks": { "onInstall": "noop", "onEnable": "noop" },
   "compatibility": {
-    "resonantOS": ">=2.0.0-alpha <3.0.0",
-    "sdk": "^0.1.0"
+    "shellVersion": "^0.1.0",
+    "platforms": ["macOS", "linux"]
   }
 }
 ```
 
 The package format is `.rpkg` (per `ADDON_PACKAGE_AND_MANIFEST_SPEC_V0.1.md`).
 A package may be a deterministic ZIP container internally; the file
-extension and packaging conventions are `.rpkg`. The
-`scripts/check-repo-hygiene.mjs` archive-zip rule is amended to add
-`.rpkg` to the allowlist (see §12.1, C6).
+extension and packaging conventions are `.rpkg`. This ADR proposes a
+corresponding amendment to `scripts/check-repo-hygiene.mjs` to add
+`.rpkg` to the archive-zip allowlist (see §12.1, C6) — the amendment
+is **not yet present** in the script on `dev` (verified 2026-09-11).
+The security pipeline would validate `.rpkg` packages separately;
+the hygiene rule is not the security boundary.
 
 ```text
 example-notes-1.0.0.rpkg
@@ -583,16 +615,14 @@ The section is structured as: V0.1 commitments first (these become
 implementation gates once the prose is filled in), then cross-references
 to source documents, then the deferrals that survive V0.1.
 
-### 12.1 V0.1 commitments
-> **Re-classified 2026-08-31 (§15.2):** C6, C7, C8, C10, C11 below are beta.2
-> distribution deferrals, not V0.1 commitments. See §15.2 for the mapping.
-
 - **C6 container format** — **V0.1:** `.rpkg` is the official package
-  format per `ADDON_PACKAGE_AND_MANIFEST_SPEC_V0.1.md`. The
-  `scripts/check-repo-hygiene.mjs` archive-zip rule is amended to add
-  `.rpkg` to the allowlist (one-line change). Test fixtures live under
-  `tests/fixtures/`. The security pipeline validates `.rpkg` packages
-  separately; the hygiene rule is not the security boundary.
+  format. The ADR proposes amending
+  `scripts/check-repo-hygiene.mjs` to add `.rpkg` to the allowlist
+  (a one-line change); the amendment is **not yet present** on `dev`
+  (verified 2026-09-11). Test fixtures would live under
+  `tests/fixtures/`. The security pipeline would validate `.rpkg`
+  packages separately; the hygiene rule is not the security
+  boundary.
 - **C7 compatibility evaluation** — install + launch; fold into Phase 1.
 - **C8 sideload enablement** — **V0.1:** enable + harden; security-pipeline
   review is its own gate before Tier 1 (Developer/Sideloaded) add-ons
@@ -696,34 +726,25 @@ See also:
   add-on) is **yet to be determined**. Deferred to a follow-on ADR,
   candidate **ADR-057**.
 
-- **Communication-channel capability refinement** — **V0.1:** add
-  `channel.send` and `channel.account-write` as new manifest
-  capabilities alongside the existing `notifications.send`.
-  `channel.receive` and `channel.account-read` are deferred to V1.
-  `notifications.send` remains for V0.1 backward-compat. The SDK
-  spec records the migration in
-  `RESONANT_ADDON_SDK_SPEC_V0.1.md` Capability Model section. The C5
-  mapping table picks up the new entries in the same file.
-
-- **Post-V0.1 sandbox surface** — deferred. M0 Test A (Hello Resonant
-  with a UI surface) was deferred past V0.1 by `RESOLUTIONS_V0.1.md` C4.
-  The "what defines V0.1 done" exit criteria are: Phase 3.5 hardening
-  landed; M0 Test B (Local Files) and M0 Test C (Local AI) green; the
-  capability-mapping table operational; signing + registry metadata in
-  place per Phase 6/8. Only then is Test A reopened.
+- **Communication-channel capability refinement** — **proposed.**
+  The ADR proposes adding `channel.send` and `channel.account-write`
+  as new manifest capabilities alongside the existing
+  `notifications` capability (note: the runtime capability is
+  `notifications`, not `notifications.send`). `channel.receive` and
+  `channel.account-read` are deferred to V1. The SDK spec records
+  the migration in `RESONANT_ADDON_SDK_SPEC_V0.1.md` Capability Model
+  section once the proposal is accepted; the C5 mapping table picks
+  up the new entries in the same file.
 
 ### 12.2 Cross-references
 
-Every commitment above is grounded in source documents:
-
 | Decision | Source |
 |---|---|
-| §4 Trust Model mapping table | `RESOLUTIONS_V0.1.md` C1 + `PROPOSAL-resonant-extension-framework.md` Trust Tiers |
+| `channel.send` / `channel.account-write` proposed (not yet in `ADDON_CAPABILITIES`) | §5 Capability Model; `RESOLUTIONS_V0.1.md` C5 (proposed) |
 | `personal-local` display-only stance | `ADDON_PERSONAL_PLUGIN_GOVERNANCE.md` + user policy |
-| `channel.send` / `channel.account-write` V0.1 additions | `packages/addon-sdk/README.md` Capability additions |
 | `channel.receive` / `channel.account-read` V1 deferral | §5 Capability Model |
 | Public SDK external boundary inventory | Phase 0 deliverable; `IMPLEMENTATION_ROADMAP_V0.1.md` Phase 0 |
-| C6 `.rpkg` stays official | `ADDON_PACKAGE_AND_MANIFEST_SPEC_V0.1.md` + `check-repo-hygiene.mjs` amend |
+| C6 `.rpkg` proposed (allowlist amend not yet present in `check-repo-hygiene.mjs` on `dev`, verified 2026-09-11) | `ADDON_PACKAGE_AND_MANIFEST_SPEC_V0.1.md`; hygiene amend pending |
 | C8 sideload enablement | `RESOLUTIONS_V0.1.md` C8 + Phase 3.5 hardening notes |
 | C9 naming (`releaseTrustTier`, `capabilityRiskClass`) | `RESOLUTIONS_V0.1.md` C9 |
 | C10 registry metadata format | `RESOLUTIONS_V0.1.md` C10 + ADR-023/024 |
@@ -880,12 +901,22 @@ Source: `PROPOSAL-resonant-extension-framework.md` Consequences;
 ## 15. Maintainer Disposition Reconciliation (2026-08-31; verified against upstream `dev` 2026-09-10)
 
 This section records ADR-055 against the upstream maintainer's actual
-release-scope dispositions. It is not a review of REF — the maintainer has
-not reviewed this ADR or PR #327. These dispositions are *maintainer
-precedents that constrain how REF should be proposed*: scope/timing
-decisions captured in the upstream issue record (#109, #180, #215, #137),
-each drafted via Claude Code as noted in the issue comments. They are read
-from the upstream issue comment record on 2026-08-31.
+release-scope dispositions. **Review history (verified 2026-09-11).**
+The maintainer posted review comments on PR #327 on 2026-09-08
+(static-readout of the original PR, covering design and enforcement,
+not just release timing) and on 2026-09-10 (the closeout that
+drove the split into two PRs — ADR-only first, then the 17 REF
+documents). The 2026-09-10 closeout also captured per-PR blockers
+on `#327`–`#331` (see `fork-cleanup/PR_BLOCKERS_SUMMARY.md`); the
+substantive findings are addressed in the corresponding resubmitted
+PRs (`#440`, `#441`). The "~8/10 / not design" assessment referenced
+in earlier revisions of this section came from an external AI review,
+not from the maintainer, and has been removed from this version. These
+dispositions are *maintainer precedents that constrain how REF should
+be proposed*: scope/timing decisions captured in the upstream issue
+record (#109, #180, #215, #137), each drafted via Claude Code as noted
+in the issue comments. They are read from the upstream issue comment
+record on 2026-08-31.
 
 Issue states re-verified against the live record on 2026-09-10: #109 OPEN,
 #137 OPEN, #180 OPEN (task 1 landed in `dev`), #215 CLOSED. §15.1 now
@@ -938,17 +969,26 @@ boundary.
 
 ADR-055 already defers the marketplace and distribution machinery (§14,
 §12.3); this section pins those deferrals to the maintainer's beta.2
-boundary rather than to ADR-023/024 alone. Tom's #180 finding — disable
-retains every granted capability and a single re-enable restores full grants
-with no re-consent prompt (`src/modules/addons/controller.ts:58-89`) — is
-being addressed upstream in tasks. Task 1 landed in `dev`: the `uninstalled`
-installation state with tombstone rebase and fresh-grant snapshot semantics,
-with reinstall rebuilding fresh grants from the manifest (design note
-`docs/addons/addon-lifecycle-uninstall-design.md`). #180 remains OPEN;
-complete grant cleanup on disable/uninstall and residue reconciliation are
-still beta.2 gates and are **not** resolved by V0.1. The distinction
-to preserve is `disable ≠ uninstall ≠ re-authorize` — now a first-class
-contract in §16.
+boundary rather than to ADR-023/024 alone. **Verified 2026-09-11:**
+`uninstallAddon` on `dev` already clears grants, private-provider links
+and configuration (`src/modules/addons/controller.ts:182-240`) and the
+host already exposes running-work/uninstall-audit/user-data routes.
+The original disable-vs-retain-grants concern from Tom's earlier #180
+review (disable retaining every granted capability; a single re-enable
+restoring full grants with no re-consent) is no longer the gap: the
+remaining `disable` semantics are the residue and reconciliation items
+called out below, not the basic grant-clear-on-uninstall path. Tom's
+#180 finding — disable retains every granted capability and a single
+re-enable restores full grants with no re-consent prompt
+(`src/modules/addons/controller.ts:58-89`) — is being addressed upstream
+in tasks. Task 1 landed in `dev`: the `uninstalled` installation
+state with tombstone rebase and fresh-grant snapshot semantics, with
+reinstall rebuilding fresh grants from the manifest (design note
+`docs/addons/addon-lifecycle-uninstall-design.md`). #180 remains
+OPEN; complete grant cleanup on `disable` (not `uninstall`) and
+residue reconciliation are still beta.2 gates and are **not** resolved
+by V0.1. The distinction to preserve is `disable ≠ uninstall ≠
+re-authorize` — now a first-class contract in §16.
 
 ### 15.3 Still requiring maintainer decision
 

--- a/docs/architecture/ADR-055-resonant-extension-framework.md
+++ b/docs/architecture/ADR-055-resonant-extension-framework.md
@@ -1,0 +1,1087 @@
+# ADR-055 — Resonant Extension Framework
+
+> **Draft.** The ADR's body prose is drafted from the framework package and
+> the resolution documents. The §12 walk is complete; every conflict
+> from `OPEN_DESIGN_CONFLICTS_V0.1.md` and `RESOLUTIONS_V0.1.md` has a
+> V0.1 commitment or an explicit future-ADR pointer. The Decision Metadata
+> still records the ADR as `Deferred` (draft stage) pending proposer
+> review and acceptance. The body prose is reviewable section by
+> section.
+
+## Decision Metadata
+
+- Decision status: **Deferred**
+- Superseded by: None
+- Alpha applicability: **Partial**
+- Owner: Add-on SDK
+- Decision date: **pending** (will be set when promoted to Accepted)
+- Maintainer disposition reconciliation: §15 (recorded 2026-08-31; verified against upstream `dev` and the live issue record 2026-09-10; upstream #109, #180, #215, #137)
+- Lifecycle security contract: §16 (recorded 2026-08-31; updated 2026-09-10 for the #180 task-1 landing in upstream `dev`)
+
+The trust-tier mapping (§4), capability model (§5), and runtime boundary (§7) are locked enough to be cross-referenced from `RESOLUTIONS_V0.1.md`. The remaining sections (1, 2, 3, 6, 8, 9, 10, 11, 13, 14) are drafted prose from existing source documents, ready for reviewer shaping.
+- Source: forked from `PROPOSAL-resonant-extension-framework.md`, with the resolutions from `RESOLUTIONS_V0.1.md`, the conflict framing from `OPEN_DESIGN_CONFLICTS_V0.1.md`, the review-feedback notes (`EXTERNAL_REVIEW_FEEDBACK_V0.1.md`, `ADDON_PERSONAL_PLUGIN_GOVERNANCE.md`), and the runtime hardening notes (`docs/addons/resonant-extension-framework/REF_HARDENING_NOTES_V0.1.md`).
+
+## 1. Decision
+
+ResonantOS formalizes its existing add-on architecture as the
+**Resonant Extension Framework (REF)** — extension of, not replacement
+for, ADR-006 and ADR-018.
+
+REF is the governed system by which third-party and first-party add-ons
+are defined, validated, tested, reviewed, signed, distributed, installed,
+granted capabilities, executed, updated, disabled, and removed. The
+existing `src/sdk/addons/` contracts remain the starting point; the
+framework packages and hardens those boundaries into a stable
+developer-facing contract.
+
+An add-on that wants to operate inside ResonantOS must:
+
+1. declare itself using the Resonant Add-on SDK manifest contract;
+2. request all capabilities explicitly;
+3. pass SDK validation;
+4. execute privileged operations only through host-mediated APIs;
+5. pass the applicable automated certification suite;
+6. be cryptographically signed for verified or approved distribution;
+7. receive explicit user grants before using requested capabilities.
+
+Official catalog distribution additionally requires ResonantOS review and
+approval for the specific add-on version.
+
+Source: `PROPOSAL-resonant-extension-framework.md` Decision; the four
+questions of the architectural principle (§2); ADR-006 (Add-on Runtime
+& SDK); ADR-018 (Add-on SDK V0).
+
+## 2. Architectural Principle
+
+The framework separates four questions that must never be conflated:
+
+1. **What is the add-on?** — declared by the manifest.
+2. **What does the add-on request?** — declared capabilities.
+3. **What may the add-on do on this machine?** — decided by the
+   ResonantOS host and user grants.
+4. **What does the ResonantOS project trust and distribute?** —
+   decided by certification and signing policy.
+
+The trust flow is therefore:
+
+```text
+Add-on Declaration
+        |
+        v
+Capability Request
+        |
+        v
+SDK Validation
+        |
+        v
+Certification / Review
+        |
+        v
+Signature / Distribution Trust
+        |
+        v
+User Installation
+        |
+        v
+User Capability Grant
+        |
+        v
+Host-Mediated Execution
+```
+
+The core principle, restated from the framework package and
+`OPEN_DESIGN_CONFLICTS_V0.1.md`:
+
+> Manifest declares. Validation checks. Certification evaluates.
+> Signature identifies. User grants. Host enforces.
+>
+> Approval is never a substitute for runtime authorization.
+
+SDK validation, approval, and runtime authority stay separate. A
+positive review decision **never lowers** a runtime authority check.
+
+Source: `PROPOSAL-resonant-extension-framework.md` Architectural
+Principle; `OPEN_DESIGN_CONFLICTS_V0.1.md` Background in Sixty Seconds.
+
+## 3. Lineage
+
+ADR-055 is an evolution of existing work, not a replacement.
+
+```text
+ADR-006 Add-on Runtime & SDK
+    ↓
+ADR-018 Add-on SDK V0  (binding internal standard, src/sdk/addons)
+    ↓
+ADR-055 Resonant Extension Framework (public evolution; declarative-only V0.1)
+    ↓
+ADR-023 / ADR-024 (registry / commerce — deferred per C10)
+```
+
+ADR-006 establishes the Add-on Runtime & SDK with manifest validation,
+provenance, capabilities, and host mediation. ADR-018 establishes the
+binding internal standard at `src/sdk/addons/`. ADR-055 extends both
+toward a public, third-party-capable contract.
+
+Future public/third-party work should extend the existing Add-on SDK
+decisions rather than introduce an unrelated extension framework that
+duplicates manifests, capabilities, lifecycle, or runtime authority.
+
+The framework package (`docs/addons/resonant-extension-framework/`)
+carries the design-stage documentation that this ADR accepts. On
+acceptance, the proposal becomes the body of this ADR and the
+specifications move to `docs/addons/`, per the framework README
+"Staging" section.
+
+Source: `EXTERNAL_REVIEW_FEEDBACK_V0.1.md` Alignment Map and Fork
+Strategy; framework package README.
+
+## 4. Trust Model
+
+The four-state core rule governs every add-on, regardless of trust tier:
+
+```text
+VALID != VERIFIED != APPROVED != GRANTED
+```
+
+`ADDON_CERTIFICATION_AND_SIGNING_V0.1.md` documents the rule in full. REF
+inherits it unchanged.
+
+REF's three trust tiers map onto the existing `AddOnProvenanceTier` enum
+(`bundled-core | curated-signed | enterprise-signed | sideloaded-unverified`)
+per `RESOLUTIONS_V0.1.md` C1 (option a — Map only). The mapping table:
+
+| REF tier | Existing enums |
+|---|---|
+| Developer / Sideloaded | `sideloaded-unverified` + `unverified` + `unreviewed` |
+| Verified | `curated-signed` + `verified` + `reviewed` |
+| Resonant Approved | `curated-signed` + `verified` + `approved`, bound to per-`(addonId, version)` approval record |
+
+`bundled-core` is first-party (trust-by-bundling, not signature). `enterprise-signed`
+is a future value with no V0.1 work. Per-version approval is mandatory — the
+package digest and manifest digest both bind to the approval record.
+
+### User policy for personal / self-built add-ons
+
+`ADDON_PERSONAL_PLUGIN_GOVERNANCE.md` records the user's policy: approved
+add-ons appear in the official listing stamped by the ResonantOS team;
+private or self-built add-ons are **not approved** and **may cause a
+ResonantOS crash requiring automatic recovery**. The chip-UI warning text
+is the user-facing surface for this consequence. The runtime contract
+itself does not distinguish "personal" from "sideloaded" by enum value —
+that distinction is a display concern in V0.1, recorded as the
+`personal-local` deferred item in §12.
+
+### The boundary the runtime enforces
+
+Capability grants (manifest declared → user-granted → host-mediated →
+audit-attributed via Phase 3.5) are authoritative regardless of trust
+tier. Approval is never a substitute for runtime authorization.
+
+## 5. Capability Model
+
+Three vocabularies coexist today:
+
+1. **Manifest capabilities** (13 coarse + 2 V0.1 additions; see
+   §12.1): `filesystem`, `archive-read`, `archive-intake-write`,
+   `chat-interface`, `memory-provider`, `providers`, `shell`, `network`,
+   `ui-embedding`, `browser-control`, `agent-delegation`,
+   `notifications`, `device-integration`, plus `channel.send` and
+   `channel.account-write` per the §12 commitment.
+2. **Bridge route capabilities** (23, fine-grained): the per-route
+   capability-token set at `browser-first/host/bridge-capability-tokens.mjs`.
+   A consistency test locks this list to the extension-side allowlist.
+3. **Browser-first add-on capabilities** (informal): a second, untyped
+   manifest format at `browser-first/addons/*/addon.json` for the
+   bundled first-party add-ons.
+
+`RESOLUTIONS_V0.1.md` C5 (option a) ships a single mapping table owned
+by the SDK package. The mapping is a versioned data file inside the
+public SDK (`packages/addon-sdk/`). Validation warns when a requested
+manifest capability maps to nothing; the bridge authorises at route
+granularity using the same data.
+
+```text
+Manifest capability (coarse, public SDK surface)
+        |
+        v
+SDK-owned capability-mapping table (data, not code)
+        |
+        v
+Bridge route capability (fine-grained, runtime)
+```
+
+The principle: **manifest declares; bridge enforces at route granularity.**
+The host retains final authority over what any operation actually does,
+independent of manifest or signing.
+
+The deferred refinement for V1 is `channel.receive` and
+`channel.account-read` as further subdivisions of the
+`communication-channel` capability. The C5 mapping table picks up all
+capability entries including the `channel.*` additions.
+
+Source: `OPEN_DESIGN_CONFLICTS_V0.1.md` §"Three capability
+vocabularies coexist"; `RESOLUTIONS_V0.1.md` C5.
+
+## 6. Manifest & Package Format
+
+The manifest is the developer-facing source of truth. V0.1 retains the
+existing `AddOnManifest` shape from `RESONANT_ADDON_SDK_SPEC_V0.1.md`
+and `src/sdk/addons/contracts.ts`:
+
+```json
+{
+  "schemaVersion": "0.1",
+  "id": "addon.example.notes",
+  "name": "Example Notes",
+  "version": "1.0.0",
+  "author": "Example Developer",
+  "description": "Example note integration.",
+  "category": "knowledge",
+  "runtimeType": "local-service",
+  "sdkVersion": "^0.1.0",
+  "surfaces": [],
+  "requestedCapabilities": [],
+  "providerRequirements": [],
+  "archiveIntegration": {},
+  "health": {},
+  "installHooks": {},
+  "compatibility": {
+    "resonantOS": ">=2.0.0-alpha <3.0.0",
+    "sdk": "^0.1.0"
+  }
+}
+```
+
+The package format is `.rpkg` (per `ADDON_PACKAGE_AND_MANIFEST_SPEC_V0.1.md`).
+A package may be a deterministic ZIP container internally; the file
+extension and packaging conventions are `.rpkg`. The
+`scripts/check-repo-hygiene.mjs` archive-zip rule is amended to add
+`.rpkg` to the allowlist (see §12.1, C6).
+
+```text
+example-notes-1.0.0.rpkg
+|
++-- resonant.addon.json
++-- package/
+|   +-- compiled add-on assets
+|   +-- UI assets
+|   +-- service assets
++-- skills/
++-- docs/
++-- tests/
++-- provenance/
+|   +-- checksums.json
+|   +-- build.json
++-- signatures/
+    +-- publisher.sig
+    +-- resonant-approval.sig   # official releases only
+```
+
+Certification binds to a cryptographic digest of the normalized package.
+The digest and manifest digest both bind to the per-version approval
+record (`§4 Trust Model`). Updates are new packages with new release
+identities; permission expansion returns the release to manual review.
+
+Source: `RESONANT_ADDON_SDK_SPEC_V0.1.md` Required Manifest Fields;
+`ADDON_PACKAGE_AND_MANIFEST_SPEC_V0.1.md` Package Layout and Required
+Package Properties; §12.1, C6 resolution.
+
+## 7. Runtime Boundary
+
+Add-on code reaches privileged resources only through the chain:
+
+```text
+Add-on / Extension UI
+        |
+        v
+Resonant SDK API
+        |
+        v
+Authenticated Resonant Bridge  (browser-first/host/bridge-server.mjs)
+        |
+        v
+Capability Broker / Policy
+        |
+        v
+Named Host Service
+        |
+        v
+Local privileged resource
+```
+
+The bridge and named host services remain the authority boundary.
+Provider secrets, raw credential values, protected user state, trusted
+archive promotion, unrestricted process launch, and other privileged
+resources remain host-side. Add-ons never receive raw provider
+credentials (§8 Phase 3.5 hardening).
+
+`RESOLUTIONS_V0.1.md` C3 (option c) scope-excludes the browser-first
+`browser-first/addons/*` add-on system from REF V0.1: those add-ons are
+declared *extension-internal*, not third-party. The boundary is the
+privilege boundary, not the directory boundary: anything reachable from
+extension content scripts without going through the Phase 3.5
+bridge-caller-token machinery is first-party and out of REF scope.
+
+The boundary clause:
+
+> Third-party add-on code cannot invoke any bridge route that is not
+> gated by a caller-attributed token minted under Phase 3.5. The
+> browser-first executable content scripts remain first-party because
+> they are not in the add-on loader path.
+
+V0.1 add-ons are declarative-only per §9: no shipped third-party code
+runs in the shell.
+
+Source: `PROPOSAL-resonant-extension-framework.md` Runtime Boundary;
+`RESOLUTIONS_V0.1.md` C3; §8 Phase 3.5 — Caller-Attributed Capability Tokens;
+`REF_HARDENING_NOTES_V0.1.md`.
+
+## 8. Phase 3.5 — Caller-Attributed Capability Tokens
+
+The runtime kernel of REF in this fork is Phase 3.5 caller-attributed
+capability tokens. `RESOLUTIONS_V0.1.md` C2 (option a) records the
+decision: a per-caller grant store keyed `(callerId, capability,
+scope)`, with HMAC-signed tokens per caller.
+
+The implementation landed on branch `spike/caller-attributed-tokens` and
+is documented in `docs/addons/resonant-extension-framework/REF_HARDENING_NOTES_V0.1.md`.
+The H1–H4 design choices — HMAC-signed tokens, denied-audit reason
+codes, redaction pipeline, rotation, allowlist, fail-fast, boot log —
+are part of REF's runtime contract, not optional hardening:
+
+- **H1 callerId-bound HMAC tokens.** Each token carries
+  `{ callerId, capability, expiresAt, nonce }` inside an HMAC-SHA256-signed
+  payload separated by `.`. The bridge auth path prefers a
+  `callerGrantVerifier` callback from the live grants store over the
+  snapshot map, so revocation takes effect immediately.
+- **H2 denied-audit emission with reason codes.** Every deny path
+  inside `evaluateBridgeRequestForSelfTest` emits a JSONL record with
+  a structured reason: `bridge-token` (401), `unknown-route` (404),
+  `bootstrap-missing` (403), `capability-denied` (403),
+  `internal-error` (500), or `authorized` (200). Records never carry the
+  supplied capability token.
+- **H3 redaction, rotation, allowlist, fail-fast, boot log.** Audit
+  records are redacted (URL/header parameters) before serialisation. The
+  ledger rotates at a configurable byte cap with rolling files. The
+  grants store accepts an optional `callerIdAllowlist` that constrains
+  the keyspace. The minimal launcher fails fast on audit-ledger init
+  failure. A boot log line summarises caller count, grant count, and a
+  short tokenKey fingerprint.
+
+Phase 3.5 is the gate before Phase 4 (host install + lifecycle) and
+before M0 Tests B and C. The runtime hardening work landed on the
+spike branch `spike/caller-attributed-tokens`; it is not in upstream
+`dev` and is outside this ADR's acceptance scope.
+
+Source: `RESOLUTIONS_V0.1.md` C2; `REF_HARDENING_NOTES_V0.1.md`;
+`IMPLEMENTATION_ROADMAP_V0.1.md` Phase 3.5.
+
+## 9. V0.1 is Declarative-Only
+
+`RESOLUTIONS_V0.1.md` C4 locks V0.1 as declarative-only:
+
+> **Decision:** Option (a) — V0.1 is declarative-only.
+
+V0.1 add-ons are manifest + host-mediated tools + local services; no
+shipped third-party code runs in the shell. The runtime is responsible
+for any executable surface.
+
+Consequences:
+
+- **M0 Test A (Hello Resonant with a UI surface) is removed** from the
+  M0 milestone and renamed to "post-V0.1 sandbox surface" (§12.3).
+- **C4 (executable surface)** is the largest hidden work item in the
+  proposal. No roadmap phase builds it in V0.1.
+- The "no shipped third-party code runs in the shell" rule is locked
+  for V0.1. Add-ons that need to ship code (e.g. local services) ship
+  it through the host-mediated local-service definition; the host runs
+  it; the add-on declares it.
+
+V0.1 still delivers the ecosystem's enforcement half (trust tiers,
+capability model, lifecycle, certification, signing, registry, capability
+mapping, Phase 3.5 hardening). It defers the code-running half until
+after Phase 3.5 is mature and a sandbox surface decision can be made
+with real evidence.
+
+Source: `RESOLUTIONS_V0.1.md` C4; `IMPLEMENTATION_ROADMAP_V0.1.md` V0.1
+declarative-only decision.
+
+## 10. Certification, Signing, Review, Registry
+
+The certification pipeline carries the four-state core rule from
+`ADDON_CERTIFICATION_AND_SIGNING_V0.1.md`:
+
+```text
+VALID != VERIFIED != APPROVED != GRANTED
+```
+
+- **Valid**: conforms to SDK contracts.
+- **Verified**: release identity/signature and required automated checks
+  are valid.
+- **Approved**: ResonantOS review accepted this exact release for official
+  distribution.
+- **Granted**: the current user or authorized policy allowed a requested
+  capability on this machine.
+
+Approval is **version-specific**. A new version must be certified again.
+A release that adds or materially broadens sensitive capabilities
+automatically returns to human review (§4 Trust Model mapping table;
+§6 Manifest & Package Format permission expansion rules).
+
+Automated certification gates (V0.1 minimum):
+
+- **Manifest**: schema valid; stable add-on id; valid semver; supported
+  SDK range; supported runtime type; tool capabilities appear in
+  requested capabilities; no unknown privileged capability; no duplicate
+  tool ids; no invalid system-slot claims.
+- **Package integrity**: structure valid; no path traversal;
+  normalized digest reproducible; no secret-like files in prohibited
+  locations; no unsigned mutation after submission.
+- **Dependencies**: dependency inventory produced; lockfile present when
+  applicable; known critical vulnerabilities flagged; prohibited
+  dependency classes flagged by policy; bundled executable/native
+  assets identified.
+- **Capability audit**: machine-readable capability report (requested,
+  granted-by-default: none, risk class, scope, reason, tools/hooks/
+  connectors requiring capability).
+- **Runtime tests**: install in clean test profile; enable; health
+  check; deterministic smoke test; disable; re-enable; remove; verify
+  no unauthorized host calls.
+- **Compatibility**: supported ResonantOS range; supported SDK range;
+  manifest schema version; runtime protocol support; deprecated API
+  warnings.
+
+Review triggers (manual review required when any of these apply):
+requests a high-risk or critical capability; expands sensitive
+capabilities from the prior approved version; launches or installs a
+local service; bundles native executable code; controls a browser;
+accesses microphone/camera/device integrations; performs external
+account mutation; requests shell-mediated commands; participates in
+identity signing; handles credentials beyond approved host references;
+supplies self-updating code; changes publisher signing identity; requests
+a broad filesystem scope; modifies installation behavior.
+
+Review outcomes: `approved`, `approved-with-constraints`,
+`changes-requested`, `rejected`, `suspended`, `revoked`. Constraints
+are machine-readable where possible.
+
+Key management: production signing keys do not live in the source
+repository. Recommended separation: offline or protected root trust
+key; rotating release-signing keys; publisher keys; revocation
+metadata. Key rotation does not invalidate historical package records
+when the old key remains trusted for its valid time window. Detailed
+key custody deferred to security pipeline review (§12.1, C11).
+
+The SDK Reviewer Agent (`SDK_REVIEWER_AGENT_V0.1.md`) is the
+dogfooded review copilot. It contributes to VALID and VERIFIED; it
+*drafts* an APPROVED review record; the APPROVED transition and the
+release signature always require a human (or explicit enterprise policy)
+decision. The agent's job is to argue against the submission.
+
+Registry (ADR-023) and commerce (ADR-024) are referenced but not
+redefined here. Per §12.1 C10, V0.1 ships metadata format and signed
+approved-release index as a versioned JSON document in the public SDK
+package; the live registry service is deferred.
+
+Source: `ADDON_CERTIFICATION_AND_SIGNING_V0.1.md`; `SDK_REVIEWER_AGENT_V0.1.md`;
+`RESOLUTIONS_V0.1.md` C10/C11; ADR-023; ADR-024.
+
+## 11. Developer Workflow
+
+The guiding principle from `ADDON_DEVELOPER_WORKFLOW_AND_CLI_V0.1.md`:
+make the safe path the easiest path. A developer should not need to
+learn ResonantOS kernel internals to produce a compliant add-on.
+
+Developer journey:
+
+```text
+npm create resonant-addon
+        |
+        v
+choose add-on template
+        |
+        v
+edit resonant.addon.json
+        |
+        v
+implement SDK-facing code
+        |
+        v
+resonant addon validate
+        |
+        v
+resonant addon test
+        |
+        v
+resonant addon audit
+        |
+        v
+resonant addon package
+        |
+        +--> sideload in developer mode
+        |
+        v
+resonant addon submit
+        |
+        v
+certification / review
+```
+
+CLI commands (`@resonantos/addon-sdk-cli`, target V0.1):
+
+- `create` — select template; generate manifest; generate tests; pin
+  compatible SDK; create example capability declaration.
+- `validate` — manifest schema; capability references; tool/connector/
+  hook references; compatibility; package identity; required fields.
+- `test` — SDK contract tests; deterministic add-on tests; smoke tests
+  against a mock host; lifecycle tests.
+- `audit` — human-readable and machine-readable report covering
+  capabilities, network access, shell access, native executables,
+  certification readiness.
+- `package` — build add-on assets; normalize package; generate
+  checksums; generate provenance metadata; produce `.rpkg`; optionally
+  create publisher signature.
+- `submit` (V0.1 may output a submission bundle rather than talking to
+  a live registry): `.rpkg` + audit + test + provenance + publisher +
+  requested certification tier.
+
+The mock host (`@resonantos/addon-sdk-testing`) rejects undeclared and
+ungranted operations. Tests prove that add-ons handle denied
+capabilities correctly.
+
+M0 reference add-ons (the three that prove the safe-path principle
+end-to-end):
+
+- **Hello Resonant** — manifest, lifecycle, enable/disable. (M0 Test A;
+  deferred past V0.1 per §9 declarative-only.)
+- **Local Files** — bounded filesystem read; denied filesystem write;
+  scope enforcement; audit output. (M0 Test B; runs in V0.1.)
+- **Local AI** — provider/inference request; local vs host-selected
+  provider abstraction; cancellation; no raw provider credential
+  exposure. (M0 Test C; runs in V0.1.)
+
+Documentation requirements for every public SDK API: purpose; authority
+boundary; capability requirement; input/output contract; error
+behavior; version stability; minimal example.
+
+Developer mode may relax distribution trust requirements but must not
+disable capability enforcement (§7 Runtime Boundary).
+
+Source: `ADDON_DEVELOPER_WORKFLOW_AND_CLI_V0.1.md`; `RESONANT_ADDON_SDK_SPEC_V0.1.md`
+Developer CLI; `IMPLEMENTATION_ROADMAP_V0.1.md` M0 Reference Tests.
+
+## 12. Decisions Recorded by This ADR
+
+The §12 walk committed V0.1 decisions for every item previously deferred
+in `RESOLUTIONS_V0.1.md` (C6–C12), recorded two new rows surfaced by
+the framework package and the user’s policy on personal/local add-ons,
+and resolved the §4 trust-model commitment. The result is that every
+conflict on the framework roadmap has either a V0.1 commitment recorded
+below or an explicit deferral to a follow-on ADR.
+
+The section is structured as: V0.1 commitments first (these become
+implementation gates once the prose is filled in), then cross-references
+to source documents, then the deferrals that survive V0.1.
+
+### 12.1 V0.1 commitments
+> **Re-classified 2026-08-31 (§15.2):** C6, C7, C8, C10, C11 below are beta.2
+> distribution deferrals, not V0.1 commitments. See §15.2 for the mapping.
+
+- **C6 container format** — **V0.1:** `.rpkg` is the official package
+  format per `ADDON_PACKAGE_AND_MANIFEST_SPEC_V0.1.md`. The
+  `scripts/check-repo-hygiene.mjs` archive-zip rule is amended to add
+  `.rpkg` to the allowlist (one-line change). Test fixtures live under
+  `tests/fixtures/`. The security pipeline validates `.rpkg` packages
+  separately; the hygiene rule is not the security boundary.
+- **C7 compatibility evaluation** — install + launch; fold into Phase 1.
+- **C8 sideload enablement** — **V0.1:** enable + harden; security-pipeline
+  review is its own gate before Tier 1 (Developer/Sideloaded) add-ons
+  can be installed. The runtime has `hasCommandHost()` hardcoded
+  `false` today; the enable step unblocks the path through the
+  host-mediated capability broker (per `RESOLUTIONS_V0.1.md` C2 / Phase
+  3.5 hardening, already landed). Per `ADDON_PERSONAL_PLUGIN_GOVERNANCE.md`,
+  the personal/local tier follows the same enablement gate with the
+  user-facing warning covering the auto-unplug safety policy (deferred to
+  ADR-057).
+- **C9 naming** — **V0.1:** rename in REF only — `releaseTrustTier`
+  (releases) and `capabilityRiskClass` (capabilities) replace any
+  parallel vocabulary in REF-produced artifacts. The existing
+  `agents[].trustTier` field stays (it describes agent personas, not
+  add-on release trust); renaming it is out of REF scope. The rename
+  is **landed in docs**: `RESONANT_ADDON_SDK_SPEC_V0.1.md` gains a
+  "REF Vocabulary" reference section and
+  `ADDON_CERTIFICATION_AND_SIGNING_V0.1.md` gains a "REF Vocabulary
+  (C9)" section with the canonical table and explicit values
+  (`developer`/`verified`/`approved` for `releaseTrustTier`;
+  `low`/`moderate`/`high`/`critical` for `capabilityRiskClass`).
+  The runtime fields `provenance.tier` and `agents[].trustTier`
+  keep their existing value sets for V0.1 backward compat; the
+  formal field rename lands when the SDK is extracted to
+  `packages/addon-sdk/`.
+- **C10 registry deferral** — **V0.1:** metadata format and signed
+  approved-release index ship now as a versioned JSON document in the
+  public SDK package; the live registry service is deferred per
+  ADR-023/024. The approved-release index carries per-(`addonId`,
+  `version`) records: `packageDigest`, `manifestDigest`,
+  `publisherKeyId`, `reviewId`, `signerKeyId`, `signedAt`. Index
+  rotation: a release removed from the index is no longer installable;
+  existing installations follow the revocation flow in
+  `ADDON_PACKAGE_AND_MANIFEST_SPEC_V0.1.md`.
+  **The schema is landed in docs:**
+  `docs/addons/resonant-extension-framework/REGISTRY_METADATA_SCHEMA_V0.1.md`
+  defines the canonical JSON shape, the verifier behavior, the rotation
+  rules, and the compatibility guarantees. When the SDK package is
+  extracted (Phase 1), this becomes `packages/addon-sdk/registry-metadata.schema.json`
+  plus a typed loader.
+- **C11 signing architecture** — **V0.1:** native
+  `crypto.sign` / `crypto.verify` ed25519 via Node’s built-in
+  `crypto` module. Publisher signature format:
+  `{ algorithm: ed25519, keyId, addonId, version, packageSha256,
+  signedAt, reviewId }` (mirrors the envelope in
+  `ADDON_PACKAGE_AND_MANIFEST_SPEC_V0.1.md`, with `algorithm` set to
+  ed25519). First-party bundles remain trust-by-bundling in V0.1
+  (`bundled-core` provenance tier; per-version approval records not
+  required for bundled). Key custody (offline root, rotating
+  release-signing key, publisher keys, revocation metadata) is
+  deferred to the security pipeline review.
+  **The architecture is landed in docs:**
+  `docs/addons/resonant-extension-framework/SIGNING_ARCHITECTURE_V0.1.md`
+  defines the canonical signing envelope, key id format
+  (`<role>-<owner>-<year>`), trust tier signature requirements, the
+  canonical payload format, the verifier behavior, and the V0.1
+  algorithm allowlist (`ed25519` only). When the SDK package is
+  extracted (Phase 1), this becomes `packages/addon-sdk/sign.ts`
+  plus a typed verifier.
+- **C12 package location** — **V0.1:** `packages/addon-sdk/` (and
+  `packages/addon-sdk-testing/`) from the start, per the §12 Public
+  SDK External Boundary resolution. Single source of truth immediately;
+  `src/sdk/addons/` becomes a re-export shim pointing at the new
+  package. Pay the registration cost once (root `package.json`,
+  CI install/audit blocks, release scope audit, docs links, module
+  ownership) rather than migrating it incrementally.
+  **Cutover landed (soft, fork-only):** `packages/addon-sdk/` now
+  contains the canonical 5 source files (`contracts.ts`,
+  `validation.ts`, `registry.ts`, `surface-routing.ts`, `index.ts`),
+  plus `package.json` and `README.md` documenting the intended public
+  surface. `src/sdk/addons/*.ts` are re-export shims pointing at the
+  new package. `tsconfig.json` `include` extends to `packages/addon-sdk/src`.
+  All 429 vitest tests pass through the shims unchanged. The package
+  is **not yet published** to npm; the manifest is a documentation
+  artifact recording the intended public boundary for the future
+  Phase 1 extraction. `packages/addon-sdk-testing/` lands in a
+  follow-on (B4.5 in the §B engineering walk).
+
+See also:
+  [ADR-056: Provider Fabric Boundary for External Agent Runtimes](ADR-056-provider-fabric-boundary-external-agent-runtimes.md)
+  — applies the REF runtime boundary to third-party agent runtimes
+  (DeepSeek Harness, Agent Zero); the boundary rules (no raw credentials,
+  no provider selection, host-mediated tool surface, scoped
+  filesystem/shell, capability-gated mediation) apply to any add-on
+  declaring both `providers` and `agent-delegation` capabilities.
+- **`personal-local` provenance tier** — **V0.1:** option (a) — `personal-local`
+  is a display label over `sideloaded-unverified`. The runtime contract
+  (`AddOnProvenanceTier`) is unchanged. The chip UI shows a distinct
+  badge for add-ons the user authored locally; the user-facing warning
+  text covers the consequence that loading such an add-on may crash
+  ResonantOS requiring automatic recovery. Runtime enforcement
+  (capability grants, host mediation, Phase 3.5 caller attribution) is
+  unchanged. **V1:** revisit if upstream ResonantOS requests a distinct
+  enum value.
+
+- **Add-on safety / auto-unplug mechanism** — **deferred.** A runtime
+  safety algorithm (small LLM or heuristic) that detects a failing
+  add-on, isolates it, and restores the system to a usable state is
+  needed to make the `personal-local` runtime story safe. The recovery
+  policy (auto-unplug all add-ons vs. auto-unplug only the offending
+  add-on) is **yet to be determined**. Deferred to a follow-on ADR,
+  candidate **ADR-057**.
+
+- **Communication-channel capability refinement** — **V0.1:** add
+  `channel.send` and `channel.account-write` as new manifest
+  capabilities alongside the existing `notifications.send`.
+  `channel.receive` and `channel.account-read` are deferred to V1.
+  `notifications.send` remains for V0.1 backward-compat. The SDK
+  spec records the migration in
+  `RESONANT_ADDON_SDK_SPEC_V0.1.md` Capability Model section. The C5
+  mapping table picks up the new entries in the same file.
+
+- **Post-V0.1 sandbox surface** — deferred. M0 Test A (Hello Resonant
+  with a UI surface) was deferred past V0.1 by `RESOLUTIONS_V0.1.md` C4.
+  The "what defines V0.1 done" exit criteria are: Phase 3.5 hardening
+  landed; M0 Test B (Local Files) and M0 Test C (Local AI) green; the
+  capability-mapping table operational; signing + registry metadata in
+  place per Phase 6/8. Only then is Test A reopened.
+
+### 12.2 Cross-references
+
+Every commitment above is grounded in source documents:
+
+| Decision | Source |
+|---|---|
+| §4 Trust Model mapping table | `RESOLUTIONS_V0.1.md` C1 + `PROPOSAL-resonant-extension-framework.md` Trust Tiers |
+| `personal-local` display-only stance | `ADDON_PERSONAL_PLUGIN_GOVERNANCE.md` + user policy |
+| `channel.send` / `channel.account-write` V0.1 additions | `packages/addon-sdk/README.md` Capability additions |
+| `channel.receive` / `channel.account-read` V1 deferral | §5 Capability Model |
+| Public SDK external boundary inventory | Phase 0 deliverable; `IMPLEMENTATION_ROADMAP_V0.1.md` Phase 0 |
+| C6 `.rpkg` stays official | `ADDON_PACKAGE_AND_MANIFEST_SPEC_V0.1.md` + `check-repo-hygiene.mjs` amend |
+| C8 sideload enablement | `RESOLUTIONS_V0.1.md` C8 + Phase 3.5 hardening notes |
+| C9 naming (`releaseTrustTier`, `capabilityRiskClass`) | `RESOLUTIONS_V0.1.md` C9 |
+| C10 registry metadata format | `RESOLUTIONS_V0.1.md` C10 + ADR-023/024 |
+| C11 ed25519 signing | `RESOLUTIONS_V0.1.md` C11 |
+| C12 package location | `RESOLUTIONS_V0.1.md` C12 + §12 Public SDK boundary |
+
+### 12.3 Deferred to future ADRs
+
+Three items are recorded as deferred and not addressed in V0.1:
+
+- **Add-on safety / auto-unplug mechanism** — **deferred.** A runtime
+  safety algorithm (small LLM or heuristic) that detects a failing
+  add-on, isolates it, and restores the system to a usable state is
+  needed to make the `personal-local` runtime story safe. The recovery
+  policy (auto-unplug all add-ons vs. auto-unplug only the offending
+  add-on) is **yet to be determined**. Deferred to a follow-on ADR,
+  candidate **ADR-057**.
+
+- **Post-V0.1 sandbox surface** — deferred. M0 Test A (Hello Resonant
+  with a UI surface) was deferred past V0.1 by `RESOLUTIONS_V0.1.md` C4.
+  The "what defines V0.1 done" exit criteria are: Phase 3.5 hardening
+  landed; M0 Test B (Local Files) and M0 Test C (Local AI) green; the
+  capability-mapping table operational; signing + registry metadata in
+  place per Phase 6/8. Only then is Test A reopened.
+
+- **Resonant-OS vs Third-Party SDK capability separation** —
+  **deferred to V1.** The 13 coarse manifest capabilities (plus the two
+  `channel.*` additions from item 2) are currently all exposed as
+  public SDK surface. Resonant-OS devs see internal capabilities (likely
+  candidates: `shell`, `browser-control`, `device-integration`,
+  `network`) that third-party authors should not be able to request.
+  Capability classification: each capability gets a visibility tier
+  (Resonant-OS-internal, curated-approved-only, public). The
+  third-party SDK rejects capability names above its visibility tier at
+  `validateAddOnManifest` time. V0.1 keeps the current all-public
+  surface; V1 introduces
+  the visibility-tier classification in the SDK spec and runtime.
+  The classification table itself is a follow-on design call requiring
+  review of each capability's blast radius. **Deferred record landed:**
+  `docs/addons/resonant-extension-framework/CAPABILITY_SEPARATION_V1.md`
+  captures the proposed V1 shape (parallel `PublicCapability` and
+  `InternalCapability` enums; SDK-owned mapping at the bridge
+  boundary; V1 manifest validation rules; ADR pointer) so a future
+  ADR can pick up the work without rediscovery. No V0.1 contract
+  changes.
+
+### 12.4 Summary
+
+- **4 V0.1 commitments** recorded (C9, C12, `personal-local`,
+  `communication-channel`) — the SDK contract boundary.
+- **5 beta.2 distribution deferrals** recorded (C6, C7, C8, C10, C11) —
+  re-classified per §15.2.
+- **1 §4 commitment** recorded (the trust-model mapping table).
+- **1 V0.1 commitment** recorded via cross-reference (public SDK external
+  boundary — depends on the Phase 0 inventory commit landing first; the
+  inventory is recorded as part of the §12 walk and is complete).
+- **3 future-ADR deferrals** recorded (auto-unplug, Post-V0.1 sandbox,
+  capability separation).
+- **0 unresolved** items from the original §12 outline.
+
+- **Public SDK external boundary** — **V0.1 fork-only, soft cutover
+  (alias):** create `packages/addon-sdk/` (and `packages/addon-sdk-testing/`)
+  as the public SDK contract boundary. `src/sdk/addons/` becomes a
+  thin re-export shim pointing at the new package. Single source of
+  truth immediately; consumers don't notice the change.
+  **Inventory complete (Phase 0 deliverable):** 5 SDK source files
+  move (`src/sdk/addons/{contracts,validation,registry,surface-routing,index}.ts`),
+  4 SDK test files move with them. `src/core/contracts.ts` re-exports
+  the SDK types so runtime code (chat, browser-tools, delegation,
+  logician, memory-provider, policies, runtime) keeps importing from
+  `src/core/contracts.ts` without churn. `src/modules/` consumers
+  (chip UI, settings, etc.) also unchanged — they only need the
+  add-on types, which continue to flow through `src/core/contracts.ts`.
+  No runtime blast radius; the cutover is mechanical.
+  **V1:** upstream submission happens as its own PR sequence — this
+  docs-only ADR PR first, then the `packages/addon-sdk/` relocation PR
+  (per the maintainer's 2026-09-10 closeout of #327). The cutover is prerequisite to M0
+  (external fixture project compiles and validates while importing only
+  the SDK package) and to Phase 4 (host install + lifecycle).
+
+## 13. Fork Strategy and Hygiene
+
+REF is fork-owned experimental work. Per `EXTERNAL_REVIEW_FEEDBACK_V0.1.md`
+Fork Strategy Guidance:
+
+- Build the framework **beside** the current SDK; do not rewrite the
+  Alpha core first. Adapt `src/sdk/addons` contracts into the public
+  package; change host/runtime code only when an M0 test proves a
+  specific need.
+- Mark the work clearly as fork-owned and experimental, with the
+  upstream dependency stated (`ResonantOS 2.0.0-alpha`), so it is never
+  confused with upstream ResonantOS.
+- Keep an `UPSTREAM_DELTA.md` alongside the framework: record every
+  change the fork makes to an upstream contract, so future rebases show
+  exactly where the fork diverges.
+- Suggested progression: document → extract public SDK → external
+  add-on fixture → sideload lifecycle → capability enforcement →
+  certification → signing → registry.
+
+The fork's `packages/addon-sdk/` (§12.1, public SDK boundary) is a
+*demonstration* that the boundary can exist, not a claim about how
+upstream will do it. The Phase 3.5 hardening work landed on
+`spike/caller-attributed-tokens` (§8); rebasing it back into a
+framework branch is its own conversation.
+
+Source: `EXTERNAL_REVIEW_FEEDBACK_V0.1.md` Fork Strategy Guidance;
+framework package README "Intended Repository Target".
+
+## 14. Consequence Summary
+
+ADR-055 enables:
+
+- Third-party developers receive a stable target via
+  `@resonantos/addon-sdk` (§12.1, public SDK boundary).
+- The ResonantOS team gains a repeatable review and signing process
+  (§10 certification pipeline; per-`(addonId, version)` approval
+  records).
+- Users can distinguish installed, verified, and approved software
+  (§4 Trust Model mapping table; four-state VALID/VERIFIED/APPROVED/
+  GRANTED core rule).
+- Add-ons remain modular and replaceable (replaceable system slots
+  per ADR-026; `communication-channel`, `primary-agent`, etc.).
+- Privileged authority remains with the host, not with signatures or
+  manifests (§7 Runtime Boundary; §8 Phase 3.5 hardening).
+- The existing Add-on SDK can evolve toward a public package without
+  rewriting the kernel architecture (§3 Lineage).
+
+ADR-055 does **not** require, and explicitly defers:
+
+- a commercial marketplace (per `PROPOSAL-resonant-extension-framework.md`
+  Non-Goals for V0.1; ADR-024 deferred);
+- add-on payments, ratings/reviews, revenue sharing;
+- cross-device license management;
+- arbitrary native binaries (V0.1 is declarative-only per §9);
+- remote code execution;
+- automatic approval of sensitive permission changes.
+
+The framework package's `Distribution Policy` section restates the
+catalog constraints: only certified, signed, compatible-with-running-
+ResonantOS, non-revoked, approved-for-official-distribution releases
+appear in the official catalog. Developer mode may expose additional
+sideloaded or experimental releases; it does not disable capability
+enforcement.
+
+Source: `PROPOSAL-resonant-extension-framework.md` Consequences;
+`PROPOSAL-resonant-extension-framework.md` Non-Goals for V0.1;
+`PROPOSAL-resonant-extension-framework.md` Distribution Policy;
+`RESONANT_ADDON_SDK_SPEC_V0.1.md` Public API Stability.
+
+---
+
+**See also:** [ADR-056: Provider Fabric Boundary for External Agent Runtimes](ADR-056-provider-fabric-boundary-external-agent-runtimes.md) — applies the REF runtime boundary to external agent runtimes; locks the credential-mediation and provider-routing contract for add-ons like DeepSeek Harness or Agent Zero.
+
+## 15. Maintainer Disposition Reconciliation (2026-08-31; verified against upstream `dev` 2026-09-10)
+
+This section records ADR-055 against the upstream maintainer's actual
+release-scope dispositions. It is not a review of REF — the maintainer has
+not reviewed this ADR or PR #327. These dispositions are *maintainer
+precedents that constrain how REF should be proposed*: scope/timing
+decisions captured in the upstream issue record (#109, #180, #215, #137),
+each drafted via Claude Code as noted in the issue comments. They are read
+from the upstream issue comment record on 2026-08-31.
+
+Issue states re-verified against the live record on 2026-09-10: #109 OPEN,
+#137 OPEN, #180 OPEN (task 1 landed in `dev`), #215 CLOSED. §15.1 now
+states, for each precedent, what is actually in `dev` today.
+
+### 15.1 Maintainer precedents and their state in upstream `dev` (2026-09-10)
+
+| ADR-055 position | Maintainer disposition | In upstream `dev` (verified 2026-09-10) |
+|---|---|---|
+| REF is "extension of, not replacement for, ADR-006/ADR-018" (§1) | #215 close-out: add-ons ship as governed visible capabilities over the existing SDK; no competing runtime | Landed — the beta.1 delegation lifecycle shipped under the (now closed) #215 epic; add-ons remain governed capabilities over the ADR-006/018 SDK. |
+| Browser-first Alpha boundary; no runtime change until checkpoint ADRs land (§14) | #109/#180/#215: only work blocking the Chrome extension + local browser-first bridge is in the Alpha critical path | Confirmed — the Alpha package is the browser-first extension plus local bridge (ADR-037). |
+| Governed, bundled/local catalog; host-mediated delegation; capability-gated (§4, §7) | #215: catalog is fixed and locally bundled, no install path, delegation has a six-state lifecycle | Confirmed — the catalog is bundled (`public/addons/index.json`); no install path exists. |
+| Privileged authority stays with the host, never with signature/manifest (§2, §7, §8) | #215 + #109: capability enforcement is host-owned; signing is a beta.2 distribution concern | Confirmed — capability enforcement is host-owned; no signing gate exists in `dev`. |
+| Delegation before public installation (§8 Phase 3.5, §13) | #215: governed delegation is accepted at beta.1 with no marketplace/install path | Landed — governed delegation is live at beta.1; no marketplace or install path. |
+| Failure/recovery visibility is part of the contract (§14) | #137: delegation failure states remain visible with recovery guidance; artifacts return with secret-redacted failures | Partial — #137 remains OPEN; delegation execution feedback and grant-recovery surfacing landed, deeper artifact return is an open follow-up. |
+
+### 15.2 Explicitly beta.2 / deferred — do not claim in Alpha
+
+Per #109 (deferred to beta.2; signing/hash verification "becomes gating the
+moment a remote/marketplace registry or extension-side sideload lands") and
+#180 (deferred to beta.2 as a security item — the highest-priority follow-up
+from the #215 audit), the following are distribution/lifecycle scope, not
+V0.1 SDK-contract scope:
+
+- remote registry / marketplace;
+- public sideload enablement as a shipping path;
+- signature/hash verification as a distribution gate;
+- install / update / uninstall lifecycle;
+- marketplace/store distribution;
+- complete grant cleanup on disable/uninstall.
+
+These map to §12.1 commitments as follows — re-classified here from "V0.1
+commitment" to "beta.2 distribution deferral":
+
+| §12.1 label | Re-classified |
+|---|---|
+| C6 `.rpkg` container format | beta.2 — spec drafted in `ADDON_PACKAGE_AND_MANIFEST_SPEC_V0.1.md`; install path not in Alpha |
+| C7 compatibility evaluation (install + launch) | beta.2 — install lifecycle |
+| C8 sideload enablement | beta.2 — #109: sideload hardening is gated on an install path existing |
+| C10 registry metadata | beta.2 — spec drafted in `REGISTRY_METADATA_SCHEMA_V0.1.md`; live registry deferred per ADR-023/024 |
+| C11 signing architecture | beta.2 — spec drafted in `SIGNING_ARCHITECTURE_V0.1.md`; verification "becomes gating the moment a remote/marketplace registry or extension-side sideload lands" (#109) |
+
+This re-classification supersedes the "V0.1 commitment" labeling of C6, C7,
+C8, C10, and C11 in §12.1. The V0.1 SDK-contract commitments are C9
+(vocabulary), C12 (`packages/addon-sdk/` boundary), `personal-local`, and
+`communication-channel` — the manifest, validation, capability, and boundary
+surface Tom can accept now. The five distribution items and their spec
+documents land with the beta.2 distribution work, not with the Alpha SDK
+boundary.
+
+ADR-055 already defers the marketplace and distribution machinery (§14,
+§12.3); this section pins those deferrals to the maintainer's beta.2
+boundary rather than to ADR-023/024 alone. Tom's #180 finding — disable
+retains every granted capability and a single re-enable restores full grants
+with no re-consent prompt (`src/modules/addons/controller.ts:58-89`) — is
+being addressed upstream in tasks. Task 1 landed in `dev`: the `uninstalled`
+installation state with tombstone rebase and fresh-grant snapshot semantics,
+with reinstall rebuilding fresh grants from the manifest (design note
+`docs/addons/addon-lifecycle-uninstall-design.md`). #180 remains OPEN;
+complete grant cleanup on disable/uninstall and residue reconciliation are
+still beta.2 gates and are **not** resolved by V0.1. The distinction
+to preserve is `disable ≠ uninstall ≠ re-authorize` — now a first-class
+contract in §16.
+
+### 15.3 Still requiring maintainer decision
+
+ADR-055 cannot move from Deferred to Accepted without upstream answers to:
+
+1. **REF terminology.** Whether "Resonant Extension Framework" is accepted as
+   the governance-architecture name, vs. "Add-on SDK V1" (§1; the naming
+   alternative is recorded in
+   `docs/addons/resonant-extension-framework/EXTERNAL_REVIEW_FEEDBACK_V0.1.md`).
+2. **Public package boundary.** Whether `packages/addon-sdk/` is the desired
+   long-term public SDK boundary (§12.1 C12), or only a fork-local
+   demonstration (§13).
+3. **Acceptance subset.** Which of the 9 V0.1 commitments (§12.4) the
+   maintainer wants accepted now, vs. held as fork-experimental.
+4. **Transition.** How ADR-055 moves from Deferred to Accepted /
+   partially-accepted (proposer review, then maintainer acceptance), and
+   whether "Alpha applicability: Partial" is the right frame.
+
+**Process note (2026-09-10).** The maintainer's closeout of #327 set the
+submission path: this docs-only ADR PR first, then the `packages/addon-sdk/`
+relocation as its own PR with no hygiene or capability changes. The four
+questions above remain open.
+
+### 15.4 Separate decision — ADR-056
+
+ADR-056 (Provider Fabric Boundary for External Agent Runtimes) is its own
+architecture decision and must not be required to accept the basic SDK
+boundary. The relevant maintainer precedent for ADR-056 is #137 (OPEN as of
+2026-09-10), not this ADR: governed Hermes delegation packets, an embedded dashboard, and visible
+failure/recovery are accepted; raw external-runtime prompt execution is
+outside the Alpha MVP guarantee until a safer handoff surface exists (a
+file/stdin/authenticated local API path with deterministic evidence return).
+Keep ADR-055 and ADR-056 reviewable independently.
+
+## 16. Add-on Lifecycle Security Contract
+
+Recorded 2026-08-31, per the maintainer's beta.2 disposition on #180 and the
+external review recommendation; updated 2026-09-10. This makes
+disable/uninstall/re-authorization a first-class security contract — the
+invariant the lifecycle implementation must satisfy when install/update/
+uninstall land (beta.2). When recorded, only `disable` was live. As of
+2026-09-10 `dev` also has the `uninstalled` transition with tombstone rebase
+and fresh-grant rebuild on reinstall (#180 task 1); `update` consent and
+residue reconciliation remain unimplemented.
+
+### 16.1 The four transitions
+
+| Transition | Contract |
+|---|---|
+| `disable` | Execution becomes impossible; configuration and grants are preserved. |
+| `enable` | Execution resumes only with grants the user has consented to; materially changed grants are never silently restored. |
+| `uninstall` | Atomic: revoke every grant, terminate associated runtimes, remove or reconcile host-managed residue. |
+| `update` | Diff the old and new capability manifest; expanded authority requires fresh consent before it takes effect. |
+
+### 16.2 Disable ≠ enable ≠ re-authorize
+
+The #180 audit established the behavior this contract forbids:
+
+- Disable retains every granted capability and all configuration; a single
+  re-enable restores full grants with **no re-consent prompt**
+  (`src/modules/addons/controller.ts:58-89`; state persisted via
+  `src/core/runtime.ts:1369-1380`).
+- Host-side residue has no deletion path: `Settings/addon-execution.json`
+  entries and `DelegationArtifacts/` accumulate indefinitely.
+
+Invariant: **a grant is never restored by a lifecycle transition; it is only
+re-established by explicit user consent.**
+
+### 16.3 Uninstall residue
+
+`uninstall` must reconcile:
+
+- granted capabilities — revoked, not hidden;
+- `Settings/addon-execution.json` — the add-on's record removed;
+- `DelegationArtifacts/` and per-add-on host state — removed or archived per
+  retention policy;
+- credentials the add-on introduced (the #180 audit's example: a stored
+  Telegram bot token) — removed, never orphaned.
+
+### 16.4 Update consent
+
+`update` is a capability-model diff, not a byte replacement:
+
+1. diff old vs new manifest capabilities;
+2. a newly-requested capability is **not** active until the user grants it;
+3. narrowed authority takes effect immediately (removals are always safe);
+4. the diff is auditable — recorded, never silent.
+
+### 16.5 Scope and timing
+
+- **V0.1 (now):** the contract is recorded; `disable` and `uninstall` (with
+  fresh-grant rebuild on reinstall) are live in `dev`, and the #180 exposure
+  is bounded (no third-party install path, disabled add-ons cannot execute).
+  `update` consent and residue reconciliation are not yet implemented.
+- **beta.2:** full `uninstall` residue reconciliation, `update` consent, and
+  the remaining #180 capability-cleanup tasks are implementation gates,
+  sequenced with the distribution work (#109, #215).
+
+## Appendix A — Input Source Map
+
+Every claim in this outline is traceable to one of these sources.
+
+| Source | Path | Role in ADR |
+|---|---|---|
+| Original proposal | `docs/addons/resonant-extension-framework/PROPOSAL-resonant-extension-framework.md` | Decision, principle, framework components, trust tiers, runtime boundary, replaceability |
+| Add-on SDK spec | `docs/addons/resonant-extension-framework/RESONANT_ADDON_SDK_SPEC_V0.1.md` | §6 manifest, §11 SDK modules, lifecycle, tools, connectors, agents |
+| Package & manifest spec | `docs/addons/resonant-extension-framework/ADDON_PACKAGE_AND_MANIFEST_SPEC_V0.1.md` | §6 `.rpkg`, manifest fields, publisher block, digests, signature envelope |
+| Certification & signing | `docs/addons/resonant-extension-framework/ADDON_CERTIFICATION_AND_SIGNING_V0.1.md` | §10 pipeline, gates, review triggers, signing model, revocation |
+| Developer workflow | `docs/addons/resonant-extension-framework/ADDON_DEVELOPER_WORKFLOW_AND_CLI_V0.1.md` | §11 CLI commands, mock host, reference add-ons, error codes |
+| Implementation roadmap | `docs/addons/resonant-extension-framework/IMPLEMENTATION_ROADMAP_V0.1.md` | §8 Phase 3.5, §9 M0 test ordering, §13 suggested repo additions |
+| Open design conflicts | `docs/addons/resonant-extension-framework/OPEN_DESIGN_CONFLICTS_V0.1.md` | §3 lineage grounding, §4-§7 conflict-driven decisions, §12 deferred |
+| Resolutions | `docs/addons/resonant-extension-framework/RESOLUTIONS_V0.1.md` | §4 C1, §5 C5, §7 C3, §8 C2, §9 C4, §10 sequencing, §12 deferred C6-C12 |
+| External review | `docs/addons/resonant-extension-framework/EXTERNAL_REVIEW_FEEDBACK_V0.1.md` | §13 fork strategy, alignment map |
+| Personal/local governance | `docs/addons/resonant-extension-framework/ADDON_PERSONAL_PLUGIN_GOVERNANCE.md` | §12 `personal-local` tier proposal (deferred) |
+| SDK Reviewer Agent | `docs/addons/resonant-extension-framework/SDK_REVIEWER_AGENT_V0.1.md` | §10 dogfooded reviewer add-on |
+| Runtime hardening notes | `docs/addons/resonant-extension-framework/REF_HARDENING_NOTES_V0.1.md` | §8 H1–H4 hardening is part of the runtime contract |
+| Upstream ADRs | `docs/architecture/ADR-006-*.md`, `ADR-018-*.md`, `ADR-023-*.md`, `ADR-024-*.md`, `ADR-026-*.md`, `ADR-034-*.md` | §3 lineage; §10 references |
+| Hardening implementation | branch `spike/caller-attributed-tokens`, commits `60c0129` `9e28f3f` `6617a63` `0d5f7ae` `779f16d` `92659c1` `a6ee86c` | §8 evidence; reviewable as a single squashed or cherry-picked commit when this fork merges back |
+| Framework package intake | commits `410e508` `9d244e4` `2b6d6d6` on `feat/tab-referencing` | Records the framework package's source; reviewed in §3 |
+
+---
+
+## Appendix B — Reviewer Checklist
+
+For each section above, a reviewer can shape the prose by asking:
+
+1. Does this section *commit* to something, or only *record* something
+   that was decided elsewhere? If the latter, the section is one
+   paragraph summarising the source's decision with a pointer.
+2. Is there a source in Appendix A this section doesn't yet cite?
+3. Does the section introduce any *new* commitment not in any source?
+   If yes, that's a design change and should be flagged before
+   acceptance.
+4. Does the section preserve the four-question separation from §2?
+   (Manifest declares / what it requests / what host grants / what
+   Resonant certifies.)

--- a/docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md
+++ b/docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md
@@ -76,26 +76,36 @@ Host returns model response (and streamed tokens) to runtime
 Runtime sees the response; never the credential
 ```
 
-The "routed model handle" is the wire contract:
+The "routed model handle" is the **proposed** wire contract. None of
+the following fields exist on `ProviderRoutingDecision`
+(`src/core/contracts.ts:911-921`) on `dev` (verified 2026-09-11):
+`routingDecisionId` (the handle), `expiresAt`, explicit revocation,
+and named failure responses (`routing-decision-revoked`,
+`routing-decision-expired`). They are **proposed** in this ADR. The
+runtime contract as it exists today is `authTier: AuthTier =
+"supported" | "experimental" | "unavailable"`.
 
 ```json
 {
-  "routingDecisionId": "rd-2026-08-24-001",
   "providerProfileId": "resonant-deepseek-v4-pro",
   "runtimeNodeId": "rn-local-user-mac",
+  "executionAdapterId": "deepseek-v4-pro-direct",
   "model": "deepseek-v4-pro",
-  "authTier": "subscription",
-  "costPosture": "paid-api",
-  "fallbackChain": ["rn-emergency-local", "rn-degraded-bypass"],
-  "expiresAt": "2026-08-24T01:00:00Z"
+  "authTier": "experimental",
+  "usingFallback": false,
+  "resolutionReason": "matched-shared-profile",
+  "fallbackPolicyId": "experimental-deepseek-delegated-reasoning"
 }
 ```
 
-The runtime uses the `routingDecisionId` to make subsequent calls (streaming, follow-ups, cancellation). The host resolves the ID back to a stored decision; the credential never appears on the wire. Decisions expire (default: 5 minutes; configurable in the host); the runtime must request a fresh decision if its current one expires.
-
-**What the runtime sees:** opaque IDs and the model name. **What the runtime never sees:** the API key, OAuth token, base URL secret, or any provider-internal auth material.
-
-This mirrors the Phase 3.5 caller-attributed capability token design (ADR-055 §8): an opaque, scoped, expiring handle that the host can revoke at any time. Revoking a routing decision mid-task causes the runtime's next model call to fail with `routing-decision-revoked`; the runtime is expected to surface this to its calling agent and request a new decision.
+This shape is what `ProviderRoutingDecision` carries today. The
+proposed additions for an opaque, scoped, expiring, revocable handle
+(sibling to the Phase 3.5 caller-attributed capability token design in
+ADR-055 §8) are **not yet implemented**: no `routingDecisionId`, no
+`expiresAt`, no explicit revoke path, no `routing-decision-revoked` /
+`routing-decision-expired` failure codes. This ADR proposes them; their
+land-side implementation is tracked separately and is not a V0.1
+gate.
 
 ## 5. Model Routing
 
@@ -169,9 +179,9 @@ The boundary must be testable. These failure modes are the negative tests for an
 
 **F7 — Approval skip.** A runtime invokes a `run_task`-style tool marked `requiresHumanApproval: true` without the user having approved. Expected: host blocks until approval; if approval denied, runtime receives `approval-denied` and must abort the task.
 
-**F8 — Stale routing decision.** A runtime uses a `routingDecisionId` whose `expiresAt` has passed. Expected: host rejects; returns `routing-decision-expired`; runtime requests a new decision.
+**F8 — Stale routing decision (proposed).** A runtime uses a `routingDecisionId` whose `expiresAt` has passed. Expected: host rejects; returns `routing-decision-expired`; runtime requests a new decision. The handle and the failure code are not yet implemented on `dev`.
 
-**F9 — Revoked routing decision.** A runtime uses a `routingDecisionId` after the host revoked it (e.g., user disabled the runtime). Expected: same as F8 with reason `routing-decision-revoked`.
+**F9 — Revoked routing decision (proposed).** A runtime uses a `routingDecisionId` after the host revoked it (e.g., user disabled the runtime). Expected: same as F8 with reason `routing-decision-revoked`. The handle and the failure code are not yet implemented on `dev`.
 
 **F10 — Experimental route attempt without declaration.** A runtime requests an experimental route without `allowExperimentalAuth: true`. Expected: rejected with `experimental-route-not-declared`.
 
@@ -181,7 +191,9 @@ Each F-number becomes a test case in `packages/addon-sdk-testing/` (B4 deliverab
 
 **With ADR-005 (Provider Fabric & Routing).** Unchanged. This ADR adds an explicit boundary for the external-agent-runtime case; ADR-005 remains authoritative for provider routing in all other cases.
 
-**With ADR-015 (Delegation Fabric).** Tightened. ADR-015 established that add-on agents are delegation targets; this ADR adds the credential and provider-selection constraints that make that policy enforceable for external agent runtimes. The Delegation Packet's `providerPolicy` field (newly formalized in this ADR) is the runtime's input to the routing request.
+**With ADR-015 (Delegation Fabric).** Tightened. ADR-015 established that add-on agents are delegation targets; this ADR adds the credential and provider-selection constraints that make that policy enforceable for external agent runtimes. The Delegation Packet's `providerPolicy` field
+(`src/core/contracts.ts:1982` on `dev`, verified 2026-09-11 — already
+present upstream) is the runtime's input to the routing request.
 
 **With ADR-055 (REF).** Compatible. ADR-055 §7 Runtime Boundary and §8 Phase 3.5 caller-attributed tokens are the mechanism this ADR relies on. The Phase 3.5 hardened bridge is what prevents the runtime from directly invoking privileged routes. The C2 / option (a) "per-caller grant store" decision (ADR-055 §8) is what gives the runtime a `callerId` distinguishable from first-party subsystems.
 

--- a/docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md
+++ b/docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md
@@ -1,0 +1,241 @@
+# ADR-056: Provider Fabric Boundary for External Agent Runtimes
+
+## Decision Metadata
+
+- Decision status: **Deferred**
+- Superseded by: None
+- Alpha applicability: Applies
+- Owner: Provider host / Delegation
+- Decision date: **pending** (will be set on acceptance)
+- Source: derived from ADR-005 ("Routing authority belongs to ResonantOS policy, not to add-ons"), ADR-015 ("Add-on agents are delegation targets, not trusted equals of Augmentor"), ADR-055 §7 Runtime Boundary and §8 Phase 3.5 caller-attributed capability tokens; modeled against `examples/addons/recursive-mas.json` (local-service add-on pattern) and proposed integrations with DeepSeek Harness (https://deepseek.com/harness/) and Agent Zero (https://www.agent-zero.ai/).
+
+## 1. Decision
+
+External agent runtimes — third-party systems that themselves can plan, call tools, and execute multi-step agentic loops — are integrated into ResonantOS as **local-service add-ons** under ADR-055's manifest contract. They are governed by a strict boundary that prevents them from holding raw provider credentials, choosing their own provider profile, or executing outside the host-mediated service boundary.
+
+ResonantOS owns:
+
+- **Provider credentials.** The provider fabric (ADR-005) is the only authority that holds raw API keys, OAuth tokens, and provider secrets. External agent runtimes never receive raw credentials.
+- **Provider routing.** The policy engine is the only authority that chooses the provider profile, runtime node, model, auth tier, and fallback route for any model request. External agent runtimes request routing decisions; they do not make them.
+- **Capability grants.** The host (per ADR-015 and ADR-055 §8) is the only authority that grants, scopes, and revokes capabilities on external agent runtimes.
+- **Lifecycle.** The host installs, enables, monitors, disables, and removes external agent runtimes under the standard add-on lifecycle.
+
+The external agent runtime owns:
+
+- **Local task execution.** Given a Delegation Packet (ADR-015), an approved scope, and routing decisions, the runtime performs the work in its own environment (subprocess, container, or sandbox).
+- **Tool planning.** Within the granted capability surface, the runtime may plan, sequence, and invoke tools; the host validates each tool call against the current grant set before mediation.
+- **Local artifact production.** The runtime produces artifacts in its task workspace and returns them to the host via the standard artifact return protocol.
+- **Internal state.** The runtime's own memory, context, session, and trajectory logs are its own concern; they may be exposed to the host only through declared surfaces and never substitute for the host's audit log.
+
+## 2. Principle
+
+> The external agent runtime is a worker, not an authority. ResonantOS holds the keys; ResonantOS picks the model; ResonantOS grants the capabilities; the runtime does the work.
+
+The boundary is a privilege boundary, not a directory or process boundary. Whether the external agent runtime runs as a Node subprocess, a Python container, a Docker sidecar, or a remote LAN service is irrelevant to the contract. What matters is which side of the boundary holds each authority.
+
+## 3. Boundary Rules
+
+These rules apply to any add-on whose manifest declares the `providers` capability together with the `agent-delegation` capability (the "external agent runtime" marker). Manifests declaring only `providers` (e.g., a thin provider-fabric adapter without delegation) are governed by ADR-005 alone; manifests declaring only `agent-delegation` (e.g., a delegation-routing add-on without model execution) are governed by ADR-015 alone. The conjunction triggers this ADR.
+
+**Rule 1 — No raw credentials.** The runtime MUST NOT be passed raw API keys, OAuth tokens, cookies, or any other credential material. ResonantOS invokes the runtime with **routed model handles**: opaque references that the runtime forwards back to the host's provider-fabric adapter for actual execution. The runtime never sees the underlying credential.
+
+**Rule 2 — No provider selection.** The runtime MUST NOT choose its own provider profile, runtime node, model, or auth tier. Each model request from the runtime carries a Routing Decision (ADR-005 §Routing Decision Output) supplied by the host. The runtime uses that decision; it does not override it. The runtime MAY include preferences in its request (preferred locality, latency, cost posture), and the host's policy engine resolves them; the runtime does not bypass the policy engine.
+
+**Rule 3 — Host-mediated tool surface.** Every tool the runtime can invoke must be declared in the runtime's `tools[]` block (per `examples/addons/recursive-mas.json`), each with its `requiredCapabilities`, `inputSchema`, `outputSchema`, and `audit` block. The host validates each invocation against the runtime's current capability grants before mediation. Tools not declared are unreachable.
+
+**Rule 4 — Scoped filesystem and shell.** Filesystem and shell capabilities granted to the runtime are scoped to the runtime's task workspace by default. The runtime MAY request a broader scope via a `grantPreset` (which the user must accept explicitly per ADR-015 §Delegation Quality Rules). The host enforces scope at every mediation; the runtime cannot escape its workspace by direct file or shell access.
+
+**Rule 5 — Capability-gated mediation.** Every privileged action by the runtime (file read/write, shell exec, network, archive read/write, knowledge page write) goes through a host-mediated bridge route. The runtime holds no privileged capability directly. The bridge enforces caller-attributed capability tokens (ADR-055 §8 Phase 3.5); tokens minted for the runtime's `callerId` are scoped to the runtime's current grant set and cannot be transferred.
+
+**Rule 6 — Delegation Packet only.** The runtime accepts work only via an ADR-015 Delegation Packet. It MUST NOT accept free-form user prompts directly. The packet's `mission`, `context`, `providerPolicy`, `costPolicy`, `allowedTools`, `forbiddenActions`, `capabilityGrants`, and `verificationRequirements` are authoritative; the runtime MAY add local notes but MUST NOT relax the packet's constraints.
+
+**Rule 7 — Audit before return.** Every tool call, model request, file access, and shell execution by the runtime emits an audit record through the host's bridge before the runtime can return artifacts. The runtime cannot "skip" audit by returning artifacts directly to the calling agent; the artifact return path itself runs through the host's audit layer.
+
+**Rule 8 — Approval before irreversible work.** Any tool call marked `requiresHumanApproval: true` in the manifest blocks until the host has surfaced an approval prompt and recorded the user's decision. The runtime cannot proceed around this. Per ADR-015, all `run_task`-style tools that take an approved Delegation Packet carry this flag by default.
+
+## 4. Credential Mediation
+
+External agent runtimes never receive raw provider credentials. The mediation flow:
+
+```text
+Runtime model request
+       |
+       v
+Runtime sends { prompt, routing_decision } to host provider-fabric adapter
+       |
+       v
+Host validates routing decision against current policy
+       |
+       v
+Host invokes the chosen provider profile with raw credentials
+       |
+       v
+Host returns model response (and streamed tokens) to runtime
+       |
+       v
+Runtime sees the response; never the credential
+```
+
+The "routed model handle" is the wire contract:
+
+```json
+{
+  "routingDecisionId": "rd-2026-08-24-001",
+  "providerProfileId": "resonant-deepseek-v4-pro",
+  "runtimeNodeId": "rn-local-user-mac",
+  "model": "deepseek-v4-pro",
+  "authTier": "subscription",
+  "costPosture": "paid-api",
+  "fallbackChain": ["rn-emergency-local", "rn-degraded-bypass"],
+  "expiresAt": "2026-08-24T01:00:00Z"
+}
+```
+
+The runtime uses the `routingDecisionId` to make subsequent calls (streaming, follow-ups, cancellation). The host resolves the ID back to a stored decision; the credential never appears on the wire. Decisions expire (default: 5 minutes; configurable in the host); the runtime must request a fresh decision if its current one expires.
+
+**What the runtime sees:** opaque IDs and the model name. **What the runtime never sees:** the API key, OAuth token, base URL secret, or any provider-internal auth material.
+
+This mirrors the Phase 3.5 caller-attributed capability token design (ADR-055 §8): an opaque, scoped, expiring handle that the host can revoke at any time. Revoking a routing decision mid-task causes the runtime's next model call to fail with `routing-decision-revoked`; the runtime is expected to surface this to its calling agent and request a new decision.
+
+## 5. Model Routing
+
+The runtime requests a routing decision; the host's policy engine returns one. The runtime does not pick.
+
+```text
+Runtime -> Host: { taskClass, localityPreference, costPosturePreference,
+                   latencySensitivity, fallbackTolerance, modelHints }
+Host -> Policy Engine: resolve
+Policy Engine -> Runtime: { routingDecisionId, chosenProfile,
+                            chosenRuntime, chosenModel, chosenAuthTier,
+                            fallbackChain, routingReason,
+                            executionAdapterCapabilities }
+Runtime: stores routingDecisionId, uses it for all model calls
+```
+
+Fields the runtime MAY set as preferences:
+
+- `taskClass`: `primary-chat`, `recovery`, `archive-ingest`, `routine`, `coding`, `specialist-reasoning` (extensible).
+- `localityPreference`: `local-only`, `prefer-local`, `prefer-cloud`, `cloud-only`.
+- `costPosturePreference`: `free-local`, `subscription`, `paid-api`, `emergency-only`.
+- `latencySensitivity`: `interactive`, `batch`, `background`.
+- `fallbackTolerance`: `strict`, `moderate`, `aggressive`.
+- `modelHints`: free-form (e.g., "needs 1M context", "function-calling preferred"). Hints are advisory; the policy engine may ignore them.
+
+Fields the runtime MAY NOT set:
+
+- `providerProfileId` — chosen by policy.
+- `runtimeNodeId` — chosen by policy.
+- `model` — chosen by policy.
+- `authTier` — chosen by policy.
+
+The runtime MAY use experimental routes only if the manifest declares `providerRequirements.allowExperimentalAuth: true` AND the host's policy engine has experimental routes enabled. Otherwise, requests that can only be satisfied by experimental routes return `routing-failed-experimental-required`.
+
+## 6. Capability Map
+
+External agent runtimes declared as local-service add-ons declare their capability set explicitly. The canonical mapping for the conjunction of `providers` + `agent-delegation` is:
+
+| Capability | Required for external agent runtime? | Notes |
+| --- | --- | --- |
+| `providers` | Yes (consume-side) | Runtime consumes ResonantOS provider profiles via routed handles. Never receives raw credentials. |
+| `agent-delegation` | Yes | Runtime accepts Delegation Packets; emits artifact returns; respects packet constraints. |
+| `network` | Yes (scoped) | Runtime must reach its own subprocess endpoint (e.g. `http://127.0.0.1:4891`) and the host's provider-fabric adapter. Scope: `self` for runtime's own port; `shared` for host adapter. |
+| `shell` | Optional | Granted only via a `grantPreset` that the user explicitly accepts. Scope: `system` only if the runtime needs to escape its task workspace, which is rare. Default: not granted. |
+| `filesystem` | Yes (scoped) | Scope: the runtime's task workspace by default. Broader scopes (`workspace`, `shared`) require `grantPresets` and explicit user approval. |
+| `archive-read` | Optional | If the runtime needs scoped Living Archive context. |
+| `archive-intake-write` | Optional | If the runtime returns artifacts via intake (recommended for delegation returns). |
+| `ui-embedding` | Optional | Only if the runtime surfaces a panel inside ResonantOS. |
+| `notifications` | Optional | Long-running task status notifications. |
+| `memory-provider` | V1 deferred | Per ADR-055 §12.3 (capability separation deferred). Runtime may store its own memory locally; the host does not consume it as a memory-provider slot until V1. |
+| `browser-control` | Optional | Only if the runtime hosts a headless browser. |
+| `channel.send` / `channel.account-write` | N/A | External agent runtimes are not channels. Channels (Telegram, Discord, etc.) use these; runtimes do not. |
+
+The runtime's manifest declares its capabilities in `requestedCapabilities`. The runtime cannot request a capability it doesn't list. The host validates the conjunction: declaring `providers` without `agent-delegation` is the standard provider-fabric adapter pattern (ADR-005 only); declaring `agent-delegation` without `providers` is the delegation-routing pattern (ADR-015 only); declaring **both** triggers this ADR's additional rules.
+
+## 7. Failure Modes
+
+The boundary must be testable. These failure modes are the negative tests for any external agent runtime integration:
+
+**F1 — Credential exfiltration attempt.** A runtime stores an inbound model request that contains an API key in a header, then forwards it as part of a `network` call. Expected: host blocks at the bridge; emits denied-audit record with reason `credential-in-payload`; revokes the routing decision.
+
+**F2 — Provider self-selection.** A runtime declares its own model (`model: "gpt-4o"`) in a tool call payload, bypassing the routing decision. Expected: host rejects the model request; returns `provider-self-selection-rejected`; the runtime must use its routing decision's model.
+
+**F3 — Workspace escape.** A runtime uses `shell` to `cat` a file outside its task workspace. Expected: host blocks at the bridge; denied-audit with reason `workspace-escape`; the runtime's `shell` grant is revoked if `revocationBehavior` is `hard-stop`.
+
+**F4 — Capability escalation.** A runtime claims it needs `archive-intake-write` mid-task and tries to call the archive intake route. Expected: host rejects at the bridge (caller-attributed token does not grant `archive-intake-write`); denied-audit with reason `capability-denied`.
+
+**F5 — Undeclared tool.** A runtime invokes a tool that is not in its manifest's `tools[]` block. Expected: host rejects; denied-audit with reason `unknown-tool`.
+
+**F6 — Audit bypass.** A runtime attempts to return artifacts directly to its calling agent without going through the artifact return protocol. Expected: host rejects; denied-audit with reason `audit-bypass-attempt`.
+
+**F7 — Approval skip.** A runtime invokes a `run_task`-style tool marked `requiresHumanApproval: true` without the user having approved. Expected: host blocks until approval; if approval denied, runtime receives `approval-denied` and must abort the task.
+
+**F8 — Stale routing decision.** A runtime uses a `routingDecisionId` whose `expiresAt` has passed. Expected: host rejects; returns `routing-decision-expired`; runtime requests a new decision.
+
+**F9 — Revoked routing decision.** A runtime uses a `routingDecisionId` after the host revoked it (e.g., user disabled the runtime). Expected: same as F8 with reason `routing-decision-revoked`.
+
+**F10 — Experimental route attempt without declaration.** A runtime requests an experimental route without `allowExperimentalAuth: true`. Expected: rejected with `experimental-route-not-declared`.
+
+Each F-number becomes a test case in `packages/addon-sdk-testing/` (B4 deliverable) and in the runtime's own manifest review.
+
+## 8. Compatibility
+
+**With ADR-005 (Provider Fabric & Routing).** Unchanged. This ADR adds an explicit boundary for the external-agent-runtime case; ADR-005 remains authoritative for provider routing in all other cases.
+
+**With ADR-015 (Delegation Fabric).** Tightened. ADR-015 established that add-on agents are delegation targets; this ADR adds the credential and provider-selection constraints that make that policy enforceable for external agent runtimes. The Delegation Packet's `providerPolicy` field (newly formalized in this ADR) is the runtime's input to the routing request.
+
+**With ADR-055 (REF).** Compatible. ADR-055 §7 Runtime Boundary and §8 Phase 3.5 caller-attributed tokens are the mechanism this ADR relies on. The Phase 3.5 hardened bridge is what prevents the runtime from directly invoking privileged routes. The C2 / option (a) "per-caller grant store" decision (ADR-055 §8) is what gives the runtime a `callerId` distinguishable from first-party subsystems.
+
+**With `examples/addons/recursive-mas.json`.** Compatible. The recursive-mas manifest is an existing local-service add-on with `providers` + `agent-delegation`. It pre-dates this ADR but satisfies its rules in their current form; no manifest changes required. The recursive-mas runbook (`docs/architecture/addon-runbooks/recursive-mas/ENGINEER_SETUP.md`) should be reviewed against §4 (Credential Mediation) and either confirmed compliant or amended.
+
+**With future ADRs (V1 capability separation).** Per ADR-055 §12.3, the V1 split between `PublicCapability` and `InternalCapability` may introduce a new visibility tier for "delegation-routing primitives" that this ADR doesn't constrain. External agent runtimes declared under this ADR are always at the public tier; they cannot request V1-internal capabilities.
+
+## 9. Reference Implementations
+
+Two concrete add-ons are anticipated under this ADR:
+
+1. **`addon.deepseek-harness`** — local-service add-on bridging ResonantOS to the DeepSeek Harness (https://deepseek.com/harness/) Cordis kernel runtime. Service: `http-json`, entrypoint `http://127.0.0.1:3080`. Capabilities per §6. Runbook to follow.
+
+2. **`addon.agentzero`** — local-service add-on bridging ResonantOS to the Agent Zero (https://www.agent-zero.ai/) Docker container runtime. Service: `http-json`, entrypoint `http://127.0.0.1:<agent-zero-port>`. Capabilities per §6. Runbook to follow.
+
+Both manifests will be siblings of `examples/addons/recursive-mas.json`. Both will satisfy every §3 rule, every §6 capability mapping, and every §7 failure-mode negative test before they can be installed.
+
+Neither manifest lands in this ADR; they land as separate add-on commits after B4 (SDK cutover) so they can be authored against the V0.1 SDK package.
+
+## 10. Open Questions
+
+These are explicit deferrals, not omissions:
+
+- **ProviderProfileId exposure in the routed handle.** §4 includes `providerProfileId` in the routed handle for observability. Some teams argue this leaks routing intent to the runtime. Argument: the runtime needs to know which profile it's on for logging and user-facing explanations. Counter-argument: opaque IDs are sufficient; the host can map back at audit time. **Deferred to a follow-on review.** Current decision: include for V0.1; remove in V1 if it proves leaky.
+
+- **Cross-runtime credential isolation.** When two runtimes are installed (DSH and A0), can one runtime's routing decision be presented to another as its own? **Expected: no.** The routed handle binds to the `callerId` of the requesting runtime. Cross-presentation is a denial-audit event. This is a Phase 3.5 enforcement property; ADR-055 §8 records it. **No follow-on work needed; just calling it out.**
+
+- **Runtime-supplied model name as a hint.** Some external agent runtimes have hard-coded "I prefer model X" defaults. §5 lets the runtime pass `modelHints` but not a hard selection. Some teams want a `modelPreference: "strict"` flag that causes the policy engine to fail rather than substitute. **Deferred to V1.**
+
+- **Long-running task support.** DeepSeek Harness sessions can run for hours; Agent Zero subordinates can persist. §3 Rule 7's audit-before-return implies every tool call is logged. For a 4-hour agent loop with 2000 tool calls, the audit volume is large. **No ADR-056 change; logged as a future perf concern for the audit pipeline.**
+
+## 11. Source
+
+- ADR-005: Provider Fabric & Routing (`docs/architecture/ADR-005-provider-fabric-routing.md`)
+- ADR-015: Delegation Fabric, Add-on Catalog, and Native Tool Fabric (`docs/architecture/ADR-015-delegation-fabric-addon-catalog-native-tools.md`)
+- ADR-055: Resonant Extension Framework (`docs/architecture/ADR-055-resonant-extension-framework.md`), especially §7 Runtime Boundary, §8 Phase 3.5, §12.3 deferred capability separation
+- `src/core/contracts.ts` AddOnManifest `providerRequirements` block (lines 547-555)
+- `src/sdk/addons/contracts.ts` AddOnSdkManifest (lines 26-43)
+- `examples/addons/recursive-mas.json` (canonical local-service add-on pattern)
+- `docs/architecture/addon-runbooks/recursive-mas/ENGINEER_SETUP.md`
+- `docs/addons/resonant-extension-framework/RESOLUTIONS_V0.1.md` C2 (Phase 3.5 hardening), C3 (privilege-not-directory boundary), C5 (mapping table ownership)
+- `docs/addons/resonant-extension-framework/REF_HARDENING_NOTES_V0.1.md` H1/H2/H3 caller-attributed token design
+
+## 12. Appendix — Negotiation Summary
+
+Before drafting this ADR, the following question was discussed:
+
+> When we integrate DeepSeek Harness (an external agent runtime) and Agent Zero (also an external agent runtime) into ResonantOS, what shape do their manifests take, and which side of the boundary holds which authority?
+
+The answer in one sentence: **ResonantOS holds the keys; ResonantOS picks the model; ResonantOS grants the capabilities; the runtime does the work.** This ADR records that answer as a reusable contract so future external agent runtimes (LangChain, AutoGPT, OpenHands, etc.) follow the same boundary without rediscovery.
+
+Two integration-shape alternatives were considered and rejected:
+
+- **Embedded harness** (DSH runs as a managed subprocess *inside* ResonantOS as a local-service add-on, with full trust). Rejected: gives the runtime authority it should not hold, especially provider selection and credential storage.
+- **Provider runtime node** (DSH registered as an OpenAI-compatible endpoint in the provider fabric). Rejected at the V0.1 level because DSH's primary interface is Cordis JSON-RPC, not `/v1/models`. May be revisited as an adapter in V1.
+
+The "subordinate agent bridge" shape — local-service add-on with `providers` + `agent-delegation`, governed by this ADR — is the canonical path.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -108,6 +108,8 @@ Add-on skill contracts:
 | [ADR-035](ADR-035-electron-host-rust-core-runtime.md) | Superseded | Not applicable | [ADR-037](ADR-037-browser-first-chromium-resonantos.md) | Browser architecture | Historical desktop-host direction; its components do not ship in Alpha. |
 | [ADR-036: Resonant Browser Host Architecture](ADR-036-wallet-capable-browser-host.md) | Superseded | Not applicable | [ADR-037](ADR-037-browser-first-chromium-resonantos.md) | Browser architecture | Historical external-browser sidecar direction; it is not the Alpha package. |
 | [ADR-037: Browser-First Chromium ResonantOS](ADR-037-browser-first-chromium-resonantos.md) | Accepted | Partial | - | Browser architecture | Browser-contained product direction applies; Alpha is the unpacked Chrome extension plus bridge, not a custom Chromium build. |
+| [ADR-055: Resonant Extension Framework](ADR-055-resonant-extension-framework.md) | Deferred | Partial | - | Add-on SDK | Outline stage; extends ADR-006/018, records RESOLUTIONS_V0.1.md as the conflict-resolution input, and references the runtime hardening notes for the Phase 3.5 caller-attributed bridge work. |
+| [ADR-056: Provider Fabric Boundary for External Agent Runtimes](ADR-056-provider-fabric-boundary-external-agent-runtimes.md) | Deferred | Applies | - | Provider host / Delegation | Locks the credential-mediation and provider-routing boundary for external agent runtimes (DeepSeek Harness, Agent Zero) integrated as local-service add-ons. |
 
 ## Authority Rules
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -8,6 +8,15 @@ for anyone building panels, add-ons, or app-shell UI.
   scoped runtime radius contract; preserves the existing palette and explains
   which ROSI generation informs Settings components.
 
+## Resonant Extension Framework V0.1
+
+The framework package lived here during design; when ADR-055 was drafted
+the proposal moved to [`docs/architecture/ADR-055-resonant-extension-framework.md`](../architecture/ADR-055-resonant-extension-framework.md)
+and the specifications moved to
+[`docs/addons/resonant-extension-framework/`](../addons/resonant-extension-framework/README.md).
+See that folder for the canonical list of framework specs, conflict
+documents, and resolution records.
+
 ## ROSI — Resonant OS Interface design system
 
 For implemented Settings density behavior, see


### PR DESCRIPTION
Docs-only PR — the first piece of the #327 resubmission, following your 2026-09-10 closeout path: **docs-only PR for the deferred ADRs first; `packages/addon-sdk/` relocation as its own PR next** (no hygiene or capability changes there, as here).

## Contents

- **ADR-055 — Resonant Extension Framework** and **ADR-056 — Provider Fabric Boundary for External Agent Runtimes**, both landing as *Deferred* with index rows in `docs/architecture/README.md`.
- The 17-file framework package at `docs/addons/resonant-extension-framework/` (proposal, specs, resolutions, review feedback, alignment roadmap), including `REF_HARDENING_NOTES_V0.1.md` — moved here from the spike branch so the ADR-055 §8 / ADR-056 §11 references resolve inside this PR (they dangled in #327).
- Registration only: `docs/README.md` reading list, `docs/design/README.md` pointer, **See also** cross-references from ADR-005 and ADR-015. No code, CI, scripts, or manifest changes.

## Corrections versus the #327 version (your closeout bullets)

- **Numbering:** title/body and docs now consistently say 055/056 — the only remaining `ADR-038/040` string is the renumbering *record* in the alignment roadmap.
- **`docs/design/README.md` §15 class:** ADR-055 §15 rewritten to describe what's actually in `dev`. Issue states re-verified live on 2026-09-10 (#109 OPEN, #137 OPEN, #180 OPEN, #215 CLOSED); §15.1 gained a per-precedent "In upstream dev" column; §15.2/§16 now record the #180 task-1 landing (`uninstalled` state, tombstone rebase, fresh-grant rebuild on reinstall; design note at `docs/addons/addon-lifecycle-uninstall-design.md`) instead of describing it as unresolved. The "as if reconciled" framing is gone — §15.3 keeps the four questions that genuinely need your decision, plus a process note recording the closeout path.
- **Dangling references removed:** present-tense `UPSTREAM_DELTA.md` claims dropped (remaining mentions are quoted review recommendations); spec README links the SDK at its current home (`src/sdk/addons/`) rather than the not-yet-landed `packages/addon-sdk/`; "on ADR-055 acceptance" phrasing corrected to drafting tense throughout.

## Out of scope (per closeout)

The `packages/addon-sdk/` relocation is the next PR, by itself: no `*.rpkg` hygiene exemption (the #438 guard stays exactly as wired), no `channel.*` capability additions. The rest of #327 (REF implementation) is not being resubmitted.

## Checks run

- `npm run docs:check` — pass
- `npm run test:docs` — 274/274 pass (incl. validate-docs, repo-hygiene, release-scope-audit suites)
- `npm run test:module-ownership` — pass
- `npm run repo:hygiene` — guard unmodified; local run flags one pre-existing **untracked** build artifact in my working tree (`resonantos-side-panel-extension.zip`), not part of this PR
- `node scripts/security-pipeline/run-check.mjs` — exit 0 (868 files scanned, committed-private-key-material clean)

Branch gates verified before push: malicious workflow file absent at tip; branch contains the `40dd4c58` fix. Supersedes the documentation portion of #327 (closed by the fork re-creation).