### PR TITLE
fix(drift): bound the stalled-run check to a seven-day window

### DIFF
--- a/scripts/default-branch-drift.mjs
+++ b/scripts/default-branch-drift.mjs
@@ -18,10 +18,15 @@ export function findUnknownWorkflows(paths, allowlist = WORKFLOW_ALLOWLIST) {
 
 // updated_at is GitHub's available approximation of time in the current status;
 // the REST run object does not expose the exact status-transition timestamp.
-export function findStalledRuns(runs, { now, thresholdMs }) {
-  return runs.filter((run) => run.conclusion === "action_required"
-    || (["queued", "waiting"].includes(run.status)
-      && now - Date.parse(run.updated_at ?? run.created_at) > thresholdMs));
+// maxAgeMs bounds the window: a run stuck for longer than that is treated as
+// historical noise, not live drift, so a single abandoned run cannot alert forever.
+export function findStalledRuns(runs, { now, thresholdMs, maxAgeMs }) {
+  return runs.filter((run) => {
+    const age = now - Date.parse(run.updated_at ?? run.created_at);
+    if (Number.isFinite(maxAgeMs) && !(age <= maxAgeMs)) return false;
+    return run.conclusion === "action_required"
+      || (["queued", "waiting"].includes(run.status) && age > thresholdMs);
+  });
 }
 
 export function checkBranchProtection(rules) {
@@ -149,13 +154,16 @@ export async function runDrift({ env = process.env, fetchImpl = globalThis.fetch
     (item) => typeof item.path === "string", { paginated: false });
   if (workflows) findings.unknownWorkflows = findUnknownWorkflows(workflows.map((item) => item.path));
 
+  // Same seven-day window as the commit check: bounds both the API query and the filter.
+  const STALLED_WINDOW_MS = 7 * 24 * HOUR_MS;
+  const createdFilter = encodeURIComponent(`>=${new Date(now - STALLED_WINDOW_MS).toISOString().slice(0, 10)}`);
   const stalled = new Map();
   for (const status of ["action_required", "queued", "waiting"]) {
-    const runs = await list(`/actions/runs?branch=dev&status=${status}`, `runs: ${status}`,
+    const runs = await list(`/actions/runs?branch=dev&status=${status}&created=${createdFilter}`, `runs: ${status}`,
       (item) => Number.isInteger(item.id) && typeof item.status === "string"
         && (item.conclusion === "action_required" || Number.isFinite(Date.parse(item.updated_at ?? item.created_at))),
       { runs: true });
-    if (runs) for (const run of findStalledRuns(runs, { now, thresholdMs: HOUR_MS })) stalled.set(run.id, run);
+    if (runs) for (const run of findStalledRuns(runs, { now, thresholdMs: HOUR_MS, maxAgeMs: STALLED_WINDOW_MS })) stalled.set(run.id, run);
   }
   findings.stalledRuns = [...stalled.values()];
 

--- a/scripts/default-branch-drift.test.mjs
+++ b/scripts/default-branch-drift.test.mjs
@@ -70,10 +70,23 @@ test("workflow paths use the shared allowlist and flag unknown filenames", () =>
   assert.deepEqual(findUnknownWorkflows(allowed), []);
 });
 
-test("action_required runs are flagged regardless of their age", () => {
+test("action_required runs are flagged regardless of their age when no window is given", () => {
   const blocked = { id: 1, status: "completed", conclusion: "action_required" };
   assert.deepEqual(findStalledRuns([blocked, { id: 2, status: "completed", conclusion: "success" }],
     { now, thresholdMs }), [blocked]);
+});
+
+test("a window drops action_required and queued runs older than maxAgeMs (no indefinite alerts)", () => {
+  const maxAgeMs = 7 * 24 * 60 * 60 * 1000;
+  const iso = (msAgo) => new Date(now - msAgo).toISOString();
+  const runs = [
+    { id: 1, status: "completed", conclusion: "action_required", updated_at: iso(2 * 60 * 60 * 1000) },      // 2h: flagged
+    { id: 2, status: "completed", conclusion: "action_required", updated_at: iso(30 * 24 * 60 * 60 * 1000) }, // 30d: dropped
+    { id: 3, status: "queued", updated_at: iso(3 * 60 * 60 * 1000) },                                          // 3h: flagged
+    { id: 4, status: "queued", updated_at: iso(8 * 24 * 60 * 60 * 1000) },                                     // 8d: dropped
+    { id: 5, status: "completed", conclusion: "action_required", created_at: iso(6 * 24 * 60 * 60 * 1000) }, // 6d via created_at: flagged
+  ];
+  assert.deepEqual(findStalledRuns(runs, { now, thresholdMs, maxAgeMs }).map((r) => r.id), [1, 3, 5]);
 });
 
 test("queued and waiting runs must exceed the injected age threshold", () => {


### PR DESCRIPTION
## Why
Incident report open item 12. `findStalledRuns` flagged every `action_required` run with no upper age bound and the runs query had no `created` filter, so a single run stuck awaiting approval would be reported on every scheduled drift check indefinitely (the attacker's 74 held runs would have surfaced for months). Noise like that teaches people to ignore the monitor.

## What
`scripts/default-branch-drift.mjs` (+ its test), nothing else:
- `findStalledRuns` gains `maxAgeMs`; runs older than it are treated as historical, not live drift.
- `runDrift` passes a seven-day window — the same one the unreviewed-commit check already uses — and adds `created=>=<date>` to the `/actions/runs` query so old runs are not fetched at all.

## Validation (actual)
| Command | Result |
| --- | --- |
| `node --test scripts/default-branch-drift.test.mjs` | 24 tests, 24 pass |
| same, with the `maxAgeMs` bound removed (mutation) | 23 pass, 1 fail — exactly the new test |
| restored | 24 pass |
| `npm run -s repo:hygiene` | exit 0 |
| `node --check scripts/default-branch-drift.mjs` | ok |

No workflow files, guard logic, or CI configuration touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)