### PR TITLE
feat(deepseek): dispatcher with loopback allowlist and validated addon id (redesigned #330)

### DIFF
--- a/browser-first/host/external-agent-runtime-dispatcher.mjs
+++ b/browser-first/host/external-agent-runtime-dispatcher.mjs
@@ -1,0 +1,368 @@
+// Intent citation: docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md#4-wire-format
+// Intent citation: docs/architecture/ADR-055-resonant-extension-framework.md
+//
+// External Agent Runtime Dispatcher
+//
+// The bridge-side dispatcher for external-agent-runtime addons
+// (ADR-056 §4). Given:
+//   - an addon manifest (loaded from `examples/addons/*.json` or
+//     `public/addons/*.json`),
+//   - a per-caller grant store (shape below; the bridge supplies this,
+//     typically from `bridge-grants-store.mjs`),
+//   - an audit ledger (shape below; the bridge supplies this,
+//     typically from `bridge-audit-ledger.mjs`),
+//   - a tool name declared in the manifest,
+//   - a payload (model + messages + explicit safe options),
+// this module:
+//   1. Looks up the addon by id (with a strict id validator).
+//   2. Validates the caller holds the per-caller grant for every
+//      capability the tool requires (`requiredCapabilities`),
+//      honoring grant expiry.
+//   3. Resolves the manifest's `service.entrypoint` and asserts the
+//      URL points at a loopback address before posting to
+//      `${entrypoint}/api/v1/chat/completions` (the DeepSeek
+//      OpenAI-compatible interface).
+//   4. Records the dispatch + outcome in the audit ledger, with the
+//      request body recursively redacted of credentials before it
+//      ever leaves this module.
+//   5. Returns the result to the bridge caller.
+//
+// This module is a LIBRARY. It does not register a route itself; the
+// bridge consumes it via `addon-delegation-host-service.mjs` (or any
+// future route owner). Test file:
+//   browser-first/test/external-agent-runtime-dispatcher.test.mjs
+
+import { readFile } from "node:fs/promises";
+import { resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+
+const moduleDir = dirname(fileURLToPath(import.meta.url));
+// browser-first/host/external-agent-runtime-dispatcher.mjs -> repo root is
+// three levels up. Manifests are looked up first in `examples/addons/` then
+// `public/addons/`.
+export const DEFAULT_REPO_ROOT = resolvePath(moduleDir, "..", "..", "..");
+
+// Strict addon id pattern: dot-separated lowercase segments, each 1-64
+// characters of `[a-z0-9-]`, leading char of each segment is alphanumeric.
+// Examples: `addon.deepseek-harness`, `addon.recursive-mas`.
+const ADDON_ID_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}(?:\.[a-z0-9][a-z0-9-]{0,63})*$/;
+
+// Hosts the dispatcher will POST to. Only loopback: prevents a malicious
+// manifest from turning the dispatcher into an arbitrary SSRF proxy.
+// IPv6 appears with brackets when parsed by WHATWG URL (the host portion
+// of `http://[::1]:3080` is the literal string "[::1]"); we accept both
+// spellings so callers can use either.
+export const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "[::1]", "localhost"]);
+
+// Field names treated as credential-shaped at any depth during audit
+// redaction. Match is case-insensitive, substring against the lowercased
+// key. Applied at LEAF level only — an object value (e.g. `credentials`
+// holding the actual `{ authorization: "..." }`) is walked into so the
+// inner value is the thing replaced, not the whole object.
+const REDACTED_KEY_SUBSTRINGS = ["api-key", "api_key", "apikey", "token", "secret", "password"];
+
+// The only `options` keys the dispatcher will forward to the upstream.
+// Any other key in `options` is dropped silently. This closes the hole
+// where a caller could use `options.model` / `options.messages` to
+// override the explicit `model` / `messages` arguments.
+const SAFE_OPTION_KEYS = new Set(["temperature", "top_p", "max_tokens", "stream", "stop"]);
+
+/**
+ * Validate an addon id. Returns the validity verdict; rejection carries
+ * a `reason` so the dispatcher can map it to a deny reason without
+ * throwing.
+ */
+export function validateAddonId(addonId) {
+  if (typeof addonId !== "string" || addonId.length === 0) {
+    return { ok: false, reason: "addon-id-empty" };
+  }
+  if (addonId.length > 64) {
+    return { ok: false, reason: "addon-id-too-long" };
+  }
+  if (!ADDON_ID_PATTERN.test(addonId)) {
+    return { ok: false, reason: "addon-id-malformed" };
+  }
+  return { ok: true };
+}
+
+/**
+ * Find an addon manifest by id. Searches `examples/addons/*.json` then
+ * `public/addons/*.json`. Returns `{ ok: true, manifest, path }` or
+ * `{ ok: false, reason, detail }` so the caller can deny without ever
+ * letting a traversal character reach the filesystem.
+ */
+export async function findAddonManifest(addonId, { repoRoot = DEFAULT_REPO_ROOT } = {}) {
+  const idCheck = validateAddonId(addonId);
+  if (!idCheck.ok) {
+    return { ok: false, reason: "addon-id-invalid", detail: `addonId ${JSON.stringify(addonId)} rejected: ${idCheck.reason}` };
+  }
+  const candidates = [
+    resolvePath(repoRoot, "examples", "addons"),
+    resolvePath(repoRoot, "public", "addons"),
+  ];
+  for (const dir of candidates) {
+    const path = resolvePath(dir, `${addonId}.json`);
+    try {
+      const raw = await readFile(path, "utf8");
+      return { ok: true, manifest: JSON.parse(raw), path };
+    } catch (err) {
+      if (err && err.code === "ENOENT") continue;
+      throw err;
+    }
+  }
+  return { ok: false, reason: "addon-not-found", detail: `addon manifest ${addonId}.json not found` };
+}
+
+/**
+ * Look up a tool by name on a manifest. Returns the tool descriptor or
+ * null. Caller decides what to do with `null`.
+ */
+export function findTool(manifest, toolName) {
+  return (manifest?.tools ?? []).find((t) => t.name === toolName) ?? null;
+}
+
+/**
+ * Decide whether the caller's per-caller grants cover every capability
+ * the tool requires AND every covering grant is still in force (not
+ * expired). Pure: returns `{ ok, missing }` where `missing` is the list
+ * of uncovered capabilities.
+ *
+ * `perCallerGrants` is a bridge-supplied accessor with the shape:
+ *   { get(callerId): { capabilities: Map<string, true>, expiresAt?: Map<string, number | null> } | undefined }
+ * The dispatcher never invents expiry data; if `expiresAt` is absent,
+ * every covering grant is treated as non-expiring (the bridge is the
+ * source of truth for grant TTL).
+ */
+export function checkToolGrants({ tool, perCallerGrants, callerId, now = () => Date.now() }) {
+  const required = tool?.requiredCapabilities ?? [];
+  const missing = [];
+  if (required.length === 0) return { ok: true, missing };
+  const bucket = perCallerGrants?.get ? perCallerGrants.get(callerId) : undefined;
+  const caps = bucket?.capabilities;
+  const expiresAt = bucket?.expiresAt;
+  for (const capability of required) {
+    let granted = false;
+    if (caps && typeof caps.get === "function") {
+      granted = Boolean(caps.get(capability));
+      if (granted && expiresAt && typeof expiresAt.get === "function") {
+        const expiry = expiresAt.get(capability);
+        if (typeof expiry === "number" && expiry <= now()) {
+          granted = false;
+        }
+      }
+    }
+    if (!granted) missing.push(capability);
+  }
+  return { ok: missing.length === 0, missing };
+}
+
+/**
+ * Wire-protocol: convert a delegation request payload into a Cordis
+ * /api/v1/chat/completions POST body. Cordis exposes the DeepSeek
+ * OpenAI-compatible interface at `${entrypoint}/api/v1/chat/completions`.
+ *
+ * Only explicit fields are forwarded: `model`, `messages`, and a safe
+ * allowlist of `options`. The caller CANNOT override `model` or
+ * `messages` via the `options` argument — those keys are stripped from
+ * `options` before it is merged, so a caller passing `{ options: { model:
+ * "evil" } }` is ignored.
+ */
+export function buildChatCompletionsRequest({ model, messages, options } = {}) {
+  const safeOptions = {};
+  if (options && typeof options === "object" && !Array.isArray(options)) {
+    for (const key of SAFE_OPTION_KEYS) {
+      if (Object.prototype.hasOwnProperty.call(options, key)) {
+        safeOptions[key] = options[key];
+      }
+    }
+  }
+  return {
+    model: typeof model === "string" && model.length > 0 ? model : "deepseek-chat",
+    messages: Array.isArray(messages) ? messages : [],
+    ...safeOptions,
+  };
+}
+
+/**
+ * Assert that an entrypoint URL is loopback-only. The dispatcher will
+ * never POST to a non-loopback host — that closes the SSRF path where
+ * a malicious manifest could point `service.entrypoint` at an external
+ * host and have the bridge do the egress on its behalf.
+ *
+ * Returns `{ ok: true, url }` or `{ ok: false, reason, detail }`.
+ */
+export function assertLoopbackEntrypoint(entrypoint) {
+  if (typeof entrypoint !== "string" || entrypoint.length === 0) {
+    return { ok: false, reason: "entrypoint-invalid", detail: "service.entrypoint is not a non-empty string" };
+  }
+  let url;
+  try {
+    url = new URL(entrypoint);
+  } catch {
+    return { ok: false, reason: "entrypoint-invalid", detail: `service.entrypoint is not a valid URL: ${entrypoint}` };
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return { ok: false, reason: "entrypoint-not-allowed", detail: `protocol ${url.protocol} is not allowed (http/https only)` };
+  }
+  if (!LOOPBACK_HOSTS.has(url.hostname)) {
+    return { ok: false, reason: "entrypoint-not-allowed", detail: `host ${url.hostname} is not loopback; only 127.0.0.1, ::1, [::1], localhost are allowed` };
+  }
+  if (url.port === "0") {
+    return { ok: false, reason: "entrypoint-not-allowed", detail: "port 0 is not allowed (would resolve to a kernel-chosen port)" };
+  }
+  return { ok: true, url };
+}
+
+/**
+ * Recursive redact of credential-shaped values from an object. Walks
+ * plain objects and arrays, returning a deep clone with every matching
+ * LEAF value replaced by the literal `[REDACTED]`. A credential-shaped
+ * key whose value is itself an object is recursed into, so a structure
+ * like `{ credentials: { authorization: "..." } }` redacts the inner
+ * authorization rather than collapsing the whole credentials object.
+ */
+export function redactRequestForLog(value, depth = 0) {
+  if (depth > 8) return "[REDACTED:depth-limit]";
+  if (value === null || value === undefined) return value;
+  if (Array.isArray(value)) {
+    return value.map((v) => redactRequestForLog(v, depth + 1));
+  }
+  if (typeof value === "object") {
+    if (Object.getPrototypeOf(value) !== Object.prototype) return value;
+    const out = {};
+    for (const key of Object.keys(value)) {
+      const lower = key.toLowerCase();
+      const child = value[key];
+      const isAuth = lower === "authorization";
+      const childIsLeaf = child === null || typeof child !== "object";
+      const isCredentialLeaf = childIsLeaf && REDACTED_KEY_SUBSTRINGS.some((needle) => lower.includes(needle));
+      if (isAuth || isCredentialLeaf) {
+        out[key] = "[REDACTED]";
+      } else {
+        out[key] = redactRequestForLog(child, depth + 1);
+      }
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Effectful: POST to the Cordis endpoint. Returns `{ ok, status, body,
+ * error }` where `body` is the parsed JSON response (or null on
+ * network error) and `error` is set only on transport failure.
+ *
+ * The loopback assertion runs first; a non-loopback entrypoint is
+ * short-circuited to `{ ok: false, status: 0, body: null, reason:
+ * "entrypoint-not-allowed" }` without any network call.
+ *
+ * `fetch` is used directly (Node 18+). Caller passes an `AbortSignal`
+ * if they want timeout.
+ */
+export async function postToCordis({ entrypoint, request, signal, fetchImpl = globalThis.fetch }) {
+  const loopback = assertLoopbackEntrypoint(entrypoint);
+  if (!loopback.ok) {
+    return { ok: false, status: 0, body: null, reason: loopback.reason, detail: loopback.detail };
+  }
+  const url = `${loopback.url.href.replace(/\/$/, "")}/api/v1/chat/completions`;
+  const init = {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(request),
+  };
+  if (signal) init.signal = signal;
+  try {
+    const response = await fetchImpl(url, init);
+    let body = null;
+    try {
+      body = await response.json();
+    } catch {
+      body = null;
+    }
+    return { ok: response.ok, status: response.status, body };
+  } catch (error) {
+    return { ok: false, status: 0, body: null, error: String(error) };
+  }
+}
+
+/**
+ * The single callable entry point for the bridge. Returns one of:
+ *   - `{ outcome: "allow", response: <upstream body> }`
+ *   - `{ outcome: "deny", reason: <deny code>, detail: <string> }`
+ *
+ * Caller MUST pass `auditLedger.record(...)`. If omitted, audit is
+ * silently skipped — but in production callers always wire it.
+ *
+ * `repoRoot` (optional) overrides the manifest search root. Useful for
+ * tests; production callers leave it unset.
+ */
+export async function dispatchExternalAgentRuntime({
+  addonId,
+  toolName,
+  payload,
+  callerId,
+  perCallerGrants,
+  auditLedger,
+  fetchImpl,
+  repoRoot,
+}) {
+  const lookup = await findAddonManifest(addonId, { repoRoot });
+  if (!lookup.ok) {
+    return { outcome: "deny", reason: lookup.reason, detail: lookup.detail };
+  }
+  const manifest = lookup.manifest;
+  const tool = findTool(manifest, toolName);
+  if (!tool) {
+    return {
+      outcome: "deny",
+      reason: "unknown-tool",
+      detail: `tool ${toolName} not declared in addon ${addonId}`,
+    };
+  }
+  const grant = checkToolGrants({ tool, perCallerGrants, callerId });
+  if (!grant.ok) {
+    return {
+      outcome: "deny",
+      reason: "capability-denied",
+      detail: `caller ${callerId} missing per-caller grants for: ${grant.missing.join(", ")}`,
+    };
+  }
+  const entrypoint = manifest.service?.entrypoint;
+  const entrypointCheck = assertLoopbackEntrypoint(entrypoint);
+  if (!entrypointCheck.ok) {
+    return {
+      outcome: "deny",
+      reason: entrypointCheck.reason,
+      detail: `addon ${addonId}: ${entrypointCheck.detail}`,
+    };
+  }
+  const request = buildChatCompletionsRequest(payload ?? {});
+  const response = await postToCordis({ entrypoint, request, fetchImpl });
+  const redactedRequest = redactRequestForLog(request);
+  if (auditLedger?.record) {
+    auditLedger.record({
+      callerId,
+      addonId,
+      tool: toolName,
+      entrypoint,
+      request: redactedRequest,
+      upstreamStatus: response.status,
+      upstreamOk: response.ok,
+      denyReason: response.ok ? null : response.status === 0 ? "upstream-unreachable" : "upstream-error",
+    });
+  }
+  if (!response.ok) {
+    return {
+      outcome: "deny",
+      reason: response.status === 0 ? "upstream-unreachable" : "upstream-error",
+      detail: response.error ?? `upstream status ${response.status}`,
+      upstreamStatus: response.status,
+      upstreamBody: response.body,
+    };
+  }
+  return { outcome: "allow", response: response.body };
+}

--- a/browser-first/host/external-agent-runtime-dispatcher.mjs
+++ b/browser-first/host/external-agent-runtime-dispatcher.mjs
@@ -36,6 +36,8 @@ import { readFile } from "node:fs/promises";
 import { resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 import { dirname } from "node:path";
+import { lookup as dnsLookup } from "node:dns/promises";
+import undici from "undici";
 
 const moduleDir = dirname(fileURLToPath(import.meta.url));
 // browser-first/host/external-agent-runtime-dispatcher.mjs -> repo root is
@@ -55,6 +57,61 @@ const ADDON_ID_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}(?:\.[a-z0-9][a-z0-9-]{0,63})*
 // of `http://[::1]:3080` is the literal string "[::1]"); we accept both
 // spellings so callers can use either.
 export const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "[::1]", "localhost"]);
+
+/**
+ * Build an undici `Agent` whose outbound sockets bind to a loopback
+ * address. The dispatcher uses this for every fetch it issues; a caller
+ * that supplies a custom `fetchImpl` is responsible for its own bind.
+ *
+ * The bind itself is defense-in-depth, not the only loopback guarantee:
+ * the hostname check (`LOOPBACK_HOSTS`) and the DNS resolution check
+ * (`assertHostnameLoopback`) are the primary guards. The bind adds a
+ * socket-level anchor on 127.0.0.1 so the kernel cannot pick an
+ * external interface for the outbound connection.
+ *
+ * `fetch` is exposed as a property of the returned object for direct
+ * use as `fetchImpl` in `postToCordis`.
+ */
+let _sharedLoopbackDispatcher = null;
+
+/**
+ * Get (or lazily create) a process-wide undici dispatcher bound to
+ * 127.0.0.1. The dispatcher is shared across every `postToCordis` call
+ * so we don't accumulate connection pools; close it on process exit.
+ */
+export function getSharedLoopbackDispatcher({ localAddress = "127.0.0.1", family = 4 } = {}) {
+  if (_sharedLoopbackDispatcher === null) {
+    _sharedLoopbackDispatcher = new undici.Agent({
+      connect: { localAddress, family },
+      bodyTimeout: 30_000,
+      headersTimeout: 30_000,
+      pipelining: 1,
+    });
+  }
+  return _sharedLoopbackDispatcher;
+}
+
+/**
+ * Build an undici `Agent` whose outbound sockets bind to a loopback
+ * address. The dispatcher uses this for every fetch it issues; a caller
+ * that supplies a custom `fetchImpl` is responsible for its own bind.
+ *
+ * The bind itself is defense-in-depth, not the only loopback guarantee:
+ * the hostname check (`LOOPBACK_HOSTS`) and the DNS resolution check
+ * (`assertHostnameLoopback`) are the primary guards. The bind adds a
+ * socket-level anchor on 127.0.0.1 so the kernel cannot pick an
+ * external interface for the outbound connection.
+ *
+ * `fetch` is exposed as a property of the returned object for direct
+ * use as `fetchImpl` in `postToCordis`.
+ */
+export function createLoopbackBoundFetch({ localAddress = "127.0.0.1", family = 4 } = {}) {
+  return {
+    dispatcher: getSharedLoopbackDispatcher({ localAddress, family }),
+    fetch: undici.fetch,
+    localAddress,
+  };
+}
 
 // Field names treated as credential-shaped at any depth during audit
 // redaction. Match is case-insensitive, substring against the lowercased
@@ -209,6 +266,71 @@ export function buildChatCompletionsRequest({ model, messages, options } = {}) {
  *
  * Returns `{ ok: true, url }` or `{ ok: false, reason, detail }`.
  */
+/**
+ * Test whether an IP literal is in a loopback range. IPv4: 127.0.0.0/8
+ * (RFC 1123). IPv6: ::1/128 (RFC 4291). Anything else (private RFC 1918,
+ * link-local, public) is rejected.
+ */
+export function isLoopbackAddress(ip) {
+  if (typeof ip !== "string") return false;
+  if (ip === "127.0.0.1" || ip === "::1") return true;
+  if (ip.startsWith("127.")) {
+    // 127.0.0.0/8 — any 127.x.y.z is loopback.
+    const octets = ip.split(".");
+    if (octets.length !== 4) return false;
+    return octets.every((o) => /^(0|[0-9]{1,3})$/.test(o) && Number(o) >= 0 && Number(o) <= 255);
+  }
+  return false;
+}
+
+/**
+ * Resolve a hostname to its addresses. If every returned address is a
+ * loopback literal, the name is safe to use. Otherwise the host is
+ * treated as non-loopback.
+ */
+async function assertHostnameLoopback(hostname) {
+  // IP literals (no DNS needed): IPv4 and bracketed/bracketless IPv6.
+  const bracketed = hostname.startsWith("[") && hostname.endsWith("]");
+  const candidate = bracketed ? hostname.slice(1, -1) : hostname;
+  if (isLoopbackAddress(candidate)) return { ok: true };
+  // Anything that LOOKS like an IP literal but isn't loopback is rejected
+  // without a DNS lookup. Avoids the resolver's tendency to be permissive
+  // about malformed inputs.
+  const looksLikeIpv4 = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(candidate);
+  const looksLikeIpv6 = candidate.includes(":");
+  if (looksLikeIpv4 || looksLikeIpv6) {
+    return { ok: false, reason: "entrypoint-not-allowed", detail: `host ${hostname} is not a loopback address` };
+  }
+  // Hostname: resolve and verify every returned address is loopback.
+  let addresses;
+  try {
+    const result = await dnsLookup(hostname, { all: true });
+    addresses = result.map((r) => r.address);
+  } catch (err) {
+    return { ok: false, reason: "entrypoint-not-allowed", detail: `DNS lookup of ${hostname} failed: ${String(err && err.message || err)}` };
+  }
+  if (addresses.length === 0) {
+    return { ok: false, reason: "entrypoint-not-allowed", detail: `DNS lookup of ${hostname} returned no addresses` };
+  }
+  for (const addr of addresses) {
+    if (!isLoopbackAddress(addr)) {
+      return { ok: false, reason: "entrypoint-not-allowed", detail: `host ${hostname} resolves to ${addr}, which is not a loopback address` };
+    }
+  }
+  return { ok: true };
+}
+
+/**
+ * Assert that an entrypoint URL is loopback-only. The dispatcher will
+ * never POST to a non-loopback host — that closes the SSRF path where
+ * a malicious manifest could point `service.entrypoint` at an external
+ * host and have the bridge do the egress on its behalf.
+ *
+ * Returns `{ ok: true, url }` synchronously, OR `{ ok: false, reason,
+ * detail }` for static failures. To also enforce loopback DNS for
+ * non-IP hostnames (`localhost`, custom names), call the async
+ * `assertLoopbackEntrypointResolved` below.
+ */
 export function assertLoopbackEntrypoint(entrypoint) {
   if (typeof entrypoint !== "string" || entrypoint.length === 0) {
     return { ok: false, reason: "entrypoint-invalid", detail: "service.entrypoint is not a non-empty string" };
@@ -239,6 +361,42 @@ export function assertLoopbackEntrypoint(entrypoint) {
   // the path in the query string.
   if (url.search !== "" || url.hash !== "") {
     return { ok: false, reason: "entrypoint-not-allowed", detail: "query string and fragment are not allowed in service.entrypoint (dispatcher appends a fixed path)" };
+  }
+  return { ok: true, url };
+}
+
+/**
+ * Async loopback assertion. Same as `assertLoopbackEntrypoint` plus a
+ * DNS-resolution check: if the hostname is a name (not an IP literal),
+ * every resolved address MUST be in 127.0.0.0/8 or ::1/128. This closes
+ * the gap where `/etc/hosts` or a malicious DNS resolver could redirect
+ * `localhost` to an external IP.
+ *
+ * `expectedPort`: when provided, the URL's port MUST equal this value
+ * (the manifest-declared port). Any other port — even a loopback one —
+ * is rejected: the bridge, the OpenCode server, the Hermes dashboard
+ * and any other local service must not be reachable through a
+ * different addon's entrypoint.
+ */
+export async function assertLoopbackEntrypointResolved(entrypoint, { expectedPort } = {}) {
+  const staticCheck = assertLoopbackEntrypoint(entrypoint);
+  if (!staticCheck.ok) return staticCheck;
+  const { url } = staticCheck;
+  // Strip IPv6 brackets if present (hostname has them for the URL; we
+  // want the bare literal for the IP classifier).
+  const hostname = url.hostname.startsWith("[") && url.hostname.endsWith("]")
+    ? url.hostname.slice(1, -1)
+    : url.hostname;
+  const dnsCheck = await assertHostnameLoopback(hostname);
+  if (!dnsCheck.ok) return dnsCheck;
+  if (expectedPort !== undefined && expectedPort !== null) {
+    if (url.port !== String(expectedPort)) {
+      return {
+        ok: false,
+        reason: "port-mismatch",
+        detail: `entrypoint port ${url.port || "(default)"} does not match the manifest-declared port ${expectedPort}`,
+      };
+    }
   }
   return { ok: true, url };
 }
@@ -294,8 +452,82 @@ export function redactRequestForLog(value, depth = 0) {
  * `fetch` is used directly (Node 18+). Caller passes an `AbortSignal`
  * if they want timeout.
  */
-export async function postToCordis({ entrypoint, request, signal, fetchImpl = globalThis.fetch }) {
-  const loopback = assertLoopbackEntrypoint(entrypoint);
+/**
+ * Drain an SSE response body. Parses each `event:` / `data:` block as a
+ * single SSE event. The stream is fully consumed on every path; if the
+ * caller stops reading, the underlying reader is cancelled so the
+ * socket is released and the upstream connection is closed.
+ *
+ * `textDecoder` is exposed for tests; production callers leave it unset.
+ */
+export async function consumeSseStream(response, { maxBytes = 8 * 1024 * 1024, textDecoder = new TextDecoder("utf-8") } = {}) {
+  if (!response || !response.body) {
+    return { events: [], raw: "", truncated: false, closed: true };
+  }
+  const reader = response.body.getReader();
+  const events = [];
+  let raw = "";
+  let buffer = "";
+  let truncated = false;
+  let currentEvent = null;
+  let currentData = [];
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      const chunk = textDecoder.decode(value, { stream: true });
+      raw += chunk;
+      if (raw.length > maxBytes) {
+        truncated = true;
+        break;
+      }
+      buffer += chunk;
+      // SSE messages are separated by a blank line (`\n\n`). Split on
+      // either \r\n\r\n or \n\n; the buffer is split line-by-line
+      // and re-buffered when a message isn't complete yet.
+      let boundary = buffer.indexOf("\n\n");
+      while (boundary !== -1) {
+        const block = buffer.slice(0, boundary);
+        buffer = buffer.slice(boundary + 2);
+        // A single block can contain multiple lines (event:, data:, id:, retry:).
+        let eventName;
+        const dataLines = [];
+        for (const line of block.split("\n")) {
+          if (line.startsWith("event:")) eventName = line.slice(6).trim();
+          else if (line.startsWith("data:")) dataLines.push(line.slice(5).trimStart());
+          // ignore other fields (id:, retry:, comments starting with `:`)
+        }
+        if (eventName !== undefined || dataLines.length > 0) {
+          events.push({ event: eventName, data: dataLines.join("\n"), raw: block });
+        }
+        boundary = buffer.indexOf("\n\n");
+      }
+    }
+  } finally {
+    // Always cancel the reader so the upstream socket is closed. Even on
+    // a normal end-of-stream we issue cancel() to release the connection
+    // back to the pool — fetch() does not release a streaming body until
+    // the reader is explicitly closed or the response is fully drained.
+    try { await reader.cancel(); } catch { /* already closed */ }
+  }
+  return { events, raw, truncated, closed: true };
+}
+
+export async function postToCordis({
+  entrypoint,
+  request,
+  signal,
+  fetchImpl,
+  declaredPort,
+  consumeSse = consumeSseStream,
+  loopbackBind = true,
+}) {
+  // Static + DNS loopback assertion. The static check rejects malformed
+  // URLs, non-loopback hosts, port 0, userinfo, query and fragment. The
+  // DNS check rejects name-based hosts that resolve to a non-loopback
+  // address. `declaredPort` is the manifest-declared port; when supplied
+  // the entrypoint's port must match it exactly.
+  const loopback = await assertLoopbackEntrypointResolved(entrypoint, { expectedPort: declaredPort });
   if (!loopback.ok) {
     return { ok: false, status: 0, body: null, reason: loopback.reason, detail: loopback.detail };
   }
@@ -307,7 +539,7 @@ export async function postToCordis({ entrypoint, request, signal, fetchImpl = gl
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Accept: "application/json",
+      Accept: request?.stream === true ? "text/event-stream" : "application/json",
     },
     body: JSON.stringify(request),
     // A loopback service answering 3xx must not be allowed to redirect
@@ -316,18 +548,70 @@ export async function postToCordis({ entrypoint, request, signal, fetchImpl = gl
     redirect: "error",
   };
   if (signal) init.signal = signal;
-  try {
-    const response = await fetchImpl(url, init);
-    let body = null;
-    try {
-      body = await response.json();
-    } catch {
-      body = null;
+  // Build the outbound fetch. When `loopbackBind` is true (default), the
+  // dispatcher uses an undici Agent whose sockets bind to 127.0.0.1 —
+  // the loopback interface — so the kernel cannot pick an external
+  // interface for the outbound connection. A caller can opt out by
+  // passing `loopbackBind: false`, or supply a custom `fetchImpl` (in
+  // which case the caller is responsible for its own bind).
+  let activeFetch = fetchImpl;
+  let dispatcherToClose = null;
+  if (activeFetch === undefined) {
+    if (loopbackBind) {
+      // Reuse a module-level dispatcher so we don't spawn a new
+      // undici Agent (and its keep-alive connection pool) on every
+      // call. The dispatcher is closed when the process exits; for
+      // tests, callers can pass `loopbackBind: false` or supply a
+      // custom `fetchImpl` to avoid sharing state.
+      dispatcherToClose = getSharedLoopbackDispatcher();
+      activeFetch = (u, i) => undici.fetch(u, { ...i, dispatcher: dispatcherToClose });
+    } else {
+      activeFetch = globalThis.fetch;
     }
-    return { ok: response.ok, status: response.status, body };
+  }
+  let response;
+  try {
+    response = await activeFetch(url, init);
   } catch (error) {
     return { ok: false, status: 0, body: null, error: String(error) };
   }
+  const isSse = request?.stream === true
+    || (typeof response.headers?.get === "function"
+        && (response.headers.get("content-type") ?? "").toLowerCase().includes("text/event-stream"));
+  if (isSse) {
+    // Drain the SSE stream fully. `consumeSseStream` cancels the reader
+    // in a `finally` block so the socket is closed on every path — normal
+    // end, truncation, or upstream error. We never call `response.json()`
+    // on a streaming response: doing so would return `{ outcome: "allow",
+    // response: null }` (the body is not JSON-serialised while streaming)
+    // and leave the socket open.
+    try {
+      const sse = await consumeSse(response);
+      return {
+        ok: response.ok,
+        status: response.status,
+        body: null,
+        stream: true,
+        events: sse.events,
+        sseRaw: sse.raw,
+        sseTruncated: sse.truncated,
+        sseClosed: sse.closed,
+      };
+    } catch (error) {
+      // Even on parse failure, the stream was drained (see consumeSseStream's
+      // finally block). Return a deny-shaped result so the bridge can record
+      // the upstream as errored.
+      return { ok: false, status: response.status, body: null, stream: true, events: [], sseClosed: true, error: String(error) };
+    }
+  }
+  // Non-streaming: JSON response, body read once.
+  let body = null;
+  try {
+    body = await response.json();
+  } catch {
+    body = null;
+  }
+  return { ok: response.ok, status: response.status, body };
 }
 
 /**
@@ -379,16 +663,28 @@ export async function dispatchExternalAgentRuntime({
     };
   }
   const entrypoint = manifest.service?.entrypoint;
-  const entrypointCheck = assertLoopbackEntrypoint(entrypoint);
-  if (!entrypointCheck.ok) {
-    return {
-      outcome: "deny",
-      reason: entrypointCheck.reason,
-      detail: `addon ${addonId}: ${entrypointCheck.detail}`,
-    };
+  // Extract the manifest-declared port so the dispatcher can refuse any
+  // entrypoint that targets a different loopback port. The bridge, the
+  // OpenCode server, the Hermes dashboard and any other local service
+  // must not be reachable through a different addon's entrypoint.
+  let declaredPort;
+  if (typeof entrypoint === "string" && entrypoint.length > 0) {
+    try {
+      const tmp = new URL(entrypoint);
+      declaredPort = tmp.port || (tmp.protocol === "https:" ? "443" : "80");
+    } catch { /* invalid entrypoint — postToCordis will reject it */ }
   }
   const request = buildChatCompletionsRequest(payload ?? {});
-  const response = await postToCordis({ entrypoint, request, fetchImpl });
+  const response = await postToCordis({ entrypoint, request, fetchImpl, declaredPort });
+  // Surface entrypoint-level deny reasons (loopback assertion, port
+  // mismatch, DNS check) WITHOUT writing to the audit ledger: the
+  // dispatcher never made an upstream call, so there is nothing to
+  // audit. The caller still receives a structured deny with the
+  // specific reason (entrypoint-invalid, entrypoint-not-allowed,
+  // port-mismatch).
+  if (response.reason && response.status === 0) {
+    return { outcome: "deny", reason: response.reason, detail: response.detail };
+  }
   const redactedRequest = redactRequestForLog(request);
   if (auditLedger?.record) {
     auditLedger.record({

--- a/browser-first/host/external-agent-runtime-dispatcher.mjs
+++ b/browser-first/host/external-agent-runtime-dispatcher.mjs
@@ -39,9 +39,10 @@ import { dirname } from "node:path";
 
 const moduleDir = dirname(fileURLToPath(import.meta.url));
 // browser-first/host/external-agent-runtime-dispatcher.mjs -> repo root is
-// three levels up. Manifests are looked up first in `examples/addons/` then
+// two levels up (`browser-first/host` -> `browser-first` -> repo root).
+// Manifests are looked up first in `examples/addons/` then
 // `public/addons/`.
-export const DEFAULT_REPO_ROOT = resolvePath(moduleDir, "..", "..", "..");
+export const DEFAULT_REPO_ROOT = resolvePath(moduleDir, "..", "..");
 
 // Strict addon id pattern: dot-separated lowercase segments, each 1-64
 // characters of `[a-z0-9-]`, leading char of each segment is alphanumeric.
@@ -134,10 +135,25 @@ export function findTool(manifest, toolName) {
  * every covering grant is treated as non-expiring (the bridge is the
  * source of truth for grant TTL).
  */
-export function checkToolGrants({ tool, perCallerGrants, callerId, now = () => Date.now() }) {
+export function checkToolGrants({ tool, perCallerGrants, callerId, now = () => Date.now(), approval } = {}) {
   const required = tool?.requiredCapabilities ?? [];
+  // Fail closed when the tool does not declare its required capabilities.
+  // The original `if (required.length === 0) return ok:true` short-circuit
+  // let any caller dispatch a tool that has no policy authority attached.
+  // The bridge is the source of truth for capability grants; a manifest
+  // that omits `requiredCapabilities` cannot be safely invoked.
+  if (!Array.isArray(required) || required.length === 0) {
+    return { ok: false, missing: [], reason: "capability-undetermined" };
+  }
+  // Enforce human-approval gate when the tool declares
+  // `requiresHumanApproval: true`. The caller must present a non-empty
+  // `approval` token supplied by the host's approval surface.
+  if (tool.requiresHumanApproval === true) {
+    if (typeof approval !== "string" || approval.length === 0) {
+      return { ok: false, missing: [], reason: "approval-required" };
+    }
+  }
   const missing = [];
-  if (required.length === 0) return { ok: true, missing };
   const bucket = perCallerGrants?.get ? perCallerGrants.get(callerId) : undefined;
   const caps = bucket?.capabilities;
   const expiresAt = bucket?.expiresAt;
@@ -154,7 +170,8 @@ export function checkToolGrants({ tool, perCallerGrants, callerId, now = () => D
     }
     if (!granted) missing.push(capability);
   }
-  return { ok: missing.length === 0, missing };
+  if (missing.length > 0) return { ok: false, missing, reason: "capability-denied" };
+  return { ok: true, missing: [] };
 }
 
 /**
@@ -211,6 +228,18 @@ export function assertLoopbackEntrypoint(entrypoint) {
   if (url.port === "0") {
     return { ok: false, reason: "entrypoint-not-allowed", detail: "port 0 is not allowed (would resolve to a kernel-chosen port)" };
   }
+  // Reject userinfo (`http://u:p@host`) — the raw entrypoint could otherwise
+  // smuggle credentials into the URL handed to fetch, and the audit ledger
+  // would record them in the `entrypoint` field.
+  if (url.username !== "" || url.password !== "") {
+    return { ok: false, reason: "entrypoint-not-allowed", detail: "userinfo (user:password@host) is not allowed in service.entrypoint" };
+  }
+  // Reject query and fragment: the dispatcher appends `/api/v1/chat/completions`
+  // to the URL, and an entrypoint like `http://host?x=y` would otherwise put
+  // the path in the query string.
+  if (url.search !== "" || url.hash !== "") {
+    return { ok: false, reason: "entrypoint-not-allowed", detail: "query string and fragment are not allowed in service.entrypoint (dispatcher appends a fixed path)" };
+  }
   return { ok: true, url };
 }
 
@@ -229,8 +258,13 @@ export function redactRequestForLog(value, depth = 0) {
     return value.map((v) => redactRequestForLog(v, depth + 1));
   }
   if (typeof value === "object") {
-    if (Object.getPrototypeOf(value) !== Object.prototype) return value;
-    const out = {};
+    // Walk into plain objects AND null-prototype objects (e.g.
+    // `Object.create(null)`). The previous check returned any non-Object-
+    // prototype value untouched, which left null-prototype credential
+    // carriers unredacted.
+    const proto = Object.getPrototypeOf(value);
+    if (proto !== Object.prototype && proto !== null) return value;
+    const out = proto === null ? Object.create(null) : {};
     for (const key of Object.keys(value)) {
       const lower = key.toLowerCase();
       const child = value[key];
@@ -265,7 +299,10 @@ export async function postToCordis({ entrypoint, request, signal, fetchImpl = gl
   if (!loopback.ok) {
     return { ok: false, status: 0, body: null, reason: loopback.reason, detail: loopback.detail };
   }
-  const url = `${loopback.url.href.replace(/\/$/, "")}/api/v1/chat/completions`;
+  // Build the URL from `origin` (scheme + host + port). The previous
+  // implementation appended the path to `href`, which put the path into
+  // the query string for entrypoints like `http://host?x=y`.
+  const url = `${loopback.url.origin}/api/v1/chat/completions`;
   const init = {
     method: "POST",
     headers: {
@@ -273,6 +310,10 @@ export async function postToCordis({ entrypoint, request, signal, fetchImpl = gl
       Accept: "application/json",
     },
     body: JSON.stringify(request),
+    // A loopback service answering 3xx must not be allowed to redirect
+    // the POST to another host. The dispatcher's contract is loopback-only;
+    // a redirect is by definition an attempt to leave that boundary.
+    redirect: "error",
   };
   if (signal) init.signal = signal;
   try {
@@ -309,6 +350,7 @@ export async function dispatchExternalAgentRuntime({
   auditLedger,
   fetchImpl,
   repoRoot,
+  approval,
 }) {
   const lookup = await findAddonManifest(addonId, { repoRoot });
   if (!lookup.ok) {
@@ -323,12 +365,17 @@ export async function dispatchExternalAgentRuntime({
       detail: `tool ${toolName} not declared in addon ${addonId}`,
     };
   }
-  const grant = checkToolGrants({ tool, perCallerGrants, callerId });
+  const grant = checkToolGrants({ tool, perCallerGrants, callerId, approval });
   if (!grant.ok) {
+    const detail = grant.reason === "approval-required"
+      ? `tool ${toolName} requires human approval; no approval token supplied`
+      : grant.reason === "capability-undetermined"
+        ? `tool ${toolName} declares no requiredCapabilities; cannot be dispatched without explicit policy`
+        : `caller ${callerId} missing per-caller grants for: ${grant.missing.join(", ")}`;
     return {
       outcome: "deny",
-      reason: "capability-denied",
-      detail: `caller ${callerId} missing per-caller grants for: ${grant.missing.join(", ")}`,
+      reason: grant.reason ?? "capability-denied",
+      detail,
     };
   }
   const entrypoint = manifest.service?.entrypoint;

--- a/browser-first/test/_cordis-stub-loader.mjs
+++ b/browser-first/test/_cordis-stub-loader.mjs
@@ -1,0 +1,80 @@
+// Cordis stub loader for dispatcher tests.
+//
+// Boots a minimal HTTP server that mimics the DeepSeek OpenAI-compatible
+// interface on an ephemeral loopback port. Tests get the URL back via
+// `entrypoint`, swap it into a manifest fixture, and call the dispatcher
+// end-to-end without needing a real Cordis install.
+
+import http from "node:http";
+
+export async function startCordisStub({ dir, port = 0, host = "127.0.0.1" } = {}) {
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url ?? "/", `http://${host}:${port}`);
+    if (req.method === "GET" && url.pathname === "/health") {
+      const payload = JSON.stringify({
+        status: "ok",
+        model: "stub-cordis-0.1.0-stub",
+        endpoints: ["POST /api/v1/chat/completions"],
+      });
+      res.writeHead(200, { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(payload) });
+      res.end(payload);
+      return;
+    }
+    if (req.method === "POST" && url.pathname === "/api/v1/chat/completions") {
+      let raw = "";
+      req.setEncoding("utf8");
+      for await (const chunk of req) raw += chunk;
+      let body;
+      try { body = JSON.parse(raw); } catch {
+        const msg = JSON.stringify({ error: { message: "invalid JSON body" } });
+        res.writeHead(400, { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(msg) });
+        res.end(msg);
+        return;
+      }
+      const model = typeof body?.model === "string" ? body.model : "deepseek-chat";
+      const messages = Array.isArray(body?.messages) ? body.messages : [];
+      const lastUser = [...messages].reverse().find((m) => m?.role === "user");
+      const echoed = typeof lastUser?.content === "string"
+        ? lastUser.content
+        : JSON.stringify(lastUser?.content ?? "");
+      const completion = {
+        id: `chatcmpl-${Math.random().toString(36).slice(2, 10)}`,
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model,
+        choices: [{ index: 0, message: { role: "assistant", content: `[stub] ${model}: ${echoed}` }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+      };
+      const payload = JSON.stringify(completion);
+      res.writeHead(200, { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(payload) });
+      res.end(payload);
+      return;
+    }
+    const msg = JSON.stringify({ error: { message: `not found: ${req.method} ${url.pathname}` } });
+    res.writeHead(404, { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(msg) });
+    res.end(msg);
+  });
+
+  await new Promise((resolve, reject) => {
+    const onError = (err) => { server.off("listening", onListening); reject(err); };
+    const onListening = () => {
+      server.off("error", onError);
+      resolve();
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(port, host);
+  });
+
+  const addr = server.address();
+  const actualPort = typeof addr === "object" && addr ? addr.port : port;
+  return {
+    server,
+    port: actualPort,
+    host,
+    get entrypoint() { return `http://${host}:${actualPort}`; },
+    async close() {
+      await new Promise((r) => server.close(() => r()));
+    },
+  };
+}

--- a/browser-first/test/_cordis-stub-loader.mjs
+++ b/browser-first/test/_cordis-stub-loader.mjs
@@ -8,7 +8,9 @@
 import http from "node:http";
 
 export async function startCordisStub({ dir, port = 0, host = "127.0.0.1" } = {}) {
+  let requestCount = 0;
   const server = http.createServer(async (req, res) => {
+    requestCount += 1;
     const url = new URL(req.url ?? "/", `http://${host}:${port}`);
     if (req.method === "GET" && url.pathname === "/health") {
       const payload = JSON.stringify({
@@ -73,6 +75,8 @@ export async function startCordisStub({ dir, port = 0, host = "127.0.0.1" } = {}
     port: actualPort,
     host,
     get entrypoint() { return `http://${host}:${actualPort}`; },
+    get requestCount() { return requestCount; },
+    resetRequestCount() { requestCount = 0; },
     async close() {
       await new Promise((r) => server.close(() => r()));
     },

--- a/browser-first/test/external-agent-runtime-dispatcher-sse.test.mjs
+++ b/browser-first/test/external-agent-runtime-dispatcher-sse.test.mjs
@@ -1,0 +1,214 @@
+// SSE-specific tests for the external-agent-runtime dispatcher.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+
+import {
+  postToCordis,
+  isLoopbackAddress,
+  assertLoopbackEntrypointResolved,
+  consumeSseStream,
+} from "../host/external-agent-runtime-dispatcher.mjs";
+
+// Writes all chunks synchronously so the test runner sees the test
+// complete without lingering timers.
+async function startSseStub({ chunks = ["data: hello\n\n", "data: world\n\n"], status = 200 } = {}) {
+  const server = http.createServer((req, res) => {
+    if (req.method !== "POST" || req.url !== "/api/v1/chat/completions") {
+      res.writeHead(404).end();
+      return;
+    }
+    req.on("data", () => {});
+    req.on("end", () => {
+      res.writeHead(status, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+      });
+      for (const chunk of chunks) res.write(chunk);
+      res.end();
+    });
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const port = server.address().port;
+  return {
+    port,
+    entrypoint: `http://127.0.0.1:${port}`,
+    server,
+    async close() { await new Promise((r) => server.close(() => r())); },
+  };
+}
+
+test("isLoopbackAddress: accepts 127.0.0.1, ::1, and the 127.0.0.0/8 range; rejects private/public addresses", () => {
+  for (const good of ["127.0.0.1", "127.0.0.42", "127.255.255.254", "::1"]) {
+    assert.equal(isLoopbackAddress(good), true, `expected ${good} to be loopback`);
+  }
+  for (const bad of ["10.0.0.1", "192.168.1.1", "172.16.0.1", "8.8.8.8", "0.0.0.0", "fe80::1", "::2"]) {
+    assert.equal(isLoopbackAddress(bad), false, `expected ${bad} to be non-loopback`);
+  }
+  assert.equal(isLoopbackAddress(undefined), false);
+  assert.equal(isLoopbackAddress(null), false);
+  assert.equal(isLoopbackAddress(127), false);
+});
+
+test("assertLoopbackEntrypointResolved: rejects an entrypoint whose port differs from the manifest-declared port", async () => {
+  const result = await assertLoopbackEntrypointResolved("http://127.0.0.1:7777", { expectedPort: "3080" });
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "port-mismatch");
+  assert.match(result.detail, /7777/);
+  assert.match(result.detail, /3080/);
+});
+
+test("assertLoopbackEntrypointResolved: accepts an entrypoint whose port matches the manifest-declared port", async () => {
+  const result = await assertLoopbackEntrypointResolved("http://127.0.0.1:3080", { expectedPort: "3080" });
+  assert.equal(result.ok, true);
+});
+
+test("postToCordis: streams SSE response without calling response.json()", async (t) => {
+  const stub = await startSseStub({
+    chunks: [
+      "event: message\ndata: {\"delta\":\"hello\"}\n\n",
+      "event: message\ndata: {\"delta\":\"world\"}\n\n",
+      "data: [DONE]\n\n",
+    ],
+  });
+  t.after(() => stub.close());
+
+  const result = await postToCordis({
+    entrypoint: stub.entrypoint,
+    request: { model: "deepseek-chat", messages: [{ role: "user", content: "hi" }], stream: true },
+    declaredPort: String(stub.port),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.status, 200);
+  assert.equal(result.body, null);
+  assert.equal(result.stream, true);
+  assert.ok(Array.isArray(result.events));
+  assert.ok(result.events.length >= 3, `expected at least 3 SSE events; got ${result.events.length}`);
+  assert.equal(result.events[0].event, "message");
+  assert.equal(result.events[0].data, "{\"delta\":\"hello\"}");
+  assert.equal(result.events[result.events.length - 1].data, "[DONE]");
+  assert.match(result.sseRaw, /hello/);
+  assert.match(result.sseRaw, /world/);
+  assert.equal(result.sseClosed, true);
+});
+
+test("postToCordis: SSE handler cancels the underlying reader on truncation", async (t) => {
+  const stub = await startSseStub({
+    chunks: ["data: " + "x".repeat(4000) + "\n\n"],
+  });
+  t.after(() => stub.close());
+
+  const result = await postToCordis({
+    entrypoint: stub.entrypoint,
+    request: { stream: true },
+    declaredPort: String(stub.port),
+    consumeSse: (response) => consumeSseStream(response, { maxBytes: 64 }),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.stream, true);
+  assert.equal(result.sseTruncated, true);
+  assert.equal(result.sseClosed, true);
+});
+
+test("postToCordis: SSE handler surfaces the upstream error and closes the reader when the connection drops", async (t) => {
+  const server = http.createServer((req, res) => {
+    if (req.method !== "POST" || req.url !== "/api/v1/chat/completions") {
+      res.writeHead(404).end();
+      return;
+    }
+    req.on("data", () => {});
+    req.on("end", () => {
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      res.write("data: first\n\n");
+      setTimeout(() => res.destroy(), 20);
+    });
+    req.on("close", () => {});
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  t.after(() => new Promise((r) => server.close(() => r())));
+  const port = server.address().port;
+
+  const result = await postToCordis({
+    entrypoint: `http://127.0.0.1:${port}`,
+    request: { stream: true },
+    declaredPort: String(port),
+  });
+
+  // The connection was destroyed before the reader could drain the
+  // first chunk. What matters for the gate is: the dispatcher used
+  // the SSE path (not response.json), the stream flag is set, and the
+  // reader was closed so the upstream socket is released.
+  assert.equal(result.stream, true);
+  assert.equal(result.sseClosed, true);
+});
+
+test("postToCordis: Accept header requests SSE when request.stream is true", async (t) => {
+  const seen = { accept: null };
+  const server = http.createServer((req, res) => {
+    seen.accept = req.headers["accept"];
+    req.on("data", () => {});
+    req.on("end", () => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  t.after(() => new Promise((r) => server.close(() => r())));
+  const port = server.address().port;
+
+  await postToCordis({
+    entrypoint: `http://127.0.0.1:${port}`,
+    request: { model: "x", messages: [], stream: true },
+    declaredPort: String(port),
+  });
+
+  assert.equal(seen.accept, "text/event-stream");
+});
+
+// ---------------------------------------------------------------------------
+// Loopback-port bind: verify the dispatcher exposes the bound dispatcher
+// factory and that a caller-supplied fetchImpl is used (the dispatcher does
+// not wrap a custom fetchImpl in the undici dispatcher).
+// ---------------------------------------------------------------------------
+
+import { getSharedLoopbackDispatcher } from "../host/external-agent-runtime-dispatcher.mjs";
+
+test("getSharedLoopbackDispatcher: returns an Agent whose connect options bind to a loopback address", () => {
+  const dispatcher = getSharedLoopbackDispatcher();
+  assert.ok(dispatcher, "expected a dispatcher");
+  // undici's Agent stores options under a Symbol. Walk the own-property
+  // symbols to find the options bag and verify the connect.localAddress.
+  const symbols = Object.getOwnPropertySymbols(dispatcher);
+  const optionsSymbol = symbols.find((s) => String(s) === "Symbol(options)");
+  assert.ok(optionsSymbol, "expected a Symbol(options) on the Agent");
+  const opts = dispatcher[optionsSymbol];
+  assert.ok(opts.connect, "expected connect options on the Agent");
+  assert.equal(opts.connect.localAddress, "127.0.0.1");
+});
+
+test("postToCordis: caller-supplied fetchImpl is used as-is (no undici wrapping)", async (t) => {
+  const stub = await startSseStub({ chunks: ["data: ok\n\n"] });
+  t.after(() => stub.close());
+
+  let calledWith = null;
+  const customFetch = async (url, init) => {
+    calledWith = { url, init };
+    return globalThis.fetch(url, init);
+  };
+
+  await postToCordis({
+    entrypoint: stub.entrypoint,
+    request: { model: "x", messages: [], stream: true },
+    declaredPort: String(stub.port),
+    fetchImpl: customFetch,
+  });
+
+  // The custom fetch received the URL exactly as the dispatcher would
+  // build it, with no dispatcher field injected.
+  assert.ok(calledWith, "expected custom fetch to be called");
+  assert.equal(calledWith.url, `${stub.entrypoint}/api/v1/chat/completions`);
+  assert.equal(calledWith.init.dispatcher, undefined, "expected no undici dispatcher to be injected into a custom fetchImpl");
+});

--- a/browser-first/test/external-agent-runtime-dispatcher.test.mjs
+++ b/browser-first/test/external-agent-runtime-dispatcher.test.mjs
@@ -23,9 +23,10 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve as resolvePath } from "node:path";
+import http from "node:http";
 
 import {
   dispatchExternalAgentRuntime,
@@ -36,6 +37,8 @@ import {
   validateAddonId,
   assertLoopbackEntrypoint,
   redactRequestForLog,
+  postToCordis,
+  DEFAULT_REPO_ROOT,
 } from "../host/external-agent-runtime-dispatcher.mjs";
 import { startCordisStub } from "./_cordis-stub-loader.mjs";
 
@@ -382,12 +385,91 @@ test("dispatchExternalAgentRuntime: deny path (caller missing agent-delegation)"
     perCallerGrants: grants,
     auditLedger: ledger,
     repoRoot,
+    // The `run_task` tool requires human approval; supply an opaque
+    // token so the dispatcher proceeds to the capability check.
+    approval: "approval-token-1",
   });
 
   assert.equal(result.outcome, "deny");
   assert.equal(result.reason, "capability-denied");
   assert.match(result.detail, /agent-delegation/);
   assert.equal(ledger.entries.length, 0);
+});
+
+test("dispatchExternalAgentRuntime: deny path (tool requires human approval, no approval token)", async (t) => {
+  const stub = await startCordisStub();
+  t.after(() => stub.close());
+  const repoRoot = setupManifestFixture(t, stub.entrypoint);
+
+  const ledger = makeAuditLedger();
+  const grants = makeGrantStore({
+    callerId: "caller.test",
+    grantedCapabilities: ["network", "providers", "agent-delegation"],
+  });
+
+  const result = await dispatchExternalAgentRuntime({
+    addonId: "addon.deepseek-harness",
+    toolName: "deepseek_harness.run_task",
+    payload: {},
+    callerId: "caller.test",
+    perCallerGrants: grants,
+    auditLedger: ledger,
+    repoRoot,
+    // No approval token — the dispatcher must deny with
+    // `approval-required` BEFORE any network egress.
+  });
+
+  assert.equal(result.outcome, "deny");
+  assert.equal(result.reason, "approval-required");
+  assert.match(result.detail, /human approval/);
+  // No audit entry: nothing was dispatched.
+  assert.equal(ledger.entries.length, 0);
+  // No network call: stub was never hit.
+  assert.equal(stub.requestCount, 0);
+});
+
+test("dispatchExternalAgentRuntime: deny path (tool declares no requiredCapabilities)", async (t) => {
+  const stub = await startCordisStub();
+  t.after(() => stub.close());
+  // Override the manifest: the `run_task` tool has empty
+  // requiredCapabilities and no approval gate. The dispatcher must
+  // fail closed — `capability-undetermined` — rather than let any
+  // caller through.
+  const repoRoot = setupManifestFixture(t, stub.entrypoint, {
+    tools: [
+      {
+        name: "deepseek_harness.run_task",
+        description: "run",
+        requiredCapabilities: [],
+        inputSchema: {},
+        outputSchema: {},
+        audit: { logRequest: true, logResult: true, artifactTypes: ["summary"] },
+        requiresHumanApproval: false,
+      },
+    ],
+  });
+
+  const ledger = makeAuditLedger();
+  const grants = makeGrantStore({
+    callerId: "caller.test",
+    grantedCapabilities: ["network", "providers", "agent-delegation"],
+  });
+
+  const result = await dispatchExternalAgentRuntime({
+    addonId: "addon.deepseek-harness",
+    toolName: "deepseek_harness.run_task",
+    payload: {},
+    callerId: "caller.test",
+    perCallerGrants: grants,
+    auditLedger: ledger,
+    repoRoot,
+  });
+
+  assert.equal(result.outcome, "deny");
+  assert.equal(result.reason, "capability-undetermined");
+  assert.match(result.detail, /no requiredCapabilities/);
+  assert.equal(ledger.entries.length, 0);
+  assert.equal(stub.requestCount, 0);
 });
 
 test("dispatchExternalAgentRuntime: deny path (unknown-tool)", async (t) => {
@@ -557,4 +639,164 @@ test("dispatchExternalAgentRuntime: allow-path audit entry has the request body 
   assert.equal(recorded.messages[1].content, "hi");
   const serialized = JSON.stringify(recorded);
   assert.equal(serialized.includes("sk-leaked"), false, "leaked token must not appear in the audit entry");
+});
+
+
+// ---------------------------------------------------------------------------
+// Tom's 2026-09-10 closeout-review gaps (#444 blockers + majors)
+// ---------------------------------------------------------------------------
+
+test("DEFAULT_REPO_ROOT: resolves inside the actual repo, not above it", () => {
+  // The dispatcher file is at `browser-first/host/external-agent-runtime-dispatcher.mjs`.
+  // From that file's directory, the repo root is two levels up.
+  // The previous default used three `..` which resolves to the *parent* of
+  // the repo. Verify the constant points at a directory whose parent has a
+  // `browser-first/` sibling (i.e. we're inside the repo, not above it).
+  const parent = resolvePath(DEFAULT_REPO_ROOT, "..");
+  // If we are one level above the repo, the parent's parent has a `browser-first/`
+  // child. If we are at the repo root, the parent has `browser-first/`.
+  const candidates = [
+    resolvePath(parent, "browser-first"),
+    resolvePath(parent, "..", "browser-first"),
+  ];
+  let ok = false;
+  for (const candidate of candidates) {
+    try {
+      const stat = statSync ? statSync(candidate) : null;
+      if (stat && stat.isDirectory()) { ok = true; break; }
+    } catch {}
+  }
+  // Simpler invariant: the constant must end with `/2.0.0-alpha` (this
+  // repo's root) or be the resolved realpath of `process.cwd()`.
+  assert.ok(
+    ok || DEFAULT_REPO_ROOT.endsWith("/2.0.0-alpha"),
+    `DEFAULT_REPO_ROOT (${DEFAULT_REPO_ROOT}) is not inside the repo`,
+  );
+});
+
+test("assertLoopbackEntrypoint: rejects userinfo (http://user:pass@host)", () => {
+  for (const bad of ["http://u:p@127.0.0.1:3080", "http://attacker@example.com@127.0.0.1:3080"]) {
+    const result = assertLoopbackEntrypoint(bad);
+    assert.equal(result.ok, false, `expected ${bad} to be rejected`);
+    assert.equal(result.reason, "entrypoint-not-allowed");
+    assert.match(result.detail, /userinfo/);
+  }
+});
+
+test("assertLoopbackEntrypoint: rejects query and fragment", () => {
+  for (const bad of ["http://127.0.0.1:3080?evil=1", "http://127.0.0.1:3080#frag", "http://127.0.0.1:3080/?evil=1#frag"]) {
+    const result = assertLoopbackEntrypoint(bad);
+    assert.equal(result.ok, false, `expected ${bad} to be rejected`);
+    assert.equal(result.reason, "entrypoint-not-allowed");
+    assert.match(result.detail, /query string and fragment/);
+  }
+});
+
+test("postToCordis: follows `redirect: error` — a 3xx answer does not reach the redirect target", async (t) => {
+  // Stub a redirecting service: any POST to /api/v1/chat/completions
+  // answers 307 with Location: http://example.com/... — but the dispatcher
+  // must error before following it.
+  const server = http.createServer((req, res) => {
+    if (req.method === "POST" && req.url === "/api/v1/chat/completions") {
+      res.writeHead(307, { Location: "http://example.com/api/v1/chat/completions" });
+      res.end();
+      return;
+    }
+    res.writeHead(404).end();
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  t.after(() => new Promise((r) => server.close(() => r())));
+  const port = server.address().port;
+  const entrypoint = `http://127.0.0.1:${port}`;
+  const result = await postToCordis({
+    entrypoint,
+    request: { model: "deepseek-chat", messages: [{ role: "user", content: "hi" }] },
+  });
+  assert.equal(result.ok, false, "dispatcher must not follow a redirect");
+  // `fetch` with `redirect: "error"` throws an AbortError-like error;
+  // the dispatcher maps it to `upstream-unreachable` (status 0).
+  assert.equal(result.status, 0);
+});
+
+test("redactRequestForLog: walks into null-prototype objects (Object.create(null))", () => {
+  const credentials = Object.create(null);
+  credentials.apiKey = "leaked-null-proto";
+  credentials.password = "leaked-password";
+  const payload = { headers: credentials, model: "deepseek-chat" };
+  const out = redactRequestForLog(payload);
+  // The previous implementation skipped null-prototype objects entirely;
+  // the leaked tokens survived into the audit entry.
+  assert.equal(out.headers.apiKey, "[REDACTED]");
+  assert.equal(out.headers.password, "[REDACTED]");
+  assert.equal(out.model, "deepseek-chat");
+  assert.equal(JSON.stringify(out).includes("leaked-null-proto"), false);
+});
+
+test("checkToolGrants: fails closed when requiredCapabilities is missing or empty", () => {
+  // A tool without an explicit capability list cannot be safely dispatched;
+  // the dispatcher must deny rather than admit any caller.
+  for (const tool of [{}, { requiredCapabilities: undefined }, { requiredCapabilities: null }, { requiredCapabilities: [] }]) {
+    const result = checkToolGrants({ tool, perCallerGrants: undefined, callerId: "caller.test" });
+    assert.equal(result.ok, false, `expected deny for tool ${JSON.stringify(tool)}`);
+    assert.equal(result.reason, "capability-undetermined");
+  }
+});
+
+test("checkToolGrants: enforces tool.requiresHumanApproval", () => {
+  const tool = { requiredCapabilities: ["network"], requiresHumanApproval: true };
+  const grants = makeGrantStore({ callerId: "caller.test", grantedCapabilities: ["network"] });
+  // No approval token — deny.
+  const noApproval = checkToolGrants({ tool, perCallerGrants: grants, callerId: "caller.test" });
+  assert.equal(noApproval.ok, false);
+  assert.equal(noApproval.reason, "approval-required");
+  // Empty-string approval is treated as missing.
+  const emptyApproval = checkToolGrants({ tool, perCallerGrants: grants, callerId: "caller.test", approval: "" });
+  assert.equal(emptyApproval.ok, false);
+  assert.equal(emptyApproval.reason, "approval-required");
+  // A non-empty token satisfies the gate; capability check then passes.
+  const granted = checkToolGrants({ tool, perCallerGrants: grants, callerId: "caller.test", approval: "approval-token-1" });
+  assert.equal(granted.ok, true);
+});
+
+test("dispatchExternalAgentRuntime: fetch is never called on a deny path (audit + stub requestCount are 0)", async (t) => {
+  const stub = await startCordisStub();
+  t.after(() => stub.close());
+  const repoRoot = setupManifestFixture(t, stub.entrypoint);
+
+  const ledger = makeAuditLedger();
+  const grants = makeGrantStore({
+    callerId: "caller.test",
+    grantedCapabilities: ["network", "providers", "agent-delegation"],
+  });
+
+  // Deny path #1: missing approval token.
+  const noApproval = await dispatchExternalAgentRuntime({
+    addonId: "addon.deepseek-harness",
+    toolName: "deepseek_harness.run_task",
+    payload: {},
+    callerId: "caller.test",
+    perCallerGrants: grants,
+    auditLedger: ledger,
+    repoRoot,
+  });
+  assert.equal(noApproval.outcome, "deny");
+  assert.equal(noApproval.reason, "approval-required");
+  assert.equal(stub.requestCount, 0);
+  assert.equal(ledger.entries.length, 0);
+
+  // Deny path #2: addon id invalid — the dispatcher must not even
+  // touch the network or write to the audit ledger.
+  const badId = await dispatchExternalAgentRuntime({
+    addonId: "../etc/passwd",
+    toolName: "deepseek_harness.run_task",
+    payload: {},
+    callerId: "caller.test",
+    perCallerGrants: grants,
+    auditLedger: ledger,
+    repoRoot,
+  });
+  assert.equal(badId.outcome, "deny");
+  assert.equal(badId.reason, "addon-id-invalid");
+  assert.equal(stub.requestCount, 0);
+  assert.equal(ledger.entries.length, 0);
 });

--- a/browser-first/test/external-agent-runtime-dispatcher.test.mjs
+++ b/browser-first/test/external-agent-runtime-dispatcher.test.mjs
@@ -1,0 +1,560 @@
+// Intent citation: docs/architecture/ADR-056-provider-fabric-boundary-external-agent-runtimes.md#4-wire-format
+//
+// Integration test for the external-agent-runtime dispatcher.
+//
+// Drives the allow path, the deny paths, and the closeout-review
+// security properties against an in-process Cordis stub HTTP server.
+//
+// Closeout-review property coverage (per 2026-09-10 PR_BLOCKERS_SUMMARY.md
+// for #330):
+//   - findAddonManifest validates `addonId` (no path traversal).
+//   - postToCordis / dispatchExternalAgentRuntime enforce a
+//     loopback-only entrypoint allowlist.
+//   - checkToolGrants honors grant expiry.
+//   - buildChatCompletionsRequest strips `options.model` and
+//     `options.messages` (the original dispatcher's `...options` spread
+//     let a caller override both).
+//   - audit-log entries are recursively redacted before they leave the
+//     dispatcher (nested authorization header in
+//     messages[*].content is rewritten to `[REDACTED]`).
+//
+// The dispatcher accepts a `repoRoot` override so the test doesn't have
+// to mutate any tracked files.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  dispatchExternalAgentRuntime,
+  findAddonManifest,
+  findTool,
+  buildChatCompletionsRequest,
+  checkToolGrants,
+  validateAddonId,
+  assertLoopbackEntrypoint,
+  redactRequestForLog,
+} from "../host/external-agent-runtime-dispatcher.mjs";
+import { startCordisStub } from "./_cordis-stub-loader.mjs";
+
+function makeManifest(entrypoint) {
+  return {
+    id: "addon.deepseek-harness",
+    name: "DeepSeek Harness",
+    version: "0.1.0",
+    author: "test",
+    category: "agent",
+    sdkVersion: "0.1.0",
+    description: "test",
+    runtimeType: "agent-addon",
+    surfaces: [],
+    archiveIntegration: { readScopes: [], intakeWriteScopes: [], canRequestIngest: false, canWriteKnowledgePages: false },
+    requestedCapabilities: [
+      { capability: "providers", granted: false, scope: "system", revocationBehavior: "hard-stop" },
+      { capability: "network", granted: false, scope: "self", revocationBehavior: "hard-stop" },
+      { capability: "agent-delegation", granted: false, scope: "workspace", revocationBehavior: "degrade" },
+    ],
+    provenance: { tier: "sideloaded-unverified", verificationState: "unverified", signed: false },
+    runtimeIsolation: { boundary: "host-mediated-service", supportsDegradedMode: true, requiresReviewedGrant: true },
+    grantPresets: [],
+    providerRequirements: {
+      sharedProfiles: ["openai-compatible-deepseek"],
+      supportsPrivateCredentials: true,
+      preferredRuntimeKinds: ["remote-user-owned"],
+      allowExperimentalAuth: true,
+      fallbackPolicyId: "experimental",
+    },
+    health: { strategy: "http-json-deepseek-harness-status", endpoint: `${entrypoint}/health` },
+    service: {
+      protocol: "http-json",
+      entrypoint,
+      healthCommand: "deepseek_harness_status",
+      shutdownCommand: "deepseek_harness_stop_service",
+    },
+    delegation: { acceptsTasks: true, taskTypes: ["research"], artifactReturnTypes: ["summary"], defaultTargetRuntime: "remote-user-owned", requiresHumanApprovalBeforeExecution: true, notes: [] },
+    tools: [
+      {
+        name: "deepseek_harness.status",
+        description: "status",
+        requiredCapabilities: ["network", "providers"],
+        inputSchema: {},
+        outputSchema: {},
+        audit: { logRequest: true, logResult: true, artifactTypes: ["diagnostic-report"] },
+        requiresHumanApproval: false,
+      },
+      {
+        name: "deepseek_harness.run_task",
+        description: "run",
+        requiredCapabilities: ["network", "providers", "agent-delegation"],
+        inputSchema: {},
+        outputSchema: {},
+        audit: { logRequest: true, logResult: true, artifactTypes: ["summary"] },
+        requiresHumanApproval: true,
+      },
+    ],
+    installHooks: { onInstall: "noop", onEnable: "noop" },
+    compatibility: { shellVersion: "^0.1.0", platforms: ["macOS", "linux"] },
+    agents: [],
+  };
+}
+
+function makeGrantStore({ callerId, grantedCapabilities, expiresAt = new Map() }) {
+  const caps = new Map();
+  for (const c of grantedCapabilities) caps.set(c, true);
+  const buckets = new Map();
+  buckets.set(callerId, { capabilities: caps, expiresAt });
+  return { get: (target) => buckets.get(target) };
+}
+
+function makeAuditLedger() {
+  const entries = [];
+  return { entries, record: (e) => entries.push(e) };
+}
+
+function setupManifestFixture(t, entrypoint, overrides = {}) {
+  const tmp = mkdtempSync(join(tmpdir(), "ext-agent-rt-"));
+  const examplesAddons = join(tmp, "examples", "addons");
+  mkdirSync(examplesAddons, { recursive: true });
+  const manifest = { ...makeManifest(entrypoint), ...overrides };
+  writeFileSync(
+    join(examplesAddons, "addon.deepseek-harness.json"),
+    JSON.stringify(manifest, null, 2),
+  );
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+  return tmp;
+}
+
+// ---------------------------------------------------------------------------
+// validateAddonId
+// ---------------------------------------------------------------------------
+
+test("validateAddonId: rejects empty / non-string / too-long ids", () => {
+  assert.deepEqual(validateAddonId(""), { ok: false, reason: "addon-id-empty" });
+  assert.deepEqual(validateAddonId(undefined), { ok: false, reason: "addon-id-empty" });
+  assert.deepEqual(validateAddonId(null), { ok: false, reason: "addon-id-empty" });
+  assert.deepEqual(validateAddonId(42), { ok: false, reason: "addon-id-empty" });
+  assert.equal(validateAddonId("a".repeat(65)).ok, false);
+});
+
+test("validateAddonId: rejects ids containing path traversal, slashes, or null bytes", () => {
+  for (const bad of ["../etc/passwd", "addon.deepseek/../etc", "..", "addon/with/slash", "addon\\backslash", "addon\0null", "addon..hidden", ".dotfile", "-leading-dash"]) {
+    const result = validateAddonId(bad);
+    assert.equal(result.ok, false, `expected ${JSON.stringify(bad)} to be rejected, got ${JSON.stringify(result)}`);
+  }
+});
+
+test("validateAddonId: accepts the canonical deepseek harness id and other dot-separated lowercase ids", () => {
+  assert.deepEqual(validateAddonId("addon.deepseek-harness"), { ok: true });
+  assert.deepEqual(validateAddonId("addon.recursive-mas"), { ok: true });
+  assert.deepEqual(validateAddonId("addon.simple"), { ok: true });
+});
+
+// ---------------------------------------------------------------------------
+// assertLoopbackEntrypoint
+// ---------------------------------------------------------------------------
+
+test("assertLoopbackEntrypoint: allows 127.0.0.1, [::1], and localhost", () => {
+  for (const host of ["127.0.0.1", "[::1]", "localhost"]) {
+    const result = assertLoopbackEntrypoint(`http://${host}:3080`);
+    assert.equal(result.ok, true, `expected ${host} to be allowed`);
+  }
+});
+
+test("assertLoopbackEntrypoint: rejects non-loopback hosts (SSRF guard)", () => {
+  for (const bad of ["http://example.com", "http://10.0.0.1", "http://0.0.0.0", "http://192.168.1.1", "http://api.deepseek.com", "http://[::ffff:127.0.0.1]"]) {
+    const url = `${bad}:3080`;
+    const result = assertLoopbackEntrypoint(url);
+    assert.equal(result.ok, false, `expected ${url} to be rejected`);
+    assert.equal(result.reason, "entrypoint-not-allowed");
+  }
+});
+
+test("assertLoopbackEntrypoint: rejects non-http(s) protocols and invalid URLs", () => {
+  assert.equal(assertLoopbackEntrypoint("file:///etc/passwd").ok, false);
+  assert.equal(assertLoopbackEntrypoint("gopher://127.0.0.1:1234").ok, false);
+  assert.equal(assertLoopbackEntrypoint("not a url").ok, false);
+  assert.equal(assertLoopbackEntrypoint("").ok, false);
+  assert.equal(assertLoopbackEntrypoint(undefined).ok, false);
+});
+
+test("assertLoopbackEntrypoint: rejects port 0", () => {
+  assert.equal(assertLoopbackEntrypoint("http://127.0.0.1:0").ok, false);
+});
+
+// ---------------------------------------------------------------------------
+// redactRequestForLog
+// ---------------------------------------------------------------------------
+
+test("redactRequestForLog: redacts top-level credentials", () => {
+  const out = redactRequestForLog({ model: "deepseek-chat", authorization: "Bearer sk-leaked", apiKey: "abc" });
+  assert.equal(out.authorization, "[REDACTED]");
+  assert.equal(out.apiKey, "[REDACTED]");
+  assert.equal(out.model, "deepseek-chat");
+});
+
+test("redactRequestForLog: redacts nested credentials inside arrays of objects", () => {
+  const out = redactRequestForLog({
+    model: "deepseek-chat",
+    messages: [
+      { role: "system", content: "you are a helper" },
+      { role: "user", content: { text: "hi", headers: { authorization: "Bearer sk-leaked" } } },
+    ],
+    extras: [{ api_key: "k", body: "ok" }],
+  });
+  assert.equal(out.messages[0].content, "you are a helper");
+  assert.equal(out.messages[1].content.headers.authorization, "[REDACTED]");
+  assert.equal(out.extras[0].api_key, "[REDACTED]");
+  assert.equal(out.extras[0].body, "ok");
+});
+
+test("redactRequestForLog: recurses into credential-shaped objects (does not collapse wholesale)", () => {
+  const out = redactRequestForLog({
+    messages: [{
+      role: "system",
+      content: { text: "x", credentials: { authorization: "Bearer sk-leaked", apiKey: "abc" } },
+    }],
+  });
+  assert.equal(out.messages[0].content.text, "x");
+  assert.equal(typeof out.messages[0].content.credentials, "object");
+  assert.equal(out.messages[0].content.credentials.authorization, "[REDACTED]");
+  assert.equal(out.messages[0].content.credentials.apiKey, "[REDACTED]");
+});
+
+test("redactRequestForLog: leaves plain content untouched", () => {
+  const out = redactRequestForLog({ model: "deepseek-chat", messages: [{ role: "user", content: "hi" }] });
+  assert.deepEqual(out, { model: "deepseek-chat", messages: [{ role: "user", content: "hi" }] });
+});
+
+// ---------------------------------------------------------------------------
+// findAddonManifest
+// ---------------------------------------------------------------------------
+
+test("findAddonManifest: respects repoRoot override", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "fm-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+  const examplesAddons = join(tmp, "examples", "addons");
+  mkdirSync(examplesAddons, { recursive: true });
+  writeFileSync(
+    join(examplesAddons, "addon.deepseek-harness.json"),
+    JSON.stringify(makeManifest("http://127.0.0.1:9999"), null, 2),
+  );
+  const result = await findAddonManifest("addon.deepseek-harness", { repoRoot: tmp });
+  assert.equal(result.ok, true);
+  assert.equal(result.manifest.id, "addon.deepseek-harness");
+  assert.equal(result.manifest.service.entrypoint, "http://127.0.0.1:9999");
+});
+
+test("findAddonManifest: returns addon-id-invalid for traversal-shaped ids without touching the filesystem", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "fm-traversal-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+  const result = await findAddonManifest("../etc/passwd", { repoRoot: tmp });
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "addon-id-invalid");
+});
+
+test("findAddonManifest: returns addon-not-found for an unknown but well-formed id", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "fm-missing-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+  const result = await findAddonManifest("addon.does-not-exist", { repoRoot: tmp });
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "addon-not-found");
+});
+
+// ---------------------------------------------------------------------------
+// checkToolGrants
+// ---------------------------------------------------------------------------
+
+test("checkToolGrants: deny when caller missing a required capability", () => {
+  const tool = { requiredCapabilities: ["network", "providers", "agent-delegation"] };
+  const grants = makeGrantStore({ callerId: "caller.test", grantedCapabilities: ["network"] });
+  const result = checkToolGrants({ tool, perCallerGrants: grants, callerId: "caller.test" });
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.missing.sort(), ["agent-delegation", "providers"]);
+});
+
+test("checkToolGrants: allow when all required capabilities granted", () => {
+  const tool = { requiredCapabilities: ["network", "providers", "agent-delegation"] };
+  const grants = makeGrantStore({ callerId: "caller.test", grantedCapabilities: ["network", "providers", "agent-delegation"] });
+  const result = checkToolGrants({ tool, perCallerGrants: grants, callerId: "caller.test" });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.missing, []);
+});
+
+test("checkToolGrants: deny when a grant is expired", () => {
+  const tool = { requiredCapabilities: ["network", "providers"] };
+  const expiresAt = new Map([["providers", Date.now() - 1000]]);
+  const grants = makeGrantStore({ callerId: "caller.test", grantedCapabilities: ["network", "providers"], expiresAt });
+  const result = checkToolGrants({ tool, perCallerGrants: grants, callerId: "caller.test" });
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.missing, ["providers"]);
+});
+
+test("checkToolGrants: deny when caller id is not in the grant store", () => {
+  const tool = { requiredCapabilities: ["network"] };
+  const grants = makeGrantStore({ callerId: "someone-else", grantedCapabilities: ["network"] });
+  const result = checkToolGrants({ tool, perCallerGrants: grants, callerId: "caller.test" });
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.missing, ["network"]);
+});
+
+// ---------------------------------------------------------------------------
+// buildChatCompletionsRequest
+// ---------------------------------------------------------------------------
+
+test("buildChatCompletionsRequest: shape matches OpenAI-compatible API", () => {
+  const req = buildChatCompletionsRequest({
+    model: "deepseek-reasoner",
+    messages: [{ role: "user", content: "x" }],
+  });
+  assert.equal(req.model, "deepseek-reasoner");
+  assert.equal(req.messages.length, 1);
+});
+
+test("buildChatCompletionsRequest: refuses options.model and options.messages overrides", () => {
+  const req = buildChatCompletionsRequest({
+    model: "deepseek-chat",
+    messages: [{ role: "user", content: "hello" }],
+    options: { model: "evil-model", messages: [{ role: "user", content: "evil" }], temperature: 0.7, secret: "leaked" },
+  });
+  assert.equal(req.model, "deepseek-chat");
+  assert.equal(req.messages.length, 1);
+  assert.equal(req.messages[0].content, "hello");
+  assert.equal(req.temperature, 0.7);
+  assert.equal("secret" in req, false);
+});
+
+// ---------------------------------------------------------------------------
+// findTool
+// ---------------------------------------------------------------------------
+
+test("findTool: returns null for an unknown tool", () => {
+  const manifest = makeManifest("http://127.0.0.1:3080");
+  assert.equal(findTool(manifest, "does.not.exist"), null);
+});
+
+// ---------------------------------------------------------------------------
+// dispatchExternalAgentRuntime — full scenarios
+// ---------------------------------------------------------------------------
+
+test("dispatchExternalAgentRuntime: allow path (caller has all grants, Cordis stub returns 200)", async (t) => {
+  const stub = await startCordisStub();
+  t.after(() => stub.close());
+  const repoRoot = setupManifestFixture(t, stub.entrypoint);
+
+  const ledger = makeAuditLedger();
+  const grants = makeGrantStore({ callerId: "caller.test", grantedCapabilities: ["network", "providers"] });
+
+  const result = await dispatchExternalAgentRuntime({
+    addonId: "addon.deepseek-harness",
+    toolName: "deepseek_harness.status",
+    payload: { model: "deepseek-chat", messages: [{ role: "user", content: "hello world" }] },
+    callerId: "caller.test",
+    perCallerGrants: grants,
+    auditLedger: ledger,
+    repoRoot,
+  });
+
+  assert.equal(result.outcome, "allow", JSON.stringify(result));
+  assert.equal(result.response?.choices?.[0]?.message?.role, "assistant");
+  assert.match(result.response.choices[0].message.content, /hello world/);
+  assert.equal(ledger.entries.length, 1);
+  assert.equal(ledger.entries[0].upstreamOk, true);
+  assert.equal(ledger.entries[0].upstreamStatus, 200);
+  assert.equal(ledger.entries[0].callerId, "caller.test");
+  assert.equal(ledger.entries[0].tool, "deepseek_harness.status");
+});
+
+test("dispatchExternalAgentRuntime: deny path (caller missing agent-delegation)", async (t) => {
+  const stub = await startCordisStub();
+  t.after(() => stub.close());
+  const repoRoot = setupManifestFixture(t, stub.entrypoint);
+
+  const ledger = makeAuditLedger();
+  const grants = makeGrantStore({ callerId: "caller.test", grantedCapabilities: ["network", "providers"] });
+
+  const result = await dispatchExternalAgentRuntime({
+    addonId: "addon.deepseek-harness",
+    toolName: "deepseek_harness.run_task",
+    payload: {},
+    callerId: "caller.test",
+    perCallerGrants: grants,
+    auditLedger: ledger,
+    repoRoot,
+  });
+
+  assert.equal(result.outcome, "deny");
+  assert.equal(result.reason, "capability-denied");
+  assert.match(result.detail, /agent-delegation/);
+  assert.equal(ledger.entries.length, 0);
+});
+
+test("dispatchExternalAgentRuntime: deny path (unknown-tool)", async (t) => {
+  const stub = await startCordisStub();
+  t.after(() => stub.close());
+  const repoRoot = setupManifestFixture(t, stub.entrypoint);
+
+  const ledger = makeAuditLedger();
+  const grants = makeGrantStore({ callerId: "caller.test", grantedCapabilities: ["network", "providers", "agent-delegation"] });
+
+  const result = await dispatchExternalAgentRuntime({
+    addonId: "addon.deepseek-harness",
+    toolName: "deepseek_harness.unknown_tool",
+    payload: {},
+    callerId: "caller.test",
+    perCallerGrants: grants,
+    auditLedger: ledger,
+    repoRoot,
+  });
+
+  assert.equal(result.outcome, "deny");
+  assert.equal(result.reason, "unknown-tool");
+});
+
+test("dispatchExternalAgentRuntime: deny path (addon-not-found)", async () => {
+  const ledger = makeAuditLedger();
+  const grants = makeGrantStore({ callerId: "caller.test", grantedCapabilities: ["network"] });
+  const result = await dispatchExternalAgentRuntime({
+    addonId: "addon.does-not-exist",
+    toolName: "any.tool",
+    payload: {},
+    callerId: "caller.test",
+    perCallerGrants: grants,
+    auditLedger: ledger,
+    repoRoot: "/tmp/never-existed",
+  });
+  assert.equal(result.outcome, "deny");
+  assert.equal(result.reason, "addon-not-found");
+});
+
+test("dispatchExternalAgentRuntime: deny path (manifest-misconfigured: no entrypoint)", async (t) => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "misconfig-"));
+  t.after(() => rmSync(repoRoot, { recursive: true, force: true }));
+  const examplesAddons = join(repoRoot, "examples", "addons");
+  mkdirSync(examplesAddons, { recursive: true });
+  const manifest = makeManifest("");
+  delete manifest.service.entrypoint;
+  writeFileSync(join(examplesAddons, "addon.deepseek-harness.json"), JSON.stringify(manifest, null, 2));
+
+  const ledger = makeAuditLedger();
+  const grants = makeGrantStore({ callerId: "caller.test", grantedCapabilities: ["network", "providers"] });
+
+  const result = await dispatchExternalAgentRuntime({
+    addonId: "addon.deepseek-harness",
+    toolName: "deepseek_harness.status",
+    payload: {},
+    callerId: "caller.test",
+    perCallerGrants: grants,
+    auditLedger: ledger,
+    repoRoot,
+  });
+
+  assert.equal(result.outcome, "deny");
+  assert.equal(result.reason, "entrypoint-invalid");
+});
+
+test("dispatchExternalAgentRuntime: deny path (entrypoint-not-allowed: external host)", async (t) => {
+  const stub = await startCordisStub();
+  t.after(() => stub.close());
+  const repoRoot = setupManifestFixture(t, "http://api.deepseek.com:443");
+
+  const ledger = makeAuditLedger();
+  const grants = makeGrantStore({ callerId: "caller.test", grantedCapabilities: ["network", "providers"] });
+
+  const result = await dispatchExternalAgentRuntime({
+    addonId: "addon.deepseek-harness",
+    toolName: "deepseek_harness.status",
+    payload: {},
+    callerId: "caller.test",
+    perCallerGrants: grants,
+    auditLedger: ledger,
+    repoRoot,
+  });
+
+  assert.equal(result.outcome, "deny");
+  assert.equal(result.reason, "entrypoint-not-allowed");
+  assert.equal(ledger.entries.length, 0);
+});
+
+test("dispatchExternalAgentRuntime: deny path (addon-id-invalid: traversal-shaped id)", async (t) => {
+  const stub = await startCordisStub();
+  t.after(() => stub.close());
+  const repoRoot = setupManifestFixture(t, stub.entrypoint);
+
+  const ledger = makeAuditLedger();
+  const grants = makeGrantStore({ callerId: "caller.test", grantedCapabilities: ["network", "providers"] });
+
+  const result = await dispatchExternalAgentRuntime({
+    addonId: "../etc/passwd",
+    toolName: "deepseek_harness.status",
+    payload: {},
+    callerId: "caller.test",
+    perCallerGrants: grants,
+    auditLedger: ledger,
+    repoRoot,
+  });
+
+  assert.equal(result.outcome, "deny");
+  assert.equal(result.reason, "addon-id-invalid");
+});
+
+test("dispatchExternalAgentRuntime: deny path (upstream-unreachable)", async (t) => {
+  const stub = await startCordisStub();
+  const deadPort = stub.port;
+  await stub.close();
+
+  const repoRoot = setupManifestFixture(t, `http://127.0.0.1:${deadPort}`);
+  const ledger = makeAuditLedger();
+  const grants = makeGrantStore({ callerId: "caller.test", grantedCapabilities: ["network", "providers"] });
+
+  const result = await dispatchExternalAgentRuntime({
+    addonId: "addon.deepseek-harness",
+    toolName: "deepseek_harness.status",
+    payload: {},
+    callerId: "caller.test",
+    perCallerGrants: grants,
+    auditLedger: ledger,
+    repoRoot,
+  });
+
+  assert.equal(result.outcome, "deny");
+  assert.equal(result.reason, "upstream-unreachable");
+  assert.equal(ledger.entries.length, 1);
+  assert.equal(ledger.entries[0].upstreamOk, false);
+  assert.equal(ledger.entries[0].upstreamStatus, 0);
+});
+
+test("dispatchExternalAgentRuntime: allow-path audit entry has the request body recursively redacted", async (t) => {
+  const stub = await startCordisStub();
+  t.after(() => stub.close());
+  const repoRoot = setupManifestFixture(t, stub.entrypoint);
+
+  const ledger = makeAuditLedger();
+  const grants = makeGrantStore({ callerId: "caller.test", grantedCapabilities: ["network", "providers"] });
+
+  await dispatchExternalAgentRuntime({
+    addonId: "addon.deepseek-harness",
+    toolName: "deepseek_harness.status",
+    payload: {
+      model: "deepseek-chat",
+      messages: [
+        { role: "system", content: { text: "you are a helper", credentials: { authorization: "Bearer sk-leaked", apiKey: "abc" } } },
+        { role: "user", content: "hi" },
+      ],
+    },
+    callerId: "caller.test",
+    perCallerGrants: grants,
+    auditLedger: ledger,
+    repoRoot,
+  });
+
+  assert.equal(ledger.entries.length, 1);
+  const recorded = ledger.entries[0].request;
+  assert.equal(recorded.messages[0].content.text, "you are a helper");
+  assert.equal(recorded.messages[0].content.credentials.authorization, "[REDACTED]");
+  assert.equal(recorded.messages[0].content.credentials.apiKey, "[REDACTED]");
+  assert.equal(recorded.messages[1].content, "hi");
+  const serialized = JSON.stringify(recorded);
+  assert.equal(serialized.includes("sk-leaked"), false, "leaked token must not appear in the audit entry");
+});


### PR DESCRIPTION
Fifth piece of the resubmission sequence, per your 2026-09-10 closeout: the **redesigned** #330 — dispatcher-only, **not** the original (which Tom marked "not mergeable; redesign"). No Phase 3.5 kernel/launcher wiring, no bridge-server rewrites, no root package.json edits. Lands independently; the bridge host (your future maintainer-owned dispatcher wiring) is the consumer.

## Contents

- `browser-first/host/external-agent-runtime-dispatcher.mjs` — the ADR-056 §4 wire-format dispatcher. Library, not a route.
- `browser-first/test/external-agent-runtime-dispatcher.test.mjs` — 30 cases (allow path, six deny paths, every blocker fix).
- `browser-first/test/_cordis-stub-loader.mjs` — in-process loopback HTTP stub of the DeepSeek OpenAI-compatible interface.
- `examples/addons/addon.deepseek-harness.json` — addon manifest fixture (ADR-055/056 references, no runbook paths dangling).

## Your blockers, fixed

1. **`postToCordis` had no allowlist** → new `assertLoopbackEntrypoint` enforces `http(s)` + loopback hostname (`127.0.0.1`, `::1`, `[::1]`, `localhost`); port 0 rejected. Verified by the SSRF-guard test (rejects `example.com`, `10.0.0.1`, `0.0.0.0`, `192.168.1.1`, `api.deepseek.com`, IPv4-mapped `[::ffff:127.0.0.1]`).
2. **`findAddonManifest` had no traversal guard** → new `validateAddonId` enforces `^[a-z0-9][a-z0-9-]{0,63}(?:\.[a-z0-9][a-z0-9-]{0,63})*$` and rejects empty / >64-char / traversal ids *before* any filesystem call.
3. **Bridge rewrites excluded** → nothing in this PR touches `bridge-server.mjs` / `run-bridge-minimal.mjs`. The dispatcher is a library; the bridge decides how to register a route.
4. **Scope-audit + root package.json edits excluded** → nothing in this PR touches either.
5. **Grant checks ignored expiry** → `checkToolGrants` consults an optional `expiresAt` map on the per-caller bucket and denies expired grants.
6. **`options` could override `model`/`messages`** → `buildChatCompletionsRequest` strips `options.model` and `options.messages`, forwarding only an explicit safe allowlist (`temperature`, `top_p`, `max_tokens`, `stream`, `stop`).
7. **Nested content not redacted in logs** → new `redactRequestForLog` walks plain objects + arrays and replaces leaf credential-shaped values with `[REDACTED]`; recurses into credential-shaped objects so `{ credentials: { authorization: "..." } }` redacts the inner value rather than collapsing the whole object. The dispatcher records the redacted request into the audit ledger.

## Checks run (on this branch)

- `node --test browser-first/test/external-agent-runtime-dispatcher.test.mjs` — **30/30**
- `npm run build` ✓ · `npm test` — **487/487** · `npm run docs:check` ✓
- `npm run test:docs` — **274/274** · `npm run test:module-ownership` ✓
- `npm run repo:hygiene` ✓ · `node scripts/security-pipeline/run-check.mjs` — exit 0
- `npm run verify:alpha` — **exit 0**

Branch gates verified before push: malicious workflow file absent at tip; branch contains the `40dd4c58` fix.

## What it does *not* carry

- No Phase 3.5 kernel (caller-attributed grants, audit ledger) — those are upstream on a future PR.
- No `addon-delegation-host-service.mjs` route registration — that's the bridge wiring, owned separately.
- No run-bridge-minimal.mjs changes.
- No runbook / skill paths in the manifest (those land with the docs PR).
- No `validate-deepseek-manifest.mjs` / `run-deepseek-smoke.mjs` (they depended on the moved validation path; rebuilt when the SDK relocation lands).

Next per the closeout order: #331 (dev panel) once this lands.