### PR TITLE
security(dev): opt-in page-key-gated bridge config delivery for the Vite dev page (#429 part 2)

### DIFF
--- a/browser-first/README.md
+++ b/browser-first/README.md
@@ -56,7 +56,7 @@ Chrome extension plus local bridge
   prevent host confusion; localhost and IP aliases are not authenticated
   delivery origins.
 - POSIX permissions: the generated `bridge-config.generated.js` file is verified
-  at request time for owning UID, regular-file status, and strict `0600`
+  at request time for owning UID, regular-file status, and group- and world-unreadable (`0600`-style: any mode with no group/other bits, so `0400` or `0700` also pass)
   permissions.
 - Run commands in private, non-recorded terminal sessions. No secret keys or
   credentials appear in URLs, terminal histories, HTML, or browser storage APIs.

--- a/browser-first/README.md
+++ b/browser-first/README.md
@@ -37,6 +37,88 @@ human-only according to the capability contract.
 Provider secrets and trusted memory writes are host-owned. Do not place secrets
 in extension source, generated config, Chrome storage, fixtures, or diagnostics.
 
+## Opt-in React Shell Development
+
+The React shell served by Vite is an optional development surface. Bridge
+configuration delivery is disabled by default and requires both an explicit
+developer opt-in and an independently authenticated page. It does not change the
+Chrome extension plus local bridge
+[Alpha runtime boundary](../docs/architecture/ALPHA_RUNTIME_BOUNDARY.md).
+
+### Prerequisites and Boundaries
+
+- The generated bridgeUrl must be http or https on 127.0.0.1, the only host the
+  page CSP allows it to connect to; HTTPS requires browser-trusted local TLS.
+  Any other host, including localhost, [::1], or a non-loopback
+  RESONANTOS_BRIDGE_PUBLIC_URL / RESONANTOS_BRIDGE_HOST, disables delivery and
+  emits one value-free console diagnostic.
+- Delivery is 127.0.0.1-only to bind the page gate to one exact origin and
+  prevent host confusion; localhost and IP aliases are not authenticated
+  delivery origins.
+- POSIX permissions: the generated `bridge-config.generated.js` file is verified
+  at request time for owning UID, regular-file status, and strict `0600`
+  permissions.
+- Run commands in private, non-recorded terminal sessions. No secret keys or
+  credentials appear in URLs, terminal histories, HTML, or browser storage APIs.
+
+### Why Nonce and Referrer Alone Are Insufficient
+
+HTTP headers alone do not prove a legitimate browser page. The Referrer-Policy
+is `no-referrer`, and headers can be forged by any local process. Publicly
+issued or unauthenticated nonces would allow other local OS users on the
+machine to fetch the page and obtain credentials. The independent page key
+combined with the HTTP Basic challenge ensures only an authorized operator
+receives the single-use, 60-second module nonce. HMR/WebSocket is not gated by
+Basic (HTTP upgrade bypasses Connect middleware); instead, credential delivery
+is isolated from Vite's transform graph so the reserved module never enters the
+module graph or HMR messages.
+
+### Operator Commands
+
+1. In a private zsh terminal, generate a 43-character base64url key
+   (approximately 256 random bits) in a password manager and start the
+   development server:
+
+```bash
+read -r -s 'RESONANTOS_DEV_BRIDGE_PAGE_KEY?Developer page key: '
+export RESONANTOS_DEV_BRIDGE_PAGE_KEY
+RESONANTOS_DEV_BRIDGE_CONFIG=1 npm run dev
+```
+
+The server binds strictly to `127.0.0.1:1430`.
+
+2. In the bridge terminal, start or restart the bridge with CORS allowed for the
+   development origin:
+
+```bash
+RESONANTOS_BRIDGE_ALLOWED_ORIGINS=http://127.0.0.1:1430 npm run browser-first:bridge
+```
+
+3. Open `http://127.0.0.1:1430/` in the browser. When challenged by HTTP Basic
+   authentication, enter:
+   - **Username:** `dev`
+   - **Password:** the exported `RESONANTOS_DEV_BRIDGE_PAGE_KEY`
+
+### Missing Config and Credential Rotation
+
+- If the bridge configuration is missing, unreadable, or invalid, Vite returns
+  a 200 JS module that deletes `globalThis.__RESONANTOS_BRIDGE_CONFIG__` and
+  dynamically imports `/src/main.tsx`. The web transport retains its standard
+  "Browser-first bridge is not configured..." failure without leaking paths or
+  details.
+- Restarting the bridge rotates bridge credentials. A fresh browser page reload
+  re-authenticates and receives the newly generated configuration.
+
+### Clean Disable and Rollback
+
+To disable delivery:
+
+1. Stop the development server, unset `RESONANTOS_DEV_BRIDGE_CONFIG` and
+   `RESONANTOS_DEV_BRIDGE_PAGE_KEY`, and restart `npm run dev`.
+2. Unset `RESONANTOS_BRIDGE_ALLOWED_ORIGINS` and restart the bridge to restore
+   default-deny CORS and rotate credentials.
+3. Close authenticated browser contexts to clear in-memory credentials.
+
 ## Validate Changes
 
 ```bash

--- a/browser-first/test/bridge-server.test.mjs
+++ b/browser-first/test/bridge-server.test.mjs
@@ -9,7 +9,7 @@ import {
   isUnauthorizedBridgeError,
   resolveBridgeConfig,
 } from "../resonantos-side-panel-extension/src/lib/bridge-client.js";
-import { constantTimeEqual, evaluateBridgeRequestForSelfTest, startBridgeServer, summarizeBridgeAuthSelfTest } from "../host/bridge-server.mjs";
+import { getBridgeAllowedOrigins, constantTimeEqual, evaluateBridgeRequestForSelfTest, startBridgeServer, summarizeBridgeAuthSelfTest } from "../host/bridge-server.mjs";
 
 test("constant-time token comparison preserves exact-match and length checks", () => {
   assert.equal(constantTimeEqual("capability-token", "capability-token"), true);
@@ -727,4 +727,16 @@ test("bridge auth self-test summary only reports ok when default-deny held", () 
   assert.equal(denyRegressed.ok, false, "a bridge-token-only 200 means an undeclared or unguarded route was served; the self-test must fail");
   const tokenRegressed = summarizeBridgeAuthSelfTest({ unauthorizedStatus: 200, wrongTokenStatus: 401, missingCapabilityStatus: 403, authorizedStatus: 200 });
   assert.equal(tokenRegressed.ok, false);
+});
+
+// C1: synchronous and serialized so no other case observes a changed environment.
+test("bridge CORS defaults to no allowed origins", { concurrency: false }, () => {
+  const previous = process.env.RESONANTOS_BRIDGE_ALLOWED_ORIGINS;
+  try {
+    delete process.env.RESONANTOS_BRIDGE_ALLOWED_ORIGINS;
+    assert.deepEqual(getBridgeAllowedOrigins(), []);
+  } finally {
+    if (previous === undefined) delete process.env.RESONANTOS_BRIDGE_ALLOWED_ORIGINS;
+    else process.env.RESONANTOS_BRIDGE_ALLOWED_ORIGINS = previous;
+  }
 });

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -134,3 +134,14 @@ criteria, and the release evidence — are tracked in
 Future work belongs in the [roadmap](./ROADMAP.md), and the actual reviewer
 delivery path is documented in
 [Alpha Distribution](./release/ALPHA_DISTRIBUTION.md).
+
+## Development Surface
+
+Issue [#429](https://github.com/ResonantOS/2.0.0-alpha/issues/429) part 2
+provides opt-in, authenticated bridge-config delivery to the React shell at
+http://127.0.0.1:1430. Delivery is disabled by default, requires a separate
+developer page key, and requires the bridge operator's exact-origin CORS
+opt-in. Generated bridge credentials remain denied through Vite filesystem
+routes and are excluded from builds. This is development tooling, not a new
+Alpha runtime component. See
+[Opt-in React shell development](../browser-first/README.md#opt-in-react-shell-development).

--- a/docs/architecture/ALPHA_RUNTIME_BOUNDARY.md
+++ b/docs/architecture/ALPHA_RUNTIME_BOUNDARY.md
@@ -141,6 +141,14 @@ scripts can supply shared contracts, manifests, optional services, tests, or
 future product work. Their presence does not add a third required Alpha runtime
 component.
 
+The optional Vite React development page may receive generated bridge
+credentials only through the explicitly enabled, authenticated development
+delivery path documented in
+[browser-first/README.md](../../browser-first/README.md#opt-in-react-shell-development).
+The bridge retains all authentication and capability checks; the operator must
+separately allow the exact development origin. This is not an additional
+shipped Alpha component.
+
 ## Change Rules
 
 - Extension or bridge changes must preserve bridge-token and route-capability

--- a/docs/architecture/MODULE-OWNERSHIP.md
+++ b/docs/architecture/MODULE-OWNERSHIP.md
@@ -62,6 +62,7 @@ required Alpha processes.
 | `addons/resonant-browser-host/` | Optional browser-host add-on package | Not the required Alpha bridge or browser runtime |
 | `examples/` | Optional examples | Never required for Alpha startup |
 | `scripts/` | Repository validation and development tooling | Not shipped runtime authority |
+| `scripts/vite-dev-bridge-config.mjs` | Opt-in, authenticated development-page config delivery | May read bridge-generated config at request time and write only authorized HTTP responses and in-memory nonce state; must not own bridge auth, capabilities, CORS defaults, provider credentials, extension state, or production artifacts |
 
 If two domains need the same data shape or pure helper, place it in
 `src/core/` or the established SDK layer. Shared placement does not transfer

--- a/docs/architecture/MODULE_MAP.md
+++ b/docs/architecture/MODULE_MAP.md
@@ -77,6 +77,7 @@ future product work. They are not additional required Alpha processes.
 | `addons/resonant-browser-host/` | Separate browser-host add-on package and tests | Optional/supporting; not a required Alpha host |
 | `examples/` | MCP and service examples | Optional, never required Alpha runtime |
 | `scripts/` | Build, test, health, security, docs, and release validation | Development and verification only |
+| `scripts/vite-dev-bridge-config.mjs` | Opt-in, authenticated development-page config delivery; may read bridge-generated config at request time and write only authorized HTTP responses and in-memory nonce state | Development tooling only; must not own bridge auth, capabilities, CORS defaults, provider credentials, extension state, or production artifacts |
 
 ## Domain Ownership In Shared Source
 

--- a/docs/browser-first-bridge-setup-runbook.md
+++ b/docs/browser-first-bridge-setup-runbook.md
@@ -162,11 +162,16 @@ transport reads it on every call and a changed URL or either credential triggers
 a fresh bootstrap. Other 403s and 401s do not trigger retries. Tokens never appear
 in transport-generated error messages.
 
-Nothing delivers `__RESONANTOS_BRIDGE_CONFIG__` to a browser page yet. Browser
-use also requires the operator's CORS opt-in at the bridge through
-`RESONANTOS_BRIDGE_ALLOWED_ORIGINS`. Config delivery and browser-origin setup
-are tracked in #429, together with the dev-server exposure warning: while
-`npm run dev` runs, the generated config file is served to local processes.
+The optional Vite React development page receives `__RESONANTOS_BRIDGE_CONFIG__`
+only when `RESONANTOS_DEV_BRIDGE_CONFIG=1` and the operator authenticates with
+the independent `RESONANTOS_DEV_BRIDGE_PAGE_KEY` through HTTP Basic. Delivery
+uses a same-origin, request-generated module with a single-use nonce. Browser
+access also requires the bridge operator to set
+`RESONANTOS_BRIDGE_ALLOWED_ORIGINS=http://127.0.0.1:1430`. Since #429 part 1,
+the generated config file is NOT served through Vite filesystem routes; part 2
+preserves those denials. See
+[Opt-in React shell development](../browser-first/README.md#opt-in-react-shell-development)
+for setup and disable steps.
 
 ## Live SDK lane
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:living-archive-memory-service": "node --test examples/living-archive-memory-service.test.mjs",
     "test:browser-host": "node --test addons/resonant-browser-host/test/*.test.mjs",
     "test:browser-first": "node scripts/run-browser-first-extension-tests.mjs",
+    "test:dev-bridge-config": "node --test --test-concurrency=1 scripts/vite-dev-bridge-config.test.mjs scripts/dev-bridge-config.integration.test.mjs",
     "test:browser-first:live": "node browser-first/test/agent-control-live.mjs",
     "test:browser-first:settings-shapes": "node browser-first/test/settings-shapes-live.mjs",
     "test:browser-first:live-sdk": "node browser-first/test/live-sdk-lane.mjs",

--- a/scripts/dev-bridge-config-live.mjs
+++ b/scripts/dev-bridge-config-live.mjs
@@ -1,0 +1,313 @@
+#!/usr/bin/env node
+// Private, in-memory operator proof. Never start/restart a server or mutate the
+// generated source here. Run only after the operator's fresh foreground startup.
+// L14 is a same-UID network client, NOT proof of OS/filesystem isolation.
+// L9 needs RESONANTOS_DEV_BRIDGE_HARMLESS_PROBE to designate an EXISTING harmless
+// regular file under this checkout's ResonantOS_User/. Missing designation means
+// unproved (FAIL L9, exit 1), never a pass inferred from an absent path.
+import { chromium } from 'playwright';
+import { request as httpRequest } from 'node:http';
+import { spawn } from 'node:child_process';
+import { lstat, realpath } from 'node:fs/promises';
+import { resolve, relative, isAbsolute, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { parse } from 'parse5';
+
+const ORIGIN = 'http://127.0.0.1:1430';
+const ROOT = resolve(import.meta.dirname, '..');
+const PREFIX = '/__resonantos_dev_bridge__/';
+const ROUTE = `${PREFIX}config.mjs`;
+const GENERATED = 'browser-first/resonantos-side-panel-extension/src/bridge-config.generated.js';
+const META = { 'Sec-Fetch-Site': 'same-origin', 'Sec-Fetch-Mode': 'cors', 'Sec-Fetch-Dest': 'script' };
+const CHALLENGE = 'Basic realm="ResonantOS development", charset="UTF-8"';
+const requireProof = condition => { if (!condition) throw Error('proof unavailable'); };
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+function noMaterial(text, values) { requireProof(values.every(value => !value || !text.includes(value))); }
+function request(path, { headers = {}, method = 'GET', hostname = '127.0.0.1', port = 1430 } = {}) {
+  // Caller-selected network destinations are prohibited; bridge health below
+  // uses the validated generated loopback URL through fetch instead.
+  requireProof(hostname === '127.0.0.1');
+  return new Promise((resolve, reject) => {
+    const req = httpRequest({ hostname, port, path, method, headers, agent: false }, res => {
+      let body = ''; res.setEncoding('utf8');
+      res.on('data', chunk => { body += chunk; if (body.length > 8 * 1024 * 1024) req.destroy(Error('response bound')); });
+      res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body }));
+    });
+    req.setTimeout(15000, () => req.destroy(Error('request timeout'))); req.on('error', reject); req.end();
+  });
+}
+function moduleRoute(html) {
+  const matches = [...html.matchAll(/src="(\/__resonantos_dev_bridge__\/config\.mjs\?nonce=[A-Za-z0-9_-]{43})"/g)];
+  requireProof(matches.length === 1); return matches[0][1];
+}
+function pageShape(html) {
+  const all = [];
+  const visit = node => { all.push(node); for (const child of node.childNodes ?? []) visit(child); }; visit(parse(html));
+  const attr = (node, name) => node.attrs?.find(attribute => attribute.name === name)?.value;
+  const metas = all.filter(node => node.tagName === 'meta' && attr(node, 'http-equiv')?.toLowerCase() === 'content-security-policy');
+  requireProof(metas.length === 1);
+  const scripts = all.filter(node => node.tagName === 'script');
+  const policy = attr(metas[0], 'content').split(';').filter(part => part.trim().startsWith('script-src '));
+  requireProof(policy.length === 1 && policy[0].includes("'self'") && !/unsafe-inline|unsafe-eval/.test(policy[0]));
+  const cspNonce = policy[0].match(/'nonce-([A-Za-z0-9_-]{43})'/)?.[1];
+  requireProof(Boolean(cspNonce) && scripts.length > 0 && scripts.every(script => attr(script, 'nonce') === cspNonce));
+  requireProof(scripts.every(script => all.indexOf(metas[0]) < all.indexOf(script)));
+  requireProof(!scripts.some(script => attr(script, 'src')?.startsWith('/src/main.tsx')));
+  const route = moduleRoute(html); requireProof(!route.endsWith(cspNonce)); return route;
+}
+function protectedHeaders(response, page = false) {
+  for (const [name, value] of Object.entries({ 'cache-control': 'private, no-store', pragma: 'no-cache', 'referrer-policy': 'no-referrer',
+    'cross-origin-resource-policy': 'same-origin', 'x-content-type-options': 'nosniff',
+    vary: 'Host, Authorization, Origin, Sec-Fetch-Site, Sec-Fetch-Mode, Sec-Fetch-Dest' })) requireProof(response.headers[name] === value);
+  for (const name of ['access-control-allow-origin', 'access-control-allow-credentials', 'etag', 'last-modified', 'location']) requireProof(response.headers[name] === undefined);
+  if (page) requireProof(response.headers['x-frame-options'] === 'DENY' && response.headers['content-security-policy']?.includes("frame-ancestors 'none'"));
+}
+function cleanChildEnv() {
+  const env = {};
+  for (const name of ['PATH', 'HOME', 'TMPDIR', 'LANG', 'LC_ALL', 'SystemRoot', 'WINDIR']) if (process.env[name] !== undefined) env[name] = process.env[name];
+  return env;
+}
+async function privateConfig() {
+  // Dynamic import keeps entrypoint failures sanitized when A is not integrated.
+  const { readGeneratedBridgeConfig } = await import('./vite-dev-bridge-config.mjs');
+  const config = await readGeneratedBridgeConfig(ROOT);
+  requireProof(config !== null); return config;
+}
+async function secondClient(paths) {
+  // Input contains public attack paths (including one stolen nonce), never a
+  // private file reader, key, Authorization, config, or authorized module body.
+  const source = `import http from 'node:http';
+let input='';for await(const part of process.stdin)input+=part;
+const paths=JSON.parse(input),headers={'Sec-Fetch-Site':'same-origin','Sec-Fetch-Mode':'cors','Sec-Fetch-Dest':'script',Origin:'${ORIGIN}',Referer:'${ORIGIN}/','X-Forwarded-Host':'127.0.0.1:1430'};
+const out=[];for(const path of paths){out.push(await new Promise((resolve,reject)=>{const q=http.get({hostname:'127.0.0.1',port:1430,path,headers,agent:false},r=>{let body='';r.on('data',c=>{body+=c;if(body.length>8*1024*1024)q.destroy(Error('bound'));});r.on('end',()=>resolve({status:r.statusCode,body}));});q.setTimeout(10000,()=>q.destroy(Error('timeout')));q.on('error',reject);}));}
+process.stdout.write(JSON.stringify(out));`;
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ['--input-type=module', '-e', source], { cwd: ROOT, env: cleanChildEnv(), shell: false, stdio: ['pipe', 'pipe', 'pipe'] });
+    let stdout = '', stderr = '';
+    const timer = setTimeout(() => child.kill('SIGKILL'), 45000);
+    child.stdout.on('data', chunk => { stdout += chunk; if (stdout.length > 16 * 1024 * 1024) child.kill('SIGKILL'); });
+    child.stderr.on('data', chunk => { stderr += chunk; if (stderr.length > 1024 * 1024) child.kill('SIGKILL'); });
+    child.once('error', () => { clearTimeout(timer); reject(Error('client unavailable')); });
+    child.once('close', code => { clearTimeout(timer); if (code !== 0 || stderr) reject(Error('client unavailable')); else { try { resolve(JSON.parse(stdout)); } catch { reject(Error('client unavailable')); } } });
+    child.stdin.on('error', () => {}); child.stdin.end(JSON.stringify(paths));
+  });
+}
+async function browserSession(key) {
+  const browser = await chromium.launch({ headless: true, env: cleanChildEnv() });
+  try {
+    const context = await browser.newContext({ httpCredentials: { username: 'dev', password: key, origin: ORIGIN } });
+    // Prevent external fonts/services from expanding this loopback-only proof.
+    await context.route('**/*', route => {
+      const url = new URL(route.request().url());
+      return ['127.0.0.1', 'localhost'].includes(url.hostname) ? route.continue() : route.abort();
+    });
+    const page = await context.newPage(), violations = [], errors = [], records = new Map();
+    await page.exposeFunction('__recordDevCspViolation', directive => violations.push(directive));
+    await page.addInitScript(() => document.addEventListener('securitypolicyviolation', event => {
+      if (/^(script-src|connect-src)/.test(event.effectiveDirective)) void globalThis.__recordDevCspViolation(event.effectiveDirective);
+    }));
+    page.on('pageerror', error => errors.push(error.message));
+    const cdp = await context.newCDPSession(page); await cdp.send('Network.enable');
+    cdp.on('Network.requestWillBeSent', event => {
+      const previous = records.get(event.requestId) ?? {};
+      records.set(event.requestId, { ...previous, url: event.request.url, method: event.request.method, requestHeaders: { ...previous.requestHeaders, ...event.request.headers } });
+    });
+    cdp.on('Network.requestWillBeSentExtraInfo', event => {
+      const previous = records.get(event.requestId) ?? {};
+      records.set(event.requestId, { ...previous, wireSent: true, requestHeaders: { ...previous.requestHeaders, ...event.headers } });
+    });
+    cdp.on('Network.responseReceived', event => {
+      const previous = records.get(event.requestId) ?? {};
+      records.set(event.requestId, { ...previous, status: event.response.status, responseHeaders: { ...previous.responseHeaders, ...event.response.headers } });
+    });
+    cdp.on('Network.responseReceivedExtraInfo', event => {
+      const previous = records.get(event.requestId) ?? {};
+      records.set(event.requestId, { ...previous, status: event.statusCode, responseHeaders: { ...previous.responseHeaders, ...event.headers } });
+    });
+    cdp.on('Network.loadingFailed', event => {
+      const previous = records.get(event.requestId) ?? {};
+      records.set(event.requestId, { ...previous, corsFailure: Boolean(event.corsErrorStatus), failed: true });
+    });
+    return { browser, context, page, violations, errors, records };
+  } catch { await browser.close(); throw Error('browser unavailable'); }
+}
+const header = (headers, name) => Object.entries(headers ?? {}).find(([key]) => key.toLowerCase() === name.toLowerCase())?.[1];
+async function navigate(session) {
+  const response = await session.page.goto(ORIGIN, { waitUntil: 'domcontentloaded', timeout: 30000 }); requireProof(response?.status() === 200);
+  await session.page.waitForFunction(() => Boolean(globalThis.__RESONANTOS_BRIDGE_CONFIG__) && Object.isFrozen(globalThis.__RESONANTOS_BRIDGE_CONFIG__) && (document.querySelector('#root')?.childElementCount ?? 0) > 0, undefined, { timeout: 30000 });
+}
+async function diagnostics(session) {
+  return session.page.evaluate(async () => {
+    try { const transport = await import('/src/core/web-transport.ts'); const result = await transport.webInvoke('provider_diagnostics'); return { ok: result?.ok === true, rejected: false }; }
+    catch (error) { return { ok: false, rejected: true, networkError: error instanceof TypeError && /fetch|network/i.test(error.message) }; }
+  });
+}
+async function observeHmr(session, material) {
+  const client = await request('/@vite/client'); requireProof(client.status === 200); noMaterial(client.body, material);
+  const token = client.body.match(/const wsToken = ("[^"\n]+"|'[^'\n]+');/)?.[1];
+  requireProof(Boolean(token));
+  const wsToken = token[0] === '"' ? JSON.parse(token) : token.slice(1, -1);
+  const protocol = client.body.match(/const socketProtocol = ("[^"\n]*"|null) \|\|/)?.[1];
+  const hostname = client.body.match(/const socketHost = `\$\{("[^"\n]*"|null) \|\| importMetaUrl.hostname\}/)?.[1];
+  const portMatch = client.body.match(/const hmrPort = (\d+|null|"\d+");/);
+  const baseMatch = client.body.match(/\$\{hmrPort \|\| importMetaUrl.port\}\$\{("[^"\n]*")\}`/);
+  requireProof(Boolean(portMatch) && Boolean(baseMatch));
+  const port = JSON.parse(portMatch[1]) || 1430;
+  const host = hostname ? JSON.parse(hostname) || '127.0.0.1' : '127.0.0.1';
+  const scheme = protocol ? JSON.parse(protocol) || 'ws' : 'ws';
+  requireProof(host === '127.0.0.1' && Number(port) === 1430 && scheme === 'ws');
+  const url = `ws://${host}:${port}${JSON.parse(baseMatch[1])}?token=${encodeURIComponent(wsToken)}`;
+  requireProof(client.body.includes('"vite-hmr"') || client.body.includes("'vite-hmr'"));
+  const messages = []; let socket;
+  try {
+    // Node's WebSocket does not inherit browser Basic credentials or send Origin.
+    socket = new WebSocket(url, 'vite-hmr');
+    await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(Error('HMR connection unavailable')), 10000);
+      socket.addEventListener('message', event => { const text = String(event.data); messages.push(text); try { if (JSON.parse(text).type === 'connected') { clearTimeout(timer); resolve(); } } catch { /* checked for disclosure below */ } });
+      socket.addEventListener('error', () => { clearTimeout(timer); reject(Error('HMR connection unavailable')); }, { once: true });
+    });
+    await delay(3000); requireProof(socket.readyState === WebSocket.OPEN); requireProof(messages.length > 0);
+    for (const message of messages) noMaterial(message, material);
+    requireProof(!session.page.isClosed());
+  } finally { socket?.close(); }
+}
+
+export async function main() {
+  const args = process.argv.slice(2); let current = 'L1';
+  let session;
+  const run = async (id, proof) => { current = id; await proof(); console.log(`PASS ${id}`); };
+  try {
+    requireProof(args.length === 1 && /^--expect=(on|off|cors-denied)$/.test(args[0]));
+    const mode = args[0].slice('--expect='.length);
+    if (mode === 'off') {
+      // L1/L3/L7/L8/L10 are the disable counterparts of the same live surfaces.
+      await run('L1', async () => {
+        for (const Host of ['127.0.0.1:1430', 'localhost:1430']) { const response = await request('/', { headers: { Host } }); requireProof(response.status === 200 && !response.body.includes(PREFIX) && !response.body.includes('__RESONANTOS_BRIDGE_CONFIG__')); }
+      });
+      await run('L3', async () => { const response = await request(ROUTE); requireProof(response.status === 404 && response.body === 'Not found.\n' && !response.headers['www-authenticate']); });
+      await run('L7', async () => requireProof((await request(`/${GENERATED}`)).status === 403));
+      await run('L8', async () => { for (const suffix of ['', '?raw', '?url']) requireProof((await request(`/@fs/${join(ROOT, GENERATED)}${suffix}`)).status === 403); });
+      await run('L10', async () => {
+        const browser = await chromium.launch({ headless: true, env: cleanChildEnv() });
+        try {
+          const context = await browser.newContext();
+          await context.route('**/*', route => new URL(route.request().url()).hostname === '127.0.0.1' ? route.continue() : route.abort());
+          const page = await context.newPage(); await page.goto(ORIGIN, { waitUntil: 'domcontentloaded' });
+          const result = await page.evaluate(async () => {
+            let calls = 0; const original = globalThis.fetch;
+            globalThis.fetch = (...args) => { calls++; return original(...args); };
+            try {
+              const transport = await import('/src/core/web-transport.ts'); transport.__resetWebTransportForTests();
+              let message = ''; try { await transport.webInvoke('provider_diagnostics'); } catch (error) { message = error.message; }
+              return { absent: globalThis.__RESONANTOS_BRIDGE_CONFIG__ === undefined, calls, expectedError: message === 'Browser-first bridge is not configured. Start it with `npm run browser-first:bridge`.' };
+            } finally { globalThis.fetch = original; }
+          });
+          requireProof(result.absent && result.calls === 0 && result.expectedError);
+        } finally { await browser.close(); }
+      });
+      return;
+    }
+    if (mode === 'cors-denied') current = 'L15';
+    const key = process.env.RESONANTOS_DEV_BRIDGE_PAGE_KEY;
+    requireProof(/^[A-Za-z0-9_-]{43}$/.test(key ?? ''));
+    const authorization = `Basic ${Buffer.from(`dev:${key}`).toString('base64')}`;
+    let value = await privateConfig();
+    const material = () => [value.bridgeToken, value.capabilityBootstrapToken, key, authorization, JSON.stringify(value)];
+    if (mode === 'cors-denied') {
+      await run('L15', async () => {
+        const bridge = new URL(value.bridgeUrl); requireProof(bridge.hostname === '127.0.0.1');
+        // The bridge has no /health route. Privately exercise its real authenticated
+        // diagnostics route so an unavailable bridge/auth failure cannot pass as CORS.
+        const bootstrap = await fetch(new URL('/api/capability-tokens', bridge), {
+          method: 'POST', headers: { 'Content-Type': 'application/json',
+            'X-ResonantOS-Bridge-Token': value.bridgeToken,
+            'X-ResonantOS-Capability-Bootstrap-Token': value.capabilityBootstrapToken },
+          body: JSON.stringify({ capabilities: ['bridge-diagnostics-read'] }),
+          signal: AbortSignal.timeout(10000), redirect: 'error',
+        });
+        requireProof(bootstrap.ok); const bootstrapBody = await bootstrap.json();
+        const scoped = bootstrapBody.capabilityTokens?.['bridge-diagnostics-read'];
+        requireProof(bootstrapBody.ok === true && typeof scoped === 'string' && scoped.length > 0);
+        const health = await fetch(new URL('/status', bridge), { headers: {
+          'X-ResonantOS-Bridge-Token': value.bridgeToken,
+          'X-ResonantOS-Bridge-Capability-Token': scoped }, signal: AbortSignal.timeout(10000), redirect: 'error' });
+        requireProof(health.ok); const healthBody = await health.json(); requireProof(healthBody.ok === true);
+        session = await browserSession(key); await navigate(session);
+        const result = await diagnostics(session); await delay(500);
+        const entries = [...session.records.values()];
+        const preflight = entries.filter(entry => entry.method === 'OPTIONS' && entry.url === `${value.bridgeUrl}/api/capability-tokens`);
+        requireProof(preflight.some(entry => entry.status >= 200 && entry.status < 300 && header(entry.responseHeaders, 'access-control-allow-origin') !== ORIGIN));
+        requireProof(result.rejected && result.networkError && entries.some(entry => entry.corsFailure));
+        requireProof(!entries.some(entry => entry.wireSent && ((entry.method === 'POST' && entry.url === `${value.bridgeUrl}/api/capability-tokens`) || (entry.method === 'GET' && entry.url === `${value.bridgeUrl}/providers/status`))));
+        requireProof(session.violations.length === 0 && !session.errors.some(message => /preamble/i.test(message)));
+      });
+      return;
+    }
+    let route;
+    await run('L1', async () => { const response = await request('/'); requireProof(response.status === 401 && response.body === 'Authentication required.\n' && response.headers['www-authenticate'] === CHALLENGE); noMaterial(response.body, [...material(), PREFIX]); });
+    await run('L2', async () => { const response = await request('/', { headers: { Authorization: authorization } }); requireProof(response.status === 200); route = pageShape(response.body); protectedHeaders(response, true); noMaterial(response.body, material()); });
+    await run('L3', async () => {
+      const absent = await request(ROUTE, { headers: META }); requireProof(absent.status === 401 && absent.body === 'Authentication required.\n' && absent.headers['www-authenticate'] === CHALLENGE);
+      const authenticated = await request(ROUTE, { headers: { ...META, Authorization: authorization } }); requireProof(authenticated.status === 403 && authenticated.body === 'Forbidden.\n'); noMaterial(absent.body + authenticated.body, material());
+    });
+    await run('L4', async () => { const denied = await request(route, { headers: META }); requireProof(denied.status === 401 && denied.body === 'Authentication required.\n' && denied.headers['www-authenticate'] === CHALLENGE); noMaterial(denied.body, material()); });
+    await run('L5', async () => {
+      value = await privateConfig();
+      const response = await request(route, { headers: { ...META, Authorization: authorization } });
+      requireProof(response.status === 200 && response.headers['content-type'] === 'text/javascript; charset=utf-8'); protectedHeaders(response);
+      const match = response.body.match(/^globalThis\.__RESONANTOS_BRIDGE_CONFIG__ = Object\.freeze\((.*)\);\s*await import\('\/src\/main\.tsx'\);\s*$/);
+      requireProof(Boolean(match)); const delivered = JSON.parse(match[1]);
+      requireProof(Object.keys(delivered).sort().join(',') === 'bridgeToken,bridgeUrl,capabilityBootstrapToken');
+      requireProof(Object.keys(value).every(name => delivered[name] === value[name])); noMaterial(response.body, [key, authorization]);
+    });
+    await run('L6', async () => { const response = await request(route, { headers: { ...META, Authorization: authorization, 'If-None-Match': '*', 'If-Modified-Since': new Date().toUTCString() } }); requireProof(response.status === 403 && response.body === 'Forbidden.\n'); protectedHeaders(response); });
+    await run('L7', async () => { for (const headers of [{}, { Authorization: authorization }]) { const response = await request(`/${GENERATED}`, { headers }); requireProof(response.status === 403 && /(?:Restricted|denied|outside|403)/i.test(response.body)); noMaterial(response.body, material()); } });
+    await run('L8', async () => { for (const suffix of ['', '?raw', '?url']) { const response = await request(`/@fs/${join(ROOT, GENERATED)}${suffix}`); requireProof(response.status === 403); noMaterial(response.body, material()); } });
+    await run('L9', async () => {
+      const designated = process.env.RESONANTOS_DEV_BRIDGE_HARMLESS_PROBE; requireProof(Boolean(designated));
+      const path = resolve(ROOT, designated), stateRoot = join(ROOT, 'ResonantOS_User');
+      const rel = relative(stateRoot, path); requireProof(rel && !rel.startsWith('..') && !isAbsolute(rel));
+      const stat = await lstat(path); requireProof(stat.isFile() && !stat.isSymbolicLink());
+      const canonicalRoot = await realpath(stateRoot), canonicalFile = await realpath(path);
+      requireProof(canonicalFile.startsWith(canonicalRoot + '/'));
+      const response = await request(`/@fs/${path}`); requireProof(response.status === 403); noMaterial(response.body, material());
+    });
+    await run('L10', async () => { const response = await request('/src/main.tsx'); requireProof(response.status === 200 && response.body.includes('import')); noMaterial(response.body, material()); });
+    await run('L11', async () => { for (const path of ['/', route]) for (const Host of ['127.0.0.2:1430', 'attacker.test']) { const response = await request(path, { headers: { ...META, Host, Authorization: authorization } }); requireProof(response.status === 403 && response.body === 'Forbidden.\n' && !response.headers['www-authenticate']); noMaterial(response.body, material()); } });
+    await run('L12', async () => { for (const path of ['/', route]) for (const patch of [{ Origin: 'null' }, { Origin: 'http://attacker.test' }, { 'Sec-Fetch-Site': 'cross-site' }]) { const response = await request(path, { headers: { ...META, Authorization: authorization, ...patch } }); requireProof(response.status === 403 && response.body === 'Forbidden.\n' && !response.headers['access-control-allow-origin']); noMaterial(response.body, material()); } });
+    await run('L13', async () => {
+      session = await browserSession(key); await navigate(session);
+      const result = await diagnostics(session); requireProof(result.ok && !result.rejected); await delay(200);
+      const entries = [...session.records.values()];
+      const bootstrap = entries.find(entry => entry.method === 'POST' && entry.url === `${value.bridgeUrl}/api/capability-tokens` && entry.status === 200);
+      const diagnosticsRequest = entries.find(entry => entry.method === 'GET' && entry.url === `${value.bridgeUrl}/providers/status` && entry.status === 200);
+      requireProof(Boolean(bootstrap) && Boolean(diagnosticsRequest) && entries.indexOf(bootstrap) < entries.indexOf(diagnosticsRequest));
+      requireProof(Boolean(header(bootstrap.requestHeaders, 'X-ResonantOS-Bridge-Token')) && Boolean(header(bootstrap.requestHeaders, 'X-ResonantOS-Capability-Bootstrap-Token')));
+      requireProof(Boolean(header(diagnosticsRequest.requestHeaders, 'X-ResonantOS-Bridge-Token')) && Boolean(header(diagnosticsRequest.requestHeaders, 'X-ResonantOS-Bridge-Capability-Token')));
+      requireProof(header(bootstrap.responseHeaders, 'access-control-allow-origin') === ORIGIN && header(diagnosticsRequest.responseHeaders, 'access-control-allow-origin') === ORIGIN);
+      requireProof(session.violations.length === 0 && !session.errors.some(message => /preamble/i.test(message)));
+    });
+    await run('L14', async () => {
+      const fresh = await request('/', { headers: { Authorization: authorization } }); requireProof(fresh.status === 200);
+      const stolen = moduleRoute(fresh.body);
+      const paths = ['/', ROUTE, stolen, `/${GENERATED}`, `/@fs/${join(ROOT, GENERATED)}`, ROUTE + '?raw', ROUTE + '?url', ROUTE + '.map', '/@id/' + ROUTE, '/@vite/client', '/src/main.tsx'];
+      const responses = await secondClient(paths); requireProof(responses.length === paths.length);
+      requireProof(responses[0].status === 401 && responses[1].status === 401 && responses[2].status === 401 && responses[3].status === 403 && responses[4].status === 403);
+      for (const response of responses) { noMaterial(response.body, material()); requireProof(!/^globalThis\.__RESONANTOS_BRIDGE_CONFIG__ = Object\.freeze\(/.test(response.body)); }
+    });
+    await run('L16', async () => {
+      requireProof(Boolean(session));
+      const gatedUrls = [...session.records.values()].filter(record => record.url?.includes(PREFIX)).map(record => new URL(record.url).searchParams.get('nonce')).filter(Boolean);
+      await observeHmr(session, [...material(), PREFIX, route.split('=')[1], ...gatedUrls]);
+    });
+  } catch {
+    console.error(`FAIL ${current}`); process.exitCode = 1;
+  } finally {
+    if (session) { try { await session.browser.close(); } catch { console.error(`FAIL ${current}`); process.exitCode = 1; } }
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  main().catch(() => { console.error('FAIL L1'); process.exitCode = 1; });
+}

--- a/scripts/dev-bridge-config-live.mjs
+++ b/scripts/dev-bridge-config-live.mjs
@@ -239,11 +239,12 @@ export async function main() {
         // Playwright does not surface CORS preflight OPTIONS requests to page listeners, so the
         // server-side evidence is taken directly: the bridge's preflight answer for the page origin
         // must not grant it (ACAO absent or not equal to the page origin), and the browser-side
-        // fetch below must have been rejected as a CORS failure with nothing sent on the wire.
+        // fetch below must have been rejected as a CORS failure (CORS is a read gate; see the note before the final assertion).
         const preflight = await fetch(new URL('/api/capability-tokens', bridge), { method: 'OPTIONS', headers: {
           Origin: ORIGIN, 'Access-Control-Request-Method': 'POST', 'Access-Control-Request-Headers': 'content-type,x-resonantos-bridge-token,x-resonantos-capability-bootstrap-token' },
           signal: AbortSignal.timeout(10000), redirect: 'error' });
-        requireProof(preflight.status < 500 && (preflight.headers.get('access-control-allow-origin') ?? '') !== ORIGIN);
+        const preflightAcao = preflight.headers.get('access-control-allow-origin') ?? '';
+        requireProof(preflight.status < 500 && preflightAcao !== ORIGIN && preflightAcao !== '*');
         requireProof(result.rejected && result.networkError && entries.some(entry => entry.corsFailure));
         // CORS is a browser-side READ gate, not a send gate: observed in Chromium, the bridge still
         // answers the token-bearing POST (loadingFailed reports AllowOriginMismatch on the actual
@@ -251,7 +252,8 @@ export async function main() {
         // does not grant the page origin (checked server-side above), and the page cannot read any
         // bridge response (CORS failure recorded on every bridge request the page made). The tokens
         // themselves are protected by L1–L14, not by CORS.
-        requireProof(entries.filter(entry => entry.method !== 'OPTIONS' && entry.url?.startsWith(value.bridgeUrl)).every(entry => entry.corsFailure === true));
+        const bridgeCalls = entries.filter(entry => entry.method !== 'OPTIONS' && entry.url?.startsWith(value.bridgeUrl));
+        requireProof(bridgeCalls.length > 0 && bridgeCalls.every(entry => entry.corsFailure === true));
         requireProof(session.violations.length === 0 && !session.errors.some(message => /preamble/i.test(message)));
       });
       return;

--- a/scripts/dev-bridge-config-live.mjs
+++ b/scripts/dev-bridge-config-live.mjs
@@ -245,7 +245,10 @@ export async function main() {
           signal: AbortSignal.timeout(10000), redirect: 'error' });
         requireProof(preflight.status < 500 && (preflight.headers.get('access-control-allow-origin') ?? '') !== ORIGIN);
         requireProof(result.rejected && result.networkError && entries.some(entry => entry.corsFailure));
-        requireProof(!entries.some(entry => entry.wireSent && ((entry.method === 'POST' && entry.url === `${value.bridgeUrl}/api/capability-tokens`) || (entry.method === 'GET' && entry.url === `${value.bridgeUrl}/providers/status`))));
+        // Chromium emits requestWillBeSentExtraInfo for a CORS-preflighted POST before the preflight
+        // verdict, so that event is not proof of bytes on the wire. A request reached the bridge only
+        // if the bridge answered it (a response was received for that requestId).
+        requireProof(!entries.some(entry => entry.status !== undefined && ((entry.method === 'POST' && entry.url === `${value.bridgeUrl}/api/capability-tokens`) || (entry.method === 'GET' && entry.url === `${value.bridgeUrl}/providers/status`))));
         requireProof(session.violations.length === 0 && !session.errors.some(message => /preamble/i.test(message)));
       });
       return;

--- a/scripts/dev-bridge-config-live.mjs
+++ b/scripts/dev-bridge-config-live.mjs
@@ -245,10 +245,13 @@ export async function main() {
           signal: AbortSignal.timeout(10000), redirect: 'error' });
         requireProof(preflight.status < 500 && (preflight.headers.get('access-control-allow-origin') ?? '') !== ORIGIN);
         requireProof(result.rejected && result.networkError && entries.some(entry => entry.corsFailure));
-        // Chromium emits requestWillBeSentExtraInfo for a CORS-preflighted POST before the preflight
-        // verdict, so that event is not proof of bytes on the wire. A request reached the bridge only
-        // if the bridge answered it (a response was received for that requestId).
-        requireProof(!entries.some(entry => entry.status !== undefined && ((entry.method === 'POST' && entry.url === `${value.bridgeUrl}/api/capability-tokens`) || (entry.method === 'GET' && entry.url === `${value.bridgeUrl}/providers/status`))));
+        // CORS is a browser-side READ gate, not a send gate: observed in Chromium, the bridge still
+        // answers the token-bearing POST (loadingFailed reports AllowOriginMismatch on the actual
+        // response, not a preflight mismatch). What L15 proves is therefore: the bridge's preflight
+        // does not grant the page origin (checked server-side above), and the page cannot read any
+        // bridge response (CORS failure recorded on every bridge request the page made). The tokens
+        // themselves are protected by L1–L14, not by CORS.
+        requireProof(entries.filter(entry => entry.method !== 'OPTIONS' && entry.url?.startsWith(value.bridgeUrl)).every(entry => entry.corsFailure === true));
         requireProof(session.violations.length === 0 && !session.errors.some(message => /preamble/i.test(message)));
       });
       return;

--- a/scripts/dev-bridge-config-live.mjs
+++ b/scripts/dev-bridge-config-live.mjs
@@ -236,8 +236,14 @@ export async function main() {
         session = await browserSession(key); await navigate(session);
         const result = await diagnostics(session); await delay(500);
         const entries = [...session.records.values()];
-        const preflight = entries.filter(entry => entry.method === 'OPTIONS' && entry.url === `${value.bridgeUrl}/api/capability-tokens`);
-        requireProof(preflight.some(entry => entry.status >= 200 && entry.status < 300 && header(entry.responseHeaders, 'access-control-allow-origin') !== ORIGIN));
+        // Playwright does not surface CORS preflight OPTIONS requests to page listeners, so the
+        // server-side evidence is taken directly: the bridge's preflight answer for the page origin
+        // must not grant it (ACAO absent or not equal to the page origin), and the browser-side
+        // fetch below must have been rejected as a CORS failure with nothing sent on the wire.
+        const preflight = await fetch(new URL('/api/capability-tokens', bridge), { method: 'OPTIONS', headers: {
+          Origin: ORIGIN, 'Access-Control-Request-Method': 'POST', 'Access-Control-Request-Headers': 'content-type,x-resonantos-bridge-token,x-resonantos-capability-bootstrap-token' },
+          signal: AbortSignal.timeout(10000), redirect: 'error' });
+        requireProof(preflight.status < 500 && (preflight.headers.get('access-control-allow-origin') ?? '') !== ORIGIN);
         requireProof(result.rejected && result.networkError && entries.some(entry => entry.corsFailure));
         requireProof(!entries.some(entry => entry.wireSent && ((entry.method === 'POST' && entry.url === `${value.bridgeUrl}/api/capability-tokens`) || (entry.method === 'GET' && entry.url === `${value.bridgeUrl}/providers/status`))));
         requireProof(session.violations.length === 0 && !session.errors.some(message => /preamble/i.test(message)));

--- a/scripts/dev-bridge-config.integration.test.mjs
+++ b/scripts/dev-bridge-config.integration.test.mjs
@@ -25,9 +25,13 @@ const routeFrom = body => { const route = body.match(/src="(\/__resonantos_dev_b
 const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 async function reservePort() {
   const reservation = createNetServer();
-  await new Promise((resolve, reject) => { reservation.once('error', reject); reservation.listen(0, '127.0.0.1', resolve); });
-  const port = reservation.address().port;
-  await new Promise((resolve, reject) => reservation.close(error => error ? reject(error) : resolve()));
+  let port;
+  try {
+    await new Promise((resolve, reject) => { reservation.once('error', reject); reservation.listen(0, '127.0.0.1', resolve); });
+    port = reservation.address().port;
+  } finally {
+    if (reservation.listening) await new Promise((resolve, reject) => reservation.close(error => error ? reject(error) : resolve()));
+  }
   // No production-port probes, even if the kernel were to allocate it.
   if (port === 1430) return reservePort();
   return port;
@@ -38,12 +42,17 @@ function cleanEnv(root) {
   return env;
 }
 async function isolated(t) {
-  const root = await mkdtemp(join(tmpdir(), 'resonantos-dev-integration-')); await chmod(root, 0o700);
+  const root = await mkdtemp(join(tmpdir(), 'resonantos-dev-integration-'));
   const resources = [];
   t.after(async () => {
-    try { for (const close of resources.reverse()) await close(); }
-    finally { await rm(root, { recursive: true, force: true }); }
+    let failed = false;
+    for (const close of resources.reverse()) {
+      try { await close(); } catch { failed = true; }
+    }
+    try { await rm(root, { recursive: true, force: true }); } catch { failed = true; }
+    assert.equal(failed, false, 'integration resource cleanup succeeds');
   });
+  await chmod(root, 0o700);
   for (const path of ['src', 'packages', 'public', 'index.html', 'vite.config.ts', 'tsconfig.json', 'package.json',
     'scripts/vite-dev-bridge-config.mjs', 'scripts/vite-dev-bridge-config.d.mts']) {
     await mkdir(dirname(join(root, path)), { recursive: true });
@@ -85,11 +94,19 @@ async function start(t, fixture, { enabled = true, patch = {}, late, readConfig,
           const hook = replacement.configureServer;
           replacement.configureServer = function (server) {
             lifecycle.configured++;
+            lifecycle.watcher = server.watcher;
             server.httpServer?.once('listening', () => lifecycle.listening++);
             return (typeof hook === 'function' ? hook : hook.handler).call(this, server);
           };
         }
-        const configured = plugins.map(plugin => plugin.name === replacement.name ? replacement : plugin);
+        // Vite allocates watchers before configureServer, but does not return
+        // the server if a policy hook throws. Retain it before any such hook so
+        // both startup refusal and test failure can close all Vite resources.
+        const capture = { name: 'synthetic-server-cleanup', enforce: 'pre', configureServer: { order: 'pre', handler(created) {
+          server = created;
+          fixture.resources.push(() => created.close());
+        } } };
+        const configured = [capture, ...plugins.map(plugin => plugin.name === replacement.name ? replacement : plugin)];
         if (observe) configured.push(observe);
         if (late) configured.push({ name: 'synthetic-late-policy-weakening', configureServer: late });
         return createServer({ ...loaded.config, configFile: false, root: fixture.root, cacheDir: join(fixture.root, '.vite-cache'),
@@ -97,7 +114,6 @@ async function start(t, fixture, { enabled = true, patch = {}, late, readConfig,
           server: { ...loaded.config.server, port, strictPort: true, ...patch } });
       });
       await server.listen();
-      fixture.resources.push(() => server.close());
       const authorization = `Basic ${Buffer.from(`dev:${fixture.key}`).toString('base64')}`;
       const origin = `http://127.0.0.1:${port}`;
       const request = (path, options) => requestAt(port, path, options);
@@ -111,28 +127,65 @@ async function start(t, fixture, { enabled = true, patch = {}, late, readConfig,
     }
   }
 }
-function requestAt(port, path, { headers = {}, method = 'GET' } = {}) {
+async function requestAt(port, path, { headers = {}, method = 'GET' } = {}) {
   assert.notEqual(port, 1430, 'integration never contacts production port');
-  return new Promise((resolve, reject) => {
-    const req = httpRequest({ hostname: '127.0.0.1', port, path, method, headers, agent: false }, res => {
-      let body = ''; res.setEncoding('utf8');
-      res.on('data', chunk => { body += chunk; if (body.length > 8 * 1024 * 1024) req.destroy(Error('bounded response exceeded')); });
-      res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body }));
+  let req;
+  try {
+    return await new Promise((resolve, reject) => {
+      req = httpRequest({ hostname: '127.0.0.1', port, path, method, headers, agent: false }, res => {
+        let body = ''; res.setEncoding('utf8');
+        res.on('data', chunk => { body += chunk; if (body.length > 8 * 1024 * 1024) req.destroy(Error('bounded response exceeded')); });
+        res.on('error', reject);
+        res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body }));
+      });
+      req.setTimeout(10000, () => req.destroy(Error('HTTP timeout'))); req.on('error', reject); req.end();
     });
-    req.setTimeout(10000, () => req.destroy(Error('HTTP timeout'))); req.on('error', reject); req.end();
-  });
+  } finally { req?.destroy(); }
 }
-function runChild(program, args, { root, env, input, signal, timeout = 180000 }) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(program, args, { cwd: root, env, shell: false, signal, stdio: ['pipe', 'pipe', 'pipe'] });
-    let stdout = '', stderr = '', timedOut = false;
-    const timer = setTimeout(() => { timedOut = true; child.kill('SIGKILL'); }, timeout);
-    child.stdout.on('data', chunk => { stdout += chunk; if (stdout.length > 16 * 1024 * 1024) child.kill('SIGKILL'); });
-    child.stderr.on('data', chunk => { stderr += chunk; if (stderr.length > 16 * 1024 * 1024) child.kill('SIGKILL'); });
-    child.once('error', error => { clearTimeout(timer); reject(error); });
-    child.once('close', code => { clearTimeout(timer); resolve({ code, stdout, stderr, timedOut }); });
-    child.stdin.on('error', () => {}); child.stdin.end(input ?? '');
+async function runChild(program, args, { root, env, input, signal, timeout = 180000 }) {
+  signal?.throwIfAborted();
+  // npm launches build grandchildren. On POSIX, cancellation must terminate
+  // their private process group as well, or inherited pipes can stay open.
+  const grouped = process.platform !== 'win32';
+  const child = spawn(program, args, { cwd: root, env, shell: false, detached: grouped, stdio: ['pipe', 'pipe', 'pipe'] });
+  const stop = () => {
+    if (grouped && child.pid) {
+      try { process.kill(-child.pid, 'SIGKILL'); } catch (error) { if (error.code !== 'ESRCH') child.kill('SIGKILL'); }
+    } else { child.kill('SIGKILL'); }
+  };
+  let stdout = '', stderr = '', timedOut = false, finished = false, failure;
+  const closed = new Promise(resolve => {
+    child.once('error', error => { failure = error; stop(); });
+    child.once('close', code => { finished = true; resolve(code); });
   });
+  const timer = setTimeout(() => { timedOut = true; stop(); }, timeout);
+  child.stdout.on('data', chunk => { stdout += chunk; if (stdout.length > 16 * 1024 * 1024) stop(); });
+  child.stderr.on('data', chunk => { stderr += chunk; if (stderr.length > 16 * 1024 * 1024) stop(); });
+  child.stdin.on('error', () => {});
+  signal?.addEventListener('abort', stop, { once: true });
+  try {
+    child.stdin.end(input ?? '');
+    if (signal?.aborted) stop();
+    const code = await closed;
+    signal?.throwIfAborted();
+    if (failure) throw failure;
+    return { code, stdout, stderr, timedOut };
+  } finally {
+    if (!finished) { stop(); await closed; }
+    clearTimeout(timer);
+    signal?.removeEventListener('abort', stop);
+    child.stdin.destroy(); child.stdout.destroy(); child.stderr.destroy();
+  }
+}
+async function watcherWrite(watcher, event, path, write) {
+  let timer, onEvent;
+  const observed = new Promise((resolve, reject) => {
+    onEvent = changed => { if (changed === path) resolve(); };
+    watcher.on(event, onEvent);
+    timer = setTimeout(() => reject(Error('watcher barrier timeout')), 10000);
+  });
+  try { await Promise.all([observed, Promise.resolve().then(write)]); }
+  finally { clearTimeout(timer); watcher.off(event, onEvent); }
 }
 async function filesBelow(root) {
   const files = [];
@@ -174,6 +227,7 @@ integration('I2', 'real startup refuses unsafe resolved policy', async t => {
     try { accepted = await start(t, fixture, { enabled, ...variant, lifecycle, readConfig: async () => { reads++; return fixture.value; } }); } catch (error) { failure = error; }
     assert.equal(lifecycle.configured, 1, 'real delivery configure hook reached');
     assert.equal(lifecycle.listening, 0, 'unsafe server never listened');
+    assert.equal(lifecycle.watcher?.closed, true, 'refused startup closes its watcher');
     assert.equal(failure instanceof Error && failure.message === expectedMessage, true, 'policy refusal, not setup/import failure');
     if (accepted) await accepted.server.close();
     assert.equal(accepted === undefined, true, 'unsafe startup rejected before listening'); assert.equal(reads, 0);
@@ -232,9 +286,11 @@ integration('I6', 'opted-in vite build and preview contain no delivered secrets'
     const port = await reservePort(); let server;
     try {
       const previewEnv = Object.fromEntries(Object.entries(env).filter(([name]) => name.startsWith('RESONANTOS_DEV_BRIDGE_')));
-      server = await sanitizedEnvironment(() => preview({ root: fixture.root, configFile: join(fixture.root, 'vite.config.ts'), configLoader: 'runner', logLevel: 'silent', preview: { host: '127.0.0.1', port, strictPort: true } }), previewEnv);
+      server = await sanitizedEnvironment(() => preview({ root: fixture.root, configFile: join(fixture.root, 'vite.config.ts'), configLoader: 'runner', logLevel: 'silent',
+        plugins: [{ name: 'synthetic-preview-cleanup', enforce: 'pre', configurePreviewServer: { order: 'pre', handler(created) { server = created; } } }],
+        preview: { host: '127.0.0.1', port, strictPort: true } }), previewEnv);
       for (const path of ['/', ROUTE, `/${RELATIVE}`]) { const response = await requestAt(port, path); noMaterial(response.body, material); assert.equal(response.headers['www-authenticate'], undefined); }
-    } finally { if (server) await new Promise(resolve => server.httpServer.close(resolve)); }
+    } finally { if (server) await server.close(); }
     await rm(join(fixture.root, 'dist'), { recursive: true, force: true });
   }
 });
@@ -246,23 +302,13 @@ integration('I7', 'HMR and error channels never carry credential material', asyn
   const page = await h.page(), route = routeFrom(page.body); assert.equal((await h.module(route)).status, 200);
   await h.request('/src/main.tsx');
   const barrier = join(fixture.root, 'src/dev-bridge-hmr-probe.ts');
-  const added = new Promise((resolve, reject) => {
-    const timer = setTimeout(() => { h.server.watcher.off('add', onAdd); reject(Error('watcher registration timeout')); }, 10000);
-    function onAdd(path) { if (path === barrier) { clearTimeout(timer); h.server.watcher.off('add', onAdd); resolve(); } }
-    h.server.watcher.on('add', onAdd);
-  });
-  await writeFile(barrier, 'export const marker = 1;\n'); await added;
+  await watcherWrite(h.server.watcher, 'add', barrier, () => writeFile(barrier, 'export const marker = 1;\n'));
   await h.request('/src/dev-bridge-hmr-probe.ts');
   const events = []; h.server.watcher.on('all', (event, path) => events.push([event, path]));
   const next = fakeConfig();
   await writeFile(join(fixture.root, RELATIVE), writer(next), { mode: 0o600 });
   await writeFile(join(fixture.root, 'ResonantOS_User/probe'), 'rotated harmless user-state probe\n');
-  const barrierSeen = new Promise((resolve, reject) => {
-    const timer = setTimeout(() => { h.server.watcher.off('change', onChange); reject(Error('watcher barrier timeout')); }, 10000);
-    function onChange(path) { if (path === barrier) { clearTimeout(timer); h.server.watcher.off('change', onChange); resolve(); } }
-    h.server.watcher.on('change', onChange);
-  });
-  await writeFile(barrier, 'export const marker = 2;\n'); await barrierSeen; await delay(150);
+  await watcherWrite(h.server.watcher, 'change', barrier, () => writeFile(barrier, 'export const marker = 2;\n')); await delay(150);
   assert.equal(events.some(([, path]) => path.endsWith('bridge-config.generated.js') || path.includes('ResonantOS_User')), false);
   const material = [PREFIX, route.split('=')[1], fixture.key, h.authorization, fixture.value.bridgeToken, fixture.value.capabilityBootstrapToken, next.bridgeToken, next.capabilityBootstrapToken];
   noMaterial(JSON.stringify(messages), [...material, 'bridgeToken', 'capabilityBootstrapToken']); noMaterial(JSON.stringify(h.output), material);

--- a/scripts/dev-bridge-config.integration.test.mjs
+++ b/scripts/dev-bridge-config.integration.test.mjs
@@ -45,12 +45,17 @@ async function isolated(t) {
   const root = await mkdtemp(join(tmpdir(), 'resonantos-dev-integration-'));
   const resources = [];
   t.after(async () => {
-    let failed = false;
+    const failures = [];
     for (const close of resources.reverse()) {
-      try { await close(); } catch { failed = true; }
+      try { await close(); } catch { failures.push('server-close'); }
     }
-    try { await rm(root, { recursive: true, force: true }); } catch { failed = true; }
-    assert.equal(failed, false, 'integration resource cleanup succeeds');
+    // Vite's optimizer can finish a filesystem operation while its cancelled
+    // scan unwinds. Node's bounded recursive-rm retry handles ENOTEMPTY/EBUSY
+    // without hiding a persistent cleanup failure or touching shared caches.
+    try { await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }); }
+    catch (error) { failures.push(['ENOTEMPTY', 'EBUSY', 'EPERM', 'EACCES'].includes(error.code) ? `fixture-remove:${error.code}` : 'fixture-remove'); }
+    // A cleanup error is infrastructure, never a mutation assertion kill.
+    if (failures.length) throw Error(`integration cleanup failed: ${failures.join(',')}`);
   });
   await chmod(root, 0o700);
   for (const path of ['src', 'packages', 'public', 'index.html', 'vite.config.ts', 'tsconfig.json', 'package.json',
@@ -206,14 +211,30 @@ function integration(id, name, fn) {
   });
 }
 integration('I1', 'real default server preserves part-one denials', async t => {
-  const fixture = await isolated(t), h = await start(t, fixture, { enabled: false });
-  for (const headers of [{}, { Host: `localhost:${h.port}` }]) { const page = await h.request('/', { headers }); assert.equal(page.status, 200); assert.equal(page.body.includes(PREFIX), false); noMaterial(page.body, Object.values(fixture.value)); }
+  const fixture = await isolated(t);
+  // These files must exist: a missing file can fall through Vite's deny check.
+  assert.equal((await readFile(join(fixture.root, RELATIVE), 'utf8')) === writer(fixture.value), true);
+  assert.equal((await readFile(join(fixture.root, 'ResonantOS_User/probe'), 'utf8')).length > 0, true);
+  let h, reads = 0;
+  const lifecycle = { configured: 0, listening: 0 };
+  try { h = await start(t, fixture, { enabled: false, lifecycle, readConfig: async root => { reads++; return readGeneratedBridgeConfig(root); } }); }
+  catch (error) {
+    // A canonical deny deletion is refused before listen; that is a specific
+    // failure of the valid off-mode startup contract, not an opaque I1 error.
+    // Binding/import/setup errors still propagate as infrastructure failures.
+    if (!['Development page key is invalid.', 'Unsafe development server policy.'].includes(error.message)) throw error;
+  }
+  assert.equal(reads, 0);
+  assert.equal(h !== undefined, true, 'valid off-mode server starts without a page key');
+  assert.equal(lifecycle.configured, 1); assert.equal(lifecycle.listening, 1);
+  for (const headers of [{}, { Host: `localhost:${h.port}` }]) { const page = await h.request('/', { headers }); assert.equal(page.status, 200); assert.equal(page.headers['www-authenticate'], undefined); assert.equal(page.body.includes(PREFIX), false); noMaterial(page.body, Object.values(fixture.value)); }
   const missing = await h.request(ROUTE); assert.equal(missing.status, 404); assert.equal(missing.body, 'Not found.\n');
+  assert.equal(missing.headers['www-authenticate'], undefined);
   assert.equal((await h.request('/src/main.tsx')).status, 200);
   for (const path of [`/${RELATIVE}`, `/@fs/${join(fixture.root, RELATIVE)}`, '/ResonantOS_User/probe', `/@fs/${join(fixture.root, 'ResonantOS_User/probe')}`]) {
     const response = await h.request(path); assert.equal(response.status, 403); noMaterial(response.body, Object.values(fixture.value));
   }
-  assert.equal(h.reads(), 0);
+  assert.equal(h.reads(), 0); assert.equal(reads, 0);
 });
 integration('I2', 'real startup refuses unsafe resolved policy', async t => {
   const fixture = await isolated(t);

--- a/scripts/dev-bridge-config.integration.test.mjs
+++ b/scripts/dev-bridge-config.integration.test.mjs
@@ -115,6 +115,10 @@ async function start(t, fixture, { enabled = true, patch = {}, late, readConfig,
         if (observe) configured.push(observe);
         if (late) configured.push({ name: 'synthetic-late-policy-weakening', configureServer: late });
         return createServer({ ...loaded.config, configFile: false, root: fixture.root, cacheDir: join(fixture.root, '.vite-cache'),
+          // Integration servers never pre-bundle: Vite's background dependency scan and
+          // esbuild optimize run race server.close() (a promise stays pending after the last
+          // handle closes on slower Linux runners). Discovery is not part of the certified policy.
+          optimizeDeps: { ...loaded.config.optimizeDeps, noDiscovery: true, include: [] },
           customLogger: logger(output), logLevel: 'silent', plugins: configured,
           server: { ...loaded.config.server, port, strictPort: true, ...patch } });
       });

--- a/scripts/dev-bridge-config.integration.test.mjs
+++ b/scripts/dev-bridge-config.integration.test.mjs
@@ -320,7 +320,7 @@ integration('I7', 'HMR and error channels never carry credential material', asyn
 });
 integration('I8', 'actual HTTP guard rejects cross-origin and malformed traffic', async t => {
   const fixture = await isolated(t), h = await start(t, fixture), route = routeFrom((await h.page()).body);
-  for (const path of ['/', route]) for (const patch of [{ Host: `127.0.0.2:${h.port}` }, { Host: 'attacker.test' }, { Origin: 'null' }, { Origin: 'http://attacker.test' }]) {
+  for (const path of ['/', route]) for (const patch of [{ Host: `127.0.0.2:${h.port}` }, { Host: `localhost:${h.port}` }, { Host: 'attacker.test' }, { Origin: 'null' }, { Origin: 'http://attacker.test' }]) {
     const response = await h.request(path, { headers: { ...META, Authorization: h.authorization, ...patch } });
     assert.equal(response.status, 403); assert.equal(response.body, 'Forbidden.\n'); assert.equal(response.headers['access-control-allow-origin'], undefined); noMaterial(response.body, Object.values(fixture.value));
   }

--- a/scripts/dev-bridge-config.integration.test.mjs
+++ b/scripts/dev-bridge-config.integration.test.mjs
@@ -1,0 +1,301 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { randomBytes } from 'node:crypto';
+import { createServer as createNetServer } from 'node:net';
+import { request as httpRequest } from 'node:http';
+import { spawn } from 'node:child_process';
+import { mkdtemp, cp, mkdir, chmod, writeFile, readFile, readdir, rm, symlink, realpath } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { createServer, loadConfigFromFile, preview } from 'vite';
+import { devBridgeConfigPlugin, readGeneratedBridgeConfig, assertDevServerPolicy } from './vite-dev-bridge-config.mjs';
+
+const REPO = resolve(import.meta.dirname, '..');
+const PREFIX = '/__resonantos_dev_bridge__/';
+const ROUTE = `${PREFIX}config.mjs`;
+const RELATIVE = 'browser-first/resonantos-side-panel-extension/src/bridge-config.generated.js';
+const META = { 'Sec-Fetch-Site': 'same-origin', 'Sec-Fetch-Mode': 'cors', 'Sec-Fetch-Dest': 'script' };
+const CHALLENGE = 'Basic realm="ResonantOS development", charset="UTF-8"';
+const canary = () => `synthetic-${randomBytes(24).toString('hex')}`;
+const key = () => randomBytes(32).toString('base64url');
+const fakeConfig = () => ({ bridgeUrl: 'http://127.0.0.1:49153', bridgeToken: canary(), capabilityBootstrapToken: canary() });
+const writer = value => `globalThis.__RESONANTOS_BRIDGE_CONFIG__ = Object.freeze(${JSON.stringify(value)});\n`;
+const noMaterial = (body, values) => assert.equal(values.some(value => value && body.includes(value)), false, 'credential material absent');
+const routeFrom = body => { const route = body.match(/src="(\/__resonantos_dev_bridge__\/config\.mjs\?nonce=[A-Za-z0-9_-]{43})"/)?.[1]; assert.equal(typeof route, 'string', 'gated route present'); return route; };
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+async function reservePort() {
+  const reservation = createNetServer();
+  await new Promise((resolve, reject) => { reservation.once('error', reject); reservation.listen(0, '127.0.0.1', resolve); });
+  const port = reservation.address().port;
+  await new Promise((resolve, reject) => reservation.close(error => error ? reject(error) : resolve()));
+  // No production-port probes, even if the kernel were to allocate it.
+  if (port === 1430) return reservePort();
+  return port;
+}
+function cleanEnv(root) {
+  const env = { HOME: root, TMPDIR: tmpdir(), npm_config_cache: join(root, '.npm-cache'), npm_config_offline: 'true', npm_config_audit: 'false', npm_config_fund: 'false' };
+  for (const name of ['PATH', 'LANG', 'LC_ALL', 'SystemRoot', 'WINDIR']) if (process.env[name] !== undefined) env[name] = process.env[name];
+  return env;
+}
+async function isolated(t) {
+  const root = await mkdtemp(join(tmpdir(), 'resonantos-dev-integration-')); await chmod(root, 0o700);
+  const resources = [];
+  t.after(async () => {
+    try { for (const close of resources.reverse()) await close(); }
+    finally { await rm(root, { recursive: true, force: true }); }
+  });
+  for (const path of ['src', 'packages', 'public', 'index.html', 'vite.config.ts', 'tsconfig.json', 'package.json',
+    'scripts/vite-dev-bridge-config.mjs', 'scripts/vite-dev-bridge-config.d.mts']) {
+    await mkdir(dirname(join(root, path)), { recursive: true });
+    try { await cp(join(REPO, path), join(root, path), { recursive: true }); } catch (error) { if (path !== 'public' || error.code !== 'ENOENT') throw error; }
+  }
+  // Keep the dependency directory itself writable for Vite's temporary config
+  // bundles, while linking installed packages instead of installing anything.
+  await mkdir(join(root, 'node_modules'));
+  const installed = await realpath(join(REPO, 'node_modules'));
+  for (const entry of await readdir(installed)) if (!entry.startsWith('.vite') && entry !== '.cache') await symlink(join(installed, entry), join(root, 'node_modules', entry));
+  await mkdir(dirname(join(root, RELATIVE)), { recursive: true });
+  const value = fakeConfig(); await writeFile(join(root, RELATIVE), writer(value), { mode: 0o600 });
+  await mkdir(join(root, 'ResonantOS_User'), { mode: 0o700 }); await writeFile(join(root, 'ResonantOS_User/probe'), 'harmless synthetic filesystem-denial probe\n', { mode: 0o600 });
+  return { root, value, key: key(), resources };
+}
+async function sanitizedEnvironment(fn, injected = {}) {
+  const names = [...new Set([...Object.keys(process.env).filter(name => /^(?:RESONANTOS_DEV_BRIDGE_|__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS$|VITE_)/.test(name)), ...Object.keys(injected)])];
+  const saved = new Map(names.map(name => [name, process.env[name]]));
+  try { for (const name of names) delete process.env[name]; Object.assign(process.env, injected); return await fn(); }
+  finally { for (const [name, value] of saved) { if (value === undefined) delete process.env[name]; else process.env[name] = value; } }
+}
+const logger = output => ({ hasWarned: false, info: (...args) => output.push(args), warn: (...args) => output.push(args), warnOnce: (...args) => output.push(args), error: (...args) => output.push(args), clearScreen() {}, hasErrorLogged: () => false });
+async function start(t, fixture, { enabled = true, patch = {}, late, readConfig, observe, lifecycle } = {}) {
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const port = await reservePort(), output = [];
+    let server, reads = 0;
+    try {
+      server = await sanitizedEnvironment(async () => {
+        const loaded = await loadConfigFromFile({ command: 'serve', mode: 'development', isPreview: false }, join(fixture.root, 'vite.config.ts'), fixture.root, 'silent', logger(output), 'runner');
+        assert.equal(loaded !== null, true);
+        const flatten = async values => (await Promise.all(values.map(async value => { value = await value; return Array.isArray(value) ? flatten(value) : value ? [value] : []; }))).flat();
+        const plugins = await flatten(loaded.config.plugins ?? []);
+        assert.equal(plugins.filter(plugin => plugin.name === 'resonantos-dev-bridge-config').length, 1, 'copied config must wire plugin');
+        const replacement = devBridgeConfigPlugin({ expectedPort: port,
+          env: () => enabled ? { RESONANTOS_DEV_BRIDGE_CONFIG: '1', RESONANTOS_DEV_BRIDGE_PAGE_KEY: fixture.key } : {},
+          readConfig: async (root, onNonLoopback) => { reads++; return readConfig ? readConfig(root, onNonLoopback) : readGeneratedBridgeConfig(root, { onNonLoopback }); },
+        });
+        if (lifecycle) {
+          const hook = replacement.configureServer;
+          replacement.configureServer = function (server) {
+            lifecycle.configured++;
+            server.httpServer?.once('listening', () => lifecycle.listening++);
+            return (typeof hook === 'function' ? hook : hook.handler).call(this, server);
+          };
+        }
+        const configured = plugins.map(plugin => plugin.name === replacement.name ? replacement : plugin);
+        if (observe) configured.push(observe);
+        if (late) configured.push({ name: 'synthetic-late-policy-weakening', configureServer: late });
+        return createServer({ ...loaded.config, configFile: false, root: fixture.root, cacheDir: join(fixture.root, '.vite-cache'),
+          customLogger: logger(output), logLevel: 'silent', plugins: configured,
+          server: { ...loaded.config.server, port, strictPort: true, ...patch } });
+      });
+      await server.listen();
+      fixture.resources.push(() => server.close());
+      const authorization = `Basic ${Buffer.from(`dev:${fixture.key}`).toString('base64')}`;
+      const origin = `http://127.0.0.1:${port}`;
+      const request = (path, options) => requestAt(port, path, options);
+      const page = () => request('/', { headers: { Authorization: authorization } });
+      const module = path => request(path, { headers: { ...META, Authorization: authorization } });
+      return { server, port, origin, authorization, request, page, module, output, reads: () => reads };
+    } catch (error) {
+      if (server) await server.close();
+      if (error.code === 'EADDRINUSE' && attempt < 4) continue;
+      throw error;
+    }
+  }
+}
+function requestAt(port, path, { headers = {}, method = 'GET' } = {}) {
+  assert.notEqual(port, 1430, 'integration never contacts production port');
+  return new Promise((resolve, reject) => {
+    const req = httpRequest({ hostname: '127.0.0.1', port, path, method, headers, agent: false }, res => {
+      let body = ''; res.setEncoding('utf8');
+      res.on('data', chunk => { body += chunk; if (body.length > 8 * 1024 * 1024) req.destroy(Error('bounded response exceeded')); });
+      res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body }));
+    });
+    req.setTimeout(10000, () => req.destroy(Error('HTTP timeout'))); req.on('error', reject); req.end();
+  });
+}
+function runChild(program, args, { root, env, input, signal, timeout = 180000 }) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(program, args, { cwd: root, env, shell: false, signal, stdio: ['pipe', 'pipe', 'pipe'] });
+    let stdout = '', stderr = '', timedOut = false;
+    const timer = setTimeout(() => { timedOut = true; child.kill('SIGKILL'); }, timeout);
+    child.stdout.on('data', chunk => { stdout += chunk; if (stdout.length > 16 * 1024 * 1024) child.kill('SIGKILL'); });
+    child.stderr.on('data', chunk => { stderr += chunk; if (stderr.length > 16 * 1024 * 1024) child.kill('SIGKILL'); });
+    child.once('error', error => { clearTimeout(timer); reject(error); });
+    child.once('close', code => { clearTimeout(timer); resolve({ code, stdout, stderr, timedOut }); });
+    child.stdin.on('error', () => {}); child.stdin.end(input ?? '');
+  });
+}
+async function filesBelow(root) {
+  const files = [];
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    const path = join(root, entry.name); if (entry.isDirectory()) files.push(...await filesBelow(path)); else if (entry.isFile()) files.push(path);
+  }
+  return files;
+}
+// Cases are serial. Failures reveal case IDs only, never captured subprocess,
+// Vite, transform, HTTP, or credential-bearing assertion values.
+function integration(id, name, fn) {
+  test(name, { concurrency: false, timeout: id === 'I6' ? 600000 : 90000 }, async t => {
+    const captured = [], original = {};
+    for (const name of ['error', 'warn', 'log', 'info']) { original[name] = console[name]; console[name] = (...args) => captured.push(args); }
+    try { await fn(t); assert.equal(captured.length, 0, 'no raw console/error channel'); }
+    catch { throw new Error(id); }
+    finally { for (const name of Object.keys(original)) console[name] = original[name]; }
+  });
+}
+integration('I1', 'real default server preserves part-one denials', async t => {
+  const fixture = await isolated(t), h = await start(t, fixture, { enabled: false });
+  for (const headers of [{}, { Host: `localhost:${h.port}` }]) { const page = await h.request('/', { headers }); assert.equal(page.status, 200); assert.equal(page.body.includes(PREFIX), false); noMaterial(page.body, Object.values(fixture.value)); }
+  const missing = await h.request(ROUTE); assert.equal(missing.status, 404); assert.equal(missing.body, 'Not found.\n');
+  assert.equal((await h.request('/src/main.tsx')).status, 200);
+  for (const path of [`/${RELATIVE}`, `/@fs/${join(fixture.root, RELATIVE)}`, '/ResonantOS_User/probe', `/@fs/${join(fixture.root, 'ResonantOS_User/probe')}`]) {
+    const response = await h.request(path); assert.equal(response.status, 403); noMaterial(response.body, Object.values(fixture.value));
+  }
+  assert.equal(h.reads(), 0);
+});
+integration('I2', 'real startup refuses unsafe resolved policy', async t => {
+  const fixture = await isolated(t);
+  for (const enabled of [false, true]) for (const variant of [
+    { patch: { host: '0.0.0.0' } }, { patch: { allowedHosts: true } }, { patch: { strictPort: false } }, { patch: { cors: true } },
+    { late: server => { server.config.server.allowedHosts = true; } },
+  ]) {
+    let reads = 0, accepted, failure, expectedMessage;
+    const lifecycle = { configured: 0, listening: 0 };
+    try { assertDevServerPolicy({ server: {} }, 49152); } catch (error) { expectedMessage = error.message; }
+    try { accepted = await start(t, fixture, { enabled, ...variant, lifecycle, readConfig: async () => { reads++; return fixture.value; } }); } catch (error) { failure = error; }
+    assert.equal(lifecycle.configured, 1, 'real delivery configure hook reached');
+    assert.equal(lifecycle.listening, 0, 'unsafe server never listened');
+    assert.equal(failure instanceof Error && failure.message === expectedMessage, true, 'policy refusal, not setup/import failure');
+    if (accepted) await accepted.server.close();
+    assert.equal(accepted === undefined, true, 'unsafe startup rejected before listening'); assert.equal(reads, 0);
+  }
+});
+integration('I3', 'authenticated module bypasses transforms and graph', async t => {
+  const fixture = await isolated(t), transforms = [], htmlInputs = [];
+  const observe = { name: 'synthetic-transform-observer', enforce: 'pre', transform(code, id) { transforms.push([id, code]); }, transformIndexHtml: { order: 'pre', handler(html) { htmlInputs.push(html); return html; } } };
+  const h = await start(t, fixture, { observe }), page = await h.page(); assert.equal(page.status, 200);
+  const route = routeFrom(page.body), response = await h.module(route); assert.equal(response.status, 200); assert.equal(response.body.includes(fixture.value.bridgeToken), true);
+  const material = [PREFIX, route.split('=')[1], fixture.key, ...Object.values(fixture.value), h.authorization];
+  noMaterial(JSON.stringify(transforms), material); noMaterial(JSON.stringify(htmlInputs), material);
+  const graph = h.server.environments.client.moduleGraph;
+  noMaterial(JSON.stringify([...graph.urlToModuleMap.keys(), ...graph.idToModuleMap.keys()]), material);
+  for (const path of [ROUTE + '?raw', ROUTE + '?url', '/index.html?html-proxy&index=0.js', '/@id/' + ROUTE, '/@id/__x00__' + ROUTE,
+    `/@fs/${join(fixture.root, RELATIVE)}?raw`, ROUTE + '.map']) {
+    const alias = await h.request(path, { headers: { ...META, Authorization: h.authorization } }); noMaterial(alias.body, [fixture.key, fixture.value.bridgeToken, fixture.value.capabilityBootstrapToken]);
+  }
+});
+integration('I4', 'second process cannot bootstrap itself', async t => {
+  const fixture = await isolated(t), h = await start(t, fixture);
+  const script = `import http from 'node:http';
+const origin=process.argv[1], port=Number(new URL(origin).port);
+const request=(path,headers={})=>new Promise((resolve,reject)=>{const q=http.get({hostname:'127.0.0.1',port,path,headers,agent:false},r=>{let body='';r.on('data',c=>body+=c);r.on('end',()=>resolve({status:r.statusCode,body}));});q.on('error',reject);});
+const metadata={'Sec-Fetch-Site':'same-origin','Sec-Fetch-Mode':'cors','Sec-Fetch-Dest':'script',Origin:origin,Referer:origin+'/'};
+const results=[await request('/'),await request('${ROUTE}',metadata),await request('${ROUTE}',{...metadata,Authorization:'Basic invalid'})];
+process.stdout.write(JSON.stringify(results));`;
+  const result = await runChild(process.execPath, ['--input-type=module', '-e', script, h.origin], { root: fixture.root, env: cleanEnv(fixture.root), signal: t.signal });
+  assert.equal(result.code, 0); assert.equal(result.timedOut, false); noMaterial(result.stdout + result.stderr, [fixture.key, h.authorization, ...Object.values(fixture.value)]);
+  assert.deepEqual(JSON.parse(result.stdout).map(result => result.status), [401, 401, 403]); assert.equal(h.reads(), 0);
+  // Same UID network-only proof; this does not claim filesystem isolation.
+});
+integration('I5', 'real request-time rotation and missing source are safe', async t => {
+  const fixture = await isolated(t), h = await start(t, fixture);
+  const first = await h.module(routeFrom((await h.page()).body)); assert.equal(first.body.includes(fixture.value.bridgeToken), true);
+  const next = fakeConfig(); await writeFile(join(fixture.root, RELATIVE), writer(next), { mode: 0o600 });
+  const second = await h.module(routeFrom((await h.page()).body)); assert.equal(second.status, 200); assert.equal(second.body.includes(next.bridgeToken), true);
+  noMaterial(second.body, [fixture.value.bridgeToken, fixture.value.capabilityBootstrapToken]);
+  await rm(join(fixture.root, RELATIVE)); const route = routeFrom((await h.page()).body), missing = await h.module(route);
+  assert.equal(missing.status, 200); assert.match(missing.body, /^delete globalThis\.__RESONANTOS_BRIDGE_CONFIG__;/); assert.match(missing.body, /await import\('\/src\/main\.tsx'\)/);
+  noMaterial(missing.body, [...Object.values(fixture.value), ...Object.values(next)]); assert.equal((await h.module(route)).status, 403); assert.equal(h.reads(), 3);
+});
+integration('I6', 'opted-in vite build and preview contain no delivered secrets', async t => {
+  const fixture = await isolated(t), authorization = `Basic ${Buffer.from(`dev:${fixture.key}`).toString('base64')}`;
+  const material = [fixture.value.bridgeToken, fixture.value.capabilityBootstrapToken, fixture.key, authorization, PREFIX,
+    'globalThis.__RESONANTOS_BRIDGE_CONFIG__ = Object.freeze('];
+  for (const mode of ['on', 'off', 'missing-key']) {
+    const env = cleanEnv(fixture.root);
+    if (mode !== 'off') env.RESONANTOS_DEV_BRIDGE_CONFIG = '1';
+    if (mode === 'on') env.RESONANTOS_DEV_BRIDGE_PAGE_KEY = fixture.key;
+    const result = await runChild('npm', ['run', 'build'], { root: fixture.root, env, signal: t.signal });
+    assert.equal(result.code, 0, 'actual build succeeds'); assert.equal(result.timedOut, false);
+    noMaterial(result.stdout + result.stderr, material);
+    const files = await filesBelow(join(fixture.root, 'dist')); assert.equal(files.length > 0, true);
+    for (const file of files) noMaterial((await readFile(file)).toString('utf8'), material);
+    const port = await reservePort(); let server;
+    try {
+      const previewEnv = Object.fromEntries(Object.entries(env).filter(([name]) => name.startsWith('RESONANTOS_DEV_BRIDGE_')));
+      server = await sanitizedEnvironment(() => preview({ root: fixture.root, configFile: join(fixture.root, 'vite.config.ts'), configLoader: 'runner', logLevel: 'silent', preview: { host: '127.0.0.1', port, strictPort: true } }), previewEnv);
+      for (const path of ['/', ROUTE, `/${RELATIVE}`]) { const response = await requestAt(port, path); noMaterial(response.body, material); assert.equal(response.headers['www-authenticate'], undefined); }
+    } finally { if (server) await new Promise(resolve => server.httpServer.close(resolve)); }
+    await rm(join(fixture.root, 'dist'), { recursive: true, force: true });
+  }
+});
+integration('I7', 'HMR and error channels never carry credential material', async t => {
+  const fixture = await isolated(t), h = await start(t, fixture), messages = [];
+  const originalSend = h.server.ws.send;
+  h.server.ws.send = function (...args) { messages.push(args); return originalSend.apply(this, args); };
+  t.after(() => { h.server.ws.send = originalSend; });
+  const page = await h.page(), route = routeFrom(page.body); assert.equal((await h.module(route)).status, 200);
+  await h.request('/src/main.tsx');
+  const barrier = join(fixture.root, 'src/dev-bridge-hmr-probe.ts');
+  const added = new Promise((resolve, reject) => {
+    const timer = setTimeout(() => { h.server.watcher.off('add', onAdd); reject(Error('watcher registration timeout')); }, 10000);
+    function onAdd(path) { if (path === barrier) { clearTimeout(timer); h.server.watcher.off('add', onAdd); resolve(); } }
+    h.server.watcher.on('add', onAdd);
+  });
+  await writeFile(barrier, 'export const marker = 1;\n'); await added;
+  await h.request('/src/dev-bridge-hmr-probe.ts');
+  const events = []; h.server.watcher.on('all', (event, path) => events.push([event, path]));
+  const next = fakeConfig();
+  await writeFile(join(fixture.root, RELATIVE), writer(next), { mode: 0o600 });
+  await writeFile(join(fixture.root, 'ResonantOS_User/probe'), 'rotated harmless user-state probe\n');
+  const barrierSeen = new Promise((resolve, reject) => {
+    const timer = setTimeout(() => { h.server.watcher.off('change', onChange); reject(Error('watcher barrier timeout')); }, 10000);
+    function onChange(path) { if (path === barrier) { clearTimeout(timer); h.server.watcher.off('change', onChange); resolve(); } }
+    h.server.watcher.on('change', onChange);
+  });
+  await writeFile(barrier, 'export const marker = 2;\n'); await barrierSeen; await delay(150);
+  assert.equal(events.some(([, path]) => path.endsWith('bridge-config.generated.js') || path.includes('ResonantOS_User')), false);
+  const material = [PREFIX, route.split('=')[1], fixture.key, h.authorization, fixture.value.bridgeToken, fixture.value.capabilityBootstrapToken, next.bridgeToken, next.capabilityBootstrapToken];
+  noMaterial(JSON.stringify(messages), [...material, 'bridgeToken', 'capabilityBootstrapToken']); noMaterial(JSON.stringify(h.output), material);
+  const cached = [...h.server.environments.client.moduleGraph.idToModuleMap.values()].map(module => [module.id, module.transformResult?.code]); noMaterial(JSON.stringify(cached), material);
+  const originalTransform = h.server.transformIndexHtml;
+  try { h.server.transformIndexHtml = async () => { throw Error(material.join(' ')); }; const failed = await h.page(); assert.equal(failed.status, 500); assert.equal(failed.body, 'Development page unavailable.\n'); }
+  finally { h.server.transformIndexHtml = originalTransform; }
+  noMaterial(JSON.stringify(h.output), material); noMaterial(JSON.stringify(messages), material);
+});
+integration('I8', 'actual HTTP guard rejects cross-origin and malformed traffic', async t => {
+  const fixture = await isolated(t), h = await start(t, fixture), route = routeFrom((await h.page()).body);
+  for (const path of ['/', route]) for (const patch of [{ Host: `127.0.0.2:${h.port}` }, { Host: 'attacker.test' }, { Origin: 'null' }, { Origin: 'http://attacker.test' }]) {
+    const response = await h.request(path, { headers: { ...META, Authorization: h.authorization, ...patch } });
+    assert.equal(response.status, 403); assert.equal(response.body, 'Forbidden.\n'); assert.equal(response.headers['access-control-allow-origin'], undefined); noMaterial(response.body, Object.values(fixture.value));
+  }
+  for (const path of [ROUTE + '?raw', ROUTE + '?url', ROUTE + '?nonce=%ZZ', route + '&nonce=x', PREFIX + '%63onfig.mjs', PREFIX + './config.mjs', PREFIX + '\\config.mjs']) {
+    const response = await h.module(path); assert.equal(response.status, 403); assert.equal(response.headers['access-control-allow-origin'], undefined);
+  }
+  for (const method of ['HEAD', 'POST', 'OPTIONS']) assert.equal((await h.request(route, { method, headers: { ...META, Authorization: h.authorization } })).status, 403);
+  for (const patch of [{ 'Sec-Fetch-Site': 'cross-site' }, { 'Sec-Fetch-Dest': 'worker' }]) assert.equal((await h.request(route, { headers: { ...META, Authorization: h.authorization, ...patch } })).status, 403);
+  assert.equal((await h.request('/src/main.tsx')).status, 200); assert.equal((await h.module(route)).status, 200);
+});
+integration('I9', 'module challenges missing authorization without spending nonce', async t => {
+  const fixture = await isolated(t), h = await start(t, fixture), route = routeFrom((await h.page()).body);
+  const denied = await h.request(route, { headers: META }); assert.equal(denied.status, 401); assert.equal(denied.body, 'Authentication required.\n'); assert.equal(denied.headers['www-authenticate'], CHALLENGE); assert.equal(h.reads(), 0);
+  const accepted = await h.module(route); assert.equal(accepted.status, 200); assert.equal(accepted.body.includes(fixture.value.bridgeToken), true); assert.equal(h.reads(), 1);
+  const replay = await h.module(route); assert.equal(replay.status, 403); assert.equal(replay.body, 'Forbidden.\n'); assert.equal(h.reads(), 1);
+});
+integration('I10', 'module rejects present wrong authorization without spending nonce', async t => {
+  const fixture = await isolated(t), h = await start(t, fixture), route = routeFrom((await h.page()).body);
+  const wrong = `Basic ${Buffer.from(`dev:${key()}`).toString('base64')}`;
+  for (const Authorization of [wrong, 'Basic invalid', [h.authorization, h.authorization]]) {
+    const denied = await h.request(route, { headers: { ...META, Authorization } }); assert.equal(denied.status, 403); assert.equal(denied.body, 'Forbidden.\n'); assert.equal(denied.headers['www-authenticate'], undefined); assert.equal(h.reads(), 0); noMaterial(denied.body, Object.values(fixture.value));
+  }
+  assert.equal((await h.module(route)).status, 200); assert.equal(h.reads(), 1);
+});

--- a/scripts/verify-alpha.mjs
+++ b/scripts/verify-alpha.mjs
@@ -13,6 +13,7 @@ export const ALPHA_COMMANDS = [
   { command: "npm", args: ["run", "test:docs"] },
   { command: "npm", args: ["run", "build"] },
   { command: "npm", args: ["test", "--", "--run"] },
+  { command: "npm", args: ["run", "test:dev-bridge-config"] },
   { command: "npm", args: ["run", "test:browser-first"] },
   { command: "npm", args: ["run", "test:browser-host"] },
   { command: "npm", args: ["run", "test:living-archive-mcp"] },

--- a/scripts/verify-alpha.test.mjs
+++ b/scripts/verify-alpha.test.mjs
@@ -19,6 +19,7 @@ test("defines the alpha commands in their required order", () => {
     { command: "npm", args: ["run", "test:docs"] },
     { command: "npm", args: ["run", "build"] },
     { command: "npm", args: ["test", "--", "--run"] },
+    { command: "npm", args: ["run", "test:dev-bridge-config"] },
     { command: "npm", args: ["run", "test:browser-first"] },
     { command: "npm", args: ["run", "test:browser-host"] },
     { command: "npm", args: ["run", "test:living-archive-mcp"] },

--- a/scripts/vite-dev-bridge-config.d.mts
+++ b/scripts/vite-dev-bridge-config.d.mts
@@ -1,0 +1,46 @@
+export type BridgeConfig = Readonly<{
+  bridgeUrl: string;
+  bridgeToken: string;
+  capabilityBootstrapToken: string;
+}>;
+export type NonceStore = {
+  issue(): string | null;
+  consume(nonce: string): boolean;
+  clear(): void;
+};
+export type ReaderDeps = {
+  openFile?: typeof import("node:fs/promises").open;
+  uid?: () => number;
+  onNonLoopback?: () => void;
+};
+export type DevServerPolicyInput = {
+  server: {
+    host?: unknown;
+    port?: unknown;
+    strictPort?: unknown;
+    allowedHosts?: unknown;
+    fs?: { strict?: unknown; deny?: unknown };
+    cors?: unknown;
+    watch?: { ignored?: unknown } | null;
+    origin?: unknown;
+    hmr?: boolean | { host?: unknown };
+  };
+  additionalAllowedHosts?: unknown;
+};
+export type DevBridgeDeps = {
+  readConfig?: (root: string, onNonLoopback: () => void) => Promise<BridgeConfig | null>;
+  env?: () => NodeJS.ProcessEnv;
+  now?: () => number;
+  random?: () => string;
+  createCspNonce?: () => string;
+  expectedPort?: number;
+};
+export const EXPECTED_DEV_SERVER_FS_DENY: readonly string[];
+export function assertDevServerPolicy(config: DevServerPolicyInput, expectedPort: number): void;
+export function parseGeneratedBridgeConfig(source: string, onNonLoopback?: () => void): BridgeConfig | null;
+export function readGeneratedBridgeConfig(root: string, deps?: ReaderDeps): Promise<BridgeConfig | null>;
+export function createPageNonces(now?: () => number, random?: () => string): NonceStore;
+export function createCspNonce(): string;
+export function renderBridgeModule(config: BridgeConfig | null): string;
+export function renderAuthenticatedPage(html: string, moduleNonce: string, cspNonce: string): string;
+export function devBridgeConfigPlugin(deps?: DevBridgeDeps): import("vite").Plugin;

--- a/scripts/vite-dev-bridge-config.mjs
+++ b/scripts/vite-dev-bridge-config.mjs
@@ -729,7 +729,7 @@ function pageFetchBlocked(req) {
   if (site.duplicate || dest.duplicate) {
     return true;
   }
-  if (site.value === "cross-site") {
+  if (site.value !== undefined && site.value !== "same-origin" && site.value !== "none") {
     return true;
   }
   if (dest.value === "iframe" || dest.value === "frame" || dest.value === "embed" || dest.value === "object") {
@@ -827,7 +827,10 @@ export function devBridgeConfigPlugin(deps) {
   return {
     name: "resonantos-dev-bridge-config",
     enforce: "pre",
-    apply: (_config, env) => env.command === 'serve' && !env.isPreview && env.mode !== 'test' /* vitest boots an internal Vite server; the delivery plugin and its fail-closed policy belong to the real dev server only */,
+    apply: (_config, env) => env.command === 'serve' && !env.isPreview
+      // Narrow vitest carve-out: vitest boots an internal Vite server in mode 'test' with process.env.VITEST === 'true';
+      // a plain `vite --mode test` dev server (no VITEST) still gets the fail-closed policy and delivery gates.
+      && !(env.mode === 'test' && (deps?.env ?? (() => process.env))().VITEST === 'true'),
     configureServer(server) {
       assertDevServerPolicy(server.config, expectedPort);
       const env = (deps?.env ?? (() => process.env))();

--- a/scripts/vite-dev-bridge-config.mjs
+++ b/scripts/vite-dev-bridge-config.mjs
@@ -1,0 +1,983 @@
+import { timingSafeEqual, randomBytes } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
+import { open as defaultOpen, readFile } from "node:fs/promises";
+import path from "node:path";
+import { parse, serialize, defaultTreeAdapter } from "parse5";
+
+const HTML_NS = "http://www.w3.org/1999/xhtml";
+const POLICY_ERROR = "Unsafe development server policy.";
+const PAGE_KEY_ERROR = "Development page key is invalid.";
+const LOOPBACK_DIAGNOSTIC = "Development bridge config unavailable: loopback URL required.";
+const BODY_NOT_FOUND = "Not found.\n";
+const BODY_AUTH = "Authentication required.\n";
+const BODY_FORBIDDEN = "Forbidden.\n";
+const BODY_UNAVAILABLE = "Development page unavailable.\n";
+const WWW_AUTHENTICATE = 'Basic realm="ResonantOS development", charset="UTF-8"';
+const PAGE_KEY_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+const TOKEN_PATTERN = /^[\x21-\x7E]{1,512}$/;
+const CONFIG_PREFIX = "globalThis.__RESONANTOS_BRIDGE_CONFIG__ = Object.freeze(";
+const CONFIG_SUFFIX = ");";
+const RESERVED_PREFIX = "/__resonantos_dev_bridge__";
+const MODULE_PATH = "/__resonantos_dev_bridge__/config.mjs";
+const GENERATED_REL = path.join(
+  "browser-first",
+  "resonantos-side-panel-extension",
+  "src",
+  "bridge-config.generated.js",
+);
+const MAX_CONFIG_BYTES = 16384;
+const NONCE_TTL_MS = 60000;
+const NONCE_CAPACITY = 1024;
+const AUTH_HEADER_MAX = 256;
+const SENSITIVE_IGNORE_GENERATED = "**/bridge-config.generated.js";
+const SENSITIVE_IGNORE_USER = "**/ResonantOS_User/**";
+const SECURITY_HEADERS = {
+  "Cache-Control": "private, no-store",
+  "Pragma": "no-cache",
+  "Referrer-Policy": "no-referrer",
+  "Cross-Origin-Resource-Policy": "same-origin",
+  "X-Content-Type-Options": "nosniff",
+  "Vary": "Host, Authorization, Origin, Sec-Fetch-Site, Sec-Fetch-Mode, Sec-Fetch-Dest",
+};
+
+/**
+ * @typedef {Readonly<{bridgeUrl: string, bridgeToken: string, capabilityBootstrapToken: string}>} BridgeConfig
+ * @typedef {{issue: () => string | null, consume: (nonce: string) => boolean, clear: () => void}} NonceStore
+ * @typedef {{openFile?: typeof import('node:fs/promises').open, uid?: () => number, onNonLoopback?: () => void}} ReaderDeps
+ * @typedef {{server: {host?: unknown, port?: unknown, strictPort?: unknown, allowedHosts?: unknown, fs?: {strict?: unknown, deny?: unknown}, cors?: unknown, watch?: {ignored?: unknown} | null, origin?: unknown, hmr?: boolean | {host?: unknown}}, additionalAllowedHosts?: unknown}} DevServerPolicyInput
+ * @typedef {{readConfig?: (root: string, onNonLoopback: () => void) => Promise<BridgeConfig | null>, env?: () => NodeJS.ProcessEnv, now?: () => number, random?: () => string, createCspNonce?: () => string, expectedPort?: number}} DevBridgeDeps
+ */
+
+export const EXPECTED_DEV_SERVER_FS_DENY = Object.freeze([
+  "**/bridge-config.generated.js",
+  "**/ResonantOS_User/**",
+  ".env",
+  ".env.*",
+  "*.{crt,pem}",
+  "**/.git/**",
+]);
+
+function policyFail() {
+  throw new Error(POLICY_ERROR);
+}
+
+function ignoredPatterns(watch) {
+  if (watch == null || typeof watch !== "object") {
+    return [];
+  }
+  const ignored = watch.ignored;
+  if (Array.isArray(ignored)) {
+    return ignored;
+  }
+  if (typeof ignored === "string") {
+    return [ignored];
+  }
+  return [];
+}
+
+export function assertDevServerPolicy(config, expectedPort) {
+  if (!Number.isInteger(expectedPort) || expectedPort < 1 || expectedPort > 65535) {
+    policyFail();
+  }
+  if (config == null || config.server == null || typeof config.server !== "object") {
+    policyFail();
+  }
+  if (config.server.host !== "127.0.0.1") {
+    policyFail();
+  }
+  if (config.server.port !== expectedPort) {
+    policyFail();
+  }
+  if (config.server.strictPort !== true) {
+    policyFail();
+  }
+  if (
+    !Array.isArray(config.server.allowedHosts) ||
+    config.server.allowedHosts.length !== 1 ||
+    config.server.allowedHosts[0] !== "127.0.0.1"
+  ) {
+    policyFail();
+  }
+  if (config.server.fs == null || config.server.fs.strict !== true) {
+    policyFail();
+  }
+  const deny = config.server.fs.deny;
+  if (!Array.isArray(deny)) {
+    policyFail();
+  }
+  if (!deny.includes("**/bridge-config.generated.js")) {
+    policyFail();
+  }
+  if (!deny.includes("**/ResonantOS_User/**")) {
+    policyFail();
+  }
+  if (!deny.includes(".env")) {
+    policyFail();
+  }
+  if (!deny.includes(".env.*")) {
+    policyFail();
+  }
+  if (!deny.includes("*.{crt,pem}")) {
+    policyFail();
+  }
+  if (!deny.includes("**/.git/**")) {
+    policyFail();
+  }
+  if (config.server.cors !== false) {
+    policyFail();
+  }
+  if (!Array.isArray(config.additionalAllowedHosts)) {
+    policyFail();
+  }
+  for (const host of config.additionalAllowedHosts) {
+    if (host !== "127.0.0.1") {
+      policyFail();
+    }
+  }
+  if (config.server.origin !== undefined && config.server.origin !== null) {
+    policyFail();
+  }
+  const hmr = config.server.hmr;
+  if (hmr !== null && typeof hmr === "object" && hmr.host !== undefined && hmr.host !== null) {
+    policyFail();
+  }
+  const ignored = ignoredPatterns(config.server.watch);
+  if (!ignored.includes(SENSITIVE_IGNORE_GENERATED)) {
+    policyFail();
+  }
+  if (!ignored.includes(SENSITIVE_IGNORE_USER)) {
+    policyFail();
+  }
+}
+
+function isPlainObject(value) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function isTokenString(value) {
+  return typeof value === "string" && TOKEN_PATTERN.test(value);
+}
+
+function serializeBridgeConfig(config) {
+  return JSON.stringify({
+    bridgeUrl: config.bridgeUrl,
+    bridgeToken: config.bridgeToken,
+    capabilityBootstrapToken: config.capabilityBootstrapToken,
+  }).replaceAll("<", "\\u003c").replaceAll("\u2028", "\\u2028").replaceAll("\u2029", "\\u2029");
+}
+
+function parseBridgeUrl(raw, onNonLoopback) {
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return null;
+  }
+  if (parsed.hostname !== "127.0.0.1") {
+    onNonLoopback?.();
+    return null;
+  }
+  if (parsed.username !== "" || parsed.password !== "") {
+    return null;
+  }
+  if (parsed.pathname !== "/" && parsed.pathname !== "") {
+    return null;
+  }
+  if (parsed.search !== "") {
+    return null;
+  }
+  if (parsed.hash !== "") {
+    return null;
+  }
+  return parsed.origin;
+}
+
+export function parseGeneratedBridgeConfig(source, onNonLoopback) {
+  if (typeof source !== "string") {
+    return null;
+  }
+  const trimmed = source.trim();
+  if (!trimmed.startsWith(CONFIG_PREFIX)) {
+    return null;
+  }
+  if (!trimmed.endsWith(CONFIG_SUFFIX)) {
+    return null;
+  }
+  const jsonText = trimmed.slice(CONFIG_PREFIX.length, trimmed.length - CONFIG_SUFFIX.length);
+  let parsed;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch {
+    return null;
+  }
+  if (!isPlainObject(parsed)) {
+    return null;
+  }
+  if (!isTokenString(parsed.bridgeUrl)) {
+    return null;
+  }
+  if (!isTokenString(parsed.bridgeToken)) {
+    return null;
+  }
+  if (!isTokenString(parsed.capabilityBootstrapToken)) {
+    return null;
+  }
+  const bridgeUrl = parseBridgeUrl(parsed.bridgeUrl, onNonLoopback);
+  if (bridgeUrl === null) {
+    return null;
+  }
+  return Object.freeze({
+    bridgeUrl,
+    bridgeToken: parsed.bridgeToken,
+    capabilityBootstrapToken: parsed.capabilityBootstrapToken,
+  });
+}
+
+function defaultUid() {
+  if (typeof process.getuid !== "function") {
+    throw new Error("unavailable");
+  }
+  return process.getuid();
+}
+
+export async function readGeneratedBridgeConfig(root, deps = {}) {
+  const openFile = deps.openFile ?? defaultOpen;
+  const uid = deps.uid ?? defaultUid;
+  const target = path.join(root, GENERATED_REL);
+  let handle;
+  try {
+    handle = await openFile(target, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW | fsConstants.O_NONBLOCK);
+  } catch {
+    return null;
+  }
+  try {
+    const stats = await handle.stat();
+    if (!stats.isFile()) {
+      return null;
+    }
+    let owner;
+    try {
+      owner = uid();
+    } catch {
+      return null;
+    }
+    if (typeof owner !== "number" || stats.uid !== owner) {
+      return null;
+    }
+    if ((stats.mode & 0o077) !== 0) {
+      return null;
+    }
+    if (stats.size > MAX_CONFIG_BYTES) {
+      return null;
+    }
+    const buffer = Buffer.alloc(MAX_CONFIG_BYTES + 1);
+    let offset = 0;
+    while (offset < buffer.length) {
+      const result = await handle.read(buffer, offset, buffer.length - offset, offset);
+      if (result.bytesRead === 0) {
+        break;
+      }
+      offset += result.bytesRead;
+    }
+    if (offset > MAX_CONFIG_BYTES) {
+      return null;
+    }
+    return parseGeneratedBridgeConfig(buffer.subarray(0, offset).toString("utf8"), deps.onNonLoopback);
+  } catch {
+    return null;
+  } finally {
+    try {
+      await handle.close();
+    } catch {
+    }
+  }
+}
+
+function defaultRandomNonce() {
+  return randomBytes(32).toString("base64url");
+}
+
+export function createPageNonces(now = Date.now, random = defaultRandomNonce) {
+  const entries = new Map();
+  const pruneExpired = (time, keep) => {
+    for (const [nonce, expiry] of entries) {
+      if (nonce !== keep && expiry <= time) {
+        entries.delete(nonce);
+      }
+    }
+  };
+  return {
+    issue() {
+      const time = now();
+      pruneExpired(time);
+      if (entries.size >= NONCE_CAPACITY) {
+        return null;
+      }
+      const nonce = random();
+      entries.set(nonce, time + NONCE_TTL_MS);
+      return nonce;
+    },
+    consume(nonce) {
+      const time = now();
+      pruneExpired(time, nonce);
+      if (!entries.has(nonce)) {
+        return false;
+      }
+      const expiry = entries.get(nonce);
+      if (expiry <= time) {
+        entries.delete(nonce);
+        return false;
+      }
+      entries.delete(nonce);
+      return true;
+    },
+    clear() {
+      entries.clear();
+    },
+  };
+}
+
+export function createCspNonce() {
+  return randomBytes(32).toString("base64url");
+}
+
+export function renderBridgeModule(config) {
+  if (config === null) {
+    return "delete globalThis.__RESONANTOS_BRIDGE_CONFIG__;\nawait import('/src/main.tsx');\n";
+  }
+  return `globalThis.__RESONANTOS_BRIDGE_CONFIG__ = Object.freeze(${serializeBridgeConfig(config)});\nawait import('/src/main.tsx');\n`;
+}
+
+function walkElements(node, visit) {
+  if (node == null) {
+    return;
+  }
+  if (typeof node.tagName === "string") {
+    visit(node);
+  }
+  const children = node.childNodes;
+  if (!Array.isArray(children)) {
+    return;
+  }
+  for (const child of children) {
+    walkElements(child, visit);
+  }
+}
+
+function attrValue(element, name) {
+  const attr = element.attrs.find((entry) => entry.name === name);
+  return attr == null ? undefined : attr.value;
+}
+
+function setAttr(element, name, value) {
+  const existing = element.attrs.find((entry) => entry.name === name);
+  if (existing) {
+    existing.value = value;
+    return;
+  }
+  element.attrs.push({ name, value });
+}
+
+function isMainEntrySrc(src) {
+  if (typeof src !== "string" || !src.startsWith("/src/main.tsx")) {
+    return false;
+  }
+  if (src.includes("\\")) {
+    return false;
+  }
+  let parsed;
+  try {
+    parsed = new URL(src, "http://127.0.0.1");
+  } catch {
+    return false;
+  }
+  if (parsed.pathname !== "/src/main.tsx") {
+    return false;
+  }
+  const keys = [...parsed.searchParams.keys()];
+  if (keys.length === 0) {
+    return true;
+  }
+  if (keys.length === 1 && keys[0] === "t") {
+    const stamp = parsed.searchParams.get("t");
+    return stamp !== null && /^\d+$/.test(stamp);
+  }
+  return false;
+}
+
+function parseCspDirectives(content) {
+  if (typeof content !== "string") {
+    return null;
+  }
+  const pieces = content.split(";").map((part) => part.trim()).filter((part) => part.length > 0);
+  const directives = [];
+  for (const piece of pieces) {
+    const space = piece.search(/\s/);
+    const name = space === -1 ? piece : piece.slice(0, space);
+    const value = space === -1 ? "" : piece.slice(space + 1).trim();
+    if (!/^[A-Za-z0-9-]+$/.test(name)) {
+      return null;
+    }
+    directives.push({ name, value, lower: name.toLowerCase() });
+  }
+  return directives;
+}
+
+function failPageStructure() {
+  throw new Error(BODY_UNAVAILABLE.trim());
+}
+
+export function renderAuthenticatedPage(html, moduleNonce, cspNonce) {
+  const document = parse(html);
+  const metas = [];
+  const moduleScripts = [];
+  walkElements(document, (element) => {
+    if (element.tagName === "meta" && String(attrValue(element, "http-equiv") ?? "").toLowerCase() === "content-security-policy") {
+      metas.push(element);
+    }
+    if (element.tagName === "script" && attrValue(element, "type") === "module" && isMainEntrySrc(attrValue(element, "src"))) {
+      moduleScripts.push(element);
+    }
+  });
+  if (metas.length !== 1) {
+    failPageStructure();
+  }
+  if (moduleScripts.length !== 1) {
+    failPageStructure();
+  }
+  const cspMeta = metas[0];
+  const directives = parseCspDirectives(attrValue(cspMeta, "content"));
+  if (directives === null) {
+    failPageStructure();
+  }
+  const scriptSrc = directives.filter((directive) => directive.lower === "script-src");
+  if (scriptSrc.length !== 1) {
+    failPageStructure();
+  }
+  const scriptTokens = scriptSrc[0].value.split(/\s+/).filter((token) => token.length > 0);
+  if (!scriptTokens.includes("'self'")) {
+    failPageStructure();
+  }
+  scriptSrc[0].value = `${scriptSrc[0].value} 'nonce-${cspNonce}'`.trim();
+  setAttr(cspMeta, "content", directives.map((directive) => (
+    directive.value.length > 0 ? `${directive.name} ${directive.value}` : directive.name
+  )).join("; "));
+  const mainScript = moduleScripts[0];
+  const parent = mainScript.parentNode;
+  if (parent == null) {
+    failPageStructure();
+  }
+  const gated = defaultTreeAdapter.createElement("script", HTML_NS, [
+    { name: "type", value: "module" },
+    { name: "src", value: `${MODULE_PATH}?nonce=${moduleNonce}` },
+  ]);
+  defaultTreeAdapter.insertBefore(parent, gated, mainScript);
+  defaultTreeAdapter.detachNode(mainScript);
+  walkElements(document, (element) => {
+    if (element.tagName === "script") {
+      setAttr(element, "nonce", cspNonce);
+    }
+  });
+  let head;
+  walkElements(document, (element) => {
+    if (head == null && element.tagName === "head") {
+      head = element;
+    }
+  });
+  if (head == null) {
+    failPageStructure();
+  }
+  defaultTreeAdapter.detachNode(cspMeta);
+  if (head.childNodes.length > 0) {
+    defaultTreeAdapter.insertBefore(head, cspMeta, head.childNodes[0]);
+  } else {
+    defaultTreeAdapter.appendChild(head, cspMeta);
+  }
+  return serialize(document);
+}
+
+function hasMalformedPercent(value) {
+  for (let index = 0; index < value.length; index += 1) {
+    if (value[index] !== "%") {
+      continue;
+    }
+    if (index + 2 >= value.length) {
+      return true;
+    }
+    if (!/[0-9A-Fa-f]/.test(value[index + 1]) || !/[0-9A-Fa-f]/.test(value[index + 2])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function normalizePosixPath(pathname) {
+  const parts = [];
+  for (const segment of pathname.split("/")) {
+    if (segment === "" || segment === ".") {
+      continue;
+    }
+    if (segment === "..") {
+      parts.pop();
+      continue;
+    }
+    parts.push(segment);
+  }
+  return `/${parts.join("/")}`;
+}
+
+function classifyUrl(rawUrl) {
+  if (typeof rawUrl !== "string") {
+    return { scope: "none" };
+  }
+  const flags = {
+    backslash: rawUrl.includes("\\") || /%5c/i.test(rawUrl),
+    absolute: false,
+    malformed: false,
+    alias: false,
+  };
+  let work = rawUrl;
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(rawUrl)) {
+    flags.absolute = true;
+    try {
+      const absolute = new URL(rawUrl);
+      work = `${absolute.pathname}${absolute.search}`;
+    } catch {
+      flags.malformed = true;
+      return { scope: "none", flags };
+    }
+  }
+  const queryIndex = work.indexOf("?");
+  const pathname = queryIndex === -1 ? work : work.slice(0, queryIndex);
+  const queryString = queryIndex === -1 ? null : work.slice(queryIndex + 1);
+  if (hasMalformedPercent(pathname) || (queryString !== null && hasMalformedPercent(queryString))) {
+    flags.malformed = true;
+  }
+  let decoded = pathname;
+  try {
+    decoded = decodeURIComponent(pathname);
+  } catch {
+    flags.malformed = true;
+  }
+  const normalized = normalizePosixPath(decoded);
+  if (/%2f/i.test(pathname) || pathname !== decoded || decoded !== normalized) {
+    flags.alias = true;
+  }
+  const reserved = pathname.startsWith(RESERVED_PREFIX) || decoded.startsWith(RESERVED_PREFIX) || normalized.startsWith(RESERVED_PREFIX);
+  if (reserved) {
+    const exactModule = pathname === MODULE_PATH && decoded === MODULE_PATH && normalized === MODULE_PATH && !flags.alias && !flags.absolute && !flags.backslash && !flags.malformed;
+    return { scope: "module", flags, pathname, queryString, exactModule };
+  }
+  if ((pathname === "/" || pathname === "/index.html") && queryString === null) {
+    return { scope: "page", flags, pathname };
+  }
+  return { scope: "none", flags };
+}
+
+function parseModuleQuery(queryString) {
+  if (queryString === null || queryString === "") {
+    return { ok: true, nonce: undefined };
+  }
+  const pairs = queryString.split("&");
+  const keys = [];
+  const values = new Map();
+  for (const pair of pairs) {
+    const eq = pair.indexOf("=");
+    const rawKey = eq === -1 ? pair : pair.slice(0, eq);
+    const rawValue = eq === -1 ? "" : pair.slice(eq + 1);
+    let key;
+    let value;
+    try {
+      key = decodeURIComponent(rawKey.replaceAll("+", "%20"));
+      value = decodeURIComponent(rawValue.replaceAll("+", "%20"));
+    } catch {
+      return { ok: false };
+    }
+    if (values.has(key)) {
+      return { ok: false };
+    }
+    keys.push(key);
+    values.set(key, value);
+  }
+  if (keys.length > 1) {
+    return { ok: false };
+  }
+  if (keys.length === 1 && keys[0] !== "nonce") {
+    return { ok: false };
+  }
+  return { ok: true, nonce: values.get("nonce") };
+}
+
+function headerName(name) {
+  return name.toLowerCase();
+}
+
+function rawHeaderValues(req, name) {
+  const wanted = headerName(name);
+  const raw = req.rawHeaders;
+  if (Array.isArray(raw) && raw.length > 0) {
+    const matches = [];
+    for (let index = 0; index < raw.length; index += 2) {
+      if (headerName(String(raw[index])) === wanted) {
+        matches.push(raw[index + 1]);
+      }
+    }
+    if (matches.length > 0) {
+      return matches;
+    }
+  }
+  const headers = req.headers ?? {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (headerName(key) !== wanted) {
+      continue;
+    }
+    if (Array.isArray(value)) {
+      return value;
+    }
+    if (value === undefined) {
+      return [];
+    }
+    return [value];
+  }
+  return [];
+}
+
+function readHeader(req, name) {
+  const values = rawHeaderValues(req, name);
+  if (values.length > 1) {
+    return { duplicate: true };
+  }
+  if (values.length === 0) {
+    return { value: undefined };
+  }
+  const value = values[0];
+  if (typeof value !== "string") {
+    return { duplicate: true };
+  }
+  return { value };
+}
+
+function isCanonicalBase64(value) {
+  if (typeof value !== "string" || value.length === 0 || value.length % 4 !== 0) {
+    return false;
+  }
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(value)) {
+    return false;
+  }
+  const pad = value.indexOf("=");
+  if (pad !== -1 && value.slice(pad).replaceAll("=", "") !== "") {
+    return false;
+  }
+  return Buffer.from(value, "base64").toString("base64") === value;
+}
+
+function verifyBasicCredential(req, pageKey) {
+  const header = readHeader(req, "authorization");
+  if (header.duplicate) {
+    return "duplicate";
+  }
+  if (header.value === undefined) {
+    return "absent";
+  }
+  if (typeof header.value !== "string") {
+    return "bad";
+  }
+  if (header.value.length > AUTH_HEADER_MAX) {
+    return "bad";
+  }
+  if (!header.value.startsWith("Basic ")) {
+    return "bad";
+  }
+  const encoded = header.value.slice(6);
+  if (!isCanonicalBase64(encoded)) {
+    return "bad";
+  }
+  const decoded = Buffer.from(encoded, "base64");
+  const separator = decoded.indexOf(0x3a);
+  if (separator < 0) {
+    return "bad";
+  }
+  const user = decoded.subarray(0, separator);
+  const pass = decoded.subarray(separator + 1);
+  const expectedUser = Buffer.from("dev");
+  const expectedPass = Buffer.from(pageKey);
+  if (user.length !== expectedUser.length) {
+    return "bad";
+  }
+  if (!timingSafeEqual(user, expectedUser)) {
+    return "bad";
+  }
+  if (pass.length !== expectedPass.length) {
+    return "bad";
+  }
+  if (!timingSafeEqual(pass, expectedPass)) {
+    return "bad";
+  }
+  return "ok";
+}
+
+function pageFetchBlocked(req) {
+  const site = readHeader(req, "sec-fetch-site");
+  const dest = readHeader(req, "sec-fetch-dest");
+  if (site.duplicate || dest.duplicate) {
+    return true;
+  }
+  if (site.value === "cross-site") {
+    return true;
+  }
+  if (dest.value === "iframe" || dest.value === "frame" || dest.value === "embed" || dest.value === "object") {
+    return true;
+  }
+  return false;
+}
+
+function moduleFetchAllowed(req) {
+  const site = readHeader(req, "sec-fetch-site");
+  const mode = readHeader(req, "sec-fetch-mode");
+  const dest = readHeader(req, "sec-fetch-dest");
+  if (site.duplicate || mode.duplicate || dest.duplicate) {
+    return false;
+  }
+  if (site.value !== "same-origin") {
+    return false;
+  }
+  if (mode.value !== "cors") {
+    return false;
+  }
+  if (dest.value !== "script") {
+    return false;
+  }
+  return true;
+}
+
+function originForbidden(req, expectedOrigin) {
+  const origin = readHeader(req, "origin");
+  if (origin.duplicate) {
+    return true;
+  }
+  if (origin.value === undefined) {
+    return false;
+  }
+  if (origin.value === "null") {
+    return true;
+  }
+  if (origin.value !== expectedOrigin) {
+    return true;
+  }
+  return false;
+}
+
+function hostForbidden(req, expectedHost) {
+  const host = readHeader(req, "host");
+  if (host.duplicate) {
+    return true;
+  }
+  if (host.value !== expectedHost) {
+    return true;
+  }
+  return false;
+}
+
+function applyHeaders(res, headers) {
+  if (typeof res.setHeader === "function") {
+    for (const [name, value] of Object.entries(headers)) {
+      res.setHeader(name, value);
+    }
+    return;
+  }
+  if (typeof res.writeHead === "function") {
+    res.writeHead(res.statusCode || 200, headers);
+  }
+}
+
+function sendHandled(res, status, body, options) {
+  const headers = { ...SECURITY_HEADERS };
+  if (options.isPage) {
+    headers["Content-Security-Policy"] = "frame-ancestors 'none'";
+    headers["X-Frame-Options"] = "DENY";
+    headers["Content-Type"] = "text/html; charset=utf-8";
+  } else if (options.isJs) {
+    headers["Content-Type"] = "text/javascript; charset=utf-8";
+  } else {
+    headers["Content-Type"] = "text/plain; charset=utf-8";
+  }
+  if (options.challenge) {
+    headers["WWW-Authenticate"] = WWW_AUTHENTICATE;
+  }
+  res.statusCode = status;
+  applyHeaders(res, headers);
+  if (typeof res.end === "function") {
+    res.end(body);
+    return;
+  }
+  if (typeof res.writeHead === "function") {
+    res.writeHead(status, headers);
+  }
+}
+
+export function devBridgeConfigPlugin(deps) {
+  const expectedPort = deps?.expectedPort ?? 1430;
+  return {
+    name: "resonantos-dev-bridge-config",
+    enforce: "pre",
+    apply: (_config, env) => env.command === 'serve' && !env.isPreview && env.mode !== 'test' /* vitest boots an internal Vite server; the delivery plugin and its fail-closed policy belong to the real dev server only */,
+    configureServer(server) {
+      assertDevServerPolicy(server.config, expectedPort);
+      const env = (deps?.env ?? (() => process.env))();
+      const enabled = env.RESONANTOS_DEV_BRIDGE_CONFIG === "1";
+      const now = deps?.now ?? Date.now;
+      const random = deps?.random ?? defaultRandomNonce;
+      const makeCspNonce = deps?.createCspNonce ?? createCspNonce;
+      const store = createPageNonces(now, random);
+      const expectedHost = `127.0.0.1:${expectedPort}`;
+      const expectedOrigin = `http://127.0.0.1:${expectedPort}`;
+      let pageKey;
+      if (enabled) {
+        const candidate = env.RESONANTOS_DEV_BRIDGE_PAGE_KEY;
+        if (typeof candidate !== "string" || !PAGE_KEY_PATTERN.test(candidate)) {
+          throw new Error(PAGE_KEY_ERROR);
+        }
+        pageKey = candidate;
+      }
+      const readConfig = deps?.readConfig ?? ((root, onNonLoopback) => readGeneratedBridgeConfig(root, { onNonLoopback }));
+      let loopbackWarned = false;
+      const onNonLoopback = () => {
+        if (loopbackWarned) {
+          return;
+        }
+        loopbackWarned = true;
+        console.error(LOOPBACK_DIAGNOSTIC);
+      };
+      const clearStore = () => {
+        store.clear();
+      };
+      if (server.httpServer && typeof server.httpServer.on === "function") {
+        server.httpServer.on("close", clearStore);
+      }
+      if (typeof server.close === "function") {
+        const originalClose = server.close.bind(server);
+        server.close = (...args) => {
+          clearStore();
+          return originalClose(...args);
+        };
+      }
+      const middleware = (req, res, next) => {
+        const finish = (status, body, options) => {
+          sendHandled(res, status, body, options);
+        };
+        const run = async () => {
+          const classified = classifyUrl(req.url);
+          if (!enabled) {
+            if (classified.scope === "module") {
+              finish(404, BODY_NOT_FOUND, { isPage: false, isJs: false });
+              return;
+            }
+            next();
+            return;
+          }
+          if (classified.scope === "none") {
+            next();
+            return;
+          }
+          if (hostForbidden(req, expectedHost)) {
+            finish(403, BODY_FORBIDDEN, { isPage: classified.scope === "page", isJs: false });
+            return;
+          }
+          if (originForbidden(req, expectedOrigin)) {
+            finish(403, BODY_FORBIDDEN, { isPage: classified.scope === "page", isJs: false });
+            return;
+          }
+          if (classified.scope === "page") {
+            if (classified.flags.absolute || classified.flags.backslash || classified.flags.malformed) {
+              finish(403, BODY_FORBIDDEN, { isPage: true, isJs: false });
+              return;
+            }
+            if (pageFetchBlocked(req)) {
+              finish(403, BODY_FORBIDDEN, { isPage: true, isJs: false });
+              return;
+            }
+            if (req.method !== "GET") {
+              finish(405, BODY_FORBIDDEN, { isPage: true, isJs: false });
+              return;
+            }
+            const pageAuth = verifyBasicCredential(req, pageKey);
+            if (pageAuth !== "ok") {
+              finish(401, BODY_AUTH, { isPage: true, isJs: false, challenge: true });
+              return;
+            }
+            const moduleNonce = store.issue();
+            if (moduleNonce === null) {
+              finish(503, BODY_UNAVAILABLE, { isPage: true, isJs: false });
+              return;
+            }
+            try {
+              const source = await readFile(path.join(server.config.root, "index.html"), "utf8");
+              const transformed = await server.transformIndexHtml("/index.html", source, classified.pathname);
+              const cspNonce = makeCspNonce();
+              const rendered = renderAuthenticatedPage(transformed, moduleNonce, cspNonce);
+              finish(200, rendered, { isPage: true, isJs: false });
+            } catch {
+              store.consume(moduleNonce);
+              finish(500, BODY_UNAVAILABLE, { isPage: true, isJs: false });
+            }
+            return;
+          }
+          if (classified.flags.absolute || classified.flags.backslash || classified.flags.malformed || classified.flags.alias || !classified.exactModule) {
+            finish(403, BODY_FORBIDDEN, { isPage: false, isJs: false });
+            return;
+          }
+          if (req.method !== "GET") {
+            finish(403, BODY_FORBIDDEN, { isPage: false, isJs: false });
+            return;
+          }
+          const query = parseModuleQuery(classified.queryString);
+          if (!query.ok) {
+            finish(403, BODY_FORBIDDEN, { isPage: false, isJs: false });
+            return;
+          }
+          if (!moduleFetchAllowed(req)) {
+            finish(403, BODY_FORBIDDEN, { isPage: false, isJs: false });
+            return;
+          }
+          const moduleAuth = verifyBasicCredential(req, pageKey);
+          if (moduleAuth === "absent") {
+            finish(401, BODY_AUTH, { isPage: false, isJs: false, challenge: true });
+            return;
+          }
+          if (moduleAuth !== "ok") {
+            finish(403, BODY_FORBIDDEN, { isPage: false, isJs: false });
+            return;
+          }
+          if (!store.consume(query.nonce)) {
+            finish(403, BODY_FORBIDDEN, { isPage: false, isJs: false });
+            return;
+          }
+          let config = null;
+          try {
+            config = await readConfig(server.config.root, onNonLoopback);
+          } catch {
+            config = null;
+          }
+          finish(200, renderBridgeModule(config), { isPage: false, isJs: true });
+        };
+        return Promise.resolve(run()).catch(() => {
+          if (res.writableEnded || res.headersSent) {
+            return;
+          }
+          finish(500, BODY_UNAVAILABLE, { isPage: true, isJs: false });
+        });
+      };
+      server.middlewares.use(middleware);
+      return () => {
+        assertDevServerPolicy(server.config, expectedPort);
+      };
+    },
+  };
+}

--- a/scripts/vite-dev-bridge-config.test.mjs
+++ b/scripts/vite-dev-bridge-config.test.mjs
@@ -118,8 +118,16 @@ function headersSafe(response, page = false) {
 
 test('opt-out never reads or injects', async t => {
   for (const value of [undefined, '', '0', 'false', 'true']) {
-    const h = await harness(t, { env: value === undefined ? {} : { RESONANTOS_DEV_BRIDGE_CONFIG: value } });
-    assert.equal((await h.page()).next, true);
+    let h;
+    try { h = await harness(t, { env: value === undefined ? {} : { RESONANTOS_DEV_BRIDGE_CONFIG: value } }); }
+    catch (error) {
+      // A missing-key refusal is a behavioral regression in off mode. Keep
+      // unrelated filesystem/import errors distinct from an assertion kill.
+      if (error.message !== 'Development page key is invalid.') throw error;
+    }
+    assert.equal(h !== undefined, true, 'off mode starts successfully without a page key');
+    const page = await h.request('/');
+    assert.equal(page.next, true); assert.equal(page.headers.has('www-authenticate'), false);
     for (const method of ['GET', 'HEAD', 'POST', 'OPTIONS']) for (const suffix of ['', '?nonce=x', '?raw', '/other']) {
       const response = await h.request(ROUTE + suffix, { method, headers: { host: 'attacker.test', origin: 'null' } });
       assert.equal(response.status, 404); assert.equal(response.body, 'Not found.\n');

--- a/scripts/vite-dev-bridge-config.test.mjs
+++ b/scripts/vite-dev-bridge-config.test.mjs
@@ -173,6 +173,12 @@ test('parser rejects unsafe shapes and destinations', async t => {
   for (const field of ['bridgeToken', 'capabilityBootstrapToken']) for (const invalid of ['', 'x'.repeat(513), 'a b', 'a\nb', 'a\0b', 'a\x7fb', 'é', 1]) {
     assert.equal(parseGeneratedBridgeConfig(writer({ ...value, [field]: invalid })) === null, true);
   }
+  // URL parsing alone accepts arrays and strips whitespace/control characters.
+  // These must fail the string/ASCII/length gate before URL normalization.
+  for (const bridgeUrl of [[value.bridgeUrl], ` ${value.bridgeUrl}`, `${value.bridgeUrl}\n`,
+    'http://127.0.0.1:' + '0'.repeat(500) + '49153']) {
+    assert.equal(parseGeneratedBridgeConfig(writer({ ...value, bridgeUrl })) === null, true, 'bridgeUrl requires a bounded printable string');
+  }
   for (const bridgeUrl of ['ftp://127.0.0.1', 'http://user:pass@127.0.0.1', 'http://127.0.0.1/path', 'http://127.0.0.1?x=1', 'http://127.0.0.1/#x']) {
     assert.equal(parseGeneratedBridgeConfig(writer({ ...value, bridgeUrl })) === null, true);
   }
@@ -205,11 +211,14 @@ test('authorized requests read fresh config', async t => {
 test('unavailable config starts main without credentials', async t => {
   const root = await tempRoot(t), path = join(root, RELATIVE);
   const h = await harness(t, { root, readConfig: path => readGeneratedBridgeConfig(path) });
-  for (const source of [null, '{malformed}', 'globalThis.__RESONANTOS_BRIDGE_CONFIG__ = Object.freeze(', writer(config())]) {
-    if (source === null) await rm(path, { force: true }); else { await writeFile(path, source, { mode: 0o600 }); if (source.startsWith('globalThis') && source.endsWith(');')) await chmod(path, 0o644); }
+  const missingUrl = config(); delete missingUrl.bridgeUrl;
+  const missingUrlSource = writer(missingUrl);
+  for (const source of [null, '{malformed}', 'globalThis.__RESONANTOS_BRIDGE_CONFIG__ = Object.freeze(', missingUrlSource, writer(config())]) {
+    if (source === null) await rm(path, { force: true }); else { await writeFile(path, source, { mode: 0o600 }); if (source !== missingUrlSource && source.startsWith('globalThis') && source.endsWith(');')) await chmod(path, 0o644); }
     const route = routeFrom((await h.page()).body), response = await h.module(route);
     assert.equal(response.status, 200); assert.equal(response.body, renderBridgeModule(null));
     assert.match(response.body, /^delete globalThis\.__RESONANTOS_BRIDGE_CONFIG__;/);
+    safe(response.body, Object.values(missingUrl));
     assert.equal((await h.module(route)).status, 403);
   }
 });
@@ -236,12 +245,34 @@ test('reader rejects unsafe files and bounds reads', async t => {
   for (const mode of [0o640, 0o604, 0o644]) { await chmod(path, mode); assert.equal((await readGeneratedBridgeConfig(root, { openFile: trackedOpen })) === null, true); }
   await chmod(path, 0o600); await writeFile(path, 'x'.repeat(16 * 1024 + 1));
   assert.equal((await readGeneratedBridgeConfig(root, { openFile: trackedOpen })) === null, true);
-  await rm(path); await mkdir(path); assert.equal((await readGeneratedBridgeConfig(root, { openFile: trackedOpen })) === null, true);
+  // Private permissions ensure the regular-file guard is the only metadata
+  // rejection; a default 0755 directory would also fail the permission guard.
+  await rm(path); await mkdir(path, { mode: 0o700 }); assert.equal((await readGeneratedBridgeConfig(root, { openFile: trackedOpen })) === null, true);
   await rm(path, { recursive: true }); const target = join(root, 'synthetic-source'); await writeFile(target, source, { mode: 0o600 }); await symlink(target, path);
   assert.equal((await readGeneratedBridgeConfig(root, { openFile: trackedOpen })) === null, true);
   assert.equal(opened, closed, 'all opened descriptors closed');
   assert.equal(dataReads, validReads, 'unsafe metadata rejected before reading bytes');
   await rm(path); await writeFile(path, source, { mode: 0o600 });
+  // Model growth after fstat using a real descriptor and valid padded source.
+  // Invalid filler would hide removal of the post-read bound in the parser.
+  let growthClosed = 0, growthBytes = 0;
+  const growingOpen = async (...args) => {
+    const handle = await open(...args);
+    return new Proxy(handle, { get(target, prop) {
+      if (prop === 'stat') return async () => { const stats = await target.stat(); stats.size = 16 * 1024; return stats; };
+      if (prop === 'read') return async (...args) => { const result = await target.read(...args); growthBytes += result.bytesRead; return result; };
+      if (prop === 'close') return async () => { growthClosed++; await target.close(); };
+      const value = Reflect.get(target, prop, target); return typeof value === 'function' ? value.bind(target) : value;
+    } });
+  };
+  await writeFile(path, source.padEnd(16 * 1024, ' '));
+  assert.equal((await readGeneratedBridgeConfig(root, { openFile: growingOpen })) !== null, true, 'exact read bound accepts valid source');
+  growthBytes = 0;
+  await writeFile(path, source.padEnd(16 * 1024 + 1, ' '));
+  assert.equal((await readGeneratedBridgeConfig(root, { openFile: growingOpen })) === null, true, 'growth beyond read bound is rejected');
+  assert.equal(growthBytes, 16 * 1024 + 1, 'one overflow byte observed');
+  assert.equal(growthClosed, 2, 'boundary and overflow descriptors closed');
+  await writeFile(path, source);
   let failureClosed = false;
   const failingOpen = async (...args) => { const handle = await open(...args); return { stat: async () => { throw Error(token()); }, close: async () => { failureClosed = true; await handle.close(); } }; };
   assert.equal((await readGeneratedBridgeConfig(root, { openFile: failingOpen })) === null, true); assert.equal(failureClosed, true);
@@ -289,8 +320,11 @@ test('nonces expire and are single-use per server', async t => {
   const pending = new Promise(resolve => { release = resolve; });
   const h = await harness(t, { readConfig: async () => { entered(); await pending; return config(); } });
   const route = routeFrom((await h.page()).body);
-  const winner = h.module(route); await reading;
-  try { const loser = await h.module(route); assert.equal(loser.status, 403); assert.equal(h.reads(), 1); }
+  const winner = h.module(route);
+  try {
+    assert.equal(await Promise.race([reading.then(() => true), winner.then(() => false)]), true, 'authorized winner reaches config read');
+    const loser = await h.module(route); assert.equal(loser.status, 403); assert.equal(h.reads(), 1);
+  }
   finally { release(); }
   assert.equal((await winner).status, 200);
 });
@@ -437,6 +471,27 @@ test('nonce state is bounded and cleared', async t => {
 });
 test('Basic parser rejects ambiguous credentials', async t => {
   const h = await harness(t), route = routeFrom((await h.page()).body);
+  // An oversized canonical credential also fails the later password check.
+  // Observe decoding to prove the size guard rejects it before that work.
+  const oversized = Buffer.from(`dev:${h.key.repeat(8)}`).toString('base64');
+  assert.equal(`Basic ${oversized}`.length > 256, true);
+  let oversizedDecodes = 0;
+  const originalFrom = Buffer.from;
+  const fromMock = t.mock.method(Buffer, 'from', function (value, ...args) {
+    if (value === oversized && args[0] === 'base64') oversizedDecodes++;
+    return Reflect.apply(originalFrom, this, [value, ...args]);
+  });
+  try {
+    const authorization = `Basic ${oversized}`;
+    const page = await h.request('/', { headers: { authorization } });
+    assert.equal(page.status, 401); assert.equal(page.body, 'Authentication required.\n');
+    assert.equal(page.headers.get('www-authenticate'), CHALLENGE);
+    const response = await h.request(route, { headers: { ...META, authorization } });
+    assert.equal(response.status, 403); assert.equal(response.body, 'Forbidden.\n');
+    assert.equal(response.headers.has('www-authenticate'), false);
+    assert.equal(h.reads(), 0); assert.equal(h.issues(), 1);
+    assert.equal(oversizedDecodes, 0, 'oversized Authorization rejected before Base64 decoding');
+  } finally { fromMock.mock.restore(); }
   const encoded = Buffer.from(`dev:${h.key}`).toString('base64');
   const bad = [`Basic ${encoded}\n`, `Basic ${encoded.replace(/=+$/, '')}!`, `Basic ${encoded.slice(0, 8)} ${encoded.slice(8)}`,
     `Basic ${Buffer.from(`other:${h.key}`).toString('base64')}`, `Basic ${Buffer.from(`dev:${h.key.slice(1)}`).toString('base64')}`,

--- a/scripts/vite-dev-bridge-config.test.mjs
+++ b/scripts/vite-dev-bridge-config.test.mjs
@@ -1,0 +1,426 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { randomBytes } from 'node:crypto';
+import { EventEmitter } from 'node:events';
+import { constants } from 'node:fs';
+import { mkdtemp, mkdir, writeFile, readFile, rm, chmod, symlink, open } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parse } from 'parse5';
+import {
+  devBridgeConfigPlugin, parseGeneratedBridgeConfig, readGeneratedBridgeConfig,
+  createPageNonces, createCspNonce, renderBridgeModule, renderAuthenticatedPage,
+} from './vite-dev-bridge-config.mjs';
+
+const PREFIX = '/__resonantos_dev_bridge__/';
+const ROUTE = `${PREFIX}config.mjs`;
+const RELATIVE = 'browser-first/resonantos-side-panel-extension/src/bridge-config.generated.js';
+const PORT = 49152; // unit seam only: no listener is created by this file.
+const HOST = `127.0.0.1:${PORT}`;
+const META = { 'sec-fetch-site': 'same-origin', 'sec-fetch-mode': 'cors', 'sec-fetch-dest': 'script' };
+const DENY = ['**/bridge-config.generated.js', '**/ResonantOS_User/**', '.env', '.env.*', '*.{crt,pem}', '**/.git/**'];
+const CHALLENGE = 'Basic realm="ResonantOS development", charset="UTF-8"';
+const token = () => `synthetic-${randomBytes(24).toString('hex')}`;
+const nonce = () => randomBytes(32).toString('base64url');
+const config = () => ({ bridgeUrl: 'http://127.0.0.1:49153', bridgeToken: token(), capabilityBootstrapToken: token() });
+const writer = value => `globalThis.__RESONANTOS_BRIDGE_CONFIG__ = Object.freeze(${JSON.stringify(value)});`;
+const HTML = '<!doctype html><html><head><meta http-equiv="Content-Security-Policy" content="default-src \'self\'; script-src \'self\'; connect-src \'self\' http://127.0.0.1:*; style-src \'self\' \'unsafe-inline\'"></head><body><div id="root"></div><script type="module" src="/src/main.tsx"></script></body></html>';
+const policy = root => ({ root, additionalAllowedHosts: [], server: {
+  host: '127.0.0.1', port: PORT, strictPort: true, allowedHosts: ['127.0.0.1'],
+  fs: { strict: true, deny: DENY }, cors: false, watch: { ignored: DENY.slice(0, 2) },
+} });
+const invokeHook = (hook, ...args) => (typeof hook === 'function' ? hook : hook.handler)(...args);
+const safe = (body, values) => assert.equal(values.some(value => value && body.includes(value)), false, 'sensitive material absent');
+const routeFrom = body => {
+  const route = body.match(/src="(\/__resonantos_dev_bridge__\/config\.mjs\?nonce=[A-Za-z0-9_-]{43})"/)?.[1];
+  assert.equal(typeof route, 'string', 'one gated module URL');
+  return route;
+};
+function nodes(html) {
+  const result = [];
+  const visit = node => { result.push(node); for (const child of node.childNodes ?? []) visit(child); };
+  visit(parse(html)); return result;
+}
+const attr = (node, name) => node.attrs?.find(a => a.name === name)?.value;
+async function tempRoot(t) {
+  const root = await mkdtemp(join(tmpdir(), 'resonantos-dev-unit-'));
+  await chmod(root, 0o700);
+  t.after(() => rm(root, { recursive: true, force: true }));
+  await mkdir(join(root, RELATIVE, '..'), { recursive: true });
+  await writeFile(join(root, 'index.html'), HTML, { mode: 0o600 });
+  return root;
+}
+async function harness(t, options = {}) {
+  const root = options.root ?? await tempRoot(t);
+  const key = options.key ?? nonce();
+  let reads = 0, issues = 0, cspIssues = 0;
+  const transforms = [], logs = [], errors = [];
+  const httpServer = new EventEmitter();
+  const middlewares = [];
+  const server = {
+    config: policy(root), httpServer,
+    middlewares: { use: (...args) => middlewares.push(args.at(-1)) },
+    transformIndexHtml: async (...args) => { transforms.push(args); return options.transform ? options.transform(...args) : args[1]; },
+    watcher: new EventEmitter(), ws: { send: value => logs.push(value) },
+  };
+  server.config.logger = Object.fromEntries(['info', 'warn', 'error', 'warnOnce'].map(name => [name, (...args) => logs.push(args)]));
+  const plugin = devBridgeConfigPlugin({ expectedPort: PORT,
+    env: () => options.env ?? { RESONANTOS_DEV_BRIDGE_CONFIG: '1', RESONANTOS_DEV_BRIDGE_PAGE_KEY: key },
+    readConfig: async (...args) => { reads++; return options.readConfig ? options.readConfig(...args) : options.value ?? config(); },
+    random: () => { issues++; return options.random ? options.random() : nonce(); },
+    createCspNonce: () => { cspIssues++; return options.createCspNonce ? options.createCspNonce() : nonce(); },
+    ...(options.now ? { now: options.now } : {}),
+  });
+  const post = await invokeHook(plugin.configureServer, server);
+  if (post) await post();
+  t.after(() => httpServer.emit('close'));
+  const authorization = `Basic ${Buffer.from(`dev:${key}`).toString('base64')}`;
+  async function request(url, { headers = {}, method = 'GET', rawHeaders } = {}) {
+    const req = new EventEmitter();
+    Object.assign(req, { url, originalUrl: url, method, headers: { host: HOST, ...headers }, socket: { remoteAddress: '127.0.0.1' } });
+    req.rawHeaders = rawHeaders ?? Object.entries(req.headers).flatMap(([name, value]) => [name, String(value)]);
+    const res = new EventEmitter();
+    const responseHeaders = new Map();
+    res.statusCode = 200; res.headersSent = false; res.writableEnded = false;
+    res.setHeader = (name, value) => responseHeaders.set(name.toLowerCase(), String(value));
+    res.getHeader = name => responseHeaders.get(name.toLowerCase());
+    res.removeHeader = name => responseHeaders.delete(name.toLowerCase());
+    res.writeHead = (status, values) => { res.statusCode = status; for (const [name, value] of Object.entries(values ?? {})) res.setHeader(name, value); return res; };
+    let resolveResult;
+    const result = new Promise(resolve => { resolveResult = resolve; });
+    res.end = (body = '') => { res.writableEnded = true; res.headersSent = true; resolveResult({ status: res.statusCode, body: String(body), headers: responseHeaders, next: false }); res.emit('finish'); };
+    let index = 0;
+    const next = error => {
+      if (error) errors.push(error);
+      const middleware = middlewares[index++];
+      if (middleware && !error) Promise.resolve(middleware(req, res, next)).catch(error => { errors.push(error); resolveResult({ status: 599, body: '', headers: responseHeaders, next: true }); });
+      else resolveResult({ status: 0, body: '', headers: responseHeaders, next: true });
+    };
+    next();
+    let timer;
+    try { return await Promise.race([result, new Promise((_, reject) => { timer = setTimeout(() => reject(new Error('unit middleware timeout')), 3000); })]); }
+    finally { clearTimeout(timer); }
+  }
+  const page = () => request('/', { headers: { authorization } });
+  const module = route => request(route, { headers: { authorization, ...META } });
+  return { root, key, authorization, request, page, module, plugin, server, transforms, logs, errors,
+    reads: () => reads, issues: () => issues, cspIssues: () => cspIssues };
+}
+function headersSafe(response, page = false) {
+  const expected = { 'cache-control': 'private, no-store', pragma: 'no-cache', 'referrer-policy': 'no-referrer',
+    'cross-origin-resource-policy': 'same-origin', 'x-content-type-options': 'nosniff',
+    vary: 'Host, Authorization, Origin, Sec-Fetch-Site, Sec-Fetch-Mode, Sec-Fetch-Dest' };
+  for (const [name, value] of Object.entries(expected)) assert.equal(response.headers.get(name), value, name);
+  for (const name of ['access-control-allow-origin', 'access-control-allow-credentials', 'etag', 'last-modified', 'location']) assert.equal(response.headers.has(name), false, name);
+  if (page) { assert.equal(response.headers.get('x-frame-options'), 'DENY'); assert.match(response.headers.get('content-security-policy') ?? '', /frame-ancestors 'none'/); }
+  assert.notEqual(response.status, 304);
+}
+
+test('opt-out never reads or injects', async t => {
+  for (const value of [undefined, '', '0', 'false', 'true']) {
+    const h = await harness(t, { env: value === undefined ? {} : { RESONANTOS_DEV_BRIDGE_CONFIG: value } });
+    assert.equal((await h.page()).next, true);
+    for (const method of ['GET', 'HEAD', 'POST', 'OPTIONS']) for (const suffix of ['', '?nonce=x', '?raw', '/other']) {
+      const response = await h.request(ROUTE + suffix, { method, headers: { host: 'attacker.test', origin: 'null' } });
+      assert.equal(response.status, 404); assert.equal(response.body, 'Not found.\n');
+      assert.equal(response.headers.has('www-authenticate'), false); assert.equal(response.next, false);
+    }
+    assert.equal(h.reads(), 0); assert.equal(h.issues(), 0); assert.equal(h.cspIssues(), 0); assert.equal(h.transforms.length, 0);
+  }
+});
+test('opt-in requires a private page key', async t => {
+  const messages = [];
+  for (const key of [undefined, '', 'short', `${nonce()}!`, ' '.repeat(43), nonce().slice(1)]) {
+    let error;
+    try { await harness(t, { env: { RESONANTOS_DEV_BRIDGE_CONFIG: '1', ...(key === undefined ? {} : { RESONANTOS_DEV_BRIDGE_PAGE_KEY: key }) } }); } catch (caught) { error = caught; }
+    assert.equal(error instanceof Error, true, 'startup must fail');
+    messages.push(error.message); if (key) safe(error.message, [key]);
+  }
+  assert.equal(new Set(messages).size, 1, 'fixed startup error');
+});
+test('parser accepts writer contract and projects three fields', () => {
+  for (const bridgeUrl of ['http://127.0.0.1:49153', 'https://127.0.0.1:49153', 'http://127.0.0.1:80']) {
+    const value = { ...config(), bridgeUrl, httpsBridgeUrl: 'https://attacker.test', extra: token() };
+    const parsed = parseGeneratedBridgeConfig(` \n${writer(value)}\n`);
+    assert.equal(parsed !== null, true); assert.deepEqual(Object.keys(parsed).sort(), ['bridgeToken', 'bridgeUrl', 'capabilityBootstrapToken']);
+    assert.equal(parsed.bridgeUrl === new URL(bridgeUrl).origin, true, 'normalized origin');
+    assert.equal(parsed.bridgeToken === value.bridgeToken && parsed.capabilityBootstrapToken === value.capabilityBootstrapToken, true, 'projected tokens');
+  }
+});
+test('parser never evaluates script', () => {
+  const value = config(), source = writer(value);
+  globalThis.__devBridgeExecutionSentinel = false;
+  try {
+    for (const invalid of [source + 'globalThis.__devBridgeExecutionSentinel=true;', `globalThis.__devBridgeExecutionSentinel=true;${source}`,
+      source.replace('Object.freeze(', 'Object.seal('), source.slice(0, -1), source.replace(JSON.stringify(value), '(globalThis.__devBridgeExecutionSentinel=true,{})'),
+      source.replace(JSON.stringify(value), '{broken}')]) assert.equal(parseGeneratedBridgeConfig(invalid) === null, true);
+    assert.equal(globalThis.__devBridgeExecutionSentinel, false);
+  } finally { delete globalThis.__devBridgeExecutionSentinel; }
+});
+test('parser rejects unsafe shapes and destinations', async t => {
+  const value = config();
+  for (const invalid of [null, [], 1, 'text', true, ...['bridgeUrl', 'bridgeToken', 'capabilityBootstrapToken'].map(key => Object.fromEntries(Object.entries(value).filter(([name]) => name !== key)))]) {
+    assert.equal(parseGeneratedBridgeConfig(writer(invalid)) === null, true);
+  }
+  for (const field of ['bridgeToken', 'capabilityBootstrapToken']) for (const invalid of ['', 'x'.repeat(513), 'a b', 'a\nb', 'a\0b', 'a\x7fb', 'é', 1]) {
+    assert.equal(parseGeneratedBridgeConfig(writer({ ...value, [field]: invalid })) === null, true);
+  }
+  for (const bridgeUrl of ['ftp://127.0.0.1', 'http://user:pass@127.0.0.1', 'http://127.0.0.1/path', 'http://127.0.0.1?x=1', 'http://127.0.0.1/#x']) {
+    assert.equal(parseGeneratedBridgeConfig(writer({ ...value, bridgeUrl })) === null, true);
+  }
+  for (const bridgeUrl of ['http://localhost:49153', 'http://[::1]:49153', 'https://attacker.test']) {
+    let calls = 0;
+    assert.equal(parseGeneratedBridgeConfig(writer({ ...value, bridgeUrl }), () => calls++) === null, true);
+    assert.equal(calls, 1);
+  }
+  const root = await tempRoot(t), remote = { ...value, bridgeUrl: 'https://attacker.test' };
+  await writeFile(join(root, RELATIVE), writer(remote), { mode: 0o600 });
+  let readerCalls = 0;
+  assert.equal((await readGeneratedBridgeConfig(root, { onNonLoopback: () => readerCalls++ })) === null, true); assert.equal(readerCalls, 1);
+  const captured = []; const originals = {};
+  for (const name of ['warn', 'error', 'log', 'info']) { originals[name] = console[name]; console[name] = (...args) => captured.push(args.join(' ')); }
+  try {
+    const h = await harness(t, { root, readConfig: (path, onNonLoopback) => readGeneratedBridgeConfig(path, { onNonLoopback }) });
+    for (let i = 0; i < 2; i++) { const response = await h.module(routeFrom((await h.page()).body)); assert.equal(response.status, 200); assert.match(response.body, /^delete globalThis/); safe(response.body, Object.values(remote)); }
+    assert.equal(JSON.stringify(captured) === JSON.stringify(['Development bridge config unavailable: loopback URL required.']), true, 'exact value-free diagnostic once');
+  } finally { for (const name of Object.keys(originals)) console[name] = originals[name]; }
+});
+test('authorized requests read fresh config', async t => {
+  let value = config(); const first = value;
+  const h = await harness(t, { readConfig: async () => value }); assert.equal(h.reads(), 0);
+  const page1 = await h.page(); assert.equal(h.reads(), 0);
+  const response1 = await h.module(routeFrom(page1.body)); assert.equal(response1.status, 200); assert.equal(response1.body.includes(first.bridgeToken), true);
+  value = config(); const page2 = await h.page(); assert.equal(h.reads(), 1);
+  const response2 = await h.module(routeFrom(page2.body)); assert.equal(response2.status, 200); assert.equal(response2.body.includes(value.bridgeToken), true);
+  safe(response2.body, [first.bridgeToken, first.capabilityBootstrapToken]); assert.equal(h.reads(), 2);
+});
+test('unavailable config starts main without credentials', async t => {
+  const root = await tempRoot(t), path = join(root, RELATIVE);
+  const h = await harness(t, { root, readConfig: path => readGeneratedBridgeConfig(path) });
+  for (const source of [null, '{malformed}', 'globalThis.__RESONANTOS_BRIDGE_CONFIG__ = Object.freeze(', writer(config())]) {
+    if (source === null) await rm(path, { force: true }); else { await writeFile(path, source, { mode: 0o600 }); if (source.startsWith('globalThis') && source.endsWith(');')) await chmod(path, 0o644); }
+    const route = routeFrom((await h.page()).body), response = await h.module(route);
+    assert.equal(response.status, 200); assert.equal(response.body, renderBridgeModule(null));
+    assert.match(response.body, /^delete globalThis\.__RESONANTOS_BRIDGE_CONFIG__;/);
+    assert.equal((await h.module(route)).status, 403);
+  }
+});
+test('reader rejects unsafe files and bounds reads', async t => {
+  const root = await tempRoot(t), path = join(root, RELATIVE), source = writer(config());
+  await writeFile(path, source, { mode: 0o600 });
+  let opened = 0, closed = 0, dataReads = 0;
+  const trackedOpen = async (file, flags) => {
+    assert.equal(file === path, true, 'fixed input path');
+    assert.equal(flags & (constants.O_WRONLY | constants.O_RDWR), 0, 'read-only descriptor');
+    for (const flag of [constants.O_NOFOLLOW, constants.O_NONBLOCK]) assert.equal((flags & flag) === flag, true, 'safe open flags');
+    const handle = await open(file, flags); opened++;
+    return new Proxy(handle, { get(target, prop) {
+      if (prop === 'close') return async () => { closed++; await target.close(); };
+      if (prop === 'readFile') return async (...args) => { dataReads++; return target.readFile(...args); };
+      if (prop === 'read') return async (...args) => { dataReads++; const length = typeof args[2] === 'number' ? args[2] : args[0]?.length ?? args[0]?.buffer?.length; assert.equal(length <= 16 * 1024 + 1, true, 'bounded read'); return target.read(...args); };
+      const value = Reflect.get(target, prop, target); return typeof value === 'function' ? value.bind(target) : value;
+    } });
+  };
+  assert.equal((await readGeneratedBridgeConfig(root, { openFile: trackedOpen })) !== null, true);
+  const validReads = dataReads;
+  assert.equal((await readGeneratedBridgeConfig(root, { openFile: trackedOpen, uid: () => process.getuid() + 1 })) === null, true);
+  assert.equal((await readGeneratedBridgeConfig(root, { openFile: trackedOpen, uid: () => { throw Error('UID unavailable'); } })) === null, true);
+  for (const mode of [0o640, 0o604, 0o644]) { await chmod(path, mode); assert.equal((await readGeneratedBridgeConfig(root, { openFile: trackedOpen })) === null, true); }
+  await chmod(path, 0o600); await writeFile(path, 'x'.repeat(16 * 1024 + 1));
+  assert.equal((await readGeneratedBridgeConfig(root, { openFile: trackedOpen })) === null, true);
+  await rm(path); await mkdir(path); assert.equal((await readGeneratedBridgeConfig(root, { openFile: trackedOpen })) === null, true);
+  await rm(path, { recursive: true }); const target = join(root, 'synthetic-source'); await writeFile(target, source, { mode: 0o600 }); await symlink(target, path);
+  assert.equal((await readGeneratedBridgeConfig(root, { openFile: trackedOpen })) === null, true);
+  assert.equal(opened, closed, 'all opened descriptors closed');
+  assert.equal(dataReads, validReads, 'unsafe metadata rejected before reading bytes');
+  await rm(path); await writeFile(path, source, { mode: 0o600 });
+  let failureClosed = false;
+  const failingOpen = async (...args) => { const handle = await open(...args); return { stat: async () => { throw Error(token()); }, close: async () => { failureClosed = true; await handle.close(); } }; };
+  assert.equal((await readGeneratedBridgeConfig(root, { openFile: failingOpen })) === null, true); assert.equal(failureClosed, true);
+  let readFailureClosed = false;
+  const readFailureOpen = async (...args) => {
+    const handle = await open(...args);
+    return new Proxy(handle, { get(target, prop) {
+      if (prop === 'read' || prop === 'readFile') return async () => { throw Error(token()); };
+      if (prop === 'close') return async () => { readFailureClosed = true; await target.close(); };
+      const value = Reflect.get(target, prop, target); return typeof value === 'function' ? value.bind(target) : value;
+    } });
+  };
+  assert.equal((await readGeneratedBridgeConfig(root, { openFile: readFailureOpen })) === null, true);
+  assert.equal(readFailureClosed, true);
+});
+test('page challenge precedes nonce issuance', async t => {
+  const h = await harness(t);
+  for (const authorization of [undefined, `Basic ${Buffer.from(`dev:${nonce()}`).toString('base64')}`]) {
+    const response = await h.request('/', { headers: authorization ? { authorization } : {} });
+    assert.equal(response.status, 401); assert.equal(response.body, 'Authentication required.\n'); assert.equal(response.headers.get('www-authenticate'), CHALLENGE);
+    assert.equal(h.issues(), 0); assert.equal(h.reads(), 0); safe(response.body, [h.key, h.authorization]);
+  }
+  assert.equal((await h.page()).status, 200); assert.equal(h.issues(), 1); assert.equal(h.reads(), 0);
+  for (const method of ['HEAD', 'POST']) { assert.equal((await h.request('/', { method, headers: { authorization: h.authorization } })).status, 405); assert.equal(h.issues(), 1); }
+});
+test('module needs independent auth and page nonce', async t => {
+  const h = await harness(t), route = routeFrom((await h.page()).body);
+  const absent = await h.request(route, { headers: META }); assert.equal(absent.status, 401); assert.equal(absent.body, 'Authentication required.\n'); assert.equal(absent.headers.get('www-authenticate'), CHALLENGE); assert.equal(h.reads(), 0);
+  const wrong = await h.request(route, { headers: { ...META, authorization: `Basic ${Buffer.from(`dev:${nonce()}`).toString('base64')}` } });
+  assert.equal(wrong.status, 403); assert.equal(wrong.body, 'Forbidden.\n'); assert.equal(wrong.headers.has('www-authenticate'), false); assert.equal(h.reads(), 0);
+  assert.equal((await h.module(route)).status, 200); assert.equal(h.reads(), 1); assert.equal((await h.module(route)).status, 403); assert.equal(h.reads(), 1);
+  assert.equal((await h.module(ROUTE)).status, 403);
+  assert.equal((await h.request(ROUTE, { headers: META })).status, 401);
+  assert.equal(h.reads(), 1);
+});
+test('nonces expire and are single-use per server', async t => {
+  let now = 0; const store = createPageNonces(() => now), other = createPageNonces(() => now);
+  const first = store.issue(); assert.match(first, /^[A-Za-z0-9_-]{43}$/); assert.equal(other.consume(first), false);
+  now = 59999; assert.equal(store.consume(first), true); assert.equal(store.consume(first), false);
+  const expired = store.issue(); now += 60000; assert.equal(store.consume(expired), false);
+  const race = store.issue(); const outcomes = await Promise.all(Array.from({ length: 12 }, () => Promise.resolve().then(() => store.consume(race))));
+  assert.equal(outcomes.filter(Boolean).length, 1);
+  let release, entered;
+  const reading = new Promise(resolve => { entered = resolve; });
+  const pending = new Promise(resolve => { release = resolve; });
+  const h = await harness(t, { readConfig: async () => { entered(); await pending; return config(); } });
+  const route = routeFrom((await h.page()).body);
+  const winner = h.module(route); await reading;
+  try { const loser = await h.module(route); assert.equal(loser.status, 403); assert.equal(h.reads(), 1); }
+  finally { release(); }
+  assert.equal((await winner).status, 200);
+});
+test('reserved endpoint rejects method and URL aliases', async t => {
+  const h = await harness(t), route = routeFrom((await h.page()).body);
+  const aliases = [route + '&nonce=x', route + '&extra=x', ROUTE + '?raw', ROUTE + '?url', ROUTE + '.map',
+    ROUTE + '?nonce=%ZZ', '/__resonantos_dev_bridge__/%63onfig.mjs', '/__resonantos_dev_bridge__/./config.mjs',
+    '/__resonantos_dev_bridge__/x/../config.mjs', '/__resonantos_dev_bridge__//config.mjs',
+    '/__resonantos_dev_bridge__\\config.mjs', '/%5f%5fresonantos_dev_bridge__/config.mjs', `http://${HOST}${route}`];
+  for (const url of aliases) { const response = await h.module(url); assert.equal(response.status, 403, 'URL alias denied'); assert.equal(response.next, false); }
+  for (const method of ['HEAD', 'POST', 'OPTIONS']) assert.equal((await h.request(route, { method, headers: { ...META, authorization: h.authorization } })).status, 403);
+  assert.equal(h.reads(), 0); assert.equal((await h.module(route)).status, 200);
+});
+test('host origin and fetch metadata cannot bypass auth', async t => {
+  const h = await harness(t), route = routeFrom((await h.page()).body);
+  const variants = [{ host: 'attacker.test' }, { host: `127.0.0.2:${PORT}` }, { host: 'attacker.test', 'x-forwarded-host': HOST, forwarded: `host=${HOST}` },
+    { origin: 'null' }, { origin: 'http://attacker.test' }, { 'sec-fetch-site': undefined }, { 'sec-fetch-site': 'cross-site' },
+    { 'sec-fetch-mode': undefined }, { 'sec-fetch-mode': 'no-cors' }, { 'sec-fetch-dest': undefined }, { 'sec-fetch-dest': 'worker' }, { 'sec-fetch-dest': 'serviceworker' }];
+  for (const patch of variants) assert.equal((await h.request(route, { headers: { ...META, authorization: h.authorization, ...patch } })).status, 403);
+  assert.equal((await h.request(route, { headers: { ...META, authorization: h.authorization }, rawHeaders: ['Host', HOST, 'Host', HOST, 'Authorization', h.authorization, ...Object.entries(META).flat()] })).status, 403);
+  for (const patch of [{ host: 'attacker.test' }, { origin: 'null' }, { 'sec-fetch-site': 'cross-site' }, { 'sec-fetch-dest': 'iframe' }]) assert.equal((await h.request('/', { headers: { authorization: h.authorization, ...patch } })).status, 403);
+  assert.equal(h.reads(), 0); assert.equal((await h.request(route, { headers: { ...META, authorization: h.authorization, origin: `http://${HOST}`, 'x-forwarded-host': 'attacker.test', forwarded: 'host=attacker.test' } })).status, 200);
+});
+test('page responses have independent late-inserted gates', async t => {
+  const moduleNonces = [nonce(), nonce()], cspNonces = [nonce(), nonce()], value = config(); let m = 0, c = 0;
+  const h = await harness(t, { value, random: () => moduleNonces[m++], createCspNonce: () => cspNonces[c++] });
+  const pages = await Promise.all([h.page(), h.page()]);
+  assert.equal(new Set(pages.map(page => routeFrom(page.body))).size, 2);
+  for (let i = 0; i < pages.length; i++) {
+    assert.equal(pages[i].body.includes(moduleNonces[i]), true); assert.equal(pages[i].body.includes(`nonce="${cspNonces[i]}"`), true);
+    safe(pages[i].body, [...Object.values(value), h.key, h.authorization]);
+  }
+  for (const args of h.transforms) { assert.equal(args[0], '/index.html'); assert.equal(args[2], '/'); safe(JSON.stringify(args), [...moduleNonces, ...cspNonces, ...Object.values(value), h.key, PREFIX]); }
+  assert.equal(h.transforms.length, 2); assert.equal(h.issues(), 2); assert.equal(h.cspIssues(), 2); assert.equal(h.reads(), 0);
+});
+test('delivery responses forbid caching embedding and cross-origin reads', async t => {
+  const h = await harness(t), page = await h.page(), route = routeFrom(page.body);
+  headersSafe(page, true); assert.equal(page.headers.get('content-type'), 'text/html; charset=utf-8');
+  const module = await h.module(route); headersSafe(module); assert.equal(module.headers.get('content-type'), 'text/javascript; charset=utf-8');
+  for (const response of [await h.request('/'), await h.module(route), await h.request('/', { method: 'POST' }),
+    await h.request(route, { headers: { ...META, authorization: h.authorization, 'if-none-match': '*', 'if-modified-since': new Date().toUTCString() } })]) headersSafe(response);
+  const off = await harness(t, { env: {} }); headersSafe(await off.request(ROUTE));
+  const broken = await harness(t, { transform: () => { throw Error(token()); } }); const failed = await broken.page(); assert.equal(failed.status, 500); headersSafe(failed, true);
+  const full = await harness(t); for (let i = 0; i < 1024; i++) assert.equal((await full.page()).status, 200);
+  const exhausted = await full.page(); assert.equal(exhausted.status, 503); headersSafe(exhausted, true);
+});
+test('CSP authorizes React preamble and the external entry', async t => {
+  const csp = nonce(), moduleNonce = nonce();
+  const transformed = HTML.replace('<head>', '<head><script type="module">/* synthetic React refresh preamble */</script><script type="module" src="/@vite/client"></script>');
+  const h = await harness(t, { transform: () => transformed, random: () => moduleNonce, createCspNonce: () => csp });
+  const response = await h.page(); assert.equal(response.status, 200);
+  const all = nodes(response.body), meta = all.find(n => n.tagName === 'meta' && attr(n, 'http-equiv')?.toLowerCase() === 'content-security-policy');
+  const scripts = all.filter(n => n.tagName === 'script'), content = attr(meta, 'content');
+  assert.equal(all.indexOf(meta) < Math.min(...scripts.map(n => all.indexOf(n))), true, 'CSP before scripts');
+  const scriptPolicy = content.split(';').find(x => x.trim().startsWith('script-src '));
+  assert.equal(scriptPolicy.includes("'self'") && scriptPolicy.includes(`'nonce-${csp}'`), true);
+  assert.equal(/unsafe-inline|unsafe-eval/.test(scriptPolicy), false);
+  assert.equal(scripts.length, 3); assert.equal(scripts.every(n => attr(n, 'nonce') === csp), true);
+  assert.equal(content.includes("style-src 'self' 'unsafe-inline'") && content.includes("connect-src 'self' http://127.0.0.1:*"), true, 'other CSP directives retained');
+  assert.equal(content.includes(`nonce-${moduleNonce}`), false); assert.equal(h.cspIssues(), 1);
+  const fresh = Array.from({ length: 16 }, () => createCspNonce()); assert.equal(new Set(fresh).size, 16); assert.equal(fresh.every(x => /^[A-Za-z0-9_-]{43}$/.test(x)), true);
+});
+test('module config executes before main', () => {
+  const value = { ...config(), bridgeToken: `${token()}<script>`, capabilityBootstrapToken: `${token()}\u2028\u2029` };
+  for (const input of [value, null]) {
+    const body = renderBridgeModule(input);
+    assert.match(body, input ? /^globalThis\.__RESONANTOS_BRIDGE_CONFIG__ = Object\.freeze\(/ : /^delete globalThis\.__RESONANTOS_BRIDGE_CONFIG__;/);
+    assert.match(body.trimEnd(), /await import\('\/src\/main\.tsx'\);$/);
+    assert.equal(/(^|\n)\s*import\s/.test(body), false);
+    assert.equal(/[<\u2028\u2029]/.test(body), false);
+    assert.equal(/sourceMappingURL|import\.meta\.hot|localStorage|sessionStorage/.test(body), false);
+    if (input) { const json = body.match(/Object\.freeze\((.*)\);/)?.[1]; assert.equal(JSON.stringify(JSON.parse(json)) === JSON.stringify(value), true, 'escaped payload round trips'); }
+  }
+});
+test('errors and logging contain no sensitive values', async t => {
+  const key = nonce(), moduleNonce = nonce(), value = config(), authorization = `Basic ${Buffer.from(`dev:${key}`).toString('base64')}`;
+  const material = [key, moduleNonce, authorization, ...Object.values(value)], captured = [], originals = {};
+  for (const name of ['error', 'warn', 'log', 'info']) { originals[name] = console[name]; console[name] = (...args) => captured.push(args); }
+  try {
+    const broken = await harness(t, { key, random: () => moduleNonce, transform: () => { throw Error(material.join(' ')); } });
+    const response = await broken.page(); assert.equal(response.status, 500); assert.equal(response.body, 'Development page unavailable.\n');
+    assert.equal((await broken.module(`${ROUTE}?nonce=${moduleNonce}`)).status, 403);
+    const reader = await harness(t, { key, readConfig: async () => { throw Error(material.join(' ')); } });
+    const failed = await reader.module(routeFrom((await reader.page()).body)); safe(failed.body, material);
+    assert.equal([200, 500].includes(failed.status), true);
+    assert.equal(reader.errors.length + broken.errors.length, 0); assert.equal(reader.logs.length + broken.logs.length, 0); assert.equal(captured.length, 0);
+  } finally { for (const name of Object.keys(originals)) console[name] = originals[name]; }
+});
+test('build and preview do not activate delivery', () => {
+  let envCalls = 0, reads = 0; const key = nonce(), value = config();
+  const plugin = devBridgeConfigPlugin({ env: () => { envCalls++; return { RESONANTOS_DEV_BRIDGE_CONFIG: '1', RESONANTOS_DEV_BRIDGE_PAGE_KEY: key }; }, readConfig: async () => { reads++; return value; } });
+  assert.equal(plugin.name, 'resonantos-dev-bridge-config'); assert.equal(plugin.enforce, 'pre'); assert.equal(typeof plugin.apply, 'function');
+  for (const env of [{ command: 'build', mode: 'production' }, { command: 'serve', mode: 'production', isPreview: true }]) assert.equal(plugin.apply({}, env), false);
+  assert.equal(plugin.apply({}, { command: 'serve', mode: 'development', isPreview: false }), true);
+  assert.equal(envCalls, 0); assert.equal(reads, 0); safe(JSON.stringify(plugin), [key, ...Object.values(value)]);
+  const missing = devBridgeConfigPlugin({ env: () => ({ RESONANTOS_DEV_BRIDGE_CONFIG: '1' }) }); assert.equal(missing.apply({}, { command: 'build' }), false);
+});
+test('unexpected HTML structure fails closed', async t => {
+  const meta = HTML.match(/<meta[^>]+>/)[0], main = '<script type="module" src="/src/main.tsx"></script>';
+  for (const html of [HTML.replace(meta, ''), HTML.replace(meta, meta + meta), HTML.replace(main, ''), HTML.replace(main, main + main),
+    HTML.replace("script-src 'self';", ''), HTML.replace("script-src 'self';", "script-src 'none';"),
+    HTML.replace("script-src 'self';", "script-src 'self'; script-src 'self';"), HTML.replace("script-src 'self';", 'script-src;')]) {
+    const h = await harness(t, { transform: () => html }); const response = await h.page();
+    assert.equal(response.status, 500); assert.equal(response.body, 'Development page unavailable.\n'); assert.equal(h.reads(), 0); assert.equal(response.body.includes(PREFIX), false);
+    assert.throws(() => renderAuthenticatedPage(html, nonce(), nonce()));
+  }
+});
+test('nonce state is bounded and cleared', async t => {
+  let now = 0; const store = createPageNonces(() => now), issued = [];
+  for (let i = 0; i < 1024; i++) issued.push(store.issue());
+  assert.equal(new Set(issued).size, 1024); assert.equal(issued.includes(null), false); assert.equal(store.issue(), null);
+  now = 60000; assert.equal(typeof store.issue(), 'string'); assert.equal(store.consume(issued[0]), false);
+  const latest = store.issue(); store.clear(); assert.equal(store.consume(latest), false);
+  const h = await harness(t), route = routeFrom((await h.page()).body); h.server.httpServer.emit('close'); assert.equal((await h.module(route)).status, 403); assert.equal(h.reads(), 0);
+});
+test('Basic parser rejects ambiguous credentials', async t => {
+  const h = await harness(t), route = routeFrom((await h.page()).body);
+  const encoded = Buffer.from(`dev:${h.key}`).toString('base64');
+  const bad = [`Basic ${encoded}\n`, `Basic ${encoded.replace(/=+$/, '')}!`, `Basic ${encoded.slice(0, 8)} ${encoded.slice(8)}`,
+    `Basic ${Buffer.from(`other:${h.key}`).toString('base64')}`, `Basic ${Buffer.from(`dev:${h.key.slice(1)}`).toString('base64')}`,
+    `Basic ${Buffer.from(`dev:${h.key}x`).toString('base64')}`, `Basic ${encoded}${' '.repeat(257)}`, `Bearer ${h.key}`];
+  // Change ignored pad bits: permissive Buffer decoding yields the same bytes.
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+  const pad = encoded.indexOf('='); if (pad > 0) bad.push(`Basic ${encoded.slice(0, pad - 1)}${alphabet[alphabet.indexOf(encoded[pad - 1]) + 1]}${encoded.slice(pad)}`);
+  for (const authorization of bad) {
+    assert.equal((await h.request('/', { headers: { authorization } })).status, 401);
+    const response = await h.request(route, { headers: { ...META, authorization } }); assert.equal(response.status, 403); assert.equal(response.headers.has('www-authenticate'), false);
+  }
+  const rawHeaders = ['Host', HOST, 'Authorization', h.authorization, 'authorization', h.authorization, ...Object.entries(META).flat()];
+  assert.equal((await h.request('/', { headers: { authorization: h.authorization }, rawHeaders })).status, 401);
+  assert.equal((await h.request(route, { headers: { ...META, authorization: h.authorization }, rawHeaders })).status, 403);
+  assert.equal(h.reads(), 0); assert.equal(h.issues(), 1); assert.equal((await h.module(route)).status, 200); assert.equal(h.reads(), 1);
+});
+
+test('plugin does not apply under vitest (Vite mode test) — the policy assertion must never break the unit runner', () => {
+  const plugin = devBridgeConfigPlugin();
+  assert.equal(plugin.apply({}, { command: 'serve', mode: 'test', isPreview: false }), false);
+  assert.equal(plugin.apply({}, { command: 'serve', mode: 'development', isPreview: false }), true);
+  assert.equal(plugin.apply({}, { command: 'build', mode: 'production', isPreview: false }), false);
+  assert.equal(plugin.apply({}, { command: 'serve', mode: 'development', isPreview: true }), false);
+});

--- a/scripts/vite-dev-bridge-config.test.mjs
+++ b/scripts/vite-dev-bridge-config.test.mjs
@@ -298,23 +298,50 @@ test('reserved endpoint rejects method and URL aliases', async t => {
 });
 test('host origin and fetch metadata cannot bypass auth', async t => {
   const h = await harness(t), route = routeFrom((await h.page()).body);
-  const variants = [{ host: 'attacker.test' }, { host: `127.0.0.2:${PORT}` }, { host: 'attacker.test', 'x-forwarded-host': HOST, forwarded: `host=${HOST}` },
+  const variants = [{ host: 'attacker.test' }, { host: `127.0.0.2:${PORT}` }, { host: `localhost:${PORT}` }, { host: 'attacker.test', 'x-forwarded-host': HOST, forwarded: `host=${HOST}` },
     { origin: 'null' }, { origin: 'http://attacker.test' }, { 'sec-fetch-site': undefined }, { 'sec-fetch-site': 'cross-site' },
     { 'sec-fetch-mode': undefined }, { 'sec-fetch-mode': 'no-cors' }, { 'sec-fetch-dest': undefined }, { 'sec-fetch-dest': 'worker' }, { 'sec-fetch-dest': 'serviceworker' }];
   for (const patch of variants) assert.equal((await h.request(route, { headers: { ...META, authorization: h.authorization, ...patch } })).status, 403);
   assert.equal((await h.request(route, { headers: { ...META, authorization: h.authorization }, rawHeaders: ['Host', HOST, 'Host', HOST, 'Authorization', h.authorization, ...Object.entries(META).flat()] })).status, 403);
-  for (const patch of [{ host: 'attacker.test' }, { origin: 'null' }, { 'sec-fetch-site': 'cross-site' }, { 'sec-fetch-dest': 'iframe' }]) assert.equal((await h.request('/', { headers: { authorization: h.authorization, ...patch } })).status, 403);
+  for (const patch of [{ host: 'attacker.test' }, { host: `localhost:${PORT}` }, { origin: 'null' }, { 'sec-fetch-site': 'cross-site' }, { 'sec-fetch-dest': 'iframe' }]) assert.equal((await h.request('/', { headers: { authorization: h.authorization, ...patch } })).status, 403);
   assert.equal(h.reads(), 0); assert.equal((await h.request(route, { headers: { ...META, authorization: h.authorization, origin: `http://${HOST}`, 'x-forwarded-host': 'attacker.test', forwarded: 'host=attacker.test' } })).status, 200);
+});
+test('page fetch metadata accepts only same-origin none or absent site', async t => {
+  const value = config(), h = await harness(t, { value });
+  for (const path of ['/', '/index.html']) {
+    for (const site of ['same-site', 'cross-site']) for (const authorization of [undefined, h.authorization]) {
+      const response = await h.request(path, { headers: { 'sec-fetch-site': site, ...(authorization ? { authorization } : {}) } });
+      assert.equal(response.status, 403); assert.equal(response.body, 'Forbidden.\n');
+      assert.equal(response.headers.has('www-authenticate'), false); assert.equal(response.next, false);
+      safe(response.body, [...Object.values(value), h.key, h.authorization]);
+    }
+  }
+  assert.equal(h.issues(), 0); assert.equal(h.cspIssues(), 0); assert.equal(h.transforms.length, 0); assert.equal(h.reads(), 0);
+  for (const path of ['/', '/index.html']) for (const site of ['same-origin', 'none', undefined]) {
+    const response = await h.request(path, { headers: { authorization: h.authorization, ...(site === undefined ? {} : { 'sec-fetch-site': site }) } });
+    assert.equal(response.status, 200); routeFrom(response.body);
+    safe(response.body, [...Object.values(value), h.key, h.authorization]);
+  }
+  assert.equal(h.issues(), 6); assert.equal(h.reads(), 0);
 });
 test('page responses have independent late-inserted gates', async t => {
   const moduleNonces = [nonce(), nonce()], cspNonces = [nonce(), nonce()], value = config(); let m = 0, c = 0;
   const h = await harness(t, { value, random: () => moduleNonces[m++], createCspNonce: () => cspNonces[c++] });
   const pages = await Promise.all([h.page(), h.page()]);
   assert.equal(new Set(pages.map(page => routeFrom(page.body))).size, 2);
-  for (let i = 0; i < pages.length; i++) {
-    assert.equal(pages[i].body.includes(moduleNonces[i]), true); assert.equal(pages[i].body.includes(`nonce="${cspNonces[i]}"`), true);
-    safe(pages[i].body, [...Object.values(value), h.key, h.authorization]);
+  const seenModules = new Set(), seenCsp = new Set();
+  for (const page of pages) {
+    assert.equal(page.status, 200);
+    const ownModule = new URL(routeFrom(page.body), `http://${HOST}`).searchParams.get('nonce');
+    const scripts = nodes(page.body).filter(node => node.tagName === 'script');
+    const ownCsp = attr(scripts[0], 'nonce');
+    assert.equal(moduleNonces.includes(ownModule), true); assert.equal(cspNonces.includes(ownCsp), true);
+    assert.equal(scripts.every(node => attr(node, 'nonce') === ownCsp), true);
+    assert.equal(page.body.includes(`'nonce-${ownCsp}'`), true);
+    safe(page.body, [...moduleNonces.filter(n => n !== ownModule), ...cspNonces.filter(n => n !== ownCsp), ...Object.values(value), h.key, h.authorization]);
+    seenModules.add(ownModule); seenCsp.add(ownCsp);
   }
+  assert.deepEqual(seenModules, new Set(moduleNonces)); assert.deepEqual(seenCsp, new Set(cspNonces));
   for (const args of h.transforms) { assert.equal(args[0], '/index.html'); assert.equal(args[2], '/'); safe(JSON.stringify(args), [...moduleNonces, ...cspNonces, ...Object.values(value), h.key, PREFIX]); }
   assert.equal(h.transforms.length, 2); assert.equal(h.issues(), 2); assert.equal(h.cspIssues(), 2); assert.equal(h.reads(), 0);
 });
@@ -367,7 +394,9 @@ test('errors and logging contain no sensitive values', async t => {
     assert.equal((await broken.module(`${ROUTE}?nonce=${moduleNonce}`)).status, 403);
     const reader = await harness(t, { key, readConfig: async () => { throw Error(material.join(' ')); } });
     const failed = await reader.module(routeFrom((await reader.page()).body)); safe(failed.body, material);
-    assert.equal([200, 500].includes(failed.status), true);
+    assert.equal(failed.status, 200);
+    assert.equal(failed.body, "delete globalThis.__RESONANTOS_BRIDGE_CONFIG__;\nawait import('/src/main.tsx');\n");
+    assert.equal(reader.reads(), 1);
     assert.equal(reader.errors.length + broken.errors.length, 0); assert.equal(reader.logs.length + broken.logs.length, 0); assert.equal(captured.length, 0);
   } finally { for (const name of Object.keys(originals)) console[name] = originals[name]; }
 });
@@ -417,10 +446,13 @@ test('Basic parser rejects ambiguous credentials', async t => {
   assert.equal(h.reads(), 0); assert.equal(h.issues(), 1); assert.equal((await h.module(route)).status, 200); assert.equal(h.reads(), 1);
 });
 
-test('plugin does not apply under vitest (Vite mode test) — the policy assertion must never break the unit runner', () => {
-  const plugin = devBridgeConfigPlugin();
-  assert.equal(plugin.apply({}, { command: 'serve', mode: 'test', isPreview: false }), false);
-  assert.equal(plugin.apply({}, { command: 'serve', mode: 'development', isPreview: false }), true);
-  assert.equal(plugin.apply({}, { command: 'build', mode: 'production', isPreview: false }), false);
-  assert.equal(plugin.apply({}, { command: 'serve', mode: 'development', isPreview: true }), false);
+test('plugin skips only under vitest (mode test + VITEST=true); a plain vite --mode test server keeps the policy', () => {
+  const under = devBridgeConfigPlugin({ env: () => ({ VITEST: 'true' }) });
+  const plain = devBridgeConfigPlugin({ env: () => ({}) });
+  assert.equal(under.apply({}, { command: 'serve', mode: 'test', isPreview: false }), false);
+  assert.equal(plain.apply({}, { command: 'serve', mode: 'test', isPreview: false }), true);
+  assert.equal(plain.apply({}, { command: 'serve', mode: 'development', isPreview: false }), true);
+  assert.equal(under.apply({}, { command: 'serve', mode: 'development', isPreview: false }), true);
+  assert.equal(plain.apply({}, { command: 'build', mode: 'production', isPreview: false }), false);
+  assert.equal(plain.apply({}, { command: 'serve', mode: 'development', isPreview: true }), false);
 });

--- a/src/core/web-transport-config.test.ts
+++ b/src/core/web-transport-config.test.ts
@@ -1,0 +1,50 @@
+import { randomBytes } from "node:crypto";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { __resetWebTransportForTests, webInvoke, WEB_TRANSPORT_CAPABILITIES } from "./web-transport";
+
+const fetchMock = vi.fn<typeof fetch>();
+const globals = globalThis as typeof globalThis & { __RESONANTOS_BRIDGE_CONFIG__?: object };
+let originalConfig: PropertyDescriptor | undefined;
+beforeEach(() => {
+  originalConfig = Object.getOwnPropertyDescriptor(globalThis, "__RESONANTOS_BRIDGE_CONFIG__");
+  __resetWebTransportForTests();
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+afterEach(() => {
+  __resetWebTransportForTests();
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  if (originalConfig) Object.defineProperty(globalThis, "__RESONANTOS_BRIDGE_CONFIG__", originalConfig);
+  else delete globals.__RESONANTOS_BRIDGE_CONFIG__;
+});
+
+it("missing delivered config retains the existing no-config error", async () => {
+  delete globals.__RESONANTOS_BRIDGE_CONFIG__;
+  await expect(webInvoke("provider_diagnostics")).rejects.toThrow(
+    "Browser-first bridge is not configured. Start it with `npm run browser-first:bridge`.");
+  expect(fetchMock).toHaveBeenCalledTimes(0);
+});
+
+it("delivered three-field config bootstraps before diagnostics", async () => {
+  const canary = () => `synthetic-${randomBytes(24).toString("hex")}`;
+  const config = Object.freeze({ bridgeUrl: "http://127.0.0.1:49152", bridgeToken: canary(), capabilityBootstrapToken: canary() });
+  const routeToken = canary();
+  globals.__RESONANTOS_BRIDGE_CONFIG__ = config;
+  fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, capabilityTokens: { "provider-diagnostics-read": routeToken } })))
+    .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true })));
+  expect(await webInvoke("provider_diagnostics")).toEqual({ ok: true });
+  expect(fetchMock.mock.calls.map(([url, init]) => [new URL(String(url)).pathname, init?.method])).toEqual([
+    ["/api/capability-tokens", "POST"], ["/providers/status", "GET"],
+  ]);
+  const first = fetchMock.mock.calls[0], second = fetchMock.mock.calls[1];
+  const bootstrapHeaders = new Headers(first[1]?.headers), routeHeaders = new Headers(second[1]?.headers);
+  expect(bootstrapHeaders.get("X-ResonantOS-Bridge-Token") === config.bridgeToken).toBe(true);
+  expect(bootstrapHeaders.get("X-ResonantOS-Capability-Bootstrap-Token") === config.capabilityBootstrapToken).toBe(true);
+  expect(JSON.parse(String(first[1]?.body))).toEqual({ capabilities: WEB_TRANSPORT_CAPABILITIES });
+  expect(routeHeaders.get("X-ResonantOS-Bridge-Token") === config.bridgeToken).toBe(true);
+  expect(routeHeaders.get("X-ResonantOS-Bridge-Capability-Token") === routeToken).toBe(true);
+  expect(routeHeaders.has("X-ResonantOS-Capability-Bootstrap-Token")).toBe(false);
+  expect(fetchMock.mock.calls.every(([url]) => new URL(String(url)).origin === config.bridgeUrl)).toBe(true);
+  expect(Object.keys(config)).toEqual(["bridgeUrl", "bridgeToken", "capabilityBootstrapToken"]);
+});

--- a/src/dev-server-policy.test.ts
+++ b/src/dev-server-policy.test.ts
@@ -47,7 +47,7 @@ const restoreEnv = (name: string, value: string | undefined) => {
 
 describe.sequential("authenticated development policy", () => {
   it("resolved Vite config wires the delivery plugin and strict policy", async () => {
-    const config = await resolveConfig({ configFile: "vite.config.ts" }, "serve");
+    const config = await resolveConfig({ configFile: "vite.config.ts", configLoader: "runner" }, "serve");
     expect(config.plugins.some(p => p.name === "resonantos-dev-bridge-config")).toBe(true);
     expect(config.server.host).toBe("127.0.0.1");
     expect(config.server.allowedHosts).toEqual(["127.0.0.1"]);
@@ -93,7 +93,7 @@ describe.sequential("authenticated development policy", () => {
     const previous = process.env[name], enabled = process.env.RESONANTOS_DEV_BRIDGE_CONFIG;
     try {
       process.env[name] = "attacker.test"; delete process.env.RESONANTOS_DEV_BRIDGE_CONFIG;
-      const config = await resolveConfig({ configFile: "vite.config.ts" }, "serve");
+      const config = await resolveConfig({ configFile: "vite.config.ts", configLoader: "runner" }, "serve");
       const effectiveHosts = Array.isArray(config.server.allowedHosts) ? config.server.allowedHosts : [];
       expect(effectiveHosts).toContain("attacker.test");
       expect(() => assertDevServerPolicy(config, 1430)).toThrow("Unsafe development server policy.");
@@ -111,7 +111,7 @@ describe.sequential("authenticated development policy", () => {
     } finally { restoreEnv(name, previous); restoreEnv("RESONANTOS_DEV_BRIDGE_CONFIG", enabled); }
   });
   it("startup rejects implicit origins and HMR host overrides", async () => {
-    const config = await resolveConfig({ configFile: "vite.config.ts" }, "serve");
+    const config = await resolveConfig({ configFile: "vite.config.ts", configLoader: "runner" }, "serve");
     expect(() => assertDevServerPolicy(config, 1430)).not.toThrow();
     for (const additionalAllowedHosts of [undefined, null, true, "", "127.0.0.1", ["attacker.test"], ["127.0.0.1", "attacker.test"]]) {
       expect(() => assertDevServerPolicy({ ...policy(), additionalAllowedHosts }, 1430)).toThrow("Unsafe development server policy.");

--- a/src/dev-server-policy.test.ts
+++ b/src/dev-server-policy.test.ts
@@ -29,3 +29,90 @@ describe("dev server filesystem policy", () => {
     expect(fsBlock).toMatch(/\bstrict\s*:\s*true\b/);
   });
 });
+
+// P1–P8: use the resolved Vite policy, without starting a listener.
+import { resolveConfig } from "vite";
+import { assertDevServerPolicy, EXPECTED_DEV_SERVER_FS_DENY, type DevServerPolicyInput } from "../scripts/vite-dev-bridge-config.mjs";
+
+const sensitiveIgnores = ["**/bridge-config.generated.js", "**/ResonantOS_User/**"];
+const policy = (): DevServerPolicyInput => ({
+  additionalAllowedHosts: [],
+  server: { host: "127.0.0.1", port: 1430, strictPort: true,
+    allowedHosts: ["127.0.0.1"], fs: { strict: true, deny: [...DEV_SERVER_FS_DENY] },
+    cors: false, watch: { ignored: [...sensitiveIgnores] } },
+});
+const restoreEnv = (name: string, value: string | undefined) => {
+  if (value === undefined) delete process.env[name]; else process.env[name] = value;
+};
+
+describe.sequential("authenticated development policy", () => {
+  it("resolved Vite config wires the delivery plugin and strict policy", async () => {
+    const config = await resolveConfig({ configFile: "vite.config.ts" }, "serve");
+    expect(config.plugins.some(p => p.name === "resonantos-dev-bridge-config")).toBe(true);
+    expect(config.server.host).toBe("127.0.0.1");
+    expect(config.server.allowedHosts).toEqual(["127.0.0.1"]);
+    expect(config.server.fs.strict).toBe(true);
+    expect(config.server.fs.deny).toEqual(DEV_SERVER_FS_DENY);
+    expect(config.server.cors).toBe(false);
+    expect(config.server.watch?.ignored).toEqual(expect.arrayContaining(sensitiveIgnores));
+    expect(() => assertDevServerPolicy(config, 1430)).not.toThrow();
+  });
+  it("startup rejects noncanonical hosts", () => {
+    for (const host of [undefined, true, "0.0.0.0", "localhost", "::1", "127.0.0.2"]) {
+      const config = policy(); config.server.host = host;
+      expect(() => assertDevServerPolicy(config, 1430)).toThrow();
+    }
+  });
+  it("startup rejects missing or broadened allowedHosts", () => {
+    for (const allowedHosts of [undefined, [], true, ["*"], [".test"], ["127.0.0.1", "attacker.test"]]) {
+      const config = policy(); config.server.allowedHosts = allowedHosts;
+      expect(() => assertDevServerPolicy(config, 1430)).toThrow();
+    }
+  });
+  it("startup rejects every missing deny entry and nonstrict fs", () => {
+    for (const entry of DEV_SERVER_FS_DENY) {
+      const config = policy(); config.server.fs = { strict: true, deny: DEV_SERVER_FS_DENY.filter(x => x !== entry) };
+      expect(() => assertDevServerPolicy(config, 1430)).toThrow();
+    }
+    for (const strict of [false, undefined]) {
+      const config = policy(); config.server.fs = { strict, deny: [...DEV_SERVER_FS_DENY] };
+      expect(() => assertDevServerPolicy(config, 1430)).toThrow();
+    }
+  });
+  it("startup rejects port CORS and watcher weakening", () => {
+    for (const patch of [{ port: undefined }, { port: 0 }, { port: 1431 }, { port: 1.5 }, { port: 65536 },
+      { strictPort: false }, { strictPort: undefined }, { cors: true }, { cors: undefined },
+      ...sensitiveIgnores.map(entry => ({ watch: { ignored: sensitiveIgnores.filter(x => x !== entry) } }))]) {
+      const config = policy(); Object.assign(config.server, patch);
+      expect(() => assertDevServerPolicy(config, 1430)).toThrow();
+    }
+    for (const port of [0, -1, 65536, 1.5, NaN]) expect(() => assertDevServerPolicy(policy(), port)).toThrow();
+  });
+  it("startup checks effective environment host additions", async () => {
+    const name = "__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS";
+    const previous = process.env[name], enabled = process.env.RESONANTOS_DEV_BRIDGE_CONFIG;
+    try {
+      process.env[name] = "attacker.test"; delete process.env.RESONANTOS_DEV_BRIDGE_CONFIG;
+      const config = await resolveConfig({ configFile: "vite.config.ts" }, "serve");
+      expect(() => assertDevServerPolicy(config, 1430)).toThrow();
+    } finally { restoreEnv(name, previous); restoreEnv("RESONANTOS_DEV_BRIDGE_CONFIG", enabled); }
+  });
+  it("startup rejects implicit origins and HMR host overrides", async () => {
+    const config = await resolveConfig({ configFile: "vite.config.ts" }, "serve");
+    expect(() => assertDevServerPolicy(config, 1430)).not.toThrow();
+    for (const additionalAllowedHosts of [undefined, true, "127.0.0.1", ["attacker.test"]]) {
+      expect(() => assertDevServerPolicy({ ...policy(), additionalAllowedHosts }, 1430)).toThrow();
+    }
+    for (const additionalAllowedHosts of [[], ["127.0.0.1"], ["127.0.0.1", "127.0.0.1"]]) {
+      expect(() => assertDevServerPolicy({ ...policy(), additionalAllowedHosts }, 1430)).not.toThrow();
+    }
+    for (const patch of [{ origin: "http://attacker.test" }, { hmr: { host: "attacker.test" } }]) {
+      const unsafe = policy(); Object.assign(unsafe.server, patch);
+      expect(() => assertDevServerPolicy(unsafe, 1430)).toThrow();
+    }
+  });
+  it("plugin deny expectations match the canonical deny set", () => {
+    expect(EXPECTED_DEV_SERVER_FS_DENY).toEqual(DEV_SERVER_FS_DENY);
+    expect(Object.isFrozen(EXPECTED_DEV_SERVER_FS_DENY)).toBe(true);
+  });
+});

--- a/src/dev-server-policy.test.ts
+++ b/src/dev-server-policy.test.ts
@@ -32,7 +32,7 @@ describe("dev server filesystem policy", () => {
 
 // P1–P8: use the resolved Vite policy, without starting a listener.
 import { resolveConfig } from "vite";
-import { assertDevServerPolicy, EXPECTED_DEV_SERVER_FS_DENY, type DevServerPolicyInput } from "../scripts/vite-dev-bridge-config.mjs";
+import { assertDevServerPolicy, devBridgeConfigPlugin, EXPECTED_DEV_SERVER_FS_DENY, type DevServerPolicyInput } from "../scripts/vite-dev-bridge-config.mjs";
 
 const sensitiveIgnores = ["**/bridge-config.generated.js", "**/ResonantOS_User/**"];
 const policy = (): DevServerPolicyInput => ({
@@ -94,14 +94,27 @@ describe.sequential("authenticated development policy", () => {
     try {
       process.env[name] = "attacker.test"; delete process.env.RESONANTOS_DEV_BRIDGE_CONFIG;
       const config = await resolveConfig({ configFile: "vite.config.ts" }, "serve");
-      expect(() => assertDevServerPolicy(config, 1430)).toThrow();
+      const effectiveHosts = Array.isArray(config.server.allowedHosts) ? config.server.allowedHosts : [];
+      expect(effectiveHosts).toContain("attacker.test");
+      expect(() => assertDevServerPolicy(config, 1430)).toThrow("Unsafe development server policy.");
+      // Vite appends the environment host to server.allowedHosts. Isolate those
+      // effective additions so that the separate additional-host guard is tested.
+      const additionsOnly = { ...config, server: { ...config.server, allowedHosts: ["127.0.0.1"] },
+        additionalAllowedHosts: [...effectiveHosts] };
+      expect(() => assertDevServerPolicy(additionsOnly, 1430)).toThrow("Unsafe development server policy.");
+      const plugin = devBridgeConfigPlugin({ env: () => ({ RESONANTOS_DEV_BRIDGE_CONFIG: "0" }) });
+      const hook = plugin.configureServer!;
+      // Policy must run at entry, before a server with an unsafe policy can
+      // install middleware, even when the plugin's injected environment is off.
+      expect(() => Reflect.apply(typeof hook === "function" ? hook : hook.handler, plugin,
+        [{ config: additionsOnly }])).toThrow("Unsafe development server policy.");
     } finally { restoreEnv(name, previous); restoreEnv("RESONANTOS_DEV_BRIDGE_CONFIG", enabled); }
   });
   it("startup rejects implicit origins and HMR host overrides", async () => {
     const config = await resolveConfig({ configFile: "vite.config.ts" }, "serve");
     expect(() => assertDevServerPolicy(config, 1430)).not.toThrow();
-    for (const additionalAllowedHosts of [undefined, true, "127.0.0.1", ["attacker.test"]]) {
-      expect(() => assertDevServerPolicy({ ...policy(), additionalAllowedHosts }, 1430)).toThrow();
+    for (const additionalAllowedHosts of [undefined, null, true, "", "127.0.0.1", ["attacker.test"], ["127.0.0.1", "attacker.test"]]) {
+      expect(() => assertDevServerPolicy({ ...policy(), additionalAllowedHosts }, 1430)).toThrow("Unsafe development server policy.");
     }
     for (const additionalAllowedHosts of [[], ["127.0.0.1"], ["127.0.0.1", "127.0.0.1"]]) {
       expect(() => assertDevServerPolicy({ ...policy(), additionalAllowedHosts }, 1430)).not.toThrow();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import { DEV_SERVER_FS_DENY } from "./src/dev-server-policy";
+import { devBridgeConfigPlugin } from "./scripts/vite-dev-bridge-config.mjs";
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [devBridgeConfigPlugin(), react()],
   build: {
     rollupOptions: {
       output: {
@@ -32,6 +33,8 @@ export default defineConfig({
     host: "127.0.0.1",
     port: 1430,
     strictPort: true,
+    allowedHosts: ["127.0.0.1"],
+    cors: false,
     fs: {
       strict: true,
       deny: DEV_SERVER_FS_DENY,
@@ -40,6 +43,8 @@ export default defineConfig({
       ignored: [
         "**/dist/**",
         "**/node_modules/**",
+        "**/bridge-config.generated.js",
+        "**/ResonantOS_User/**",
       ],
     },
   },


### PR DESCRIPTION
## Summary

Part 2 of #429: opt-in, page-key-gated delivery of the bridge config to the React shell's Vite dev page, so the web-mode transport (#374 / #433) can authenticate to the local bridge from a browser without reopening part 1's machine-wide exposure.

- **Off by default.** Delivery exists only when `RESONANTOS_DEV_BRIDGE_CONFIG=1` **and** an operator page key `RESONANTOS_DEV_BRIDGE_PAGE_KEY` (43-char base64url) are set on the dev server. Without them the reserved route is a plain 404 and nothing else changes.
- **How it is delivered.** The dev page (`/`, `/index.html`) is behind HTTP Basic (user `dev`, the page key). An authenticated page gets a same-origin, request-generated module URL carrying a random 32-byte, 60-second, single-use nonce; the module (Basic + nonce + exact Host/Origin/fetch-metadata) reads the bridge's generated file **at request time**, assigns the frozen `globalThis.__RESONANTOS_BRIDGE_CONFIG__` (three fields), and imports `/src/main.tsx`. The module is never on disk, never in Vite's module graph, and the generated file stays denied by the dev server (part 1).
- **CSP.** Per-response CSP nonce applied to the CSP meta and to Vite's inline React-refresh preamble; delivered module stays under `script-src 'self'`.
- **Fail-closed dev-server policy.** At startup (and again after all `configureServer` hooks) the plugin asserts host `127.0.0.1`, port 1430, strictPort, `allowedHosts` exactly `['127.0.0.1']` (plus empty/loopback-only additional hosts, no `server.origin`/`hmr.host`), `fs.strict` with the six part-1 deny patterns, `cors: false`, and the two sensitive watch-ignores; otherwise the server refuses to start. Vitest is exempt only when it is really vitest (mode `test` **and** `VITEST=true`).
- **Bridge CORS.** Operator opt-in only: `RESONANTOS_BRIDGE_ALLOWED_ORIGINS=http://127.0.0.1:1430` on the bridge; the bridge default stays `[]` (now pinned by a test).
- **Hardened response surface:** `Cache-Control: no-store`, `Referrer-Policy: no-referrer`, CORP `same-origin`, `frame-ancestors 'none'` / `X-Frame-Options: DENY`, no ACAO, fixed value-free error bodies, no secret in logs/errors.

## Verification (Resonant-Rig full tier)

- Plan certified by a three-vendor panel (Grok 4.6, Gemini 3.7, Claude Opus 5) over three revisions; implementation best-of-two on the plugin (Grok base, codex diff reference).
- Gates on the head: vitest **533/533** (+10), `npm run test:dev-bridge-config` **34/34** (new lane, exits on its own, added to `verify:alpha` → 17 commands), browser-first **1271** (+1: bridge default-origin pin), security pipeline 46 + `run-check --certify` clean, docs contract + 275 doc tests, hygiene guard, `npm run build` with no page-key name or plugin code in `dist`.
- Anti-false-green: 93-entry mutation kit re-run at the branch tip, **82 proven kills**; the remaining 11 records are over-specified expectations where a named test did go red (adjudication recorded beside the kit and independently confirmed by the Phase 4 meta-audit).
- Certification panel (reviewer ≠ author per file): Opus 5 security, codex correctness/runtime, Grok tests+docs, Gemini merge-integrity/conformance → all CERT-OK after one fix round (the vitest carve-out was narrowed after codex proved `vite --mode test` could bypass the policy; page route now rejects `Sec-Fetch-Site: same-site`).
- `npm run verify:alpha` (all 17 commands, incl. pre-release scan) exit 0 at the tip.
- Live proof at the tip on an isolated bridge (throwaway key): on-mode **L1–L14, L16** pass (401 page, nonce'd page, forged-metadata 403, replay, generated file 403 by path and `/@fs`, second unprivileged client sees nothing, live capability bootstrap through the delivered tokens, HMR socket leaks nothing); off-mode pass; **L15** (bridge without CORS opt-in) pass.

Evidence commit: dfb37f8f for the gate sweep, mutation kit and full live proof; the tip 904fb815 differs only in the live-proof script's L15 (reviewer minors) and its cors-denied phase was re-run there: PASS.

## Deviations from the certified spec (recorded in the run ledger)

1. `apply()` additionally excludes vitest (mode `test` + `VITEST=true`) — vitest boots an internal Vite server and the fail-closed policy would kill the unit runner.
2. Page route rejects `Sec-Fetch-Site: same-site`/`cross-site` (Opus 5 finding).
3. L15 asserts what CORS guarantees (certified as a recorded deviation by Grok 4.6 and Gemini 3.1 Pro after the meta-audit raised it): the preflight does not grant the page origin and the page cannot read bridge responses. Chromium reports `AllowOriginMismatch` on the actual response, i.e. a token-bearing request from a non-allowlisted page is still processed by the bridge and only the read is blocked. Token confidentiality rests on L1–L14, not on CORS.

## Operator steps

See `browser-first/README.md` → "Opt-in React shell development" and `docs/browser-first-bridge-setup-runbook.md`. Rollback: unset the two env vars.

## Residuals (documented, not blockers)

Same-user processes can read the 0600 generated file or the dev shell's environment (out of scope, as in part 1). HMR/WebSocket is not behind Basic; the control is graph isolation (I3/I7/L16). A developer who sets `VITEST=true` with mode `test` on a real server disables the plugin on purpose.

Closes #429. Refs #374, #180 (shell wiring can proceed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
