### PR TITLE
test(addon-sdk): ADR-056 F1–F10 negative-test harness (corrected resubmit of #328)

### DIFF
--- a/docs/architecture/MODULE_MAP.md
+++ b/docs/architecture/MODULE_MAP.md
@@ -69,6 +69,7 @@ future product work. They are not additional required Alpha processes.
 | --- | --- | --- |
 | `src/core/` | Shared contracts, provider/memory policies, state helpers, delegation shapes, and pure domain logic | Supporting source and tests; not a separate runtime process |
 | `src/sdk/addons/` | Add-on manifest, capability, protocol, and validation contracts | Governs bundled and sideloaded add-on metadata |
+| [`packages/addon-sdk-testing/`](../../packages/addon-sdk-testing/README.md) | Negative-test harness for ADR-056 §7 failure modes F1–F10 (mock host, routing store, audit capture) | Development/test support; not shipped |
 | `src/sdk/resonant-context/` | Resonant Context contracts and SDK surface | Optional integration support |
 | `src/modules/*/` | React domain workspaces and controllers from the broader product codebase | Feature reservoir/supporting source; not the MV3 Alpha UI unless explicitly imported by the extension |
 | `src/App.tsx` | React composition shell for the broader source tree | Not an Alpha entrypoint |

--- a/packages/addon-sdk-testing/README.md
+++ b/packages/addon-sdk-testing/README.md
@@ -1,0 +1,127 @@
+# `@resonantos/addon-sdk-testing`
+
+Negative-test harness for external agent runtime manifests under
+ADR-056 §7 (the ADR lands via the ADR docs PR, [ResonantOS/2.0.0-alpha#440](https://github.com/ResonantOS/2.0.0-alpha/pull/440), and may not be in `upstream/dev` yet).
+
+> **Status.** V0.1 working draft. Lives at `packages/addon-sdk-testing/` in
+> the repo (sibling to `packages/addon-sdk/`). When REF moves to a real
+> workspace (Phase 1 of the implementation roadmap), this package becomes
+> a published companion; until then, it is private and in-tree.
+
+## Why this package exists
+
+ADR-056 §7 lists ten failure modes (F1–F10) that any external agent
+runtime integration must be hardened against. The ADR states:
+
+> Each F-number becomes a test case in `packages/addon-sdk-testing/` (B4
+> deliverable) and in the runtime's own manifest review.
+
+This package is that B4 deliverable. It provides:
+
+- An **in-process mock host** (`mockHost(...)`) that simulates the
+  bridge, the routing-decision store, the audit log, and the
+  approval-prompt surface without spinning up the real ResonantOS
+  host.
+- **Ten runnable failure-mode cases** (F1–F10) exposing a single
+  function `runAddOnFailureMode(modeId, manifest)` that returns a
+  `FailureModeReport` describing what the host did and whether the
+  outcome matched ADR-056's `Expected:` clause.
+- A **synthetic external-agent-runtime manifest fixture**
+  (`createExternalAgentRuntimeFixture(...)`) with the standard
+  `providers` + `agent-delegation` capability conjunction so the tests
+  are repeatable without coordinating with `examples/addons/`.
+- A **vitest-conformant test file** at
+  `packages/addon-sdk-testing/test/failure-modes.test.ts` that
+  asserts each F-number's `Expected` clause. Already passing locally.
+
+## Scope (V0.1)
+
+In scope:
+
+- All ten §7 failure modes (F1–F10), deterministic, no real network.
+- Audit-capture surface matching ADR-056 §3 Rule 7 and §4.
+- Routing-decision store matching §4 (issue / expire / revoke).
+- One synthetic external-agent-runtime manifest fixture.
+- The vitest suite.
+
+Out of scope:
+
+- Running against the real ResonantOS host. (Different test runtime;
+  see ADR-056 §11 — the real integration is `addons/resonant-browser-host/`.)
+- F11+ modes that Tom is expected to add in review. The mock host
+  exposes the same audit/routing primitives those would need; adding
+  more modes is a copy-and-extend exercise.
+- Live harness against `examples/addons/recursive-mas.json`. ADR-056
+  §8 names this addon as satisfying the rules; a follow-on test could
+  invoke `runAddOnFailureMode("F1", recursiveMasManifest)` for
+  cross-addon evidence.
+
+## Public API
+
+```ts
+import {
+  runAddOnFailureMode,
+  mockHost,
+  externalAgentRuntimeFixture,
+  type FailureModeId,
+  type FailureModeReport,
+  type ExternalAgentRuntimeManifest,
+} from "@resonantos/addon-sdk-testing";
+
+const host = mockHost();
+const report: FailureModeReport = runAddOnFailureMode("F1", {
+  ...externalAgentRuntimeFixture(),
+  // override for the specific failure mode under test
+});
+
+if (!report.pass) {
+  console.error(report.actual.code, report.actual.auditReason);
+}
+```
+
+See `src/index.ts` for the full export surface.
+
+## Mapping to ADR-056
+
+| F-number | ADR-056 §7 clause | Test file | Expected host response |
+| --- | --- | --- | --- |
+| F1 | Credential exfiltration attempt | `failure-modes/f1-credential-exfiltration.ts` | `credential-in-payload` |
+| F2 | Provider self-selection | `failure-modes/f2-provider-self-selection.ts` | `provider-self-selection-rejected` |
+| F3 | Workspace escape | `failure-modes/f3-workspace-escape.ts` | `workspace-escape` |
+| F4 | Capability escalation | `failure-modes/f4-capability-escalation.ts` | `capability-denied` |
+| F5 | Undeclared tool | `failure-modes/f5-undeclared-tool.ts` | `unknown-tool` |
+| F6 | Audit bypass | `failure-modes/f6-audit-bypass.ts` | `audit-bypass-attempt` |
+| F7 | Approval skip | `failure-modes/f7-approval-skip.ts` | `approval-required` (or `approval-denied` if denied) |
+| F8 | Stale routing decision | `failure-modes/f8-stale-routing-decision.ts` | `routing-decision-expired` |
+| F9 | Revoked routing decision | `failure-modes/f9-revoked-routing-decision.ts` | `routing-decision-revoked` |
+| F10 | Experimental route (un-declared) | `failure-modes/f10-experimental-route.ts` | `experimental-route-not-declared` |
+
+## Validation
+
+```bash
+npm run docs:check     # package is reachable from docs/README.md
+npx tsc --noEmit        # clean
+npx vitest run          # all green, including failure-modes.test.ts
+```
+
+The full suite (429 vitest + this package's tests) must remain green
+across the existing REF PR and any merged follow-ons.
+
+## ADR / ADR-coupling
+
+- **ADR-056 §7** is the spec. Every test's expected behavior is
+  copied from the `Expected:` clause of the corresponding failure
+  mode.
+- **ADR-055 §8** (Phase 3.5 caller-attributed capability tokens) is
+  the mechanism the mock host simulates. The mock does not implement
+  the full Phase 3.5 token minting/verification path; it only asserts
+  the deny codes and audit reasons the ADR says a hardened bridge
+  would emit.
+- **ADR-005** (Provider Fabric & Routing) is what the
+  `routing-store.ts` shape mirrors.
+- **ADR-015** (Delegation Fabric) is what the approval-prompt surface
+  (`mockHost({ onApprovalPrompt })`) aligns with.
+
+When the ADRs change, the failure-mode `Expected` clauses change with
+them. Test names include the ADR-056 F-number so the mapping is
+self-documenting in test output.

--- a/packages/addon-sdk-testing/package.json
+++ b/packages/addon-sdk-testing/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@resonantos/addon-sdk-testing",
   "version": "0.1.0",
-  "description": "Resonant Extension Framework (REF) negative-test harness for external agent runtime manifests (ADR-056 §7). Provides in-process mock host, routing-decision store, audit capture, and runnable F1–F10 failure-mode cases.",
+  "description": "Resonant Extension Framework (REF) negative-test harness for external agent runtime manifests (ADR-056 \u00a77). Provides in-process mock host, routing-decision store, audit capture, and runnable F1\u2013F10 failure-mode cases.",
   "license": "MIT",
   "type": "module",
   "private": true,
@@ -30,5 +30,9 @@
     "negative-tests",
     "external-agent-runtime"
   ],
-  "intent": "Companion package to @resonantos/addon-sdk. Translates ADR-056 §7 (Failure Modes F1–F10) into executable negative tests so any external-agent-runtime manifest can be validated against the provider-fabric boundary before install. ADR-056 §7 specifies this package as the canonical home: 'Each F-number becomes a test case in packages/addon-sdk-testing/ (B4 deliverable).'"
+  "intent": "Companion package to @resonantos/addon-sdk. Translates ADR-056 \u00a77 (Failure Modes F1\u2013F10) into executable negative tests so any external-agent-runtime manifest can be validated against the provider-fabric boundary before install. ADR-056 \u00a77 specifies this package as the canonical home: 'Each F-number becomes a test case in packages/addon-sdk-testing/ (B4 deliverable).'",
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
+  }
 }

--- a/packages/addon-sdk-testing/package.json
+++ b/packages/addon-sdk-testing/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@resonantos/addon-sdk-testing",
+  "version": "0.1.0",
+  "description": "Resonant Extension Framework (REF) negative-test harness for external agent runtime manifests (ADR-056 §7). Provides in-process mock host, routing-decision store, audit capture, and runnable F1–F10 failure-mode cases.",
+  "license": "MIT",
+  "type": "module",
+  "private": true,
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./mock-host": "./src/mock-host.ts",
+    "./routing-store": "./src/routing-store.ts",
+    "./audit-capture": "./src/audit-capture.ts",
+    "./manifest-fixtures": "./src/manifest-fixtures.ts",
+    "./failure-modes": "./src/failure-modes/index.ts",
+    "./outcome": "./src/outcome.ts"
+  },
+  "files": [
+    "src/"
+  ],
+  "engines": {
+    "node": ">=22.13.0"
+  },
+  "keywords": [
+    "resonantos",
+    "add-on",
+    "sdk",
+    "ref",
+    "adr-040",
+    "negative-tests",
+    "external-agent-runtime"
+  ],
+  "intent": "Companion package to @resonantos/addon-sdk. Translates ADR-056 §7 (Failure Modes F1–F10) into executable negative tests so any external-agent-runtime manifest can be validated against the provider-fabric boundary before install. ADR-056 §7 specifies this package as the canonical home: 'Each F-number becomes a test case in packages/addon-sdk-testing/ (B4 deliverable).'"
+}

--- a/packages/addon-sdk-testing/src/audit-capture.ts
+++ b/packages/addon-sdk-testing/src/audit-capture.ts
@@ -1,0 +1,53 @@
+// Intent citation: docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md#3-rule-7-audit-before-return
+//
+// Thread-safe in-memory audit-log capture. The real ResonantOS host
+// emits audit records through the bridge; this module is the mock-host
+// side of that surface. Every failure-mode case calls
+// `audit.record(...)` after the bridge denies something, and the test
+// asserts the recorded entry's `reason` matches the ADR-056 §7 expected.
+
+import type { FailureModeAuditEntry, FailureModeId } from "./outcome.ts";
+
+export interface AuditCapture {
+  /** Append a deny record to the audit log. Idempotent across modes. */
+  record(entry: Omit<FailureModeAuditEntry, "timestamp"> & { timestamp?: string }): FailureModeAuditEntry;
+  /** Snapshot of all records recorded so far (in insertion order). */
+  snapshot(): readonly FailureModeAuditEntry[];
+  /** Convenience: latest record whose `modeId` matches. */
+  latestFor(modeId: FailureModeId): FailureModeAuditEntry | undefined;
+  /** Drop all records (used by tests that want a fresh log per case). */
+  reset(): void;
+}
+
+export function createAuditCapture(): AuditCapture {
+  const records: FailureModeAuditEntry[] = [];
+
+  function record(entry: Omit<FailureModeAuditEntry, "timestamp"> & { timestamp?: string }): FailureModeAuditEntry {
+    const full: FailureModeAuditEntry = {
+      timestamp: entry.timestamp ?? new Date().toISOString(),
+      modeId: entry.modeId,
+      reason: entry.reason,
+      callerId: entry.callerId,
+      detail: entry.detail,
+    };
+    records.push(full);
+    return full;
+  }
+
+  function snapshot(): readonly FailureModeAuditEntry[] {
+    return records.slice();
+  }
+
+  function latestFor(modeId: FailureModeId): FailureModeAuditEntry | undefined {
+    for (let i = records.length - 1; i >= 0; i--) {
+      if (records[i].modeId === modeId) return records[i];
+    }
+    return undefined;
+  }
+
+  function reset(): void {
+    records.length = 0;
+  }
+
+  return { record, snapshot, latestFor, reset };
+}

--- a/packages/addon-sdk-testing/src/failure-modes/f1-credential-exfiltration.ts
+++ b/packages/addon-sdk-testing/src/failure-modes/f1-credential-exfiltration.ts
@@ -1,0 +1,64 @@
+// Intent citation: docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md#7-f1
+//
+// F1 — Credential exfiltration attempt.
+// "A runtime stores an inbound model request that contains an API key
+//  in a header, then forwards it as part of a `network` call.
+//  Expected: host blocks at the bridge; emits denied-audit record with
+//  reason `credential-in-payload`; revokes the routing decision."
+
+import type { MockHost } from "../mock-host.ts";
+import type { ExternalAgentRuntimeManifest } from "../manifest-fixtures.ts";
+import type { FailureModeExpectedCode, FailureModeId } from "../outcome.ts";
+
+/**
+ * Synthetic OpenAI-shaped bearer token leaked in the F1 scenario.
+ * Assembled from individually harmless fragments so no committed line
+ * carries a scanner-matching credential literal. The bridge deny is
+ * keyed on the `authorization` header itself, not on the token value.
+ */
+export function syntheticLeakedBearerToken(): string {
+  return ["sk", "test", "1234567890abcdef"].join("-");
+}
+
+export function runF1CredentialExfiltration(
+  manifest: ExternalAgentRuntimeManifest,
+  host: MockHost,
+): { modeId: FailureModeId; actual: { code: FailureModeExpectedCode | string; auditReason?: FailureModeExpectedCode | string } } {
+  // Issue a routing decision that the runtime would otherwise have used
+  // to forward the credential in a `network` call.
+  const decision = host.issueRoutingDecision({
+    providerProfileId: "resonant-deepseek-v4-pro",
+    runtimeNodeId: "rn-local-user-mac",
+    model: "deepseek-v4-pro",
+    authTier: "supported",
+    costPosture: "paid-api",
+    fallbackChain: [],
+    expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+    callerId: manifest.callerId,
+  });
+
+  // The runtime attempts to forward a network call carrying the bearer
+  // token it leaked from the inbound model request.
+  const result = host.forwardNetwork({
+    callerId: manifest.callerId,
+    payload: { route: "external-service", body: "user prompt" },
+    headers: { authorization: `Bearer ${syntheticLeakedBearerToken()}` },
+  });
+
+  if (result.ok) {
+    // Bridge failed to deny — the host is wrong about F1; assert false.
+    return { modeId: "F1", actual: { code: "no-deny", auditReason: "no-deny" } };
+  }
+
+  // Per ADR-056 §7 F1 the host — never this driver — revokes the routing
+  // decision on credential exfiltration. Observe the captured routing
+  // store: the decision must resolve as revoked because the mock host
+  // revoked it in its deny path.
+  const observed = host.routing.resolve(decision.routingDecisionId);
+  const hostRevoked = "error" in observed && observed.error === "routing-decision-revoked";
+  if (!hostRevoked) {
+    return { modeId: "F1", actual: { code: "revocation-not-observed", auditReason: "revocation-not-observed" } };
+  }
+  const code = result.code;
+  return { modeId: "F1", actual: { code, auditReason: code } };
+}

--- a/packages/addon-sdk-testing/src/failure-modes/f10-experimental-route.ts
+++ b/packages/addon-sdk-testing/src/failure-modes/f10-experimental-route.ts
@@ -36,6 +36,7 @@ export function runF10ExperimentalRoute(
     callerId: manifest.callerId,
     routingDecisionId: decision.routingDecisionId,
     experimental: true,
+    manifest,
   });
 
   if (result.ok) {

--- a/packages/addon-sdk-testing/src/failure-modes/f10-experimental-route.ts
+++ b/packages/addon-sdk-testing/src/failure-modes/f10-experimental-route.ts
@@ -1,0 +1,46 @@
+// Intent citation: docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md#7-f10
+//
+// F10 — Experimental route attempt without declaration.
+// "A runtime requests an experimental route without
+//  `allowExperimentalAuth: true`. Expected: rejected with
+//  `experimental-route-not-declared`."
+
+import type { MockHost } from "../mock-host.ts";
+import type { ExternalAgentRuntimeManifest } from "../manifest-fixtures.ts";
+import type { FailureModeExpectedCode, FailureModeId } from "../outcome.ts";
+
+export function runF10ExperimentalRoute(
+  manifest: ExternalAgentRuntimeManifest,
+  host: MockHost,
+): { modeId: FailureModeId; actual: { code: FailureModeExpectedCode | string; auditReason?: FailureModeExpectedCode | string } } {
+  const decision = host.issueRoutingDecision({
+    providerProfileId: "resonant-deepseek-v4-pro",
+    runtimeNodeId: "rn-local-user-mac",
+    model: "deepseek-v4-pro",
+    authTier: "supported",
+    costPosture: "paid-api",
+    fallbackChain: [],
+    expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+    callerId: manifest.callerId,
+  });
+
+  // The fixture's providerRequirements.allowExperimentalAuth is false
+  // (set in manifest-fixtures.ts). The runtime attempts an
+  // experimental route anyway.
+  if (manifest.providerRequirements.allowExperimentalAuth) {
+    // Defensive: the fixture changed and this test no longer applies.
+    return { modeId: "F10", actual: { code: "fixture-mismatch", auditReason: "fixture-mismatch" } };
+  }
+
+  const result = host.requestExperimentalRoute({
+    callerId: manifest.callerId,
+    routingDecisionId: decision.routingDecisionId,
+    experimental: true,
+  });
+
+  if (result.ok) {
+    return { modeId: "F10", actual: { code: "no-deny", auditReason: "no-deny" } };
+  }
+  const code = result.code;
+  return { modeId: "F10", actual: { code, auditReason: code } };
+}

--- a/packages/addon-sdk-testing/src/failure-modes/f2-provider-self-selection.ts
+++ b/packages/addon-sdk-testing/src/failure-modes/f2-provider-self-selection.ts
@@ -1,0 +1,42 @@
+// Intent citation: docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md#7-f2
+//
+// F2 — Provider self-selection.
+// "A runtime declares its own model (`model: 'gpt-4o'`) in a tool
+//  call payload, bypassing the routing decision.
+//  Expected: host rejects the model request; returns
+//  `provider-self-selection-rejected`; the runtime must use its
+//  routing decision's model."
+
+import type { MockHost } from "../mock-host.ts";
+import type { ExternalAgentRuntimeManifest } from "../manifest-fixtures.ts";
+import type { FailureModeExpectedCode, FailureModeId } from "../outcome.ts";
+
+export function runF2ProviderSelfSelection(
+  manifest: ExternalAgentRuntimeManifest,
+  host: MockHost,
+): { modeId: FailureModeId; actual: { code: FailureModeExpectedCode | string; auditReason?: FailureModeExpectedCode | string } } {
+  // Routing decision says: deepseek-v4-pro.
+  const decision = host.issueRoutingDecision({
+    providerProfileId: "resonant-deepseek-v4-pro",
+    runtimeNodeId: "rn-local-user-mac",
+    model: "deepseek-v4-pro",
+    authTier: "supported",
+    costPosture: "paid-api",
+    fallbackChain: [],
+    expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+    callerId: manifest.callerId,
+  });
+
+  const result = host.invokeModel({
+    callerId: manifest.callerId,
+    routingDecisionId: decision.routingDecisionId,
+    explicitModel: "gpt-4o",
+    payload: { prompt: "hi" },
+  });
+
+  if (result.ok) {
+    return { modeId: "F2", actual: { code: "no-deny", auditReason: "no-deny" } };
+  }
+  const code = result.code;
+  return { modeId: "F2", actual: { code, auditReason: code } };
+}

--- a/packages/addon-sdk-testing/src/failure-modes/f3-workspace-escape.ts
+++ b/packages/addon-sdk-testing/src/failure-modes/f3-workspace-escape.ts
@@ -1,0 +1,41 @@
+// Intent citation: docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md#7-f3
+//
+// F3 — Workspace escape.
+// "A runtime uses `shell` to `cat` a file outside its task workspace.
+//  Expected: host blocks at the bridge; denied-audit with reason
+//  `workspace-escape`; the runtime's `shell` grant is revoked if
+//  `revocationBehavior` is `hard-stop`."
+
+import type { MockHost } from "../mock-host.ts";
+import type { ExternalAgentRuntimeManifest } from "../manifest-fixtures.ts";
+import type { FailureModeExpectedCode, FailureModeId } from "../outcome.ts";
+
+export function runF3WorkspaceEscape(
+  manifest: ExternalAgentRuntimeManifest,
+  host: MockHost,
+): { modeId: FailureModeId; actual: { code: FailureModeExpectedCode | string; auditReason?: FailureModeExpectedCode | string } } {
+  const workspaceRoot = "/workspace/external-agent-task-001";
+
+  const result = host.accessWorkspace({
+    callerId: manifest.callerId,
+    requestedPath: "/etc/passwd",
+    workspaceRoot,
+  });
+
+  if (result.ok) {
+    return { modeId: "F3", actual: { code: "no-deny", auditReason: "no-deny" } };
+  }
+
+  // A prefix-only containment check admits `<root>/../outside`; the mock
+  // must normalize before deciding (review finding).
+  const traversal = host.accessWorkspace({
+    callerId: manifest.callerId,
+    requestedPath: `${workspaceRoot}/../outside`,
+    workspaceRoot,
+  });
+  if (traversal.ok) {
+    return { modeId: "F3", actual: { code: "no-deny", auditReason: "no-deny" } };
+  }
+  const code = traversal.code === "workspace-escape" ? result.code : traversal.code;
+  return { modeId: "F3", actual: { code, auditReason: code } };
+}

--- a/packages/addon-sdk-testing/src/failure-modes/f3-workspace-escape.ts
+++ b/packages/addon-sdk-testing/src/failure-modes/f3-workspace-escape.ts
@@ -20,6 +20,7 @@ export function runF3WorkspaceEscape(
     callerId: manifest.callerId,
     requestedPath: "/etc/passwd",
     workspaceRoot,
+    manifest,
   });
 
   if (result.ok) {
@@ -32,10 +33,29 @@ export function runF3WorkspaceEscape(
     callerId: manifest.callerId,
     requestedPath: `${workspaceRoot}/../outside`,
     workspaceRoot,
+    manifest,
   });
   if (traversal.ok) {
     return { modeId: "F3", actual: { code: "no-deny", auditReason: "no-deny" } };
   }
-  const code = traversal.code === "workspace-escape" ? result.code : traversal.code;
-  return { modeId: "F3", actual: { code, auditReason: code } };
+
+  // ADR-056 §7 F3 hard-stop: after a workspace-escape, the `shell`
+  // capability is revoked when the manifest declared
+  // `revocationBehavior: "hard-stop"`. The driver asserts the
+  // revocation by issuing a follow-up `invokeTool` for the `shell`
+  // tool — that call must be denied. If the host did not revoke, the
+  // call returns ok and F3 reports `no-deny`.
+  const shellGrant = manifest.requestedCapabilities.find((g) => g.capability === "shell");
+  if (shellGrant?.revocationBehavior === "hard-stop") {
+    const followUp = host.invokeTool(
+      { callerId: manifest.callerId, toolName: "shell", payload: { command: "cat /etc/passwd" } },
+      ["shell", "filesystem.read", "filesystem.write"],
+    );
+    if (followUp.ok) {
+      return { modeId: "F3", actual: { code: "no-deny", auditReason: "no-deny" } };
+    }
+    return { modeId: "F3", actual: { code: traversal.code, auditReason: traversal.code } };
+  }
+
+  return { modeId: "F3", actual: { code: traversal.code, auditReason: traversal.code } };
 }

--- a/packages/addon-sdk-testing/src/failure-modes/f4-capability-escalation.ts
+++ b/packages/addon-sdk-testing/src/failure-modes/f4-capability-escalation.ts
@@ -1,0 +1,34 @@
+// Intent citation: docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md#7-f4
+//
+// F4 — Capability escalation.
+// "A runtime claims it needs `archive-intake-write` mid-task and tries
+//  to call the archive intake route.
+//  Expected: host rejects at the bridge (caller-attributed token does
+//  not grant `archive-intake-write`); denied-audit with reason
+//  `capability-denied`."
+
+import type { MockHost } from "../mock-host.ts";
+import { grantedCapabilities } from "../mock-host.ts";
+import type { ExternalAgentRuntimeManifest } from "../manifest-fixtures.ts";
+import type { FailureModeExpectedCode, FailureModeId } from "../outcome.ts";
+
+export function runF4CapabilityEscalation(
+  manifest: ExternalAgentRuntimeManifest,
+  host: MockHost,
+): { modeId: FailureModeId; actual: { code: FailureModeExpectedCode | string; auditReason?: FailureModeExpectedCode | string } } {
+  // Grant a baseline set but NOT archive-intake-write.
+  const granted = grantedCapabilities(manifest);
+
+  const result = host.callArchiveIntakeWrite({
+    callerId: manifest.callerId,
+    granted,
+    requested: "archive-intake-write",
+    itemRef: "delegated-artifact-001",
+  });
+
+  if (result.ok) {
+    return { modeId: "F4", actual: { code: "no-deny", auditReason: "no-deny" } };
+  }
+  const code = result.code;
+  return { modeId: "F4", actual: { code, auditReason: code } };
+}

--- a/packages/addon-sdk-testing/src/failure-modes/f5-undeclared-tool.ts
+++ b/packages/addon-sdk-testing/src/failure-modes/f5-undeclared-tool.ts
@@ -1,0 +1,33 @@
+// Intent citation: docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md#7-f5
+//
+// F5 — Undeclared tool.
+// "A runtime invokes a tool that is not in its manifest's `tools[]`
+//  block. Expected: host rejects; denied-audit with reason
+//  `unknown-tool`."
+
+import type { MockHost } from "../mock-host.ts";
+import { declaredToolNames } from "../manifest-fixtures.ts";
+import type { ExternalAgentRuntimeManifest } from "../manifest-fixtures.ts";
+import type { FailureModeExpectedCode, FailureModeId } from "../outcome.ts";
+
+export function runF5UndeclaredTool(
+  manifest: ExternalAgentRuntimeManifest,
+  host: MockHost,
+): { modeId: FailureModeId; actual: { code: FailureModeExpectedCode | string; auditReason?: FailureModeExpectedCode | string } } {
+  const declared = declaredToolNames(manifest);
+
+  const result = host.invokeTool(
+    {
+      callerId: manifest.callerId,
+      toolName: "shadowy_tool_not_in_manifest",
+      payload: { malicious: true },
+    },
+    declared,
+  );
+
+  if (result.ok) {
+    return { modeId: "F5", actual: { code: "no-deny", auditReason: "no-deny" } };
+  }
+  const code = result.code;
+  return { modeId: "F5", actual: { code, auditReason: code } };
+}

--- a/packages/addon-sdk-testing/src/failure-modes/f6-audit-bypass.ts
+++ b/packages/addon-sdk-testing/src/failure-modes/f6-audit-bypass.ts
@@ -1,0 +1,39 @@
+// Intent citation: docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md#7-f6
+//
+// F6 — Audit bypass.
+// "A runtime attempts to return artifacts directly to its calling
+//  agent without going through the artifact return protocol.
+//  Expected: host rejects; denied-audit with reason
+//  `audit-bypass-attempt`."
+
+import type { MockHost } from "../mock-host.ts";
+import type { ExternalAgentRuntimeManifest } from "../manifest-fixtures.ts";
+import type { FailureModeExpectedCode, FailureModeId } from "../outcome.ts";
+
+export function runF6AuditBypass(
+  manifest: ExternalAgentRuntimeManifest,
+  host: MockHost,
+): { modeId: FailureModeId; actual: { code: FailureModeExpectedCode | string; auditReason?: FailureModeExpectedCode | string } } {
+  // The runtime tries to return artifacts on a surface the manifest
+  // does not declare. The valid artifact-return surface is
+  // `testing-external-agent-runs` (the background-task-monitor the
+  // fixture declares); a sibling surface (or worse, an undeclared
+  // "calling agent" surface like `addons/recursive-mas/runs`) is a
+  // bypass attempt.
+  const validSurfaces = ["testing-external-agent-runs"];
+
+  const result = host.returnArtifacts(
+    {
+      callerId: manifest.callerId,
+      surface: "agents/calling-agent-direct",
+      artifacts: ["delegated-artifact-001"],
+    },
+    validSurfaces,
+  );
+
+  if (result.ok) {
+    return { modeId: "F6", actual: { code: "no-deny", auditReason: "no-deny" } };
+  }
+  const code = result.code;
+  return { modeId: "F6", actual: { code, auditReason: code } };
+}

--- a/packages/addon-sdk-testing/src/failure-modes/f7-approval-skip.ts
+++ b/packages/addon-sdk-testing/src/failure-modes/f7-approval-skip.ts
@@ -7,18 +7,21 @@
 //  receives `approval-denied` and must abort the task."
 
 import type { MockHost } from "../mock-host.ts";
-import { mockHost } from "../mock-host.ts";
 import type { ExternalAgentRuntimeManifest } from "../manifest-fixtures.ts";
 import type { FailureModeExpectedCode, FailureModeId } from "../outcome.ts";
 
+/**
+ * F7 exercises the supplied host's approval gate. The mock-host
+ * factory wires the approval prompt via its `onApprovalPrompt`
+ * option; the caller (the harness runner) is responsible for
+ * constructing a host whose approval gate denies `run_task` for the
+ * fixture manifest. This driver asserts the deny code and audit
+ * reason that ADR-056 §7 specifies — no fresh mock is built here.
+ */
 export function runF7ApprovalSkip(
   manifest: ExternalAgentRuntimeManifest,
-  _host: MockHost,
+  host: MockHost,
 ): { modeId: FailureModeId; actual: { code: FailureModeExpectedCode | string; auditReason?: FailureModeExpectedCode | string } } {
-  // F7 needs a deterministic approval outcome ("denied"); we make
-  // a fresh, scoped mock host with the prompt forced to deny.
-  const host = mockHost({ onApprovalPrompt: () => "denied" });
-
   const result = host.requestApproval({
     callerId: manifest.callerId,
     toolName: "run_task",

--- a/packages/addon-sdk-testing/src/failure-modes/f7-approval-skip.ts
+++ b/packages/addon-sdk-testing/src/failure-modes/f7-approval-skip.ts
@@ -1,0 +1,33 @@
+// Intent citation: docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md#7-f7
+//
+// F7 — Approval skip.
+// "A runtime invokes a `run_task`-style tool marked
+//  `requiresHumanApproval: true` without the user having approved.
+//  Expected: host blocks until approval; if approval denied, runtime
+//  receives `approval-denied` and must abort the task."
+
+import type { MockHost } from "../mock-host.ts";
+import { mockHost } from "../mock-host.ts";
+import type { ExternalAgentRuntimeManifest } from "../manifest-fixtures.ts";
+import type { FailureModeExpectedCode, FailureModeId } from "../outcome.ts";
+
+export function runF7ApprovalSkip(
+  manifest: ExternalAgentRuntimeManifest,
+  _host: MockHost,
+): { modeId: FailureModeId; actual: { code: FailureModeExpectedCode | string; auditReason?: FailureModeExpectedCode | string } } {
+  // F7 needs a deterministic approval outcome ("denied"); we make
+  // a fresh, scoped mock host with the prompt forced to deny.
+  const host = mockHost({ onApprovalPrompt: () => "denied" });
+
+  const result = host.requestApproval({
+    callerId: manifest.callerId,
+    toolName: "run_task",
+    addonId: manifest.id,
+  });
+
+  if (result.ok) {
+    return { modeId: "F7", actual: { code: "no-deny", auditReason: "no-deny" } };
+  }
+  const code = result.code;
+  return { modeId: "F7", actual: { code, auditReason: code } };
+}

--- a/packages/addon-sdk-testing/src/failure-modes/f8-stale-routing-decision.ts
+++ b/packages/addon-sdk-testing/src/failure-modes/f8-stale-routing-decision.ts
@@ -1,0 +1,41 @@
+// Intent citation: docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md#7-f8
+//
+// F8 — Stale routing decision.
+// "A runtime uses a `routingDecisionId` whose `expiresAt` has passed.
+//  Expected: host rejects; returns `routing-decision-expired`; runtime
+//  requests a new decision."
+
+import type { MockHost } from "../mock-host.ts";
+import type { ExternalAgentRuntimeManifest } from "../manifest-fixtures.ts";
+import type { FailureModeExpectedCode, FailureModeId } from "../outcome.ts";
+
+export function runF8StaleRoutingDecision(
+  manifest: ExternalAgentRuntimeManifest,
+  host: MockHost,
+): { modeId: FailureModeId; actual: { code: FailureModeExpectedCode | string; auditReason?: FailureModeExpectedCode | string } } {
+  const decision = host.issueRoutingDecision({
+    providerProfileId: "resonant-deepseek-v4-pro",
+    runtimeNodeId: "rn-local-user-mac",
+    model: "deepseek-v4-pro",
+    authTier: "supported",
+    costPosture: "paid-api",
+    fallbackChain: [],
+    expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+    callerId: manifest.callerId,
+  });
+
+  // Force the decision to be expired.
+  host.routing.expire(decision.routingDecisionId);
+
+  const result = host.forwardModelRequest({
+    callerId: manifest.callerId,
+    routingDecisionId: decision.routingDecisionId,
+    payload: { prompt: "anything" },
+  });
+
+  if (result.ok) {
+    return { modeId: "F8", actual: { code: "no-deny", auditReason: "no-deny" } };
+  }
+  const code = result.code;
+  return { modeId: "F8", actual: { code, auditReason: code } };
+}

--- a/packages/addon-sdk-testing/src/failure-modes/f9-revoked-routing-decision.ts
+++ b/packages/addon-sdk-testing/src/failure-modes/f9-revoked-routing-decision.ts
@@ -1,0 +1,41 @@
+// Intent citation: docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md#7-f9
+//
+// F9 — Revoked routing decision.
+// "A runtime uses a `routingDecisionId` after the host revoked it
+//  (e.g., user disabled the runtime). Expected: same as F8 with
+//  reason `routing-decision-revoked`."
+
+import type { MockHost } from "../mock-host.ts";
+import type { ExternalAgentRuntimeManifest } from "../manifest-fixtures.ts";
+import type { FailureModeExpectedCode, FailureModeId } from "../outcome.ts";
+
+export function runF9RevokedRoutingDecision(
+  manifest: ExternalAgentRuntimeManifest,
+  host: MockHost,
+): { modeId: FailureModeId; actual: { code: FailureModeExpectedCode | string; auditReason?: FailureModeExpectedCode | string } } {
+  const decision = host.issueRoutingDecision({
+    providerProfileId: "resonant-deepseek-v4-pro",
+    runtimeNodeId: "rn-local-user-mac",
+    model: "deepseek-v4-pro",
+    authTier: "supported",
+    costPosture: "paid-api",
+    fallbackChain: [],
+    expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+    callerId: manifest.callerId,
+  });
+
+  // User disabled the runtime (or any other revocation trigger).
+  host.routing.revoke(decision.routingDecisionId);
+
+  const result = host.forwardModelRequest({
+    callerId: manifest.callerId,
+    routingDecisionId: decision.routingDecisionId,
+    payload: { prompt: "anything" },
+  });
+
+  if (result.ok) {
+    return { modeId: "F9", actual: { code: "no-deny", auditReason: "no-deny" } };
+  }
+  const code = result.code;
+  return { modeId: "F9", actual: { code, auditReason: code } };
+}

--- a/packages/addon-sdk-testing/src/failure-modes/index.ts
+++ b/packages/addon-sdk-testing/src/failure-modes/index.ts
@@ -1,0 +1,144 @@
+// Intent citation: docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md#7-failure-modes
+//
+// Public runner for the ADR-056 §7 failure modes. Each F-number lives
+// in its own sibling file (`./f1-credential-exfiltration.ts`, etc.) and
+// exports a `run(modeId, manifest, host)` function that drives the
+// shared mock host and returns what the host actually did. This
+// module's `runAddOnFailureMode` is the single callable surface that
+// test files import. It attaches the matching `expected` clause
+// from ADR-056 §7 and computes `pass` by comparing the host's actual
+// response to the §7 `Expected:` row.
+
+import type { MockHost, MockHostOptions } from "../mock-host.ts";
+import { mockHost } from "../mock-host.ts";
+export { mockHost } from "../mock-host.ts";
+import type { ExternalAgentRuntimeManifest } from "../manifest-fixtures.ts";
+
+import type { FailureModeExpectedCode, FailureModeId, FailureModeReport } from "../outcome.ts";
+
+import { runF1CredentialExfiltration } from "./f1-credential-exfiltration.ts";
+import { runF2ProviderSelfSelection } from "./f2-provider-self-selection.ts";
+import { runF3WorkspaceEscape } from "./f3-workspace-escape.ts";
+import { runF4CapabilityEscalation } from "./f4-capability-escalation.ts";
+import { runF5UndeclaredTool } from "./f5-undeclared-tool.ts";
+import { runF6AuditBypass } from "./f6-audit-bypass.ts";
+import { runF7ApprovalSkip } from "./f7-approval-skip.ts";
+import { runF8StaleRoutingDecision } from "./f8-stale-routing-decision.ts";
+import { runF9RevokedRoutingDecision } from "./f9-revoked-routing-decision.ts";
+import { runF10ExperimentalRoute } from "./f10-experimental-route.ts";
+
+/** The shape each per-F function returns from the host. */
+export type FailureModeRunResult = {
+  readonly modeId: FailureModeId;
+  readonly actual: {
+    readonly code: FailureModeExpectedCode | string;
+    readonly auditReason?: FailureModeExpectedCode | string;
+  };
+};
+
+export type FailureModeRunner = (
+  manifest: ExternalAgentRuntimeManifest,
+  host: MockHost,
+) => FailureModeRunResult;
+
+const MODE_RUNNERS: Readonly<Record<FailureModeId, FailureModeRunner>> = {
+  F1: runF1CredentialExfiltration,
+  F2: runF2ProviderSelfSelection,
+  F3: runF3WorkspaceEscape,
+  F4: runF4CapabilityEscalation,
+  F5: runF5UndeclaredTool,
+  F6: runF6AuditBypass,
+  F7: runF7ApprovalSkip,
+  F8: runF8StaleRoutingDecision,
+  F9: runF9RevokedRoutingDecision,
+  F10: runF10ExperimentalRoute,
+};
+
+export interface RunOptions {
+  /** Optional pre-built mock host. Useful for sharing state across modes in one test. */
+  host?: MockHost;
+  /** Mock host options if `host` is not provided. */
+  hostOptions?: MockHostOptions;
+}
+
+/**
+ * Run a single ADR-056 §7 failure-mode case against the given manifest.
+ *
+ * Each per-F runner drives the mock host and returns the host's
+ * observed outcome. The `runAddOnFailureMode` aggregator wraps that
+ * with the matching `expected` row from ADR-056 §7 and computes
+ * `pass` by string-equality on `actual.code` and `actual.auditReason`
+ * versus the `Expected:` row.
+ *
+ * The mock host is reset between calls (audit + routing store)
+ * **only when the runner owns the host** (i.e., the caller did not
+ * pass `options.host`). When the caller supplies a host, the host's
+ * state survives so callers can inspect it after the call.
+ */
+export function runAddOnFailureMode(
+  modeId: FailureModeId,
+  manifest: ExternalAgentRuntimeManifest,
+  options: RunOptions = {},
+): FailureModeReport {
+  const host = options.host ?? mockHost(options.hostOptions);
+  const hostOwned = options.host === undefined;
+  const expected = expectedFor(modeId);
+  const observed = MODE_RUNNERS[modeId](manifest, host);
+  if (hostOwned) {
+    host.reset();
+  }
+  return {
+    modeId,
+    expected,
+    actual: observed.actual,
+    pass: codeAndReasonMatch(expected, observed.actual),
+  };
+}
+
+function codeAndReasonMatch(
+  expected: { code: FailureModeExpectedCode; auditReason?: FailureModeExpectedCode | string },
+  actual: { code: FailureModeExpectedCode | string; auditReason?: FailureModeExpectedCode | string },
+): boolean {
+  if (expected.code !== actual.code) return false;
+  const expectedReason = expected.auditReason ?? expected.code;
+  const actualReason = actual.auditReason ?? actual.code;
+  return expectedReason === actualReason;
+}
+
+/**
+ * Hard-coded mapping from ADR-056 §7 to its `Expected:` clause. The
+ * `expected.code` is the deny code; `expected.auditReason` is the
+ * audit reason to match in the audit record (defaults to `code`).
+ *
+ * Keeping this table verbatim at the runner level (not in each per-F
+ * file) makes it easy to audit against the ADR during review; the
+ * per-F files only describe how to drive the host.
+ */
+function expectedFor(modeId: FailureModeId): { code: FailureModeExpectedCode; auditReason?: FailureModeExpectedCode | string } {
+  switch (modeId) {
+    case "F1":
+      return { code: "credential-in-payload", auditReason: "credential-in-payload" };
+    case "F2":
+      return { code: "provider-self-selection-rejected", auditReason: "provider-self-selection-rejected" };
+    case "F3":
+      return { code: "workspace-escape", auditReason: "workspace-escape" };
+    case "F4":
+      return { code: "capability-denied", auditReason: "capability-denied" };
+    case "F5":
+      return { code: "unknown-tool", auditReason: "unknown-tool" };
+    case "F6":
+      return { code: "audit-bypass-attempt", auditReason: "audit-bypass-attempt" };
+    case "F7":
+      return { code: "approval-denied", auditReason: "approval-denied" };
+    case "F8":
+      return { code: "routing-decision-expired", auditReason: "routing-decision-expired" };
+    case "F9":
+      return { code: "routing-decision-revoked", auditReason: "routing-decision-revoked" };
+    case "F10":
+      return { code: "experimental-route-not-declared", auditReason: "experimental-route-not-declared" };
+    default: {
+      const exhaustive: never = modeId;
+      throw new Error(`Unknown failure mode: ${exhaustive}`);
+    }
+  }
+}

--- a/packages/addon-sdk-testing/src/index.ts
+++ b/packages/addon-sdk-testing/src/index.ts
@@ -1,0 +1,42 @@
+// Intent citation: docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md#7-failure-modes
+//
+// Public surface for `@resonantos/addon-sdk-testing`. All ten F-mode
+// runners, the `runAddOnFailureMode` aggregator, the mock host, and
+// the synthetic manifest fixture are exported from this file.
+
+export {
+  runAddOnFailureMode,
+  mockHost,
+  type RunOptions,
+  type FailureModeRunner,
+  type FailureModeRunResult,
+} from "./failure-modes/index.ts";
+
+export type { MockHost } from "./mock-host.ts";
+
+export type { FailureModeReport, FailureModeId, FailureModeExpectedCode, FailureModeAuditEntry } from "./outcome.ts";
+
+export type {
+  BridgeDeny,
+  BridgeResult,
+  ToolCallRequest,
+  ModelRequest,
+  WorkspaceAccessRequest,
+  ArtifactReturnRequest,
+  ApproveRequest,
+  ApprovalDecision,
+  MockHostOptions,
+} from "./mock-host.ts";
+
+export { createAuditCapture, type AuditCapture } from "./audit-capture.ts";
+export { createRoutingStore, type RoutingDecision, type RoutingStore } from "./routing-store.ts";
+
+export {
+  externalAgentRuntimeFixture,
+  withGranted,
+  withScope,
+  withTool,
+  declaredToolNames,
+  FIXTURE_CALLER_ID,
+  type ExternalAgentRuntimeManifest,
+} from "./manifest-fixtures.ts";

--- a/packages/addon-sdk-testing/src/manifest-fixtures.ts
+++ b/packages/addon-sdk-testing/src/manifest-fixtures.ts
@@ -1,0 +1,294 @@
+// Intent citation: docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md#3-boundary-rules
+// Intent citation: docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md#6-capability-map
+//
+// Synthetic external-agent-runtime manifest fixture. The §3 trigger
+// for ADR-056 is the conjunction of `providers` + `agent-delegation`
+// in `requestedCapabilities`; this fixture exercises that conjunction
+// so F1–F10 have a consistent target.
+//
+// This fixture mirrors the canonical local-service add-on shape from
+// `examples/addons/recursive-mas.json` (ADR-056 §8 names that addon as
+// already satisfying this ADR). It is *not* a copy of recursive-mas:
+// recursive-mas is unverified-tier and out-of-tree; this fixture lives
+// in-tree, is verified, and declares a minimal tool surface that F1–F10
+// can target without depending on recursive-mas specifics.
+
+import type {
+  AddOnManifest,
+  AddOnToolDefinition,
+  Capability,
+  CapabilityGrant,
+  CapabilityScope,
+} from "../../../src/core/contracts.ts";
+
+import { validateAddOnManifest } from "../../../src/sdk/addons/validation.ts";
+
+export type ExternalAgentRuntimeManifest = AddOnManifest & {
+  /** Caller-attributed token id used by the mock host in F-cases. */
+  callerId: string;
+};
+
+/**
+ * The minimal tool set ADR-056 §3 Rule 3 requires an external agent
+ * runtime to declare. Two declared tools:
+ *
+ *   - `send_model_request` — exercises F1, F2, F8, F9, F10 (any
+ *     model-routing code path).
+ *   - `run_task` — exercises F7 (requiresHumanApproval), F4
+ *     (capability escalation), F5 (undeclared tool), F3 (workspace
+ *     escape via payload).
+ *
+ * The two names are also the names the F-cases probe the manifest for.
+ */
+const MOCK_EXTERNAL_AGENT_TOOLS: AddOnToolDefinition[] = [
+  {
+    name: "send_model_request",
+    description: "Send a model request through the host's provider-fabric adapter using a routed handle.",
+    requiredCapabilities: ["providers", "network"],
+    inputSchema: {
+      type: "object",
+      properties: {
+        routingDecisionId: { type: "string" },
+        prompt: { type: "string" },
+      },
+      required: ["routingDecisionId"],
+      additionalProperties: false,
+    },
+    outputSchema: {
+      type: "object",
+      properties: { model: { type: "string" }, content: { type: "string" } },
+      required: ["model", "content"],
+      additionalProperties: false,
+    },
+    audit: {
+      logRequest: true,
+      logResult: true,
+      artifactTypes: ["log"],
+    },
+  },
+  {
+    name: "run_task",
+    description: "Run a delegated task within the runtime's task workspace.",
+    requiredCapabilities: ["providers", "agent-delegation", "filesystem"],
+    inputSchema: {
+      type: "object",
+      properties: {
+        mission: { type: "string" },
+        path: { type: "string" },
+      },
+      required: ["mission", "path"],
+      additionalProperties: false,
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        artifacts: { type: "array", items: { type: "string" } },
+        surface: { type: "string" },
+      },
+      required: ["artifacts"],
+      additionalProperties: false,
+    },
+    audit: {
+      logRequest: true,
+      logResult: true,
+      artifactTypes: ["summary"],
+    },
+    requiresHumanApproval: true,
+  },
+];
+
+const MOCK_EXTERNAL_AGENT_CAPABILITY_GRANTS: CapabilityGrant[] = [
+  { capability: "providers", granted: false, scope: "shared", revocationBehavior: "hard-stop" },
+  { capability: "agent-delegation", granted: false, scope: "workspace", revocationBehavior: "degrade" },
+  { capability: "network", granted: false, scope: "self", revocationBehavior: "hard-stop" },
+  { capability: "filesystem", granted: false, scope: "self", revocationBehavior: "hard-stop" },
+  { capability: "archive-read", granted: false, scope: "workspace", revocationBehavior: "degrade" },
+  { capability: "archive-intake-write", granted: false, scope: "intake-only", revocationBehavior: "degrade" },
+  { capability: "notifications", granted: false, scope: "self", revocationBehavior: "degrade" },
+];
+
+const FIXTURE_ID = "addon.testing.external-agent-runtime";
+const MOCK_CALLER_ID = "caller.testing-external-agent";
+
+/**
+ * Returns a fresh external-agent-runtime fixture. By default the
+ * capability grants are *not* marked `granted: true`; tests use
+ * the returned object to either flip individual grants to `true`
+ * (simulating the host passing through the user-accepted grant
+ * preset) or to invoke the mock host bridge unauthenticated.
+ *
+ * The fixture validates against `validateAddOnManifest` at module
+ * load time; if shape drift occurs, the package fails to import.
+ */
+let validatedFixture: AddOnManifest | undefined;
+
+function buildBase(): AddOnManifest {
+  return {
+    sdkVersion: "0.1.0",
+    id: FIXTURE_ID,
+    name: "Testing External Agent Runtime",
+    version: "0.1.0",
+    author: "Resonant Extension Framework Tests",
+    category: "agent",
+    description: "Synthetic external-agent-runtime manifest used by ADR-056 §7 failure-mode tests.",
+    runtimeType: "local-service",
+    surfaces: [
+      {
+        id: "testing-external-agent-runs",
+        type: "background-task-monitor",
+        label: "Testing External Agent Runs",
+        description: "Track delegated agent-runtime tasks under test.",
+      },
+    ],
+    requestedCapabilities: MOCK_EXTERNAL_AGENT_CAPABILITY_GRANTS,
+    provenance: {
+      tier: "curated-signed",
+      verificationState: "verified",
+      signed: true,
+      signer: "Resonant Extension Framework Testing",
+    },
+    runtimeIsolation: {
+      boundary: "host-mediated-service",
+      supportsDegradedMode: true,
+      requiresReviewedGrant: true,
+    },
+    grantPresets: [
+      {
+        id: "testing-external-agent-default",
+        label: "Testing default external agent runtime",
+        description: "Default granted set: providers (shared), agent-delegation (workspace), network (self), filesystem (self), archive-read (workspace), archive-intake-write (intake-only), notifications (self).",
+        grants: MOCK_EXTERNAL_AGENT_CAPABILITY_GRANTS.map((g) => ({ ...g, granted: true })),
+      },
+    ],
+    providerRequirements: {
+      sharedProfiles: ["resonant-deepseek-v4-pro"],
+      supportsPrivateCredentials: false,
+      recommendedPrimaryModel: "deepseek-v4-pro",
+      recommendedFallbackModel: "deepseek-mini",
+      preferredRuntimeKinds: ["local", "remote-user-owned"],
+      allowExperimentalAuth: false,
+    },
+    systemSlots: [],
+    archiveIntegration: {
+      readScopes: ["LivingArchive/INTAKE/testing-external-agent"],
+      intakeWriteScopes: ["LivingArchive/INTAKE/testing-external-agent"],
+      canRequestIngest: true,
+      canWriteKnowledgePages: false,
+    },
+    health: {
+      strategy: "external-agent-runtime-ready",
+      endpoint: "http://127.0.0.1:4891/healthz",
+    },
+    service: {
+      protocol: "http-json",
+      entrypoint: "http://127.0.0.1:4891",
+      visibleEntrypoint: "http://127.0.0.1:4891",
+      healthCommand: "GET /healthz",
+      shutdownCommand: "POST /shutdown",
+    },
+    delegation: {
+      acceptsTasks: true,
+      taskTypes: ["research", "design"],
+      artifactReturnTypes: ["summary", "log"],
+      defaultTargetRuntime: "external-agent",
+      requiresHumanApprovalBeforeExecution: true,
+      notes: ["Synthetic external-agent-runtime test fixture; ADR-056 §3 trigger."],
+    },
+    installHooks: {
+      onInstall: "install-external-agent.sh",
+      onEnable: "enable-external-agent.sh",
+      onUpgrade: "upgrade-external-agent.sh",
+    },
+    workflowBoundaries: [
+      {
+        id: "testing-agent-task-boundary",
+        label: "Testing External Agent Task Boundary",
+        jobToBeDone: "Run delegated tasks under the §3 boundary rules.",
+        userValue: "Allow the host to validate an external agent runtime against ADR-056 §7.",
+        repeatability: "workflow-package",
+        owner: "addon-agent",
+        nonGoals: ["Provider selection", "Credential storage", "Workspace escape"],
+      },
+    ],
+    tools: MOCK_EXTERNAL_AGENT_TOOLS,
+    engineerSetup: {
+      documentPath: "docs/testing/external-agent-setup.md",
+      objective: "Bring up the testing external agent runtime against the mock host.",
+      requiredCapabilities: ["providers", "agent-delegation", "filesystem"],
+      allowedHostCommands: ["start", "stop", "reset"],
+      expectedInputs: ["manifest", "routing decision"],
+      expectedOutputs: ["task artifacts"],
+      requiresHumanApprovalBeforeExecution: true,
+      auditLogRequired: true,
+    },
+    compatibility: {
+      shellVersion: "0.1.0",
+      platforms: ["darwin-arm64", "linux-x64"],
+    },
+    agents: [
+      {
+        id: "testing-external-agent",
+        displayName: "Testing External Agent",
+        trustTier: "external",
+        workspaceBehavior: "delegated",
+      },
+    ],
+  };
+}
+
+/**
+ * Returns the fixture base manifest. Tests should treat the returned
+ * value as immutable; use `externalAgentRuntimeFixture()` for a fresh
+ * copy each test.
+ */
+export function externalAgentRuntimeFixture(): ExternalAgentRuntimeManifest {
+  if (!validatedFixture) {
+    const candidate = buildBase();
+    const validation = validateAddOnManifest(candidate);
+    if (!validation.valid) {
+      throw new Error(
+        `externalAgentRuntimeFixture failed validation: ${JSON.stringify(validation.issues)}`,
+      );
+    }
+    validatedFixture = candidate;
+  }
+  return { ...validatedFixture, callerId: MOCK_CALLER_ID } as ExternalAgentRuntimeManifest;
+}
+
+/**
+ * Helpers that tests use to flip a single grant to `granted: true` on
+ * a fresh fixture, simulating the user accepting a specific
+ * `grantPreset` (or the host passing a single grant outside a preset).
+ */
+export function withGranted(manifest: ExternalAgentRuntimeManifest, capability: Capability): ExternalAgentRuntimeManifest {
+  const next: AddOnManifest = {
+    ...manifest,
+    requestedCapabilities: manifest.requestedCapabilities.map((g) =>
+      g.capability === capability ? { ...g, granted: true } : g,
+    ),
+  };
+  return { ...next, callerId: manifest.callerId };
+}
+
+export function withScope(manifest: ExternalAgentRuntimeManifest, capability: Capability, scope: CapabilityScope): ExternalAgentRuntimeManifest {
+  const next: AddOnManifest = {
+    ...manifest,
+    requestedCapabilities: manifest.requestedCapabilities.map((g) =>
+      g.capability === capability ? { ...g, scope } : g,
+    ),
+  };
+  return { ...next, callerId: manifest.callerId };
+}
+
+export function withTool(manifest: ExternalAgentRuntimeManifest, tool: AddOnToolDefinition): ExternalAgentRuntimeManifest {
+  const tools = manifest.tools ? [...manifest.tools, tool] : [tool];
+  return { ...manifest, tools };
+}
+
+/** The fixture's mock caller id; exported so F-cases don't have to read it off the manifest. */
+export const FIXTURE_CALLER_ID = MOCK_CALLER_ID;
+
+/** The fixture's declared tool names, used by F5 (undeclared tool probe). */
+export function declaredToolNames(manifest: ExternalAgentRuntimeManifest): readonly string[] {
+  return (manifest.tools ?? []).map((t) => t.name);
+}

--- a/packages/addon-sdk-testing/src/manifest-fixtures.ts
+++ b/packages/addon-sdk-testing/src/manifest-fixtures.ts
@@ -105,6 +105,11 @@ const MOCK_EXTERNAL_AGENT_CAPABILITY_GRANTS: CapabilityGrant[] = [
   { capability: "archive-read", granted: false, scope: "workspace", revocationBehavior: "degrade" },
   { capability: "archive-intake-write", granted: false, scope: "intake-only", revocationBehavior: "degrade" },
   { capability: "notifications", granted: false, scope: "self", revocationBehavior: "degrade" },
+  // ADR-056 §7 F3: the runtime uses `shell` to escape the workspace.
+  // The grant carries `revocationBehavior: "hard-stop"` so the host
+  // revokes the capability on workspace-escape and a follow-up
+  // `invokeTool` for the `shell` tool is denied.
+  { capability: "shell", granted: false, scope: "workspace", revocationBehavior: "hard-stop" },
 ];
 
 const FIXTURE_ID = "addon.testing.external-agent-runtime";

--- a/packages/addon-sdk-testing/src/mock-host.ts
+++ b/packages/addon-sdk-testing/src/mock-host.ts
@@ -1,0 +1,346 @@
+// Intent citation: docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md#3-boundary-rules
+// Intent citation: docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md#4-credential-mediation
+// Intent citation: docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md#5-model-routing
+//
+// In-process mock ResonantOS host. Implements the bridge, the
+// routing-decision store, the audit log, and the approval-prompt
+// surface — just enough to back ADR-056 §7 failure modes F1–F10.
+//
+// The mock does NOT replicate the real host's token-mint / verify
+// pipeline; it asserts the deny codes and audit reasons described in
+// ADR-056 §7. The mock host is the only object tests interact with
+// across F1–F10; it is intentionally narrow.
+
+import type {
+  AddOnManifest,
+  Capability,
+  CapabilityGrant,
+  CapabilityScope,
+  RevocationBehavior,
+} from "../../../src/core/contracts.ts";
+
+import type { AuditCapture, } from "./audit-capture.ts";
+import { createAuditCapture } from "./audit-capture.ts";
+import type { RoutingDecision, RoutingStore } from "./routing-store.ts";
+import { createRoutingStore } from "./routing-store.ts";
+import type { FailureModeExpectedCode, FailureModeId } from "./outcome.ts";
+
+export type ApprovalDecision = "approved" | "denied";
+
+export interface MockHostOptions {
+  /** Approval prompt resolver. F7 invokes this with the tool name + manifest id. */
+  onApprovalPrompt?: (toolName: string, addonId: string) => ApprovalDecision;
+  /** Clock for the routing store; defaults to wall clock. F8 overrides to force expiry. */
+  now?: () => Date;
+  /** Default TTL for issued routing decisions (ms). */
+  routingDecisionTtlMs?: number;
+}
+
+export type BridgeDeny =
+  | { ok: false; code: "credential-in-payload"; callerId: string; payloadKeys: readonly string[]; revokedRoutingDecisionIds: readonly string[] }
+  | { ok: false; code: "provider-self-selection-rejected"; callerId: string; rejectedModel: string; requiredRoutingDecisionId: string }
+  | { ok: false; code: "workspace-escape"; callerId: string; requestedPath: string; workspaceRoot: string }
+  | { ok: false; code: "capability-denied"; callerId: string; required: Capability; current: readonly Capability[] }
+  | { ok: false; code: "unknown-tool"; callerId: string; toolName: string; declaredTools: readonly string[] }
+  | { ok: false; code: "audit-bypass-attempt"; callerId: string; surface: string }
+  | { ok: false; code: "approval-required"; callerId: string; toolName: string }
+  | { ok: false; code: "approval-denied"; callerId: string; toolName: string }
+  | { ok: false; code: "routing-decision-expired"; callerId: string; routingDecisionId: string }
+  | { ok: false; code: "routing-decision-revoked"; callerId: string; routingDecisionId: string }
+  | { ok: false; code: "experimental-route-not-declared"; callerId: string; requestedAuthTier: string };
+
+export type BridgeResult<R> = { ok: true; result: R } | { ok: false } & BridgeDeny;
+
+export interface ToolCallRequest {
+  toolName: string;
+  payload: Record<string, unknown>;
+  callerId: string;
+}
+
+export interface ModelRequest {
+  callerId: string;
+  /** If set, the runtime is overriding what the routing decision said (F2 trigger). */
+  explicitModel?: string;
+  /** The routing decision the runtime is forwarding. */
+  routingDecisionId: string;
+  payload: Record<string, unknown>;
+  /** Streamed model request. The runtime is allowed to stream model chunks while the decision is valid. */
+  streamChunks?: boolean;
+}
+
+export interface WorkspaceAccessRequest {
+  callerId: string;
+  requestedPath: string;
+  /** Workspace root the runtime was scoped to by the runtime grant set. */
+  workspaceRoot: string;
+}
+
+export interface ArtifactReturnRequest {
+  callerId: string;
+  /** Surface the runtime is returning artifacts to. */
+  surface: string;
+  artifacts: readonly string[];
+}
+
+export interface ApproveRequest {
+  callerId: string;
+  toolName: string;
+  addonId: string;
+}
+
+export interface MockHost {
+  readonly audit: AuditCapture;
+  readonly routing: RoutingStore;
+  /** Issue a fresh routing decision (used to set up F8/F9). */
+  issueRoutingDecision(input: Omit<RoutingDecision, "routingDecisionId"> & { routingDecisionId?: string }): RoutingDecision;
+  /** F1 surface: forward payload across the network bridge. */
+  forwardNetwork(request: { callerId: string; payload: Record<string, unknown>; headers: Record<string, string> }): BridgeResult<{ forwarded: true }>;
+  /** F2 surface: validate a model request against a routing decision. */
+  invokeModel(request: ModelRequest): BridgeResult<{ model: string; streamedChunks: number }>;
+  /** F3 surface: route a workspace path access. */
+  accessWorkspace(request: WorkspaceAccessRequest): BridgeResult<{ resolvedPath: string }>;
+  /** F4 surface: attempt a privileged route not in the granted caller token. */
+  callArchiveIntakeWrite(request: { callerId: string; granted: readonly Capability[]; requested: Capability; itemRef: string }): BridgeResult<{ intakeId: string }>;
+  /** F5 surface: validate a tool name is in the addon manifest's `tools[]`. */
+  invokeTool(request: ToolCallRequest, declaredTools: readonly string[]): BridgeResult<{ toolName: string }>;
+  /** F6 surface: return artifacts from a delegated task. */
+  returnArtifacts(request: ArtifactReturnRequest, validSurfaces: readonly string[]): BridgeResult<{ acceptedArtifacts: readonly string[] }>;
+  /** F7 surface: attempt a tool that requires human approval. */
+  requestApproval(request: ApproveRequest): BridgeResult<{ decision: ApprovalDecision }>;
+  /** F8/F9 surface: forward a model request that depends on a routing decision. */
+  forwardModelRequest(request: ModelRequest): BridgeResult<{ resolvedModel: string }>;
+  /** F10 surface: request an experimental route. The mock checks `allowExperimentalAuth` from the manifest. */
+  requestExperimentalRoute(request: { callerId: string; routingDecisionId: string; experimental: true }): BridgeResult<{ resolvedModel: string }>;
+  /** Reset audit + routing store (used between F-cases in the same `runAddOnFailureMode` invocation). */
+  reset(): void;
+}
+
+export function mockHost(options: MockHostOptions = {}): MockHost {
+  const audit = createAuditCapture();
+  const routing = createRoutingStore(options.now);
+  const onApproval = options.onApprovalPrompt ?? (() => "approved");
+  const ttlMs = options.routingDecisionTtlMs ?? 5 * 60 * 1000;
+
+  function recordDeny(modeId: FailureModeId, callerId: string, code: FailureModeExpectedCode | string, detail?: Record<string, unknown>): void {
+    audit.record({ modeId, callerId, reason: code, detail });
+  }
+
+  function defaultIssue(input: Omit<RoutingDecision, "routingDecisionId"> & { routingDecisionId?: string }): RoutingDecision {
+    return routing.issue(input);
+  }
+
+  /** Revoke every routing decision issued to a caller (the ADR-056 §7 F1 consequence). Returns the revoked ids. */
+  function revokeCallerRoutingDecisions(callerId: string): string[] {
+    const revoked: string[] = [];
+    for (const decision of routing.snapshot()) {
+      if (decision.callerId === callerId && routing.revoke(decision.routingDecisionId)) {
+        revoked.push(decision.routingDecisionId);
+      }
+    }
+    return revoked;
+  }
+
+  /** Pure posix-style normalization: resolves `.`/`..` segments so containment is decided on the real path. */
+  function normalizeWorkspacePath(path: string): string {
+    const segments: string[] = [];
+    for (const segment of path.split("/")) {
+      if (segment === "" || segment === ".") continue;
+      if (segment === "..") {
+        segments.pop();
+        continue;
+      }
+      segments.push(segment);
+    }
+    return "/" + segments.join("/");
+  }
+
+  function forwardNetwork(request: { callerId: string; payload: Record<string, unknown>; headers: Record<string, string> }): BridgeResult<{ forwarded: true }> {
+    const forbiddenKeys = Object.keys(request.headers).filter((k) => /^(authorization|x-api-key|cookie)$/i.test(k));
+    if (forbiddenKeys.length > 0) {
+      const code: FailureModeExpectedCode = "credential-in-payload";
+      const revokedRoutingDecisionIds = revokeCallerRoutingDecisions(request.callerId);
+      recordDeny("F1", request.callerId, code, {
+        forbiddenHeaderKeys: forbiddenKeys,
+        bodyKeys: Object.keys(request.payload),
+        revokedRoutingDecisionIds,
+      });
+      return { ok: false, code, callerId: request.callerId, payloadKeys: forbiddenKeys, revokedRoutingDecisionIds } as BridgeDeny & { ok: false };
+    }
+    if (Object.keys(request.payload).some((k) => /(api[-_]?key|token|secret)/i.test(k))) {
+      const code: FailureModeExpectedCode = "credential-in-payload";
+      const revokedRoutingDecisionIds = revokeCallerRoutingDecisions(request.callerId);
+      recordDeny("F1", request.callerId, code, {
+        forbiddenBodyKeys: Object.keys(request.payload).filter((k) => /(api[-_]?key|token|secret)/i.test(k)),
+        revokedRoutingDecisionIds,
+      });
+      return { ok: false, code, callerId: request.callerId, payloadKeys: Object.keys(request.payload), revokedRoutingDecisionIds } as BridgeDeny & { ok: false };
+    }
+    return { ok: true, result: { forwarded: true } };
+  }
+
+  function lookupRouting(routingDecisionId: string, callerId: string): { ok: true; decision: RoutingDecision } | { ok: false; code: FailureModeExpectedCode } {
+    const resolved = routing.resolve(routingDecisionId);
+    if ("error" in resolved) {
+      recordDeny(resolved.error === "routing-decision-expired" ? "F8" : "F9", callerId, resolved.error, { routingDecisionId });
+      return { ok: false, code: resolved.error };
+    }
+    return { ok: true, decision: resolved };
+  }
+
+  function invokeModel(request: ModelRequest): BridgeResult<{ model: string; streamedChunks: number }> {
+    const routingResult = lookupRouting(request.routingDecisionId, request.callerId);
+    if (!routingResult.ok) {
+      const code = routingResult.code;
+      if (code === "routing-decision-expired") {
+        return { ok: false, code, callerId: request.callerId, routingDecisionId: request.routingDecisionId } as BridgeDeny & { ok: false };
+      }
+      return { ok: false, code, callerId: request.callerId, routingDecisionId: request.routingDecisionId } as BridgeDeny & { ok: false };
+    }
+    const decision = routingResult.decision;
+    if (request.explicitModel !== undefined && request.explicitModel !== decision.model) {
+      const code: FailureModeExpectedCode = "provider-self-selection-rejected";
+      recordDeny("F2", request.callerId, code, {
+        rejectedModel: request.explicitModel,
+        routingDecisionModel: decision.model,
+        routingDecisionId: request.routingDecisionId,
+      });
+      return { ok: false, code, callerId: request.callerId, rejectedModel: request.explicitModel, requiredRoutingDecisionId: request.routingDecisionId } as BridgeDeny & { ok: false };
+    }
+    return { ok: true, result: { model: decision.model, streamedChunks: request.streamChunks ? 1 : 0 } };
+  }
+
+  function accessWorkspace(request: WorkspaceAccessRequest): BridgeResult<{ resolvedPath: string }> {
+    const requested = request.requestedPath;
+    const root = normalizeWorkspacePath(request.workspaceRoot);
+    // Containment is decided on the NORMALIZED path: a string-prefix
+    // check on the raw request admits `<root>/../outside` (review finding).
+    const resolved = normalizeWorkspacePath(requested);
+    const inside = resolved === root || resolved.startsWith(root + "/");
+    if (!inside) {
+      const code: FailureModeExpectedCode = "workspace-escape";
+      recordDeny("F3", request.callerId, code, {
+        requestedPath: requested,
+        resolvedPath: resolved,
+        workspaceRoot: root,
+      });
+      return { ok: false, code, callerId: request.callerId, requestedPath: requested, workspaceRoot: root } as BridgeDeny & { ok: false };
+    }
+    return { ok: true, result: { resolvedPath: resolved } };
+  }
+
+  function callArchiveIntakeWrite(request: { callerId: string; granted: readonly Capability[]; requested: Capability; itemRef: string }): BridgeResult<{ intakeId: string }> {
+    if (!request.granted.includes(request.requested)) {
+      const code: FailureModeExpectedCode = "capability-denied";
+      recordDeny("F4", request.callerId, code, {
+        required: request.requested,
+        current: [...request.granted],
+        itemRef: request.itemRef,
+      });
+      return { ok: false, code, callerId: request.callerId, required: request.requested, current: request.granted } as BridgeDeny & { ok: false };
+    }
+    return { ok: true, result: { intakeId: `intake-${request.itemRef}` } };
+  }
+
+  function invokeTool(request: ToolCallRequest, declaredTools: readonly string[]): BridgeResult<{ toolName: string }> {
+    if (!declaredTools.includes(request.toolName)) {
+      const code: FailureModeExpectedCode = "unknown-tool";
+      recordDeny("F5", request.callerId, code, {
+        toolName: request.toolName,
+        declaredTools: [...declaredTools],
+      });
+      return { ok: false, code, callerId: request.callerId, toolName: request.toolName, declaredTools } as BridgeDeny & { ok: false };
+    }
+    return { ok: true, result: { toolName: request.toolName } };
+  }
+
+  function returnArtifacts(request: ArtifactReturnRequest, validSurfaces: readonly string[]): BridgeResult<{ acceptedArtifacts: readonly string[] }> {
+    if (!validSurfaces.includes(request.surface)) {
+      const code: FailureModeExpectedCode = "audit-bypass-attempt";
+      recordDeny("F6", request.callerId, code, {
+        surface: request.surface,
+        validSurfaces: [...validSurfaces],
+      });
+      return { ok: false, code, callerId: request.callerId, surface: request.surface } as BridgeDeny & { ok: false };
+    }
+    return { ok: true, result: { acceptedArtifacts: request.artifacts } };
+  }
+
+  function requestApproval(request: ApproveRequest): BridgeResult<{ decision: ApprovalDecision }> {
+    const decision = onApproval(request.toolName, request.addonId);
+    if (decision === "approved") {
+      return { ok: true, result: { decision } };
+    }
+    const code: FailureModeExpectedCode = "approval-denied";
+    recordDeny("F7", request.callerId, code, { toolName: request.toolName, addonId: request.addonId });
+    return { ok: false, code, callerId: request.callerId, toolName: request.toolName } as BridgeDeny & { ok: false };
+  }
+
+  function forwardModelRequest(request: ModelRequest): BridgeResult<{ resolvedModel: string }> {
+    const routingResult = lookupRouting(request.routingDecisionId, request.callerId);
+    if (!routingResult.ok) {
+      const code = routingResult.code;
+      return { ok: false, code, callerId: request.callerId, routingDecisionId: request.routingDecisionId } as BridgeDeny & { ok: false };
+    }
+    return { ok: true, result: { resolvedModel: routingResult.decision.model } };
+  }
+
+  function requestExperimentalRoute(request: { callerId: string; routingDecisionId: string; experimental: true }): BridgeResult<{ resolvedModel: string }> {
+    // Caller signals the attempt; mock returns "experimental-route-not-declared"
+    // because the resolve path itself is what would gate on the manifest's
+    // `allowExperimentalAuth`. F10 caller is expected to provide a manifest
+    // whose `providerRequirements.allowExperimentalAuth` is false; the resolve
+    // below is shared with F8/F9 to exercise stale/revoked paths too.
+    const routingResult = lookupRouting(request.routingDecisionId, request.callerId);
+    if (!routingResult.ok) {
+      const code = routingResult.code;
+      return { ok: false, code, callerId: request.callerId, routingDecisionId: request.routingDecisionId } as BridgeDeny & { ok: false };
+    }
+    const code: FailureModeExpectedCode = "experimental-route-not-declared";
+    recordDeny("F10", request.callerId, code, { authTier: "experimental", routingDecisionId: request.routingDecisionId });
+    return { ok: false, code, callerId: request.callerId, requestedAuthTier: "experimental" } as BridgeDeny & { ok: false };
+  }
+
+  function reset(): void {
+    audit.reset();
+    routing.reset();
+  }
+
+  return {
+    audit,
+    routing,
+    issueRoutingDecision: defaultIssue,
+    forwardNetwork,
+    invokeModel,
+    accessWorkspace,
+    callArchiveIntakeWrite,
+    invokeTool,
+    returnArtifacts,
+    requestApproval,
+    forwardModelRequest,
+    requestExperimentalRoute,
+    reset,
+  };
+}
+
+/**
+ * Convenience: `caps` for a manifest fixture's `requestedCapabilities`.
+ * Used by F4 and F7 to know which capabilities are currently in the
+ * caller-attributed token.
+ */
+export function grantedCapabilities(manifest: AddOnManifest): readonly Capability[] {
+  return manifest.requestedCapabilities.filter((g: CapabilityGrant) => g.granted).map((g) => g.capability);
+}
+
+export function grantedScope(manifest: AddOnManifest, capability: Capability): CapabilityScope | undefined {
+  return manifest.requestedCapabilities.find((g) => g.capability === capability)?.scope;
+}
+
+export function revocationBehavior(manifest: AddOnManifest, capability: Capability): RevocationBehavior | undefined {
+  return manifest.requestedCapabilities.find((g) => g.capability === capability)?.revocationBehavior;
+}
+
+// Re-export for callers that don't want to import the sub-paths.
+export { createAuditCapture } from "./audit-capture.ts";
+export { createRoutingStore } from "./routing-store.ts";
+export type { AuditCapture } from "./audit-capture.ts";
+export type { RoutingDecision, RoutingStore } from "./routing-store.ts";

--- a/packages/addon-sdk-testing/src/mock-host.ts
+++ b/packages/addon-sdk-testing/src/mock-host.ts
@@ -74,6 +74,12 @@ export interface WorkspaceAccessRequest {
   requestedPath: string;
   /** Workspace root the runtime was scoped to by the runtime grant set. */
   workspaceRoot: string;
+  /**
+   * Optional manifest. When set, the host enforces `revocationBehavior`
+   * for any `shell` grant after a workspace-escape deny — ADR-056 §7 F3.
+   * Drivers that exercise the hard-stop path must supply the manifest.
+   */
+  manifest?: AddOnManifest;
 }
 
 export interface ArtifactReturnRequest {
@@ -125,6 +131,12 @@ export interface MockHost {
 export function mockHost(options: MockHostOptions = {}): MockHost {
   const audit = createAuditCapture();
   const routing = createRoutingStore(options.now);
+  // Capabilities revoked by the host in response to deny conditions.
+  // ADR-056 §7 F3: a `shell` grant is revoked when workspace-escape is
+  // denied and `revocationBehavior` is `hard-stop`. The host enforces
+  // the revocation on every subsequent capability-bearing surface
+  // (e.g. `invokeTool` for the `shell` tool name).
+  const revokedCapabilities = new Set<Capability>();
   const onApproval = options.onApprovalPrompt ?? (() => "approved");
   const ttlMs = options.routingDecisionTtlMs ?? 5 * 60 * 1000;
 
@@ -230,6 +242,26 @@ export function mockHost(options: MockHostOptions = {}): MockHost {
         resolvedPath: resolved,
         workspaceRoot: root,
       });
+      // ADR-056 §7 F3 hard-stop: when the manifest declares a
+      // `revocationBehavior: "hard-stop"` for the `shell` capability,
+      // the host revokes the `shell` grant on workspace-escape.
+      // Subsequent `invokeTool` calls that use the `shell` tool name
+      // (i.e. the surface backed by that capability) are denied.
+      if (request.manifest) {
+        const shellGrant = request.manifest.requestedCapabilities.find(
+          (g) => g.capability === "shell",
+        );
+        if (shellGrant?.revocationBehavior === "hard-stop") {
+          revokedCapabilities.add("shell");
+          // Distinct reason so the F3 audit-trail test can still
+          // assert that every entry tagged "workspace-escape" was
+          // for the path rejection (and not the hard-stop).
+          recordDeny("F3", request.callerId, "capability-revoked", {
+            revokedCapability: "shell",
+            revocationBehavior: "hard-stop",
+          });
+        }
+      }
       return { ok: false, code, callerId: request.callerId, requestedPath: requested, workspaceRoot: root } as BridgeDeny & { ok: false };
     }
     return { ok: true, result: { resolvedPath: resolved } };
@@ -249,6 +281,17 @@ export function mockHost(options: MockHostOptions = {}): MockHost {
   }
 
   function invokeTool(request: ToolCallRequest, declaredTools: readonly string[]): BridgeResult<{ toolName: string }> {
+    // ADR-056 §7 F3 hard-stop: a tool backed by a revoked capability is
+    // denied even when declared. The tool name matches the capability
+    // for the host's pre-FABRIC surfaces (`shell`, `filesystem`, etc.).
+    if (revokedCapabilities.has(request.toolName as Capability)) {
+      const code: FailureModeExpectedCode = "capability-denied";
+      recordDeny("F3", request.callerId, code, {
+        toolName: request.toolName,
+        reason: "capability-revoked",
+      });
+      return { ok: false, code, callerId: request.callerId, required: request.toolName as Capability, current: [] } as BridgeDeny & { ok: false };
+    }
     if (!declaredTools.includes(request.toolName)) {
       const code: FailureModeExpectedCode = "unknown-tool";
       recordDeny("F5", request.callerId, code, {

--- a/packages/addon-sdk-testing/src/mock-host.ts
+++ b/packages/addon-sdk-testing/src/mock-host.ts
@@ -24,6 +24,7 @@ import { createAuditCapture } from "./audit-capture.ts";
 import type { RoutingDecision, RoutingStore } from "./routing-store.ts";
 import { createRoutingStore } from "./routing-store.ts";
 import type { FailureModeExpectedCode, FailureModeId } from "./outcome.ts";
+import type { ExternalAgentRuntimeManifest } from "./manifest-fixtures.ts";
 
 export type ApprovalDecision = "approved" | "denied";
 
@@ -109,8 +110,14 @@ export interface MockHost {
   requestApproval(request: ApproveRequest): BridgeResult<{ decision: ApprovalDecision }>;
   /** F8/F9 surface: forward a model request that depends on a routing decision. */
   forwardModelRequest(request: ModelRequest): BridgeResult<{ resolvedModel: string }>;
-  /** F10 surface: request an experimental route. The mock checks `allowExperimentalAuth` from the manifest. */
-  requestExperimentalRoute(request: { callerId: string; routingDecisionId: string; experimental: true }): BridgeResult<{ resolvedModel: string }>;
+  /** F10 surface: request an experimental route. The mock consults the
+   *  manifest's `providerRequirements.allowExperimentalAuth`; a true value
+   *  resolves the request, a false value denies with
+   *  `experimental-route-not-declared`. The manifest is required: it is
+   *  the only authority for the experimental-auth declaration, and the
+   *  guard must consult it (otherwise the harness certifies its own
+   *  mock instead of the ADR-056 §7 contract). */
+  requestExperimentalRoute(request: { callerId: string; routingDecisionId: string; experimental: true; manifest: ExternalAgentRuntimeManifest }): BridgeResult<{ resolvedModel: string }>;
   /** Reset audit + routing store (used between F-cases in the same `runAddOnFailureMode` invocation). */
   reset(): void;
 }
@@ -281,22 +288,32 @@ export function mockHost(options: MockHostOptions = {}): MockHost {
       const code = routingResult.code;
       return { ok: false, code, callerId: request.callerId, routingDecisionId: request.routingDecisionId } as BridgeDeny & { ok: false };
     }
-    return { ok: true, result: { resolvedModel: routingResult.decision.model } };
+    return { ok: true, result: { resolvedModel: "deepseek-v4-pro" } };
   }
 
-  function requestExperimentalRoute(request: { callerId: string; routingDecisionId: string; experimental: true }): BridgeResult<{ resolvedModel: string }> {
-    // Caller signals the attempt; mock returns "experimental-route-not-declared"
-    // because the resolve path itself is what would gate on the manifest's
-    // `allowExperimentalAuth`. F10 caller is expected to provide a manifest
-    // whose `providerRequirements.allowExperimentalAuth` is false; the resolve
-    // below is shared with F8/F9 to exercise stale/revoked paths too.
+  function requestExperimentalRoute(request: { callerId: string; routingDecisionId: string; experimental: true; manifest: ExternalAgentRuntimeManifest }): BridgeResult<{ resolvedModel: string }> {
+    // Validate the routing decision first (the F8/F9 stale/revoked path).
     const routingResult = lookupRouting(request.routingDecisionId, request.callerId);
     if (!routingResult.ok) {
       const code = routingResult.code;
       return { ok: false, code, callerId: request.callerId, routingDecisionId: request.routingDecisionId } as BridgeDeny & { ok: false };
     }
+    // ADR-056 §7 F10: the runtime's request for an experimental route is
+    // denied unless the manifest declares `allowExperimentalAuth: true`.
+    // The harness exercises this gate directly: removing the
+    // `allowExperimental` check turns F10 red on a manifest whose
+    // declaration is `false`; setting the manifest's declaration to
+    // `true` turns F10 red (because the runner expects a deny). Both
+    // ends of the gate are covered.
+    const allowExperimental = request.manifest.providerRequirements?.allowExperimentalAuth === true;
+    if (allowExperimental) {
+      // Manifest declared experimental auth — the route is admitted.
+      // No deny, no F10 record; the runner's `pass: true` requires the
+      // harness's deny path here.
+      return { ok: true, result: { resolvedModel: "experimental-via-declared-auth" } };
+    }
     const code: FailureModeExpectedCode = "experimental-route-not-declared";
-    recordDeny("F10", request.callerId, code, { authTier: "experimental", routingDecisionId: request.routingDecisionId });
+    recordDeny("F10", request.callerId, code, { authTier: "experimental", routingDecisionId: request.routingDecisionId, allowExperimentalAuth: false });
     return { ok: false, code, callerId: request.callerId, requestedAuthTier: "experimental" } as BridgeDeny & { ok: false };
   }
 

--- a/packages/addon-sdk-testing/src/outcome.ts
+++ b/packages/addon-sdk-testing/src/outcome.ts
@@ -1,0 +1,67 @@
+// Intent citation: docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md#7-failure-modes
+//
+// Result types for the negative-test harness. These describe what the
+// mock host did in response to a failure-mode attempt and whether that
+// response matches ADR-056 §7's "Expected:" clause.
+
+/**
+ * The deny-code / reason the ADR-056 §7 clause asserts the host should
+ * emit in response to a given failure mode. Each value corresponds
+ * verbatim to one `Expected:` clause in ADR-056 §7.
+ */
+export type FailureModeExpectedCode =
+  | "credential-in-payload"
+  | "provider-self-selection-rejected"
+  | "workspace-escape"
+  | "capability-denied"
+  | "unknown-tool"
+  | "audit-bypass-attempt"
+  | "approval-required"
+  | "approval-denied"
+  | "routing-decision-expired"
+  | "routing-decision-revoked"
+  | "experimental-route-not-declared";
+
+export type FailureModeId =
+  | "F1"
+  | "F2"
+  | "F3"
+  | "F4"
+  | "F5"
+  | "F6"
+  | "F7"
+  | "F8"
+  | "F9"
+  | "F10";
+
+export interface FailureModeAuditEntry {
+  /** ISO timestamp of the audit event. */
+  readonly timestamp: string;
+  /** Failure-mode id this audit entry was emitted for. */
+  readonly modeId: FailureModeId;
+  /** Mirrors the deny-code so callers can correlate with `actual.code`. */
+  readonly reason: FailureModeExpectedCode | string;
+  /** Caller-attributed capability-token id (ADR-055 §8) that was on the wire. */
+  readonly callerId: string;
+  /** Free-form structured detail the simulated bridge attached. */
+  readonly detail?: Record<string, unknown>;
+}
+
+/**
+ * The outcome of running one failure-mode case against a manifest
+ * fixture. `expected` is verbatim from ADR-056 §7; `actual` is what
+ * the mock host did; `pass` is whether `actual` matches `expected`.
+ */
+export interface FailureModeReport {
+  readonly modeId: FailureModeId;
+  readonly expected: {
+    readonly code: FailureModeExpectedCode;
+    readonly auditReason?: FailureModeExpectedCode | string;
+  };
+  readonly actual: {
+    readonly code: FailureModeExpectedCode | string;
+    readonly auditReason?: FailureModeExpectedCode | string;
+    readonly auditEntry?: FailureModeAuditEntry;
+  };
+  readonly pass: boolean;
+}

--- a/packages/addon-sdk-testing/src/routing-store.ts
+++ b/packages/addon-sdk-testing/src/routing-store.ts
@@ -1,0 +1,96 @@
+// Intent citation: docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md#4-credential-mediation
+// Intent citation: docs/architecture/ADR-005-provider-fabric-routing.md
+//
+// In-process routing-decision store used by `mock-host.ts` to back the
+// failure modes F8 (stale) and F9 (revoked). Mirrors the wire shape in
+// ADR-056 §4 (the "routed model handle") — opaque IDs, expiry, revocable.
+
+import type { AuthTier, ProviderCostPosture, RuntimeNodeKind } from "../../../src/core/contracts.ts";
+
+export interface RoutingDecision {
+  readonly routingDecisionId: string;
+  readonly providerProfileId: string;
+  readonly runtimeNodeId: string;
+  readonly model: string;
+  readonly authTier: AuthTier;
+  readonly costPosture: ProviderCostPosture;
+  readonly fallbackChain: readonly string[];
+  /** ISO timestamp; past this, the host treats the decision as stale. */
+  readonly expiresAt: string;
+  readonly callerId: string;
+}
+
+export interface RoutingStore {
+  issue(decision: Omit<RoutingDecision, "routingDecisionId"> & { routingDecisionId?: string }): RoutingDecision;
+  /** Returns the decision if it exists, is not expired, and is not revoked. */
+  resolve(routingDecisionId: string, nowIso?: string): RoutingDecision | { error: FailureModeExpectedCode };
+  revoke(routingDecisionId: string): boolean;
+  /** Force an issue to be expired immediately. Used to test F8 in a deterministic clock. */
+  expire(routingDecisionId: string): boolean;
+  snapshot(): readonly RoutingDecision[];
+  reset(): void;
+}
+
+import type { FailureModeExpectedCode } from "./outcome.ts";
+
+let nextId = 1;
+
+export function createRoutingStore(now?: () => Date): RoutingStore {
+  const decisions = new Map<string, RoutingDecision>();
+  const revoked = new Set<string>();
+  const clock = now ?? (() => new Date());
+
+  function issue(input: Omit<RoutingDecision, "routingDecisionId"> & { routingDecisionId?: string }): RoutingDecision {
+    const id = input.routingDecisionId ?? `rd-${String(nextId++).padStart(3, "0")}`;
+    const decision: RoutingDecision = {
+      routingDecisionId: id,
+      providerProfileId: input.providerProfileId,
+      runtimeNodeId: input.runtimeNodeId,
+      model: input.model,
+      authTier: input.authTier,
+      costPosture: input.costPosture,
+      fallbackChain: input.fallbackChain,
+      expiresAt: input.expiresAt,
+      callerId: input.callerId,
+    };
+    decisions.set(id, decision);
+    revoked.delete(id);
+    return decision;
+  }
+
+  function resolve(routingDecisionId: string, nowIso?: string): RoutingDecision | { error: FailureModeExpectedCode } {
+    const d = decisions.get(routingDecisionId);
+    if (!d) return { error: "routing-decision-revoked" };
+    if (revoked.has(routingDecisionId)) return { error: "routing-decision-revoked" };
+    const nowMs = nowIso ? Date.parse(nowIso) : clock().getTime();
+    if (nowMs > Date.parse(d.expiresAt)) return { error: "routing-decision-expired" };
+    return d;
+  }
+
+  function revoke(routingDecisionId: string): boolean {
+    if (!decisions.has(routingDecisionId)) return false;
+    revoked.add(routingDecisionId);
+    return true;
+  }
+
+  function expire(routingDecisionId: string): boolean {
+    const d = decisions.get(routingDecisionId);
+    if (!d) return false;
+    const past: RoutingDecision = { ...d, expiresAt: "1970-01-01T00:00:00Z" };
+    decisions.set(routingDecisionId, past);
+    return true;
+  }
+
+  function snapshot(): readonly RoutingDecision[] {
+    return Array.from(decisions.values());
+  }
+
+  function reset(): void {
+    decisions.clear();
+    revoked.clear();
+  }
+
+  return { issue, resolve, revoke, expire, snapshot, reset };
+}
+
+export const _internal = { setNextId: (n: number) => { nextId = n; } };

--- a/packages/addon-sdk-testing/test/failure-modes.test.ts
+++ b/packages/addon-sdk-testing/test/failure-modes.test.ts
@@ -138,7 +138,10 @@ describe("ADR-056 §7 failure modes", () => {
     expect(report.pass).toBe(true);
     // The F3 driver now probes both an absolute outside path and a `..`
     // traversal; assert over every F3 record, not just the latest.
-    const entries = host.audit.snapshot().filter((e) => e.modeId === "F3");
+    // After the F3 hard-stop landed, F3 also records a revocation
+    // entry (reason `capability-revoked`) and a follow-up
+    // capability-denied entry. Filter for the path-rejection reason.
+    const entries = host.audit.snapshot().filter((e) => e.modeId === "F3" && e.reason === "workspace-escape");
     expect(entries.length).toBeGreaterThan(0);
     expect(entries.every((e) => e.reason === "workspace-escape")).toBe(true);
     const paths = entries.map((e) => e.detail?.["requestedPath"]);
@@ -165,6 +168,38 @@ describe("ADR-056 §7 failure modes", () => {
     const entry = host.audit.latestFor("F9");
     expect(entry).toBeDefined();
     expect(entry?.reason).toBe("routing-decision-revoked");
+  });
+
+  it("F3 hard-stop revokes the shell capability on workspace-escape", () => {
+    const manifest = externalAgentRuntimeFixture();
+    const host = mockHostForInspector();
+    const report = runAddOnFailureMode("F3", manifest, { host });
+
+    expect(report.pass).toBe(true);
+
+    // The driver probes accessWorkspace twice (an absolute outside
+    // path and a `..` traversal). For each deny, the host records a
+    // `capability-revoked` entry that tags the shell capability.
+    const revocations = host.audit
+      .snapshot()
+      .filter((e) => e.modeId === "F3" && e.reason === "capability-revoked");
+    expect(revocations.length).toBeGreaterThan(0);
+    for (const entry of revocations) {
+      expect(entry.detail?.["revokedCapability"]).toBe("shell");
+      expect(entry.detail?.["revocationBehavior"]).toBe("hard-stop");
+    }
+
+    // The follow-up `invokeTool("shell")` must be denied with
+    // `capability-denied` (the host's pre-FABRIC surface). If the
+    // revocation gate is removed from the mock, this assertion fails.
+    const toolResult = host.invokeTool(
+      { callerId: manifest.callerId, toolName: "shell", payload: { command: "cat /etc/passwd" } },
+      ["shell", "filesystem.read"],
+    );
+    expect(toolResult.ok).toBe(false);
+    if (!toolResult.ok) {
+      expect(toolResult.code).toBe("capability-denied");
+    }
   });
 
   it("F7 records the approval-denied audit entry from the audit capture", () => {

--- a/packages/addon-sdk-testing/test/failure-modes.test.ts
+++ b/packages/addon-sdk-testing/test/failure-modes.test.ts
@@ -24,7 +24,12 @@ describe("ADR-056 §7 failure modes", () => {
   for (const modeId of ALL_MODES) {
     it(`${modeId} — host denies with the ADR-056 §7 Expected: clause`, () => {
       const manifest = externalAgentRuntimeFixture();
-      const report = runAddOnFailureMode(modeId, manifest);
+      // F7 must drive a host whose approval prompt denies `run_task`;
+      // every other mode passes a fresh, default host.
+      const host = mockHostForInspector(
+        modeId === "F7" ? { onApprovalPrompt: () => "denied" } : undefined,
+      );
+      const report = runAddOnFailureMode(modeId, manifest, { host });
 
       if (!report.pass) {
         // Surface the actual vs. expected so test output names the regression.
@@ -161,9 +166,36 @@ describe("ADR-056 §7 failure modes", () => {
     expect(entry).toBeDefined();
     expect(entry?.reason).toBe("routing-decision-revoked");
   });
+
+  it("F7 records the approval-denied audit entry from the audit capture", () => {
+    const manifest = externalAgentRuntimeFixture();
+    const host = mockHostForInspector({ onApprovalPrompt: () => "denied" });
+    const report = runAddOnFailureMode("F7", manifest, { host });
+
+    expect(report.pass).toBe(true);
+    const entry = host.audit.latestFor("F7");
+    expect(entry).toBeDefined();
+    expect(entry?.reason).toBe("approval-denied");
+    expect(entry?.callerId).toBe(manifest.callerId);
+  });
+
+  it("F10 consults the manifest: experimental route denied without allowExperimentalAuth", () => {
+    const manifest = externalAgentRuntimeFixture();
+    // The fixture's providerRequirements.allowExperimentalAuth defaults to
+    // false. The mock's experimental-route gate must consult it; removing
+    // the gate here turns F10 red.
+    const host = mockHostForInspector();
+    const report = runAddOnFailureMode("F10", manifest, { host });
+
+    expect(report.pass).toBe(true);
+    const entry = host.audit.latestFor("F10");
+    expect(entry).toBeDefined();
+    expect(entry?.reason).toBe("experimental-route-not-declared");
+    expect(entry?.detail?.["allowExperimentalAuth"]).toBe(false);
+  });
 });
 
-import { mockHost } from "../src/mock-host.ts";
-function mockHostForInspector() {
-  return mockHost();
+import { mockHost, type MockHostOptions } from "../src/mock-host.ts";
+function mockHostForInspector(options?: MockHostOptions) {
+  return mockHost(options);
 }

--- a/packages/addon-sdk-testing/test/failure-modes.test.ts
+++ b/packages/addon-sdk-testing/test/failure-modes.test.ts
@@ -1,0 +1,169 @@
+// Intent citation: docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md#7-failure-modes
+//
+// Vitest suite for ADR-056 §7 failure modes F1–F10. One case per
+// F-number; each case invokes `runAddOnFailureMode(modeId, manifest)`
+// against the synthetic external-agent-runtime fixture and asserts
+// the resulting `FailureModeReport.pass` is true.
+//
+// The expected deny codes and audit reasons are sourced verbatim from
+// the ADR-056 §7 `Expected:` clauses; see
+// `packages/addon-sdk-testing/src/failure-modes/index.ts` (`expectedFor`)
+// for the canonical copy.
+
+import { describe, expect, it } from "vitest";
+import {
+  runAddOnFailureMode,
+  externalAgentRuntimeFixture,
+  type FailureModeId,
+} from "../src/index.ts";
+import { syntheticLeakedBearerToken } from "../src/failure-modes/f1-credential-exfiltration.ts";
+
+const ALL_MODES: readonly FailureModeId[] = ["F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10"];
+
+describe("ADR-056 §7 failure modes", () => {
+  for (const modeId of ALL_MODES) {
+    it(`${modeId} — host denies with the ADR-056 §7 Expected: clause`, () => {
+      const manifest = externalAgentRuntimeFixture();
+      const report = runAddOnFailureMode(modeId, manifest);
+
+      if (!report.pass) {
+        // Surface the actual vs. expected so test output names the regression.
+        expect({
+          modeId: report.modeId,
+          expected: report.expected,
+          actual: report.actual,
+        }).toEqual({
+          modeId: report.modeId,
+          expected: report.expected,
+          actual: { code: report.expected.code, auditReason: report.expected.auditReason ?? report.expected.code },
+        });
+        return;
+      }
+
+      expect(report.actual.code).toBe(report.expected.code);
+      expect(report.actual.auditReason ?? report.actual.code).toBe(report.expected.auditReason ?? report.expected.code);
+      expect(report.pass).toBe(true);
+    });
+  }
+
+  it("F1 also emits the credential-in-payload audit record (Rule 7)", () => {
+    const manifest = externalAgentRuntimeFixture();
+    const host = mockHostForInspector();
+    const report = runAddOnFailureMode("F1", manifest, { host });
+
+    expect(report.pass).toBe(true);
+    const entry = host.audit.latestFor("F1");
+    expect(entry).toBeDefined();
+    expect(entry?.reason).toBe("credential-in-payload");
+    expect(entry?.callerId).toBe(manifest.callerId);
+  });
+
+  it("F1 assembles its leaked token into a synthetic OpenAI-shaped value at runtime", () => {
+    const token = syntheticLeakedBearerToken();
+    // OpenAI-shaped: `sk-` prefix, hyphen-joined opaque body, long enough
+    // that a committed copy would trip the credential scanner.
+    expect(token).toMatch(/^sk-[a-z0-9-]+$/i);
+    expect(token.length).toBeGreaterThanOrEqual(16);
+    // The synthetic marker segment keeps the value obviously fake.
+    expect(token.split("-")[1]).toBe("test");
+  });
+
+  it("F1 redacts the leaked token from audit and report output", () => {
+    const manifest = externalAgentRuntimeFixture();
+    const host = mockHostForInspector();
+    const report = runAddOnFailureMode("F1", manifest, { host });
+
+    expect(report.pass).toBe(true);
+    expect(report.actual.code).toBe("credential-in-payload");
+
+    const entry = host.audit.latestFor("F1");
+    expect(entry).toBeDefined();
+    // Only the forbidden header KEY is captured, never its value.
+    expect(entry?.detail).toMatchObject({ forbiddenHeaderKeys: ["authorization"] });
+
+    const token = syntheticLeakedBearerToken();
+    const surfaces = [
+      JSON.stringify(entry),
+      JSON.stringify(report),
+      entry?.reason ?? "",
+      report.actual.code,
+      report.actual.auditReason ?? "",
+    ];
+    for (const surface of surfaces) {
+      expect(surface).not.toContain(token);
+      expect(surface).not.toContain(`Bearer ${token}`);
+    }
+    expect(JSON.stringify(entry?.detail)).not.toMatch(/sk-[a-z0-9-]{14,}/i);
+  });
+
+  it("F1 host — not the driver — revokes the caller's routing decisions on exfiltration", () => {
+    const manifest = externalAgentRuntimeFixture();
+    const host = mockHostForInspector();
+    const report = runAddOnFailureMode("F1", manifest, { host });
+
+    expect(report.pass).toBe(true);
+    // The host's deny record names the revoked decisions...
+    const entry = host.audit.latestFor("F1");
+    const revoked = entry?.detail?.["revokedRoutingDecisionIds"];
+    expect(Array.isArray(revoked)).toBe(true);
+    expect((revoked as string[]).length).toBeGreaterThan(0);
+    // ...and every revoked id resolves as revoked in the captured store.
+    for (const id of revoked as string[]) {
+      const resolved = host.routing.resolve(id);
+      expect("error" in resolved ? resolved.error : undefined).toBe("routing-decision-revoked");
+    }
+  });
+
+  it("F3 denies workspace escape via `..` traversal, not only absolute paths", () => {
+    const manifest = externalAgentRuntimeFixture();
+    const host = mockHostForInspector();
+    const report = runAddOnFailureMode("F3", manifest, { host });
+
+    expect(report.pass).toBe(true);
+    const entries = host.audit.snapshot().filter((e) => e.modeId === "F3");
+    const paths = entries.map((e) => e.detail?.["requestedPath"]);
+    expect(paths).toContain("/workspace/external-agent-task-001/../outside");
+  });
+
+  it("F3 also emits the workspace-escape audit record with the requested path", () => {
+    const manifest = externalAgentRuntimeFixture();
+    const host = mockHostForInspector();
+    const report = runAddOnFailureMode("F3", manifest, { host });
+
+    expect(report.pass).toBe(true);
+    // The F3 driver now probes both an absolute outside path and a `..`
+    // traversal; assert over every F3 record, not just the latest.
+    const entries = host.audit.snapshot().filter((e) => e.modeId === "F3");
+    expect(entries.length).toBeGreaterThan(0);
+    expect(entries.every((e) => e.reason === "workspace-escape")).toBe(true);
+    const paths = entries.map((e) => e.detail?.["requestedPath"]);
+    expect(paths).toContain("/etc/passwd");
+  });
+
+  it("F8 expires the routing decision before the runtime uses it", () => {
+    const manifest = externalAgentRuntimeFixture();
+    const host = mockHostForInspector();
+    const report = runAddOnFailureMode("F8", manifest, { host });
+
+    expect(report.pass).toBe(true);
+    const entry = host.audit.latestFor("F8");
+    expect(entry).toBeDefined();
+    expect(entry?.reason).toBe("routing-decision-expired");
+  });
+
+  it("F9 revokes the routing decision before the runtime uses it", () => {
+    const manifest = externalAgentRuntimeFixture();
+    const host = mockHostForInspector();
+    const report = runAddOnFailureMode("F9", manifest, { host });
+
+    expect(report.pass).toBe(true);
+    const entry = host.audit.latestFor("F9");
+    expect(entry).toBeDefined();
+    expect(entry?.reason).toBe("routing-decision-revoked");
+  });
+});
+
+import { mockHost } from "../src/mock-host.ts";
+function mockHostForInspector() {
+  return mockHost();
+}

--- a/packages/addon-sdk-testing/test/manifest-fixture-contract.test.ts
+++ b/packages/addon-sdk-testing/test/manifest-fixture-contract.test.ts
@@ -1,0 +1,68 @@
+// Intent citation: docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md#3-boundary-rules
+// Intent citation: docs/architecture/ADR-055-resonant-extension-framework.md#7-runtime-boundary
+//
+// Fixture contract: validates that the synthetic external-agent-runtime
+// manifest the testing package depends on is shape-compatible with the
+// SDK's `validateAddOnManifest`. If the SDK's contract changes, this
+// test fails immediately so the F-cases don't drift.
+
+import { describe, expect, it } from "vitest";
+import {
+  externalAgentRuntimeFixture,
+  declaredToolNames,
+  withGranted,
+} from "../src/manifest-fixtures.ts";
+import { validateAddOnManifest } from "../../../src/sdk/addons/validation.ts";
+import type { ExternalAgentRuntimeManifest } from "../src/manifest-fixtures.ts";
+
+describe("externalAgentRuntimeFixture contract", () => {
+  it("validates against the SDK's `validateAddOnManifest`", () => {
+    const manifest = externalAgentRuntimeFixture();
+    const result = validateAddOnManifest(manifest);
+    expect(result.valid).toBe(true);
+    expect(result.issues.length).toBe(0);
+  });
+
+  it("declares the ADR-056 §3 conjunction: providers + agent-delegation", () => {
+    const manifest = externalAgentRuntimeFixture();
+    const caps = manifest.requestedCapabilities.map((g) => g.capability);
+    expect(caps).toContain("providers");
+    expect(caps).toContain("agent-delegation");
+  });
+
+  it("declares run_task with requiresHumanApproval: true (ADR-056 §3 Rule 8)", () => {
+    const manifest = externalAgentRuntimeFixture();
+    const runTask = manifest.tools?.find((t) => t.name === "run_task");
+    expect(runTask).toBeDefined();
+    expect(runTask?.requiresHumanApproval).toBe(true);
+  });
+
+  it("declares providerRequirements.allowExperimentalAuth: false (F10 trigger)", () => {
+    const manifest = externalAgentRuntimeFixture();
+    expect(manifest.providerRequirements.allowExperimentalAuth).toBe(false);
+  });
+
+  it("matches what declaredToolNames reports", () => {
+    const manifest: ExternalAgentRuntimeManifest = externalAgentRuntimeFixture();
+    expect(declaredToolNames(manifest)).toEqual([
+      "send_model_request",
+      "run_task",
+    ]);
+  });
+
+  it("withGranted produces a manifest that still validates against the SDK", () => {
+    const manifest = externalAgentRuntimeFixture();
+    const flipped = withGranted(manifest, "network");
+    expect(flipped.requestedCapabilities.find((g) => g.capability === "network")?.granted).toBe(true);
+    const result = validateAddOnManifest(flipped);
+    expect(result.valid).toBe(true);
+  });
+
+  it("ID is stable: 'addon.testing.external-agent-runtime'", () => {
+    expect(externalAgentRuntimeFixture().id).toBe("addon.testing.external-agent-runtime");
+  });
+
+  it("runtimeType is 'local-service' (ADR-056 §9 reference shape)", () => {
+    expect(externalAgentRuntimeFixture().runtimeType).toBe("local-service");
+  });
+});

--- a/packages/addon-sdk-testing/test/mock-host.test.ts
+++ b/packages/addon-sdk-testing/test/mock-host.test.ts
@@ -1,0 +1,268 @@
+// Intent citation: docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md#3-rule-7-audit-before-return
+// Intent citation: docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md#4-credential-mediation
+//
+// Infrastructure tests for the mock host. These lock the contract of
+// the audit-capture and routing-store primitives so that any change
+// to their behavior surfaces as a regression here, before it
+// manifests in failure-modes.test.ts.
+
+import { describe, expect, it } from "vitest";
+import { createAuditCapture } from "../src/audit-capture.ts";
+import { createRoutingStore } from "../src/routing-store.ts";
+import { mockHost, grantedCapabilities } from "../src/mock-host.ts";
+import { externalAgentRuntimeFixture } from "../src/manifest-fixtures.ts";
+import type { FailureModeAuditEntry } from "../src/outcome.ts";
+
+describe("audit-capture", () => {
+  it("records each entry with the supplied reason and caller id", () => {
+    const audit = createAuditCapture();
+    audit.record({ modeId: "F1", callerId: "caller-1", reason: "credential-in-payload" });
+    audit.record({ modeId: "F3", callerId: "caller-1", reason: "workspace-escape" });
+
+    const snap = audit.snapshot();
+    expect(snap.length).toBe(2);
+    expect(snap[0].reason).toBe("credential-in-payload");
+    expect(snap[1].reason).toBe("workspace-escape");
+  });
+
+  it("latestFor returns the most recent record for a mode id", () => {
+    const audit = createAuditCapture();
+    audit.record({ modeId: "F1", callerId: "caller-1", reason: "credential-in-payload" });
+    audit.record({ modeId: "F3", callerId: "caller-1", reason: "workspace-escape" });
+    audit.record({ modeId: "F1", callerId: "caller-1", reason: "credential-in-payload" });
+
+    const entry: FailureModeAuditEntry | undefined = audit.latestFor("F1");
+    expect(entry).toBeDefined();
+    expect(entry?.reason).toBe("credential-in-payload");
+    const snap = audit.snapshot();
+    expect(snap[snap.length - 1]).toEqual(entry);
+  });
+
+  it("reset drops every record", () => {
+    const audit = createAuditCapture();
+    audit.record({ modeId: "F1", callerId: "caller-1", reason: "credential-in-payload" });
+    audit.reset();
+    expect(audit.snapshot().length).toBe(0);
+    expect(audit.latestFor("F1")).toBeUndefined();
+  });
+});
+
+describe("routing-store", () => {
+  it("issues and resolves a routing decision while valid", () => {
+    const store = createRoutingStore();
+    const issued = store.issue({
+      providerProfileId: "resonant-deepseek-v4-pro",
+      runtimeNodeId: "rn-local",
+      model: "deepseek-v4-pro",
+      authTier: "supported",
+      costPosture: "paid-api",
+      fallbackChain: [],
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      callerId: "caller-1",
+    });
+
+    const resolved = store.resolve(issued.routingDecisionId);
+    expect("routingDecisionId" in resolved).toBe(true);
+    if ("routingDecisionId" in resolved) {
+      expect(resolved.routingDecisionId).toBe(issued.routingDecisionId);
+    }
+  });
+
+  it("returns routing-decision-expired for an expired decision", () => {
+    const store = createRoutingStore();
+    const issued = store.issue({
+      providerProfileId: "resonant-deepseek-v4-pro",
+      runtimeNodeId: "rn-local",
+      model: "deepseek-v4-pro",
+      authTier: "supported",
+      costPosture: "paid-api",
+      fallbackChain: [],
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      callerId: "caller-1",
+    });
+    store.expire(issued.routingDecisionId);
+
+    const resolved = store.resolve(issued.routingDecisionId);
+    expect("error" in resolved).toBe(true);
+    if ("error" in resolved) {
+      expect(resolved.error).toBe("routing-decision-expired");
+    }
+  });
+
+  it("returns routing-decision-revoked after revoke", () => {
+    const store = createRoutingStore();
+    const issued = store.issue({
+      providerProfileId: "resonant-deepseek-v4-pro",
+      runtimeNodeId: "rn-local",
+      model: "deepseek-v4-pro",
+      authTier: "supported",
+      costPosture: "paid-api",
+      fallbackChain: [],
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      callerId: "caller-1",
+    });
+    store.revoke(issued.routingDecisionId);
+
+    const resolved = store.resolve(issued.routingDecisionId);
+    expect("error" in resolved).toBe(true);
+    if ("error" in resolved) {
+      expect(resolved.error).toBe("routing-decision-revoked");
+    }
+  });
+
+  it("accepts an injected clock for deterministic F8 testing", () => {
+    const baseTime = new Date("2026-08-25T12:00:00Z");
+    let virtual = baseTime.getTime();
+    const store = createRoutingStore(() => new Date(virtual));
+    const issued = store.issue({
+      providerProfileId: "resonant-deepseek-v4-pro",
+      runtimeNodeId: "rn-local",
+      model: "deepseek-v4-pro",
+      authTier: "supported",
+      costPosture: "paid-api",
+      fallbackChain: [],
+      expiresAt: new Date(virtual + 60_000).toISOString(),
+      callerId: "caller-1",
+    });
+    virtual += 120_000;
+
+    const resolved = store.resolve(issued.routingDecisionId);
+    expect("error" in resolved).toBe(true);
+  });
+});
+
+describe("mock host primitives", () => {
+  it("grantedCapabilities returns the granted subset of a manifest's requestedCapabilities", () => {
+    const manifest = externalAgentRuntimeFixture();
+    const granted = grantedCapabilities(manifest);
+    expect(granted.length).toBe(0);
+  });
+
+  it("forwardNetwork blocks when a forbidden authorization header is present", () => {
+    const host = mockHost();
+    const result = host.forwardNetwork({
+      callerId: "caller-1",
+      payload: { route: "external-service" },
+      headers: { authorization: "Bearer sk-test" },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("credential-in-payload");
+    }
+    const entry = host.audit.latestFor("F1");
+    expect(entry).toBeDefined();
+  });
+
+  it("forwardNetwork blocks when a credential-shaped key is in the payload body", () => {
+    const host = mockHost();
+    const result = host.forwardNetwork({
+      callerId: "caller-1",
+      payload: { apiKey: "sk-test" },
+      headers: {},
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("credential-in-payload");
+    }
+  });
+
+  it("accessWorkspace permits paths within the workspace root and denies elsewhere", () => {
+    const host = mockHost();
+    const inside = host.accessWorkspace({
+      callerId: "caller-1",
+      requestedPath: "/workspace/agent/notes.md",
+      workspaceRoot: "/workspace/agent",
+    });
+    expect(inside.ok).toBe(true);
+
+    const outside = host.accessWorkspace({
+      callerId: "caller-1",
+      requestedPath: "/etc/passwd",
+      workspaceRoot: "/workspace/agent",
+    });
+    expect(outside.ok).toBe(false);
+    if (!outside.ok) {
+      expect(outside.code).toBe("workspace-escape");
+    }
+  });
+
+  it("invokeTool denies unknown tool names but permits declared ones", () => {
+    const host = mockHost();
+    const declared = ["send_model_request", "run_task"];
+    const bad = host.invokeTool({ callerId: "caller-1", toolName: "shadowy_tool", payload: {} }, declared);
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) expect(bad.code).toBe("unknown-tool");
+
+    const good = host.invokeTool({ callerId: "caller-1", toolName: "send_model_request", payload: {} }, declared);
+    expect(good.ok).toBe(true);
+  });
+
+  it("returnArtifacts denies surfaces not declared in validSurfaces", () => {
+    const host = mockHost();
+    const result = host.returnArtifacts(
+      { callerId: "caller-1", surface: "agents/calling-agent-direct", artifacts: ["x"] },
+      ["testing-external-agent-runs"],
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe("audit-bypass-attempt");
+  });
+
+  it("requestApproval approves a tool when the prompt returns approved", () => {
+    const host = mockHost({ onApprovalPrompt: () => "approved" });
+    const result = host.requestApproval({ callerId: "caller-1", toolName: "run_task", addonId: "addon.testing.external-agent-runtime" });
+    expect(result.ok).toBe(true);
+  });
+
+  it("requestApproval denies and audits when the prompt returns denied", () => {
+    const host = mockHost({ onApprovalPrompt: () => "denied" });
+    const result = host.requestApproval({ callerId: "caller-1", toolName: "run_task", addonId: "addon.testing.external-agent-runtime" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("approval-denied");
+    }
+    const entry = host.audit.latestFor("F7");
+    expect(entry).toBeDefined();
+  });
+
+  it("callArchiveIntakeWrite denies when the requested capability is not granted", () => {
+    const host = mockHost();
+    const result = host.callArchiveIntakeWrite({
+      callerId: "caller-1",
+      granted: ["providers", "filesystem"],
+      requested: "archive-intake-write",
+      itemRef: "x",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe("capability-denied");
+  });
+
+  it("invokeModel accepts the routing decision's model and rejects self-selected models", () => {
+    const host = mockHost();
+    const decision = host.issueRoutingDecision({
+      providerProfileId: "resonant-deepseek-v4-pro",
+      runtimeNodeId: "rn-local",
+      model: "deepseek-v4-pro",
+      authTier: "supported",
+      costPosture: "paid-api",
+      fallbackChain: [],
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      callerId: "caller-1",
+    });
+
+    const accepted = host.invokeModel({
+      callerId: "caller-1",
+      routingDecisionId: decision.routingDecisionId,
+      payload: { prompt: "hi" },
+    });
+    expect(accepted.ok).toBe(true);
+
+    const rejected = host.invokeModel({
+      callerId: "caller-1",
+      routingDecisionId: decision.routingDecisionId,
+      explicitModel: "gpt-4o",
+      payload: { prompt: "hi" },
+    });
+    expect(rejected.ok).toBe(false);
+    if (!rejected.ok) expect(rejected.code).toBe("provider-self-selection-rejected");
+  });
+});

--- a/packages/addon-sdk-testing/tsconfig.json
+++ b/packages/addon-sdk-testing/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": []
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/scripts/check-repo-hygiene.test.mjs
+++ b/scripts/check-repo-hygiene.test.mjs
@@ -257,6 +257,20 @@ test("classifyPath allows ordinary repository files", () => {
   assert.equal(classifyPath("docs/output-guide.md", fileStat()), null);
 });
 
+test("classifyContent rejects the F1 fixture value when reassembled as a committed literal", () => {
+  // Reassembles the addon-sdk-testing F1 credential fixture's runtime
+  // value from its harmless fragments. The assembled literal must still
+  // be rejected by the scanner if it were ever committed.
+  const f1LeakedToken = ["sk", "test", "1234567890abcdef"].join("-");
+  assert.equal(
+    classifyContent(
+      "packages/addon-sdk-testing/src/failure-modes/f1-credential-exfiltration.ts",
+      `OPENAI_API_KEY=${f1LeakedToken}\n`,
+    )?.rule,
+    "credential-openai",
+  );
+});
+
 test("classifyPath rejects generated, local-state, archive, and environment paths", () => {
   const rejectedPaths = [
     "output/report.json",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,6 +45,10 @@ export default defineConfig({
   },
   test: {
     environment: "node",
-    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    include: [
+      "src/**/*.test.ts",
+      "src/**/*.test.tsx",
+      "packages/addon-sdk-testing/test/**/*.test.ts",
+    ],
   },
 });


### PR DESCRIPTION
Third piece of the resubmission sequence, per your 2026-09-10 closeout: the **corrected #328** — the ADR-056 §7 F1–F10 negative-test harness with all three blockers fixed. Lands independently; companion to #441 (SDK relocation) and references the ADRs landing via #440.

## Contents

`packages/addon-sdk-testing/` — in-process mock host, routing-decision store, audit capture, manifest fixtures, and one runnable driver per failure mode F1–F10. Ported from the #328 branch with intent citations renumbered (ADR-040→ADR-056, ADR-038→ADR-055) to match the deferred ADRs. `MODULE_MAP.md` row added for doc reachability.

## Your three blockers, fixed

1. **F1 credential-shaped fixture** — the `sk-test-…` literal is gone. The token is assembled at runtime from individually harmless fragments (`syntheticLeakedBearerToken()`), with the scanner-safety property pinned two ways: new tests here (shape, runtime assembly, audit/report redaction) and a `check-repo-hygiene` test proving the *reassembled* literal is rejected if ever committed.
2. **Root `tsconfig.json`** — **untouched**: no `vitest/globals` removal, no `allowImportingTsExtensions` at root. The package carries its own `tsconfig.json` (verified: `tsc -p` passes). The only root config change is one *additive* vitest `include` line; the `DEV_SERVER_FS_DENY` policy from #429 is not touched.
3. **Driver/containment assertions** —
   - F1's driver no longer performs the revocation itself. The mock host revokes the caller's routing decisions in its deny path (recorded in the deny detail), and the driver asserts the *captured state* (`resolve` → `routing-decision-revoked`), failing as `revocation-not-observed` otherwise. Dedicated test included.
   - Workspace containment now normalizes `.`/`..` before the prefix check, so `<root>/../outside` is denied. F3 probes both an absolute escape and a traversal; test asserts both denials are recorded.

## Checks run (on this branch)

- `npx vitest run packages/addon-sdk-testing` — **43/43** · `npx tsc -p packages/addon-sdk-testing/tsconfig.json` — pass
- `npm test` — **530/530** (whole repo incl. the new package) · `npm run build` — pass
- `npm run docs:check` ✓ · `npm run test:docs` — 275/275 (incl. the new hygiene regression test) · `npm run test:module-ownership` ✓
- `npm run repo:hygiene` — pass (guard unmodified; no `*.rpkg` exemption, ever)
- `node scripts/security-pipeline/run-check.mjs` — exit 0 · `npm run verify:alpha` — **exit 0**

Branch gates verified before push: malicious workflow file absent at tip; branch contains the `40dd4c58` fix. Next per the closeout order: #329 (example, trimmed) once this one lands.