### PR TITLE
test(agent-control-live): normalize non-array CDP /json responses

### DIFF
--- a/browser-first/test/agent-control-live.mjs
+++ b/browser-first/test/agent-control-live.mjs
@@ -512,7 +512,10 @@ async function waitForSidePanelReady(panel, label, timeoutMs = 8000) {
 }
 
 async function browserTargets() {
-  return fetch(`http://127.0.0.1:${debugPort}/json`).then((response) => response.json());
+  const response = await fetch(`http://127.0.0.1:${debugPort}/json`);
+  if (!response.ok) return [];
+  const payload = await response.json().catch(() => []);
+  return Array.isArray(payload) ? payload : [];
 }
 
 async function waitForBrowserTarget(predicate, label) {


### PR DESCRIPTION
Unblocks the Agent Control live lane for any future PR that touches \`browser-first/host/**\`. The lane's \`browserTargets()\` helper assumed the Chrome CDP \`/json\` endpoint always returned an array; when it returns an error object (e.g. during startup) the panel probe crashed with \`targets.filter is not a function\`.

Reproduced on #444 (the redesigned #330 dispatcher); the lane triggers on \`browser-first/host/**\` and the unhandled shape crashed the panel probe. Re-run of #444 confirmed flake (clean on second attempt). This commit makes the lane reliable for any future PR that touches that path filter.

- \`browserTargets()\` now \`return []\` on non-OK responses and coerces non-array JSON payloads to \`[]\`.
- Existing call sites that already \`.catch(() => [])\` are unaffected.

One-file change, no public surface. 487/487 vitest still green; no other tests exercise the live lane.